### PR TITLE
Remove Accept request header from api signature

### DIFF
--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/SpringCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/SpringCodegen.java
@@ -246,8 +246,6 @@ public class SpringCodegen extends AbstractJavaCodegen
                     additionalProperties.put(SINGLE_CONTENT_TYPES, "true");
                     this.setSingleContentTypes(true);
                 }
-                additionalProperties.put("useSpringCloudClient", true);
-
             } else {
                 apiTemplateFiles.put("apiController.mustache", "Controller.java");
                 supportingFiles.add(new SupportingFile("apiException.mustache",

--- a/modules/swagger-codegen/src/main/resources/JavaSpring/api.mustache
+++ b/modules/swagger-codegen/src/main/resources/JavaSpring/api.mustache
@@ -7,12 +7,19 @@ package {{package}};
 
 {{#imports}}import {{import}};
 {{/imports}}
-
+{{#jdk8-no-delegate}}
+import com.fasterxml.jackson.databind.ObjectMapper;
+{{/jdk8-no-delegate}}
 import io.swagger.annotations.*;
-{{#jdk8}}
+{{#jdk8-no-delegate}}
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpStatus;
-{{/jdk8}}
+{{/jdk8-no-delegate}}
 import org.springframework.http.ResponseEntity;
+{{#useBeanValidation}}
+import org.springframework.validation.annotation.Validated;
+{{/useBeanValidation}}
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
@@ -21,26 +28,54 @@ import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.multipart.MultipartFile;
-{{^useSpringCloudClient}}
-import java.io.IOException;
-{{/useSpringCloudClient}}
 
+{{#jdk8-no-delegate}}
+import javax.servlet.http.HttpServletRequest;
+{{/jdk8-no-delegate}}
+{{#useBeanValidation}}
+import javax.validation.Valid;
+import javax.validation.constraints.*;
+{{/useBeanValidation}}
+{{#jdk8-no-delegate}}
+import java.io.IOException;
+{{/jdk8-no-delegate}}
 import java.util.List;
-{{#useOptional}}
+{{#jdk8-no-delegate}}
 import java.util.Optional;
-{{/useOptional}}
+{{/jdk8-no-delegate}}
+{{^jdk8-no-delegate}}
+    {{#useOptional}}
+import java.util.Optional;
+    {{/useOptional}}
+{{/jdk8-no-delegate}}
 {{#async}}
 import java.util.concurrent.{{^jdk8}}Callable{{/jdk8}}{{#jdk8}}CompletableFuture{{/jdk8}};
 {{/async}}
-{{#useBeanValidation}}
-import org.springframework.validation.annotation.Validated;
-import javax.validation.constraints.*;
-import javax.validation.Valid;
-{{/useBeanValidation}}
 {{>generatedAnnotation}}
 @Api(value = "{{{baseName}}}", description = "the {{{baseName}}} API")
 {{#operations}}
 public interface {{classname}} {
+{{#jdk8}}
+
+    {{^isDelegate}}
+    Logger log = LoggerFactory.getLogger({{classname}}.class);
+
+    default Optional<ObjectMapper> getObjectMapper() {
+        return Optional.empty();
+    }
+
+    default Optional<HttpServletRequest> getRequest() {
+        return Optional.empty();
+    }
+
+    default Optional<String> getAcceptHeader() {
+        return getRequest().map(r -> r.getHeader("Accept"));
+    }
+    {{/isDelegate}}
+    {{#isDelegate}}
+    {{classname}}Delegate getDelegate();
+    {{/isDelegate}}
+{{/jdk8}}
 {{#operation}}
 
     @ApiOperation(value = "{{{summary}}}", nickname = "{{{operationId}}}", notes = "{{{notes}}}"{{#returnBaseType}}, response = {{{returnBaseType}}}.class{{/returnBaseType}}{{#returnContainer}}, responseContainer = "{{{returnContainer}}}"{{/returnContainer}}{{#hasAuthMethods}}, authorizations = {
@@ -66,8 +101,26 @@ public interface {{classname}} {
         consumes = { {{#consumes}}"{{{mediaType}}}"{{#hasMore}}, {{/hasMore}}{{/consumes}} },{{/hasConsumes}}{{/singleContentTypes}}
         method = RequestMethod.{{httpMethod}})
     {{#jdk8}}default {{/jdk8}}{{#responseWrapper}}{{.}}<{{/responseWrapper}}ResponseEntity<{{>returnTypes}}>{{#responseWrapper}}>{{/responseWrapper}} {{operationId}}({{#allParams}}{{>queryParams}}{{>pathParams}}{{>headerParams}}{{>bodyParams}}{{>formParams}}{{#hasMore}},{{/hasMore}}{{/allParams}}){{^jdk8}};{{/jdk8}}{{#jdk8}} {
-        // do some magic!
-        return {{#async}}CompletableFuture.completedFuture({{/async}}new ResponseEntity<{{>returnTypes}}>(HttpStatus.NOT_IMPLEMENTED){{#async}}){{/async}};
+        {{^isDelegate}}
+        if(getObjectMapper().isPresent() && getAcceptHeader().isPresent()) {
+        {{#examples}}
+            if (getAcceptHeader().get().contains("{{{contentType}}}")) {
+                try {
+                    return {{#async}}CompletableFuture.completedFuture({{/async}}new ResponseEntity<>(getObjectMapper().get().readValue("{{#lambdaRemoveLineBreak}}{{#lambdaEscapeDoubleQuote}}{{{example}}}{{/lambdaEscapeDoubleQuote}}{{/lambdaRemoveLineBreak}}", {{>exampleReturnTypes}}.class), HttpStatus.NOT_IMPLEMENTED){{#async}}){{/async}};
+                } catch (IOException e) {
+                    log.error("Couldn't serialize response for content type {{{contentType}}}", e);
+                    return {{#async}}CompletableFuture.completedFuture({{/async}}new ResponseEntity<>(HttpStatus.INTERNAL_SERVER_ERROR){{#async}}){{/async}};
+                }
+            }
+        {{/examples}}
+        } else {
+            log.warn("ObjectMapper or HttpServletRequest not configured in default {{classname}} interface so no example is generated");
+        }
+        return {{#async}}CompletableFuture.completedFuture({{/async}}new ResponseEntity<>(HttpStatus.NOT_IMPLEMENTED){{#async}}){{/async}};
+        {{/isDelegate}}
+        {{#isDelegate}}
+        return getDelegate().{{operationId}}({{#allParams}}{{paramName}}{{#hasMore}}, {{/hasMore}}{{/allParams}});
+        {{/isDelegate}}
     }{{/jdk8}}
 
 {{/operation}}

--- a/modules/swagger-codegen/src/main/resources/JavaSpring/api.mustache
+++ b/modules/swagger-codegen/src/main/resources/JavaSpring/api.mustache
@@ -65,20 +65,11 @@ public interface {{classname}} {
         produces = { {{#produces}}"{{{mediaType}}}"{{#hasMore}}, {{/hasMore}}{{/produces}} }, {{/hasProduces}}{{#hasConsumes}}
         consumes = { {{#consumes}}"{{{mediaType}}}"{{#hasMore}}, {{/hasMore}}{{/consumes}} },{{/hasConsumes}}{{/singleContentTypes}}
         method = RequestMethod.{{httpMethod}})
-{{#useSpringCloudClient}}
     {{#jdk8}}default {{/jdk8}}{{#responseWrapper}}{{.}}<{{/responseWrapper}}ResponseEntity<{{>returnTypes}}>{{#responseWrapper}}>{{/responseWrapper}} {{operationId}}({{#allParams}}{{>queryParams}}{{>pathParams}}{{>headerParams}}{{>bodyParams}}{{>formParams}}{{#hasMore}},{{/hasMore}}{{/allParams}}){{^jdk8}};{{/jdk8}}{{#jdk8}} {
         // do some magic!
         return {{#async}}CompletableFuture.completedFuture({{/async}}new ResponseEntity<{{>returnTypes}}>(HttpStatus.NOT_IMPLEMENTED){{#async}}){{/async}};
     }{{/jdk8}}
 
-{{/useSpringCloudClient}}
-{{^useSpringCloudClient}}
-    {{#jdk8}}default {{/jdk8}}{{#responseWrapper}}{{.}}<{{/responseWrapper}}ResponseEntity<{{>returnTypes}}>{{#responseWrapper}}>{{/responseWrapper}} {{operationId}}({{#allParams}}{{>queryParams}}{{>pathParams}}{{>headerParams}}{{>bodyParams}}{{>formParams}},{{/allParams}} @RequestHeader(value = "Accept", required = false) String accept) throws Exception{{^jdk8}};{{/jdk8}}{{#jdk8}} {
-        // do some magic!
-        return {{#async}}CompletableFuture.completedFuture({{/async}}new ResponseEntity<{{>returnTypes}}>(HttpStatus.OK){{#async}}){{/async}};
-    }{{/jdk8}}
-
-{{/useSpringCloudClient}}
 {{/operation}}
 }
 {{/operations}}

--- a/modules/swagger-codegen/src/main/resources/JavaSpring/apiController.mustache
+++ b/modules/swagger-codegen/src/main/resources/JavaSpring/apiController.mustache
@@ -58,12 +58,12 @@ public class {{classname}}Controller implements {{classname}} {
 
     private final ObjectMapper objectMapper;
 
-    @org.springframework.beans.factory.annotation.Autowired
-    private HttpServletRequest request;
+    private final HttpServletRequest request;
 
     @org.springframework.beans.factory.annotation.Autowired
-    public {{classname}}Controller(ObjectMapper objectMapper) {
+    public {{classname}}Controller(ObjectMapper objectMapper, HttpServletRequest request) {
         this.objectMapper = objectMapper;
+        this.request = request;
     }
 
         {{/async}}

--- a/modules/swagger-codegen/src/main/resources/JavaSpring/apiController.mustache
+++ b/modules/swagger-codegen/src/main/resources/JavaSpring/apiController.mustache
@@ -29,27 +29,18 @@ import java.util.Optional;
 {{#async}}
 import java.util.concurrent.Callable;
 {{/async}}
-{{/jdk8-no-delegate}}
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.IOException;
+import javax.servlet.http.HttpServletRequest;
 {{#useBeanValidation}}
 import javax.validation.constraints.*;
 import javax.validation.Valid;
 {{/useBeanValidation}}
+{{/jdk8-no-delegate}}
 {{>generatedAnnotation}}
 @Controller
 {{#operations}}
 public class {{classname}}Controller implements {{classname}} {
-{{^jdk8-no-delegate}}
-
-    private final Logger log = LoggerFactory.getLogger(AnotherFakeApiController.class);
-{{/jdk8-no-delegate}}
-
-    private final ObjectMapper objectMapper;
-
-    public {{classname}}Controller(ObjectMapper objectMapper) {
-        this.objectMapper = objectMapper;
-    }
 
 {{#isDelegate}}
     private final {{classname}}Delegate delegate;
@@ -61,12 +52,28 @@ public class {{classname}}Controller implements {{classname}} {
 
 {{/isDelegate}}
 {{^jdk8-no-delegate}}
+    {{^isDelegate}}
+        {{^async}}
+    private static final Logger log = LoggerFactory.getLogger({{classname}}Controller.class);
+
+    private final ObjectMapper objectMapper;
+
+    @org.springframework.beans.factory.annotation.Autowired
+    private HttpServletRequest request;
+
+    @org.springframework.beans.factory.annotation.Autowired
+    public {{classname}}Controller(ObjectMapper objectMapper) {
+        this.objectMapper = objectMapper;
+    }
+
+        {{/async}}
+    {{/isDelegate}}
 {{#operation}}
     public {{#async}}Callable<{{/async}}ResponseEntity<{{>returnTypes}}>{{#async}}>{{/async}} {{operationId}}({{#allParams}}{{>queryParams}}{{>pathParams}}{{>headerParams}}{{>bodyParams}}{{>formParams}}{{#hasMore}},{{/hasMore}}{{/allParams}}) {
         // do some magic!
         {{^isDelegate}}
         {{^async}}
-        String accept = ((ServletRequestAttributes)RequestContextHolder.getRequestAttributes()).getRequest().getHeader("Accept");
+        String accept = request.getHeader("Accept");
         {{#examples}}
         if (accept != null && accept.contains("{{{contentType}}}")) {
             try {

--- a/modules/swagger-codegen/src/main/resources/JavaSpring/apiController.mustache
+++ b/modules/swagger-codegen/src/main/resources/JavaSpring/apiController.mustache
@@ -6,6 +6,8 @@ package {{package}};
 
 import io.swagger.annotations.*;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 {{/jdk8-no-delegate}}
@@ -16,6 +18,8 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RequestPart;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.util.List;
@@ -26,10 +30,8 @@ import java.util.Optional;
 import java.util.concurrent.Callable;
 {{/async}}
 {{/jdk8-no-delegate}}
-{{^useSpringCloudClient}}
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.IOException;
-{{/useSpringCloudClient}}
 {{#useBeanValidation}}
 import javax.validation.constraints.*;
 import javax.validation.Valid;
@@ -38,6 +40,11 @@ import javax.validation.Valid;
 @Controller
 {{#operations}}
 public class {{classname}}Controller implements {{classname}} {
+{{^jdk8-no-delegate}}
+
+    private final Logger log = LoggerFactory.getLogger(AnotherFakeApiController.class);
+{{/jdk8-no-delegate}}
+
     private final ObjectMapper objectMapper;
 
     public {{classname}}Controller(ObjectMapper objectMapper) {
@@ -55,34 +62,19 @@ public class {{classname}}Controller implements {{classname}} {
 {{/isDelegate}}
 {{^jdk8-no-delegate}}
 {{#operation}}
-    public {{#async}}Callable<{{/async}}ResponseEntity<{{>returnTypes}}>{{#async}}>{{/async}} {{operationId}}({{#allParams}}{{>queryParams}}{{>pathParams}}{{>headerParams}}{{>bodyParams}}{{>formParams}},
-        {{/allParams}}@RequestHeader(value = "Accept", required = false) String accept) throws Exception {
+    public {{#async}}Callable<{{/async}}ResponseEntity<{{>returnTypes}}>{{#async}}>{{/async}} {{operationId}}({{#allParams}}{{>queryParams}}{{>pathParams}}{{>headerParams}}{{>bodyParams}}{{>formParams}}{{#hasMore}},{{/hasMore}}{{/allParams}}) {
         // do some magic!
-{{#useSpringCloudClient}}
         {{^isDelegate}}
         {{^async}}
-        return new ResponseEntity<{{>returnTypes}}>(HttpStatus.OK);
-        {{/async}}
-        {{#async}}
-        return new Callable<ResponseEntity<{{>returnTypes}}>>() {
-            @Override
-            public ResponseEntity<{{>returnTypes}}> call() throws Exception {
-                return new ResponseEntity<{{>returnTypes}}>(HttpStatus.OK);
-            }
-        };
-        {{/async}}
-        {{/isDelegate}}
-        {{#isDelegate}}
-        return delegate.{{operationId}}({{#allParams}}{{paramName}}{{#hasMore}}, {{/hasMore}}{{/allParams}});
-        {{/isDelegate}}
-{{/useSpringCloudClient}}
-{{^useSpringCloudClient}}
-        {{^isDelegate}}
-        {{^async}}
+        String accept = ((ServletRequestAttributes)RequestContextHolder.getRequestAttributes()).getRequest().getHeader("Accept");
         {{#examples}}
-
         if (accept != null && accept.contains("{{{contentType}}}")) {
-            return new ResponseEntity<{{>returnTypes}}>(objectMapper.readValue("{{#lambdaRemoveLineBreak}}{{#lambdaEscapeDoubleQuote}}{{{example}}}{{/lambdaEscapeDoubleQuote}}{{/lambdaRemoveLineBreak}}", {{>exampleReturnTypes}}.class), HttpStatus.OK);
+            try {
+                return new ResponseEntity<{{>returnTypes}}>(objectMapper.readValue("{{#lambdaRemoveLineBreak}}{{#lambdaEscapeDoubleQuote}}{{{example}}}{{/lambdaEscapeDoubleQuote}}{{/lambdaRemoveLineBreak}}", {{>exampleReturnTypes}}.class), HttpStatus.NOT_IMPLEMENTED);
+            } catch (IOException e) {
+                log.error("Couldn't serialize response for content type {{{contentType}}}", e);
+                return new ResponseEntity<{{>returnTypes}}>(HttpStatus.INTERNAL_SERVER_ERROR);
+            }
         }
 
         {{/examples}}
@@ -91,8 +83,8 @@ public class {{classname}}Controller implements {{classname}} {
         {{#async}}
         return new Callable<ResponseEntity<{{>returnTypes}}>>() {
             @Override
-            public ResponseEntity<{{>returnTypes}}> call() throws Exception {
-                return new ResponseEntity<{{>returnTypes}}>(HttpStatus.OK);
+            public ResponseEntity<{{>returnTypes}}> call() {
+                return new ResponseEntity<{{>returnTypes}}>(HttpStatus.NOT_IMPLEMENTED);
             }
         };
         {{/async}}
@@ -100,7 +92,6 @@ public class {{classname}}Controller implements {{classname}} {
         {{#isDelegate}}
         return delegate.{{operationId}}({{#allParams}}{{paramName}}{{#hasMore}}, {{/hasMore}}{{/allParams}});
         {{/isDelegate}}
-{{/useSpringCloudClient}}
     }
 
 {{/operation}}

--- a/modules/swagger-codegen/src/main/resources/JavaSpring/apiController.mustache
+++ b/modules/swagger-codegen/src/main/resources/JavaSpring/apiController.mustache
@@ -1,42 +1,53 @@
 package {{package}};
 
-{{^jdk8-no-delegate}}
+{{^jdk8}}
 {{#imports}}import {{import}};
 {{/imports}}
-
+{{/jdk8}}
+{{^isDelegate}}
+import com.fasterxml.jackson.databind.ObjectMapper;
+{{/isDelegate}}
+{{^jdk8}}
 import io.swagger.annotations.*;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-{{/jdk8-no-delegate}}
+{{/jdk8}}
 import org.springframework.stereotype.Controller;
-{{^jdk8-no-delegate}}
+{{^jdk8}}
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RequestPart;
-import org.springframework.web.context.request.RequestContextHolder;
-import org.springframework.web.context.request.ServletRequestAttributes;
 import org.springframework.web.multipart.MultipartFile;
 
-import java.util.List;
-{{#useOptional}}
-import java.util.Optional;
-{{/useOptional}}
-{{#async}}
-import java.util.concurrent.Callable;
-{{/async}}
-import com.fasterxml.jackson.databind.ObjectMapper;
-import java.io.IOException;
-import javax.servlet.http.HttpServletRequest;
-{{#useBeanValidation}}
+    {{#useBeanValidation}}
 import javax.validation.constraints.*;
 import javax.validation.Valid;
-{{/useBeanValidation}}
+    {{/useBeanValidation}}
+{{/jdk8}}
+{{^isDelegate}}
+import javax.servlet.http.HttpServletRequest;
+    {{#jdk8}}
+import java.util.Optional;
+    {{/jdk8}}
+{{/isDelegate}}
+{{^jdk8-no-delegate}}
+    {{#useOptional}}
+import java.util.Optional;
+    {{/useOptional}}
 {{/jdk8-no-delegate}}
+{{^jdk8}}
+    {{^isDelegate}}
+import java.io.IOException;
+    {{/isDelegate}}
+import java.util.List;
+    {{#async}}
+import java.util.concurrent.Callable;
+    {{/async}}
+{{/jdk8}}
 {{>generatedAnnotation}}
 @Controller
 {{#operations}}
@@ -49,13 +60,19 @@ public class {{classname}}Controller implements {{classname}} {
     public {{classname}}Controller({{classname}}Delegate delegate) {
         this.delegate = delegate;
     }
+    {{#jdk8}}
 
+    @Override
+    public {{classname}}Delegate getDelegate() {
+        return delegate;
+    }
+    {{/jdk8}}
 {{/isDelegate}}
-{{^jdk8-no-delegate}}
-    {{^isDelegate}}
-        {{^async}}
+{{^isDelegate}}
+    {{^jdk8}}
     private static final Logger log = LoggerFactory.getLogger({{classname}}Controller.class);
 
+    {{/jdk8}}
     private final ObjectMapper objectMapper;
 
     private final HttpServletRequest request;
@@ -65,12 +82,23 @@ public class {{classname}}Controller implements {{classname}} {
         this.objectMapper = objectMapper;
         this.request = request;
     }
+    {{#jdk8}}
 
-        {{/async}}
-    {{/isDelegate}}
+    @Override
+    public Optional<ObjectMapper> getObjectMapper() {
+        return Optional.ofNullable(objectMapper);
+    }
+
+    @Override
+    public Optional<HttpServletRequest> getRequest() {
+        return Optional.ofNullable(request);
+    }
+    {{/jdk8}}
+
+{{/isDelegate}}
+{{^jdk8}}
 {{#operation}}
     public {{#async}}Callable<{{/async}}ResponseEntity<{{>returnTypes}}>{{#async}}>{{/async}} {{operationId}}({{#allParams}}{{>queryParams}}{{>pathParams}}{{>headerParams}}{{>bodyParams}}{{>formParams}}{{#hasMore}},{{/hasMore}}{{/allParams}}) {
-        // do some magic!
         {{^isDelegate}}
         {{^async}}
         String accept = request.getHeader("Accept");
@@ -85,12 +113,24 @@ public class {{classname}}Controller implements {{classname}} {
         }
 
         {{/examples}}
-        return new ResponseEntity<{{>returnTypes}}>(HttpStatus.OK);
+        return new ResponseEntity<{{>returnTypes}}>(HttpStatus.NOT_IMPLEMENTED);
         {{/async}}
         {{#async}}
         return new Callable<ResponseEntity<{{>returnTypes}}>>() {
             @Override
             public ResponseEntity<{{>returnTypes}}> call() {
+                String accept = request.getHeader("Accept");
+                {{#examples}}
+                if (accept != null && accept.contains("{{{contentType}}}")) {
+                    try {
+                        return new ResponseEntity<{{>returnTypes}}>(objectMapper.readValue("{{#lambdaRemoveLineBreak}}{{#lambdaEscapeDoubleQuote}}{{{example}}}{{/lambdaEscapeDoubleQuote}}{{/lambdaRemoveLineBreak}}", {{>exampleReturnTypes}}.class), HttpStatus.NOT_IMPLEMENTED);
+                    } catch (IOException e) {
+                        log.error("Couldn't serialize response for content type {{{contentType}}}", e);
+                        return new ResponseEntity<{{>returnTypes}}>(HttpStatus.INTERNAL_SERVER_ERROR);
+                    }
+                }
+
+                {{/examples}}
                 return new ResponseEntity<{{>returnTypes}}>(HttpStatus.NOT_IMPLEMENTED);
             }
         };
@@ -102,6 +142,6 @@ public class {{classname}}Controller implements {{classname}} {
     }
 
 {{/operation}}
-{{/jdk8-no-delegate}}
+{{/jdk8}}
 }
 {{/operations}}

--- a/modules/swagger-codegen/src/main/resources/JavaSpring/apiDelegate.mustache
+++ b/modules/swagger-codegen/src/main/resources/JavaSpring/apiDelegate.mustache
@@ -28,8 +28,8 @@ public interface {{classname}}Delegate {
      */
     {{#jdk8}}default {{/jdk8}}{{#responseWrapper}}{{.}}<{{/responseWrapper}}ResponseEntity<{{>returnTypes}}>{{#responseWrapper}}>{{/responseWrapper}} {{operationId}}({{#allParams}}{{^isFile}}{{{dataType}}}{{/isFile}}{{#isFile}}MultipartFile{{/isFile}} {{paramName}}{{#hasMore}},
         {{/hasMore}}{{/allParams}}){{^jdk8}};{{/jdk8}}{{#jdk8}} {
-    // do some magic!
-    return {{#async}}CompletableFuture.completedFuture({{/async}}new ResponseEntity<{{>returnTypes}}>(HttpStatus.NOT_IMPLEMENTED){{#async}}){{/async}};
+        // do some magic!
+        return {{#async}}CompletableFuture.completedFuture({{/async}}new ResponseEntity<{{>returnTypes}}>(HttpStatus.NOT_IMPLEMENTED){{#async}}){{/async}};
     }{{/jdk8}}
 
 {{/operation}}

--- a/modules/swagger-codegen/src/main/resources/JavaSpring/apiDelegate.mustache
+++ b/modules/swagger-codegen/src/main/resources/JavaSpring/apiDelegate.mustache
@@ -29,7 +29,7 @@ public interface {{classname}}Delegate {
     {{#jdk8}}default {{/jdk8}}{{#responseWrapper}}{{.}}<{{/responseWrapper}}ResponseEntity<{{>returnTypes}}>{{#responseWrapper}}>{{/responseWrapper}} {{operationId}}({{#allParams}}{{^isFile}}{{{dataType}}}{{/isFile}}{{#isFile}}MultipartFile{{/isFile}} {{paramName}}{{#hasMore}},
         {{/hasMore}}{{/allParams}}){{^jdk8}};{{/jdk8}}{{#jdk8}} {
     // do some magic!
-    return {{#async}}CompletableFuture.completedFuture({{/async}}new ResponseEntity<{{>returnTypes}}>(HttpStatus.OK){{#async}}){{/async}};
+    return {{#async}}CompletableFuture.completedFuture({{/async}}new ResponseEntity<{{>returnTypes}}>(HttpStatus.NOT_IMPLEMENTED){{#async}}){{/async}};
     }{{/jdk8}}
 
 {{/operation}}

--- a/modules/swagger-codegen/src/main/resources/JavaSpring/apiDelegate.mustache
+++ b/modules/swagger-codegen/src/main/resources/JavaSpring/apiDelegate.mustache
@@ -2,13 +2,33 @@ package {{package}};
 
 {{#imports}}import {{import}};
 {{/imports}}
-
-import io.swagger.annotations.*;{{#jdk8}}
-import org.springframework.http.HttpStatus;{{/jdk8}}
+{{#jdk8}}
+import com.fasterxml.jackson.databind.ObjectMapper;
+{{/jdk8}}
+import io.swagger.annotations.*;
+{{#jdk8}}
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.HttpStatus;
+{{/jdk8}}
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.multipart.MultipartFile;
+{{#jdk8}}
+import java.io.IOException;
+{{/jdk8}}
 
+{{#jdk8}}
+import javax.servlet.http.HttpServletRequest;
+{{/jdk8}}
 import java.util.List;
+{{#jdk8}}
+import java.util.Optional;
+{{/jdk8}}
+{{^jdk8}}
+    {{#useOptional}}
+import java.util.Optional;
+    {{/useOptional}}
+{{/jdk8}}
 {{#async}}
 import java.util.concurrent.{{^jdk8}}Callable{{/jdk8}}{{#jdk8}}CompletableFuture{{/jdk8}};
 {{/async}}
@@ -16,11 +36,26 @@ import java.util.concurrent.{{^jdk8}}Callable{{/jdk8}}{{#jdk8}}CompletableFuture
 {{#operations}}
 /**
  * A delegate to be called by the {@link {{classname}}Controller}}.
- * Should be implemented as a controller but without the {@link org.springframework.stereotype.Controller} annotation.
- * Instead, use spring to autowire this class into the {@link {{classname}}Controller}.
+ * Implement this interface with a {@link org.springframework.stereotype.Service} annotated class.
  */
 {{>generatedAnnotation}}
 public interface {{classname}}Delegate {
+{{#jdk8}}
+
+    Logger log = LoggerFactory.getLogger({{classname}}.class);
+
+    default Optional<ObjectMapper> getObjectMapper() {
+        return Optional.empty();
+    }
+
+    default Optional<HttpServletRequest> getRequest() {
+        return Optional.empty();
+    }
+
+    default Optional<String> getAcceptHeader() {
+        return getRequest().map(r -> r.getHeader("Accept"));
+    }
+{{/jdk8}}
 
 {{#operation}}
     /**
@@ -28,8 +63,21 @@ public interface {{classname}}Delegate {
      */
     {{#jdk8}}default {{/jdk8}}{{#responseWrapper}}{{.}}<{{/responseWrapper}}ResponseEntity<{{>returnTypes}}>{{#responseWrapper}}>{{/responseWrapper}} {{operationId}}({{#allParams}}{{^isFile}}{{{dataType}}}{{/isFile}}{{#isFile}}MultipartFile{{/isFile}} {{paramName}}{{#hasMore}},
         {{/hasMore}}{{/allParams}}){{^jdk8}};{{/jdk8}}{{#jdk8}} {
-        // do some magic!
-        return {{#async}}CompletableFuture.completedFuture({{/async}}new ResponseEntity<{{>returnTypes}}>(HttpStatus.NOT_IMPLEMENTED){{#async}}){{/async}};
+        if(getObjectMapper().isPresent() && getAcceptHeader().isPresent()) {
+        {{#examples}}
+            if (getAcceptHeader().get().contains("{{{contentType}}}")) {
+                try {
+                    return {{#async}}CompletableFuture.completedFuture({{/async}}new ResponseEntity<>(getObjectMapper().get().readValue("{{#lambdaRemoveLineBreak}}{{#lambdaEscapeDoubleQuote}}{{{example}}}{{/lambdaEscapeDoubleQuote}}{{/lambdaRemoveLineBreak}}", {{>exampleReturnTypes}}.class), HttpStatus.NOT_IMPLEMENTED){{#async}}){{/async}};
+                } catch (IOException e) {
+                    log.error("Couldn't serialize response for content type {{{contentType}}}", e);
+                    return {{#async}}CompletableFuture.completedFuture({{/async}}new ResponseEntity<>(HttpStatus.INTERNAL_SERVER_ERROR){{#async}}){{/async}};
+                }
+            }
+        {{/examples}}
+        } else {
+            log.warn("ObjectMapper or HttpServletRequest not configured in default {{classname}} interface so no example is generated");
+        }
+        return {{#async}}CompletableFuture.completedFuture({{/async}}new ResponseEntity<>(HttpStatus.NOT_IMPLEMENTED){{#async}}){{/async}};
     }{{/jdk8}}
 
 {{/operation}}

--- a/modules/swagger-codegen/src/main/resources/JavaSpring/beanValidationCore.mustache
+++ b/modules/swagger-codegen/src/main/resources/JavaSpring/beanValidationCore.mustache
@@ -1,20 +1,20 @@
-{{#pattern}} @Pattern(regexp="{{{pattern}}}"){{/pattern}}{{!
+{{#pattern}}@Pattern(regexp="{{{pattern}}}") {{/pattern}}{{!
 minLength && maxLength set
-}}{{#minLength}}{{#maxLength}} @Size(min={{minLength}},max={{maxLength}}){{/maxLength}}{{/minLength}}{{!
+}}{{#minLength}}{{#maxLength}}@Size(min={{minLength}},max={{maxLength}}) {{/maxLength}}{{/minLength}}{{!
 minLength set, maxLength not
-}}{{#minLength}}{{^maxLength}} @Size(min={{minLength}}){{/maxLength}}{{/minLength}}{{!
+}}{{#minLength}}{{^maxLength}}@Size(min={{minLength}}) {{/maxLength}}{{/minLength}}{{!
 minLength not set, maxLength set
-}}{{^minLength}}{{#maxLength}} @Size(max={{maxLength}}){{/maxLength}}{{/minLength}}{{!
+}}{{^minLength}}{{#maxLength}}@Size(max={{maxLength}}) {{/maxLength}}{{/minLength}}{{!
 @Size: minItems && maxItems set
-}}{{#minItems}}{{#maxItems}} @Size(min={{minItems}},max={{maxItems}}){{/maxItems}}{{/minItems}}{{!
+}}{{#minItems}}{{#maxItems}}@Size(min={{minItems}},max={{maxItems}}) {{/maxItems}}{{/minItems}}{{!
 @Size: minItems set, maxItems not
-}}{{#minItems}}{{^maxItems}} @Size(min={{minItems}}){{/maxItems}}{{/minItems}}{{!
+}}{{#minItems}}{{^maxItems}}@Size(min={{minItems}}) {{/maxItems}}{{/minItems}}{{!
 @Size: minItems not set && maxItems set
-}}{{^minItems}}{{#maxItems}} @Size(max={{maxItems}}){{/maxItems}}{{/minItems}}{{!
+}}{{^minItems}}{{#maxItems}}@Size(max={{maxItems}}) {{/maxItems}}{{/minItems}}{{!
 check for integer or long / all others=decimal type with @Decimal*
 isInteger set
-}}{{#isInteger}}{{#minimum}} @Min({{minimum}}){{/minimum}}{{#maximum}} @Max({{maximum}}){{/maximum}}{{/isInteger}}{{!
+}}{{#isInteger}}{{#minimum}}@Min({{minimum}}){{/minimum}}{{#maximum}} @Max({{maximum}}) {{/maximum}}{{/isInteger}}{{!
 isLong set
-}}{{#isLong}}{{#minimum}} @Min({{minimum}}){{/minimum}}{{#maximum}} @Max({{maximum}}){{/maximum}}{{/isLong}}{{!
+}}{{#isLong}}{{#minimum}}@Min({{minimum}}){{/minimum}}{{#maximum}} @Max({{maximum}}) {{/maximum}}{{/isLong}}{{!
 Not Integer, not Long => we have a decimal value!
-}}{{^isInteger}}{{^isLong}}{{#minimum}} @DecimalMin("{{minimum}}"){{/minimum}}{{#maximum}} @DecimalMax("{{maximum}}"){{/maximum}}{{/isLong}}{{/isInteger}}
+}}{{^isInteger}}{{^isLong}}{{#minimum}}@DecimalMin("{{minimum}}"){{/minimum}}{{#maximum}} @DecimalMax("{{maximum}}") {{/maximum}}{{/isLong}}{{/isInteger}}

--- a/modules/swagger-codegen/src/main/resources/JavaSpring/beanValidationQueryParams.mustache
+++ b/modules/swagger-codegen/src/main/resources/JavaSpring/beanValidationQueryParams.mustache
@@ -1,1 +1,1 @@
-{{#required}} @NotNull{{/required}}{{>beanValidationCore}}
+{{#required}}@NotNull {{/required}}{{>beanValidationCore}}

--- a/samples/client/petstore/spring-cloud/src/main/java/io/swagger/api/PetApi.java
+++ b/samples/client/petstore/spring-cloud/src/main/java/io/swagger/api/PetApi.java
@@ -19,6 +19,7 @@ import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.multipart.MultipartFile;
+import java.io.IOException;
 
 import java.util.List;
 import org.springframework.validation.annotation.Validated;
@@ -71,7 +72,7 @@ public interface PetApi {
         produces = "application/json",
         consumes = "application/json",
         method = RequestMethod.GET)
-    com.netflix.hystrix.HystrixCommand<ResponseEntity<List<Pet>>> findPetsByStatus( @NotNull@ApiParam(value = "Status values that need to be considered for filter", required = true, allowableValues = "available, pending, sold") @Valid @RequestParam(value = "status", required = true) List<String> status);
+    com.netflix.hystrix.HystrixCommand<ResponseEntity<List<Pet>>> findPetsByStatus(@NotNull @ApiParam(value = "Status values that need to be considered for filter", required = true, allowableValues = "available, pending, sold") @Valid @RequestParam(value = "status", required = true) List<String> status);
 
 
     @ApiOperation(value = "Finds Pets by tags", nickname = "findPetsByTags", notes = "Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.", response = Pet.class, responseContainer = "List", authorizations = {
@@ -87,7 +88,7 @@ public interface PetApi {
         produces = "application/json",
         consumes = "application/json",
         method = RequestMethod.GET)
-    com.netflix.hystrix.HystrixCommand<ResponseEntity<List<Pet>>> findPetsByTags( @NotNull@ApiParam(value = "Tags to filter by", required = true) @Valid @RequestParam(value = "tags", required = true) List<String> tags);
+    com.netflix.hystrix.HystrixCommand<ResponseEntity<List<Pet>>> findPetsByTags(@NotNull @ApiParam(value = "Tags to filter by", required = true) @Valid @RequestParam(value = "tags", required = true) List<String> tags);
 
 
     @ApiOperation(value = "Find pet by ID", nickname = "getPetById", notes = "Returns a single pet", response = Pet.class, authorizations = {

--- a/samples/client/petstore/spring-cloud/src/main/java/io/swagger/api/PetApi.java
+++ b/samples/client/petstore/spring-cloud/src/main/java/io/swagger/api/PetApi.java
@@ -8,9 +8,9 @@ package io.swagger.api;
 import io.swagger.model.ModelApiResponse;
 import io.swagger.model.Pet;
 import org.springframework.core.io.Resource;
-
 import io.swagger.annotations.*;
 import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
@@ -19,12 +19,10 @@ import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.multipart.MultipartFile;
-import java.io.IOException;
 
-import java.util.List;
-import org.springframework.validation.annotation.Validated;
-import javax.validation.constraints.*;
 import javax.validation.Valid;
+import javax.validation.constraints.*;
+import java.util.List;
 
 @Api(value = "Pet", description = "the Pet API")
 public interface PetApi {

--- a/samples/client/petstore/spring-cloud/src/main/java/io/swagger/api/StoreApi.java
+++ b/samples/client/petstore/spring-cloud/src/main/java/io/swagger/api/StoreApi.java
@@ -7,9 +7,9 @@ package io.swagger.api;
 
 import java.util.Map;
 import io.swagger.model.Order;
-
 import io.swagger.annotations.*;
 import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
@@ -18,12 +18,10 @@ import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.multipart.MultipartFile;
-import java.io.IOException;
 
-import java.util.List;
-import org.springframework.validation.annotation.Validated;
-import javax.validation.constraints.*;
 import javax.validation.Valid;
+import javax.validation.constraints.*;
+import java.util.List;
 
 @Api(value = "Store", description = "the Store API")
 public interface StoreApi {

--- a/samples/client/petstore/spring-cloud/src/main/java/io/swagger/api/StoreApi.java
+++ b/samples/client/petstore/spring-cloud/src/main/java/io/swagger/api/StoreApi.java
@@ -18,6 +18,7 @@ import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.multipart.MultipartFile;
+import java.io.IOException;
 
 import java.util.List;
 import org.springframework.validation.annotation.Validated;
@@ -59,7 +60,7 @@ public interface StoreApi {
         produces = "application/json",
         consumes = "application/json",
         method = RequestMethod.GET)
-    com.netflix.hystrix.HystrixCommand<ResponseEntity<Order>> getOrderById( @Min(1) @Max(5)@ApiParam(value = "ID of pet that needs to be fetched",required=true) @PathVariable("orderId") Long orderId);
+    com.netflix.hystrix.HystrixCommand<ResponseEntity<Order>> getOrderById(@Min(1) @Max(5) @ApiParam(value = "ID of pet that needs to be fetched",required=true) @PathVariable("orderId") Long orderId);
 
 
     @ApiOperation(value = "Place an order for a pet", nickname = "placeOrder", notes = "", response = Order.class, tags={ "store", })

--- a/samples/client/petstore/spring-cloud/src/main/java/io/swagger/api/UserApi.java
+++ b/samples/client/petstore/spring-cloud/src/main/java/io/swagger/api/UserApi.java
@@ -7,9 +7,9 @@ package io.swagger.api;
 
 import java.util.List;
 import io.swagger.model.User;
-
 import io.swagger.annotations.*;
 import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
@@ -18,12 +18,10 @@ import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.multipart.MultipartFile;
-import java.io.IOException;
 
-import java.util.List;
-import org.springframework.validation.annotation.Validated;
-import javax.validation.constraints.*;
 import javax.validation.Valid;
+import javax.validation.constraints.*;
+import java.util.List;
 
 @Api(value = "User", description = "the User API")
 public interface UserApi {

--- a/samples/client/petstore/spring-cloud/src/main/java/io/swagger/api/UserApi.java
+++ b/samples/client/petstore/spring-cloud/src/main/java/io/swagger/api/UserApi.java
@@ -18,6 +18,7 @@ import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.multipart.MultipartFile;
+import java.io.IOException;
 
 import java.util.List;
 import org.springframework.validation.annotation.Validated;
@@ -88,7 +89,7 @@ public interface UserApi {
         produces = "application/json",
         consumes = "application/json",
         method = RequestMethod.GET)
-    com.netflix.hystrix.HystrixCommand<ResponseEntity<String>> loginUser( @NotNull@ApiParam(value = "The user name for login", required = true) @Valid @RequestParam(value = "username", required = true) String username, @NotNull@ApiParam(value = "The password for login in clear text", required = true) @Valid @RequestParam(value = "password", required = true) String password);
+    com.netflix.hystrix.HystrixCommand<ResponseEntity<String>> loginUser(@NotNull @ApiParam(value = "The user name for login", required = true) @Valid @RequestParam(value = "username", required = true) String username,@NotNull @ApiParam(value = "The password for login in clear text", required = true) @Valid @RequestParam(value = "password", required = true) String password);
 
 
     @ApiOperation(value = "Logs out current logged in user session", nickname = "logoutUser", notes = "", tags={ "user", })

--- a/samples/client/petstore/spring-stubs/src/main/java/io/swagger/api/PetApi.java
+++ b/samples/client/petstore/spring-stubs/src/main/java/io/swagger/api/PetApi.java
@@ -8,9 +8,9 @@ package io.swagger.api;
 import io.swagger.model.ModelApiResponse;
 import io.swagger.model.Pet;
 import org.springframework.core.io.Resource;
-
 import io.swagger.annotations.*;
 import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
@@ -19,12 +19,10 @@ import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.multipart.MultipartFile;
-import java.io.IOException;
 
-import java.util.List;
-import org.springframework.validation.annotation.Validated;
-import javax.validation.constraints.*;
 import javax.validation.Valid;
+import javax.validation.constraints.*;
+import java.util.List;
 
 @Api(value = "pet", description = "the pet API")
 public interface PetApi {

--- a/samples/client/petstore/spring-stubs/src/main/java/io/swagger/api/PetApi.java
+++ b/samples/client/petstore/spring-stubs/src/main/java/io/swagger/api/PetApi.java
@@ -41,7 +41,7 @@ public interface PetApi {
         produces = "application/json",
         consumes = "application/json",
         method = RequestMethod.POST)
-    ResponseEntity<Void> addPet(@ApiParam(value = "Pet object that needs to be added to the store" ,required=true )  @Valid @RequestBody Pet body, @RequestHeader(value = "Accept", required = false) String accept) throws Exception;
+    ResponseEntity<Void> addPet(@ApiParam(value = "Pet object that needs to be added to the store" ,required=true )  @Valid @RequestBody Pet body);
 
 
     @ApiOperation(value = "Deletes a pet", nickname = "deletePet", notes = "", authorizations = {
@@ -56,7 +56,7 @@ public interface PetApi {
         produces = "application/json",
         consumes = "application/json",
         method = RequestMethod.DELETE)
-    ResponseEntity<Void> deletePet(@ApiParam(value = "Pet id to delete",required=true) @PathVariable("petId") Long petId,@ApiParam(value = "" ) @RequestHeader(value="api_key", required=false) String apiKey, @RequestHeader(value = "Accept", required = false) String accept) throws Exception;
+    ResponseEntity<Void> deletePet(@ApiParam(value = "Pet id to delete",required=true) @PathVariable("petId") Long petId,@ApiParam(value = "" ) @RequestHeader(value="api_key", required=false) String apiKey);
 
 
     @ApiOperation(value = "Finds Pets by status", nickname = "findPetsByStatus", notes = "Multiple status values can be provided with comma separated strings", response = Pet.class, responseContainer = "List", authorizations = {
@@ -72,7 +72,7 @@ public interface PetApi {
         produces = "application/json",
         consumes = "application/json",
         method = RequestMethod.GET)
-    ResponseEntity<List<Pet>> findPetsByStatus( @NotNull@ApiParam(value = "Status values that need to be considered for filter", required = true, allowableValues = "available, pending, sold") @Valid @RequestParam(value = "status", required = true) List<String> status, @RequestHeader(value = "Accept", required = false) String accept) throws Exception;
+    ResponseEntity<List<Pet>> findPetsByStatus(@NotNull @ApiParam(value = "Status values that need to be considered for filter", required = true, allowableValues = "available, pending, sold") @Valid @RequestParam(value = "status", required = true) List<String> status);
 
 
     @ApiOperation(value = "Finds Pets by tags", nickname = "findPetsByTags", notes = "Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.", response = Pet.class, responseContainer = "List", authorizations = {
@@ -88,7 +88,7 @@ public interface PetApi {
         produces = "application/json",
         consumes = "application/json",
         method = RequestMethod.GET)
-    ResponseEntity<List<Pet>> findPetsByTags( @NotNull@ApiParam(value = "Tags to filter by", required = true) @Valid @RequestParam(value = "tags", required = true) List<String> tags, @RequestHeader(value = "Accept", required = false) String accept) throws Exception;
+    ResponseEntity<List<Pet>> findPetsByTags(@NotNull @ApiParam(value = "Tags to filter by", required = true) @Valid @RequestParam(value = "tags", required = true) List<String> tags);
 
 
     @ApiOperation(value = "Find pet by ID", nickname = "getPetById", notes = "Returns a single pet", response = Pet.class, authorizations = {
@@ -102,7 +102,7 @@ public interface PetApi {
         produces = "application/json",
         consumes = "application/json",
         method = RequestMethod.GET)
-    ResponseEntity<Pet> getPetById(@ApiParam(value = "ID of pet to return",required=true) @PathVariable("petId") Long petId, @RequestHeader(value = "Accept", required = false) String accept) throws Exception;
+    ResponseEntity<Pet> getPetById(@ApiParam(value = "ID of pet to return",required=true) @PathVariable("petId") Long petId);
 
 
     @ApiOperation(value = "Update an existing pet", nickname = "updatePet", notes = "", authorizations = {
@@ -119,7 +119,7 @@ public interface PetApi {
         produces = "application/json",
         consumes = "application/json",
         method = RequestMethod.PUT)
-    ResponseEntity<Void> updatePet(@ApiParam(value = "Pet object that needs to be added to the store" ,required=true )  @Valid @RequestBody Pet body, @RequestHeader(value = "Accept", required = false) String accept) throws Exception;
+    ResponseEntity<Void> updatePet(@ApiParam(value = "Pet object that needs to be added to the store" ,required=true )  @Valid @RequestBody Pet body);
 
 
     @ApiOperation(value = "Updates a pet in the store with form data", nickname = "updatePetWithForm", notes = "", authorizations = {
@@ -134,7 +134,7 @@ public interface PetApi {
         produces = "application/json",
         consumes = "application/x-www-form-urlencoded",
         method = RequestMethod.POST)
-    ResponseEntity<Void> updatePetWithForm(@ApiParam(value = "ID of pet that needs to be updated",required=true) @PathVariable("petId") Long petId,@ApiParam(value = "Updated name of the pet") @RequestPart(value="name", required=false)  String name,@ApiParam(value = "Updated status of the pet") @RequestPart(value="status", required=false)  String status, @RequestHeader(value = "Accept", required = false) String accept) throws Exception;
+    ResponseEntity<Void> updatePetWithForm(@ApiParam(value = "ID of pet that needs to be updated",required=true) @PathVariable("petId") Long petId,@ApiParam(value = "Updated name of the pet") @RequestPart(value="name", required=false)  String name,@ApiParam(value = "Updated status of the pet") @RequestPart(value="status", required=false)  String status);
 
 
     @ApiOperation(value = "uploads an image", nickname = "uploadFile", notes = "", response = ModelApiResponse.class, authorizations = {
@@ -149,6 +149,6 @@ public interface PetApi {
         produces = "application/json",
         consumes = "multipart/form-data",
         method = RequestMethod.POST)
-    ResponseEntity<ModelApiResponse> uploadFile(@ApiParam(value = "ID of pet to update",required=true) @PathVariable("petId") Long petId,@ApiParam(value = "Additional data to pass to server") @RequestPart(value="additionalMetadata", required=false)  String additionalMetadata,@ApiParam(value = "file detail") @Valid @RequestPart("file") MultipartFile file, @RequestHeader(value = "Accept", required = false) String accept) throws Exception;
+    ResponseEntity<ModelApiResponse> uploadFile(@ApiParam(value = "ID of pet to update",required=true) @PathVariable("petId") Long petId,@ApiParam(value = "Additional data to pass to server") @RequestPart(value="additionalMetadata", required=false)  String additionalMetadata,@ApiParam(value = "file detail") @Valid @RequestPart("file") MultipartFile file);
 
 }

--- a/samples/client/petstore/spring-stubs/src/main/java/io/swagger/api/StoreApi.java
+++ b/samples/client/petstore/spring-stubs/src/main/java/io/swagger/api/StoreApi.java
@@ -7,9 +7,9 @@ package io.swagger.api;
 
 import java.util.Map;
 import io.swagger.model.Order;
-
 import io.swagger.annotations.*;
 import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
@@ -18,12 +18,10 @@ import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.multipart.MultipartFile;
-import java.io.IOException;
 
-import java.util.List;
-import org.springframework.validation.annotation.Validated;
-import javax.validation.constraints.*;
 import javax.validation.Valid;
+import javax.validation.constraints.*;
+import java.util.List;
 
 @Api(value = "store", description = "the store API")
 public interface StoreApi {

--- a/samples/client/petstore/spring-stubs/src/main/java/io/swagger/api/StoreApi.java
+++ b/samples/client/petstore/spring-stubs/src/main/java/io/swagger/api/StoreApi.java
@@ -36,7 +36,7 @@ public interface StoreApi {
         produces = "application/json",
         consumes = "application/json",
         method = RequestMethod.DELETE)
-    ResponseEntity<Void> deleteOrder(@ApiParam(value = "ID of the order that needs to be deleted",required=true) @PathVariable("orderId") String orderId, @RequestHeader(value = "Accept", required = false) String accept) throws Exception;
+    ResponseEntity<Void> deleteOrder(@ApiParam(value = "ID of the order that needs to be deleted",required=true) @PathVariable("orderId") String orderId);
 
 
     @ApiOperation(value = "Returns pet inventories by status", nickname = "getInventory", notes = "Returns a map of status codes to quantities", response = Integer.class, responseContainer = "Map", authorizations = {
@@ -48,7 +48,7 @@ public interface StoreApi {
         produces = "application/json",
         consumes = "application/json",
         method = RequestMethod.GET)
-    ResponseEntity<Map<String, Integer>> getInventory( @RequestHeader(value = "Accept", required = false) String accept) throws Exception;
+    ResponseEntity<Map<String, Integer>> getInventory();
 
 
     @ApiOperation(value = "Find purchase order by ID", nickname = "getOrderById", notes = "For valid response try integer IDs with value <= 5 or > 10. Other values will generated exceptions", response = Order.class, tags={ "store", })
@@ -60,7 +60,7 @@ public interface StoreApi {
         produces = "application/json",
         consumes = "application/json",
         method = RequestMethod.GET)
-    ResponseEntity<Order> getOrderById( @Min(1) @Max(5)@ApiParam(value = "ID of pet that needs to be fetched",required=true) @PathVariable("orderId") Long orderId, @RequestHeader(value = "Accept", required = false) String accept) throws Exception;
+    ResponseEntity<Order> getOrderById(@Min(1) @Max(5) @ApiParam(value = "ID of pet that needs to be fetched",required=true) @PathVariable("orderId") Long orderId);
 
 
     @ApiOperation(value = "Place an order for a pet", nickname = "placeOrder", notes = "", response = Order.class, tags={ "store", })
@@ -71,6 +71,6 @@ public interface StoreApi {
         produces = "application/json",
         consumes = "application/json",
         method = RequestMethod.POST)
-    ResponseEntity<Order> placeOrder(@ApiParam(value = "order placed for purchasing the pet" ,required=true )  @Valid @RequestBody Order body, @RequestHeader(value = "Accept", required = false) String accept) throws Exception;
+    ResponseEntity<Order> placeOrder(@ApiParam(value = "order placed for purchasing the pet" ,required=true )  @Valid @RequestBody Order body);
 
 }

--- a/samples/client/petstore/spring-stubs/src/main/java/io/swagger/api/UserApi.java
+++ b/samples/client/petstore/spring-stubs/src/main/java/io/swagger/api/UserApi.java
@@ -7,9 +7,9 @@ package io.swagger.api;
 
 import java.util.List;
 import io.swagger.model.User;
-
 import io.swagger.annotations.*;
 import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
@@ -18,12 +18,10 @@ import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.multipart.MultipartFile;
-import java.io.IOException;
 
-import java.util.List;
-import org.springframework.validation.annotation.Validated;
-import javax.validation.constraints.*;
 import javax.validation.Valid;
+import javax.validation.constraints.*;
+import java.util.List;
 
 @Api(value = "user", description = "the user API")
 public interface UserApi {

--- a/samples/client/petstore/spring-stubs/src/main/java/io/swagger/api/UserApi.java
+++ b/samples/client/petstore/spring-stubs/src/main/java/io/swagger/api/UserApi.java
@@ -35,7 +35,7 @@ public interface UserApi {
         produces = "application/json",
         consumes = "application/json",
         method = RequestMethod.POST)
-    ResponseEntity<Void> createUser(@ApiParam(value = "Created user object" ,required=true )  @Valid @RequestBody User body, @RequestHeader(value = "Accept", required = false) String accept) throws Exception;
+    ResponseEntity<Void> createUser(@ApiParam(value = "Created user object" ,required=true )  @Valid @RequestBody User body);
 
 
     @ApiOperation(value = "Creates list of users with given input array", nickname = "createUsersWithArrayInput", notes = "", tags={ "user", })
@@ -45,7 +45,7 @@ public interface UserApi {
         produces = "application/json",
         consumes = "application/json",
         method = RequestMethod.POST)
-    ResponseEntity<Void> createUsersWithArrayInput(@ApiParam(value = "List of user object" ,required=true )  @Valid @RequestBody List<User> body, @RequestHeader(value = "Accept", required = false) String accept) throws Exception;
+    ResponseEntity<Void> createUsersWithArrayInput(@ApiParam(value = "List of user object" ,required=true )  @Valid @RequestBody List<User> body);
 
 
     @ApiOperation(value = "Creates list of users with given input array", nickname = "createUsersWithListInput", notes = "", tags={ "user", })
@@ -55,7 +55,7 @@ public interface UserApi {
         produces = "application/json",
         consumes = "application/json",
         method = RequestMethod.POST)
-    ResponseEntity<Void> createUsersWithListInput(@ApiParam(value = "List of user object" ,required=true )  @Valid @RequestBody List<User> body, @RequestHeader(value = "Accept", required = false) String accept) throws Exception;
+    ResponseEntity<Void> createUsersWithListInput(@ApiParam(value = "List of user object" ,required=true )  @Valid @RequestBody List<User> body);
 
 
     @ApiOperation(value = "Delete user", nickname = "deleteUser", notes = "This can only be done by the logged in user.", tags={ "user", })
@@ -66,7 +66,7 @@ public interface UserApi {
         produces = "application/json",
         consumes = "application/json",
         method = RequestMethod.DELETE)
-    ResponseEntity<Void> deleteUser(@ApiParam(value = "The name that needs to be deleted",required=true) @PathVariable("username") String username, @RequestHeader(value = "Accept", required = false) String accept) throws Exception;
+    ResponseEntity<Void> deleteUser(@ApiParam(value = "The name that needs to be deleted",required=true) @PathVariable("username") String username);
 
 
     @ApiOperation(value = "Get user by user name", nickname = "getUserByName", notes = "", response = User.class, tags={ "user", })
@@ -78,7 +78,7 @@ public interface UserApi {
         produces = "application/json",
         consumes = "application/json",
         method = RequestMethod.GET)
-    ResponseEntity<User> getUserByName(@ApiParam(value = "The name that needs to be fetched. Use user1 for testing. ",required=true) @PathVariable("username") String username, @RequestHeader(value = "Accept", required = false) String accept) throws Exception;
+    ResponseEntity<User> getUserByName(@ApiParam(value = "The name that needs to be fetched. Use user1 for testing. ",required=true) @PathVariable("username") String username);
 
 
     @ApiOperation(value = "Logs user into the system", nickname = "loginUser", notes = "", response = String.class, tags={ "user", })
@@ -89,7 +89,7 @@ public interface UserApi {
         produces = "application/json",
         consumes = "application/json",
         method = RequestMethod.GET)
-    ResponseEntity<String> loginUser( @NotNull@ApiParam(value = "The user name for login", required = true) @Valid @RequestParam(value = "username", required = true) String username, @NotNull@ApiParam(value = "The password for login in clear text", required = true) @Valid @RequestParam(value = "password", required = true) String password, @RequestHeader(value = "Accept", required = false) String accept) throws Exception;
+    ResponseEntity<String> loginUser(@NotNull @ApiParam(value = "The user name for login", required = true) @Valid @RequestParam(value = "username", required = true) String username,@NotNull @ApiParam(value = "The password for login in clear text", required = true) @Valid @RequestParam(value = "password", required = true) String password);
 
 
     @ApiOperation(value = "Logs out current logged in user session", nickname = "logoutUser", notes = "", tags={ "user", })
@@ -99,7 +99,7 @@ public interface UserApi {
         produces = "application/json",
         consumes = "application/json",
         method = RequestMethod.GET)
-    ResponseEntity<Void> logoutUser( @RequestHeader(value = "Accept", required = false) String accept) throws Exception;
+    ResponseEntity<Void> logoutUser();
 
 
     @ApiOperation(value = "Updated user", nickname = "updateUser", notes = "This can only be done by the logged in user.", tags={ "user", })
@@ -110,6 +110,6 @@ public interface UserApi {
         produces = "application/json",
         consumes = "application/json",
         method = RequestMethod.PUT)
-    ResponseEntity<Void> updateUser(@ApiParam(value = "name that need to be deleted",required=true) @PathVariable("username") String username,@ApiParam(value = "Updated user object" ,required=true )  @Valid @RequestBody User body, @RequestHeader(value = "Accept", required = false) String accept) throws Exception;
+    ResponseEntity<Void> updateUser(@ApiParam(value = "name that need to be deleted",required=true) @PathVariable("username") String username,@ApiParam(value = "Updated user object" ,required=true )  @Valid @RequestBody User body);
 
 }

--- a/samples/server/petstore/spring-mvc-j8-async/src/main/java/io/swagger/api/AnotherFakeApi.java
+++ b/samples/server/petstore/spring-mvc-j8-async/src/main/java/io/swagger/api/AnotherFakeApi.java
@@ -36,9 +36,9 @@ public interface AnotherFakeApi {
         produces = { "application/json" }, 
         consumes = { "application/json" },
         method = RequestMethod.PATCH)
-    default CompletableFuture<ResponseEntity<Client>> testSpecialTags(@ApiParam(value = "client model" ,required=true )  @Valid @RequestBody Client body, @RequestHeader(value = "Accept", required = false) String accept) throws Exception {
+    default CompletableFuture<ResponseEntity<Client>> testSpecialTags(@ApiParam(value = "client model" ,required=true )  @Valid @RequestBody Client body) {
         // do some magic!
-        return CompletableFuture.completedFuture(new ResponseEntity<Client>(HttpStatus.OK));
+        return CompletableFuture.completedFuture(new ResponseEntity<Client>(HttpStatus.NOT_IMPLEMENTED));
     }
 
 }

--- a/samples/server/petstore/spring-mvc-j8-async/src/main/java/io/swagger/api/AnotherFakeApi.java
+++ b/samples/server/petstore/spring-mvc-j8-async/src/main/java/io/swagger/api/AnotherFakeApi.java
@@ -6,10 +6,13 @@
 package io.swagger.api;
 
 import io.swagger.model.Client;
-
+import com.fasterxml.jackson.databind.ObjectMapper;
 import io.swagger.annotations.*;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
@@ -18,16 +21,31 @@ import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.multipart.MultipartFile;
-import java.io.IOException;
 
-import java.util.List;
-import java.util.concurrent.CompletableFuture;
-import org.springframework.validation.annotation.Validated;
-import javax.validation.constraints.*;
+import javax.servlet.http.HttpServletRequest;
 import javax.validation.Valid;
+import javax.validation.constraints.*;
+import java.io.IOException;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
 
 @Api(value = "another-fake", description = "the another-fake API")
 public interface AnotherFakeApi {
+
+    Logger log = LoggerFactory.getLogger(AnotherFakeApi.class);
+
+    default Optional<ObjectMapper> getObjectMapper() {
+        return Optional.empty();
+    }
+
+    default Optional<HttpServletRequest> getRequest() {
+        return Optional.empty();
+    }
+
+    default Optional<String> getAcceptHeader() {
+        return getRequest().map(r -> r.getHeader("Accept"));
+    }
 
     @ApiOperation(value = "To test special tags", nickname = "testSpecialTags", notes = "To test special tags", response = Client.class, tags={ "$another-fake?", })
     @ApiResponses(value = { 
@@ -37,8 +55,19 @@ public interface AnotherFakeApi {
         consumes = { "application/json" },
         method = RequestMethod.PATCH)
     default CompletableFuture<ResponseEntity<Client>> testSpecialTags(@ApiParam(value = "client model" ,required=true )  @Valid @RequestBody Client body) {
-        // do some magic!
-        return CompletableFuture.completedFuture(new ResponseEntity<Client>(HttpStatus.NOT_IMPLEMENTED));
+        if(getObjectMapper().isPresent() && getAcceptHeader().isPresent()) {
+            if (getAcceptHeader().get().contains("application/json")) {
+                try {
+                    return CompletableFuture.completedFuture(new ResponseEntity<>(getObjectMapper().get().readValue("{  \"client\" : \"client\"}", Client.class), HttpStatus.NOT_IMPLEMENTED));
+                } catch (IOException e) {
+                    log.error("Couldn't serialize response for content type application/json", e);
+                    return CompletableFuture.completedFuture(new ResponseEntity<>(HttpStatus.INTERNAL_SERVER_ERROR));
+                }
+            }
+        } else {
+            log.warn("ObjectMapper or HttpServletRequest not configured in default AnotherFakeApi interface so no example is generated");
+        }
+        return CompletableFuture.completedFuture(new ResponseEntity<>(HttpStatus.NOT_IMPLEMENTED));
     }
 
 }

--- a/samples/server/petstore/spring-mvc-j8-async/src/main/java/io/swagger/api/AnotherFakeApiController.java
+++ b/samples/server/petstore/spring-mvc-j8-async/src/main/java/io/swagger/api/AnotherFakeApiController.java
@@ -1,18 +1,8 @@
 package io.swagger.api;
 
 import org.springframework.stereotype.Controller;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import java.io.IOException;
-import javax.validation.constraints.*;
-import javax.validation.Valid;
 
 @Controller
 public class AnotherFakeApiController implements AnotherFakeApi {
-
-    private final ObjectMapper objectMapper;
-
-    public AnotherFakeApiController(ObjectMapper objectMapper) {
-        this.objectMapper = objectMapper;
-    }
 
 }

--- a/samples/server/petstore/spring-mvc-j8-async/src/main/java/io/swagger/api/AnotherFakeApiController.java
+++ b/samples/server/petstore/spring-mvc-j8-async/src/main/java/io/swagger/api/AnotherFakeApiController.java
@@ -8,6 +8,7 @@ import javax.validation.Valid;
 
 @Controller
 public class AnotherFakeApiController implements AnotherFakeApi {
+
     private final ObjectMapper objectMapper;
 
     public AnotherFakeApiController(ObjectMapper objectMapper) {

--- a/samples/server/petstore/spring-mvc-j8-async/src/main/java/io/swagger/api/AnotherFakeApiController.java
+++ b/samples/server/petstore/spring-mvc-j8-async/src/main/java/io/swagger/api/AnotherFakeApiController.java
@@ -1,8 +1,31 @@
 package io.swagger.api;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.springframework.stereotype.Controller;
+import javax.servlet.http.HttpServletRequest;
+import java.util.Optional;
 
 @Controller
 public class AnotherFakeApiController implements AnotherFakeApi {
+
+    private final ObjectMapper objectMapper;
+
+    private final HttpServletRequest request;
+
+    @org.springframework.beans.factory.annotation.Autowired
+    public AnotherFakeApiController(ObjectMapper objectMapper, HttpServletRequest request) {
+        this.objectMapper = objectMapper;
+        this.request = request;
+    }
+
+    @Override
+    public Optional<ObjectMapper> getObjectMapper() {
+        return Optional.ofNullable(objectMapper);
+    }
+
+    @Override
+    public Optional<HttpServletRequest> getRequest() {
+        return Optional.ofNullable(request);
+    }
 
 }

--- a/samples/server/petstore/spring-mvc-j8-async/src/main/java/io/swagger/api/FakeApi.java
+++ b/samples/server/petstore/spring-mvc-j8-async/src/main/java/io/swagger/api/FakeApi.java
@@ -10,10 +10,13 @@ import io.swagger.model.Client;
 import java.time.LocalDate;
 import java.time.OffsetDateTime;
 import io.swagger.model.OuterComposite;
-
+import com.fasterxml.jackson.databind.ObjectMapper;
 import io.swagger.annotations.*;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
@@ -22,16 +25,31 @@ import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.multipart.MultipartFile;
-import java.io.IOException;
 
-import java.util.List;
-import java.util.concurrent.CompletableFuture;
-import org.springframework.validation.annotation.Validated;
-import javax.validation.constraints.*;
+import javax.servlet.http.HttpServletRequest;
 import javax.validation.Valid;
+import javax.validation.constraints.*;
+import java.io.IOException;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
 
 @Api(value = "fake", description = "the fake API")
 public interface FakeApi {
+
+    Logger log = LoggerFactory.getLogger(FakeApi.class);
+
+    default Optional<ObjectMapper> getObjectMapper() {
+        return Optional.empty();
+    }
+
+    default Optional<HttpServletRequest> getRequest() {
+        return Optional.empty();
+    }
+
+    default Optional<String> getAcceptHeader() {
+        return getRequest().map(r -> r.getHeader("Accept"));
+    }
 
     @ApiOperation(value = "", nickname = "fakeOuterBooleanSerialize", notes = "Test serialization of outer boolean types", response = Boolean.class, tags={ "fake", })
     @ApiResponses(value = { 
@@ -39,8 +57,19 @@ public interface FakeApi {
     @RequestMapping(value = "/fake/outer/boolean",
         method = RequestMethod.POST)
     default CompletableFuture<ResponseEntity<Boolean>> fakeOuterBooleanSerialize(@ApiParam(value = "Input boolean as post body"  )  @Valid @RequestBody Boolean body) {
-        // do some magic!
-        return CompletableFuture.completedFuture(new ResponseEntity<Boolean>(HttpStatus.NOT_IMPLEMENTED));
+        if(getObjectMapper().isPresent() && getAcceptHeader().isPresent()) {
+            if (getAcceptHeader().get().contains("application/json")) {
+                try {
+                    return CompletableFuture.completedFuture(new ResponseEntity<>(getObjectMapper().get().readValue("{ }", Boolean.class), HttpStatus.NOT_IMPLEMENTED));
+                } catch (IOException e) {
+                    log.error("Couldn't serialize response for content type application/json", e);
+                    return CompletableFuture.completedFuture(new ResponseEntity<>(HttpStatus.INTERNAL_SERVER_ERROR));
+                }
+            }
+        } else {
+            log.warn("ObjectMapper or HttpServletRequest not configured in default FakeApi interface so no example is generated");
+        }
+        return CompletableFuture.completedFuture(new ResponseEntity<>(HttpStatus.NOT_IMPLEMENTED));
     }
 
 
@@ -50,8 +79,19 @@ public interface FakeApi {
     @RequestMapping(value = "/fake/outer/composite",
         method = RequestMethod.POST)
     default CompletableFuture<ResponseEntity<OuterComposite>> fakeOuterCompositeSerialize(@ApiParam(value = "Input composite as post body"  )  @Valid @RequestBody OuterComposite body) {
-        // do some magic!
-        return CompletableFuture.completedFuture(new ResponseEntity<OuterComposite>(HttpStatus.NOT_IMPLEMENTED));
+        if(getObjectMapper().isPresent() && getAcceptHeader().isPresent()) {
+            if (getAcceptHeader().get().contains("application/json")) {
+                try {
+                    return CompletableFuture.completedFuture(new ResponseEntity<>(getObjectMapper().get().readValue("{  \"my_string\" : { },  \"my_number\" : { },  \"my_boolean\" : { }}", OuterComposite.class), HttpStatus.NOT_IMPLEMENTED));
+                } catch (IOException e) {
+                    log.error("Couldn't serialize response for content type application/json", e);
+                    return CompletableFuture.completedFuture(new ResponseEntity<>(HttpStatus.INTERNAL_SERVER_ERROR));
+                }
+            }
+        } else {
+            log.warn("ObjectMapper or HttpServletRequest not configured in default FakeApi interface so no example is generated");
+        }
+        return CompletableFuture.completedFuture(new ResponseEntity<>(HttpStatus.NOT_IMPLEMENTED));
     }
 
 
@@ -61,8 +101,19 @@ public interface FakeApi {
     @RequestMapping(value = "/fake/outer/number",
         method = RequestMethod.POST)
     default CompletableFuture<ResponseEntity<BigDecimal>> fakeOuterNumberSerialize(@ApiParam(value = "Input number as post body"  )  @Valid @RequestBody BigDecimal body) {
-        // do some magic!
-        return CompletableFuture.completedFuture(new ResponseEntity<BigDecimal>(HttpStatus.NOT_IMPLEMENTED));
+        if(getObjectMapper().isPresent() && getAcceptHeader().isPresent()) {
+            if (getAcceptHeader().get().contains("application/json")) {
+                try {
+                    return CompletableFuture.completedFuture(new ResponseEntity<>(getObjectMapper().get().readValue("{ }", BigDecimal.class), HttpStatus.NOT_IMPLEMENTED));
+                } catch (IOException e) {
+                    log.error("Couldn't serialize response for content type application/json", e);
+                    return CompletableFuture.completedFuture(new ResponseEntity<>(HttpStatus.INTERNAL_SERVER_ERROR));
+                }
+            }
+        } else {
+            log.warn("ObjectMapper or HttpServletRequest not configured in default FakeApi interface so no example is generated");
+        }
+        return CompletableFuture.completedFuture(new ResponseEntity<>(HttpStatus.NOT_IMPLEMENTED));
     }
 
 
@@ -72,8 +123,19 @@ public interface FakeApi {
     @RequestMapping(value = "/fake/outer/string",
         method = RequestMethod.POST)
     default CompletableFuture<ResponseEntity<String>> fakeOuterStringSerialize(@ApiParam(value = "Input string as post body"  )  @Valid @RequestBody String body) {
-        // do some magic!
-        return CompletableFuture.completedFuture(new ResponseEntity<String>(HttpStatus.NOT_IMPLEMENTED));
+        if(getObjectMapper().isPresent() && getAcceptHeader().isPresent()) {
+            if (getAcceptHeader().get().contains("application/json")) {
+                try {
+                    return CompletableFuture.completedFuture(new ResponseEntity<>(getObjectMapper().get().readValue("{ }", String.class), HttpStatus.NOT_IMPLEMENTED));
+                } catch (IOException e) {
+                    log.error("Couldn't serialize response for content type application/json", e);
+                    return CompletableFuture.completedFuture(new ResponseEntity<>(HttpStatus.INTERNAL_SERVER_ERROR));
+                }
+            }
+        } else {
+            log.warn("ObjectMapper or HttpServletRequest not configured in default FakeApi interface so no example is generated");
+        }
+        return CompletableFuture.completedFuture(new ResponseEntity<>(HttpStatus.NOT_IMPLEMENTED));
     }
 
 
@@ -85,8 +147,19 @@ public interface FakeApi {
         consumes = { "application/json" },
         method = RequestMethod.PATCH)
     default CompletableFuture<ResponseEntity<Client>> testClientModel(@ApiParam(value = "client model" ,required=true )  @Valid @RequestBody Client body) {
-        // do some magic!
-        return CompletableFuture.completedFuture(new ResponseEntity<Client>(HttpStatus.NOT_IMPLEMENTED));
+        if(getObjectMapper().isPresent() && getAcceptHeader().isPresent()) {
+            if (getAcceptHeader().get().contains("application/json")) {
+                try {
+                    return CompletableFuture.completedFuture(new ResponseEntity<>(getObjectMapper().get().readValue("{  \"client\" : \"client\"}", Client.class), HttpStatus.NOT_IMPLEMENTED));
+                } catch (IOException e) {
+                    log.error("Couldn't serialize response for content type application/json", e);
+                    return CompletableFuture.completedFuture(new ResponseEntity<>(HttpStatus.INTERNAL_SERVER_ERROR));
+                }
+            }
+        } else {
+            log.warn("ObjectMapper or HttpServletRequest not configured in default FakeApi interface so no example is generated");
+        }
+        return CompletableFuture.completedFuture(new ResponseEntity<>(HttpStatus.NOT_IMPLEMENTED));
     }
 
 
@@ -101,8 +174,11 @@ public interface FakeApi {
         consumes = { "application/xml; charset=utf-8", "application/json; charset=utf-8" },
         method = RequestMethod.POST)
     default CompletableFuture<ResponseEntity<Void>> testEndpointParameters(@ApiParam(value = "None", required=true) @RequestPart(value="number", required=true)  BigDecimal number,@ApiParam(value = "None", required=true) @RequestPart(value="double", required=true)  Double _double,@ApiParam(value = "None", required=true) @RequestPart(value="pattern_without_delimiter", required=true)  String patternWithoutDelimiter,@ApiParam(value = "None", required=true) @RequestPart(value="byte", required=true)  byte[] _byte,@ApiParam(value = "None") @RequestPart(value="integer", required=false)  Integer integer,@ApiParam(value = "None") @RequestPart(value="int32", required=false)  Integer int32,@ApiParam(value = "None") @RequestPart(value="int64", required=false)  Long int64,@ApiParam(value = "None") @RequestPart(value="float", required=false)  Float _float,@ApiParam(value = "None") @RequestPart(value="string", required=false)  String string,@ApiParam(value = "None") @RequestPart(value="binary", required=false)  byte[] binary,@ApiParam(value = "None") @RequestPart(value="date", required=false)  LocalDate date,@ApiParam(value = "None") @RequestPart(value="dateTime", required=false)  OffsetDateTime dateTime,@ApiParam(value = "None") @RequestPart(value="password", required=false)  String password,@ApiParam(value = "None") @RequestPart(value="callback", required=false)  String paramCallback) {
-        // do some magic!
-        return CompletableFuture.completedFuture(new ResponseEntity<Void>(HttpStatus.NOT_IMPLEMENTED));
+        if(getObjectMapper().isPresent() && getAcceptHeader().isPresent()) {
+        } else {
+            log.warn("ObjectMapper or HttpServletRequest not configured in default FakeApi interface so no example is generated");
+        }
+        return CompletableFuture.completedFuture(new ResponseEntity<>(HttpStatus.NOT_IMPLEMENTED));
     }
 
 
@@ -115,8 +191,11 @@ public interface FakeApi {
         consumes = { "*/*" },
         method = RequestMethod.GET)
     default CompletableFuture<ResponseEntity<Void>> testEnumParameters(@ApiParam(value = "Form parameter enum test (string array)", allowableValues=">, $") @RequestPart(value="enum_form_string_array", required=false)  List<String> enumFormStringArray,@ApiParam(value = "Form parameter enum test (string)", allowableValues="_abc, -efg, (xyz)", defaultValue="-efg") @RequestPart(value="enum_form_string", required=false)  String enumFormString,@ApiParam(value = "Header parameter enum test (string array)" , allowableValues=">, $") @RequestHeader(value="enum_header_string_array", required=false) List<String> enumHeaderStringArray,@ApiParam(value = "Header parameter enum test (string)" , allowableValues="_abc, -efg, (xyz)", defaultValue="-efg") @RequestHeader(value="enum_header_string", required=false) String enumHeaderString,@ApiParam(value = "Query parameter enum test (string array)", allowableValues = ">, $") @Valid @RequestParam(value = "enum_query_string_array", required = false) List<String> enumQueryStringArray,@ApiParam(value = "Query parameter enum test (string)", allowableValues = "_abc, -efg, (xyz)", defaultValue = "-efg") @Valid @RequestParam(value = "enum_query_string", required = false, defaultValue="-efg") String enumQueryString,@ApiParam(value = "Query parameter enum test (double)", allowableValues = "1, -2") @Valid @RequestParam(value = "enum_query_integer", required = false) Integer enumQueryInteger,@ApiParam(value = "Query parameter enum test (double)", allowableValues="1.1, -1.2") @RequestPart(value="enum_query_double", required=false)  Double enumQueryDouble) {
-        // do some magic!
-        return CompletableFuture.completedFuture(new ResponseEntity<Void>(HttpStatus.NOT_IMPLEMENTED));
+        if(getObjectMapper().isPresent() && getAcceptHeader().isPresent()) {
+        } else {
+            log.warn("ObjectMapper or HttpServletRequest not configured in default FakeApi interface so no example is generated");
+        }
+        return CompletableFuture.completedFuture(new ResponseEntity<>(HttpStatus.NOT_IMPLEMENTED));
     }
 
 
@@ -127,8 +206,11 @@ public interface FakeApi {
         consumes = { "application/json" },
         method = RequestMethod.POST)
     default CompletableFuture<ResponseEntity<Void>> testInlineAdditionalProperties(@ApiParam(value = "request body" ,required=true )  @Valid @RequestBody Object param) {
-        // do some magic!
-        return CompletableFuture.completedFuture(new ResponseEntity<Void>(HttpStatus.NOT_IMPLEMENTED));
+        if(getObjectMapper().isPresent() && getAcceptHeader().isPresent()) {
+        } else {
+            log.warn("ObjectMapper or HttpServletRequest not configured in default FakeApi interface so no example is generated");
+        }
+        return CompletableFuture.completedFuture(new ResponseEntity<>(HttpStatus.NOT_IMPLEMENTED));
     }
 
 
@@ -139,8 +221,11 @@ public interface FakeApi {
         consumes = { "application/json" },
         method = RequestMethod.GET)
     default CompletableFuture<ResponseEntity<Void>> testJsonFormData(@ApiParam(value = "field1", required=true) @RequestPart(value="param", required=true)  String param,@ApiParam(value = "field2", required=true) @RequestPart(value="param2", required=true)  String param2) {
-        // do some magic!
-        return CompletableFuture.completedFuture(new ResponseEntity<Void>(HttpStatus.NOT_IMPLEMENTED));
+        if(getObjectMapper().isPresent() && getAcceptHeader().isPresent()) {
+        } else {
+            log.warn("ObjectMapper or HttpServletRequest not configured in default FakeApi interface so no example is generated");
+        }
+        return CompletableFuture.completedFuture(new ResponseEntity<>(HttpStatus.NOT_IMPLEMENTED));
     }
 
 }

--- a/samples/server/petstore/spring-mvc-j8-async/src/main/java/io/swagger/api/FakeApi.java
+++ b/samples/server/petstore/spring-mvc-j8-async/src/main/java/io/swagger/api/FakeApi.java
@@ -38,9 +38,9 @@ public interface FakeApi {
         @ApiResponse(code = 200, message = "Output boolean", response = Boolean.class) })
     @RequestMapping(value = "/fake/outer/boolean",
         method = RequestMethod.POST)
-    default CompletableFuture<ResponseEntity<Boolean>> fakeOuterBooleanSerialize(@ApiParam(value = "Input boolean as post body"  )  @Valid @RequestBody Boolean body, @RequestHeader(value = "Accept", required = false) String accept) throws Exception {
+    default CompletableFuture<ResponseEntity<Boolean>> fakeOuterBooleanSerialize(@ApiParam(value = "Input boolean as post body"  )  @Valid @RequestBody Boolean body) {
         // do some magic!
-        return CompletableFuture.completedFuture(new ResponseEntity<Boolean>(HttpStatus.OK));
+        return CompletableFuture.completedFuture(new ResponseEntity<Boolean>(HttpStatus.NOT_IMPLEMENTED));
     }
 
 
@@ -49,9 +49,9 @@ public interface FakeApi {
         @ApiResponse(code = 200, message = "Output composite", response = OuterComposite.class) })
     @RequestMapping(value = "/fake/outer/composite",
         method = RequestMethod.POST)
-    default CompletableFuture<ResponseEntity<OuterComposite>> fakeOuterCompositeSerialize(@ApiParam(value = "Input composite as post body"  )  @Valid @RequestBody OuterComposite body, @RequestHeader(value = "Accept", required = false) String accept) throws Exception {
+    default CompletableFuture<ResponseEntity<OuterComposite>> fakeOuterCompositeSerialize(@ApiParam(value = "Input composite as post body"  )  @Valid @RequestBody OuterComposite body) {
         // do some magic!
-        return CompletableFuture.completedFuture(new ResponseEntity<OuterComposite>(HttpStatus.OK));
+        return CompletableFuture.completedFuture(new ResponseEntity<OuterComposite>(HttpStatus.NOT_IMPLEMENTED));
     }
 
 
@@ -60,9 +60,9 @@ public interface FakeApi {
         @ApiResponse(code = 200, message = "Output number", response = BigDecimal.class) })
     @RequestMapping(value = "/fake/outer/number",
         method = RequestMethod.POST)
-    default CompletableFuture<ResponseEntity<BigDecimal>> fakeOuterNumberSerialize(@ApiParam(value = "Input number as post body"  )  @Valid @RequestBody BigDecimal body, @RequestHeader(value = "Accept", required = false) String accept) throws Exception {
+    default CompletableFuture<ResponseEntity<BigDecimal>> fakeOuterNumberSerialize(@ApiParam(value = "Input number as post body"  )  @Valid @RequestBody BigDecimal body) {
         // do some magic!
-        return CompletableFuture.completedFuture(new ResponseEntity<BigDecimal>(HttpStatus.OK));
+        return CompletableFuture.completedFuture(new ResponseEntity<BigDecimal>(HttpStatus.NOT_IMPLEMENTED));
     }
 
 
@@ -71,9 +71,9 @@ public interface FakeApi {
         @ApiResponse(code = 200, message = "Output string", response = String.class) })
     @RequestMapping(value = "/fake/outer/string",
         method = RequestMethod.POST)
-    default CompletableFuture<ResponseEntity<String>> fakeOuterStringSerialize(@ApiParam(value = "Input string as post body"  )  @Valid @RequestBody String body, @RequestHeader(value = "Accept", required = false) String accept) throws Exception {
+    default CompletableFuture<ResponseEntity<String>> fakeOuterStringSerialize(@ApiParam(value = "Input string as post body"  )  @Valid @RequestBody String body) {
         // do some magic!
-        return CompletableFuture.completedFuture(new ResponseEntity<String>(HttpStatus.OK));
+        return CompletableFuture.completedFuture(new ResponseEntity<String>(HttpStatus.NOT_IMPLEMENTED));
     }
 
 
@@ -84,9 +84,9 @@ public interface FakeApi {
         produces = { "application/json" }, 
         consumes = { "application/json" },
         method = RequestMethod.PATCH)
-    default CompletableFuture<ResponseEntity<Client>> testClientModel(@ApiParam(value = "client model" ,required=true )  @Valid @RequestBody Client body, @RequestHeader(value = "Accept", required = false) String accept) throws Exception {
+    default CompletableFuture<ResponseEntity<Client>> testClientModel(@ApiParam(value = "client model" ,required=true )  @Valid @RequestBody Client body) {
         // do some magic!
-        return CompletableFuture.completedFuture(new ResponseEntity<Client>(HttpStatus.OK));
+        return CompletableFuture.completedFuture(new ResponseEntity<Client>(HttpStatus.NOT_IMPLEMENTED));
     }
 
 
@@ -100,9 +100,9 @@ public interface FakeApi {
         produces = { "application/xml; charset=utf-8", "application/json; charset=utf-8" }, 
         consumes = { "application/xml; charset=utf-8", "application/json; charset=utf-8" },
         method = RequestMethod.POST)
-    default CompletableFuture<ResponseEntity<Void>> testEndpointParameters(@ApiParam(value = "None", required=true) @RequestPart(value="number", required=true)  BigDecimal number,@ApiParam(value = "None", required=true) @RequestPart(value="double", required=true)  Double _double,@ApiParam(value = "None", required=true) @RequestPart(value="pattern_without_delimiter", required=true)  String patternWithoutDelimiter,@ApiParam(value = "None", required=true) @RequestPart(value="byte", required=true)  byte[] _byte,@ApiParam(value = "None") @RequestPart(value="integer", required=false)  Integer integer,@ApiParam(value = "None") @RequestPart(value="int32", required=false)  Integer int32,@ApiParam(value = "None") @RequestPart(value="int64", required=false)  Long int64,@ApiParam(value = "None") @RequestPart(value="float", required=false)  Float _float,@ApiParam(value = "None") @RequestPart(value="string", required=false)  String string,@ApiParam(value = "None") @RequestPart(value="binary", required=false)  byte[] binary,@ApiParam(value = "None") @RequestPart(value="date", required=false)  LocalDate date,@ApiParam(value = "None") @RequestPart(value="dateTime", required=false)  OffsetDateTime dateTime,@ApiParam(value = "None") @RequestPart(value="password", required=false)  String password,@ApiParam(value = "None") @RequestPart(value="callback", required=false)  String paramCallback, @RequestHeader(value = "Accept", required = false) String accept) throws Exception {
+    default CompletableFuture<ResponseEntity<Void>> testEndpointParameters(@ApiParam(value = "None", required=true) @RequestPart(value="number", required=true)  BigDecimal number,@ApiParam(value = "None", required=true) @RequestPart(value="double", required=true)  Double _double,@ApiParam(value = "None", required=true) @RequestPart(value="pattern_without_delimiter", required=true)  String patternWithoutDelimiter,@ApiParam(value = "None", required=true) @RequestPart(value="byte", required=true)  byte[] _byte,@ApiParam(value = "None") @RequestPart(value="integer", required=false)  Integer integer,@ApiParam(value = "None") @RequestPart(value="int32", required=false)  Integer int32,@ApiParam(value = "None") @RequestPart(value="int64", required=false)  Long int64,@ApiParam(value = "None") @RequestPart(value="float", required=false)  Float _float,@ApiParam(value = "None") @RequestPart(value="string", required=false)  String string,@ApiParam(value = "None") @RequestPart(value="binary", required=false)  byte[] binary,@ApiParam(value = "None") @RequestPart(value="date", required=false)  LocalDate date,@ApiParam(value = "None") @RequestPart(value="dateTime", required=false)  OffsetDateTime dateTime,@ApiParam(value = "None") @RequestPart(value="password", required=false)  String password,@ApiParam(value = "None") @RequestPart(value="callback", required=false)  String paramCallback) {
         // do some magic!
-        return CompletableFuture.completedFuture(new ResponseEntity<Void>(HttpStatus.OK));
+        return CompletableFuture.completedFuture(new ResponseEntity<Void>(HttpStatus.NOT_IMPLEMENTED));
     }
 
 
@@ -114,9 +114,9 @@ public interface FakeApi {
         produces = { "*/*" }, 
         consumes = { "*/*" },
         method = RequestMethod.GET)
-    default CompletableFuture<ResponseEntity<Void>> testEnumParameters(@ApiParam(value = "Form parameter enum test (string array)", allowableValues=">, $") @RequestPart(value="enum_form_string_array", required=false)  List<String> enumFormStringArray,@ApiParam(value = "Form parameter enum test (string)", allowableValues="_abc, -efg, (xyz)", defaultValue="-efg") @RequestPart(value="enum_form_string", required=false)  String enumFormString,@ApiParam(value = "Header parameter enum test (string array)" , allowableValues=">, $") @RequestHeader(value="enum_header_string_array", required=false) List<String> enumHeaderStringArray,@ApiParam(value = "Header parameter enum test (string)" , allowableValues="_abc, -efg, (xyz)", defaultValue="-efg") @RequestHeader(value="enum_header_string", required=false) String enumHeaderString,@ApiParam(value = "Query parameter enum test (string array)", allowableValues = ">, $") @Valid @RequestParam(value = "enum_query_string_array", required = false) List<String> enumQueryStringArray,@ApiParam(value = "Query parameter enum test (string)", allowableValues = "_abc, -efg, (xyz)", defaultValue = "-efg") @Valid @RequestParam(value = "enum_query_string", required = false, defaultValue="-efg") String enumQueryString,@ApiParam(value = "Query parameter enum test (double)", allowableValues = "1, -2") @Valid @RequestParam(value = "enum_query_integer", required = false) Integer enumQueryInteger,@ApiParam(value = "Query parameter enum test (double)", allowableValues="1.1, -1.2") @RequestPart(value="enum_query_double", required=false)  Double enumQueryDouble, @RequestHeader(value = "Accept", required = false) String accept) throws Exception {
+    default CompletableFuture<ResponseEntity<Void>> testEnumParameters(@ApiParam(value = "Form parameter enum test (string array)", allowableValues=">, $") @RequestPart(value="enum_form_string_array", required=false)  List<String> enumFormStringArray,@ApiParam(value = "Form parameter enum test (string)", allowableValues="_abc, -efg, (xyz)", defaultValue="-efg") @RequestPart(value="enum_form_string", required=false)  String enumFormString,@ApiParam(value = "Header parameter enum test (string array)" , allowableValues=">, $") @RequestHeader(value="enum_header_string_array", required=false) List<String> enumHeaderStringArray,@ApiParam(value = "Header parameter enum test (string)" , allowableValues="_abc, -efg, (xyz)", defaultValue="-efg") @RequestHeader(value="enum_header_string", required=false) String enumHeaderString,@ApiParam(value = "Query parameter enum test (string array)", allowableValues = ">, $") @Valid @RequestParam(value = "enum_query_string_array", required = false) List<String> enumQueryStringArray,@ApiParam(value = "Query parameter enum test (string)", allowableValues = "_abc, -efg, (xyz)", defaultValue = "-efg") @Valid @RequestParam(value = "enum_query_string", required = false, defaultValue="-efg") String enumQueryString,@ApiParam(value = "Query parameter enum test (double)", allowableValues = "1, -2") @Valid @RequestParam(value = "enum_query_integer", required = false) Integer enumQueryInteger,@ApiParam(value = "Query parameter enum test (double)", allowableValues="1.1, -1.2") @RequestPart(value="enum_query_double", required=false)  Double enumQueryDouble) {
         // do some magic!
-        return CompletableFuture.completedFuture(new ResponseEntity<Void>(HttpStatus.OK));
+        return CompletableFuture.completedFuture(new ResponseEntity<Void>(HttpStatus.NOT_IMPLEMENTED));
     }
 
 
@@ -126,9 +126,9 @@ public interface FakeApi {
     @RequestMapping(value = "/fake/inline-additionalProperties",
         consumes = { "application/json" },
         method = RequestMethod.POST)
-    default CompletableFuture<ResponseEntity<Void>> testInlineAdditionalProperties(@ApiParam(value = "request body" ,required=true )  @Valid @RequestBody Object param, @RequestHeader(value = "Accept", required = false) String accept) throws Exception {
+    default CompletableFuture<ResponseEntity<Void>> testInlineAdditionalProperties(@ApiParam(value = "request body" ,required=true )  @Valid @RequestBody Object param) {
         // do some magic!
-        return CompletableFuture.completedFuture(new ResponseEntity<Void>(HttpStatus.OK));
+        return CompletableFuture.completedFuture(new ResponseEntity<Void>(HttpStatus.NOT_IMPLEMENTED));
     }
 
 
@@ -138,9 +138,9 @@ public interface FakeApi {
     @RequestMapping(value = "/fake/jsonFormData",
         consumes = { "application/json" },
         method = RequestMethod.GET)
-    default CompletableFuture<ResponseEntity<Void>> testJsonFormData(@ApiParam(value = "field1", required=true) @RequestPart(value="param", required=true)  String param,@ApiParam(value = "field2", required=true) @RequestPart(value="param2", required=true)  String param2, @RequestHeader(value = "Accept", required = false) String accept) throws Exception {
+    default CompletableFuture<ResponseEntity<Void>> testJsonFormData(@ApiParam(value = "field1", required=true) @RequestPart(value="param", required=true)  String param,@ApiParam(value = "field2", required=true) @RequestPart(value="param2", required=true)  String param2) {
         // do some magic!
-        return CompletableFuture.completedFuture(new ResponseEntity<Void>(HttpStatus.OK));
+        return CompletableFuture.completedFuture(new ResponseEntity<Void>(HttpStatus.NOT_IMPLEMENTED));
     }
 
 }

--- a/samples/server/petstore/spring-mvc-j8-async/src/main/java/io/swagger/api/FakeApiController.java
+++ b/samples/server/petstore/spring-mvc-j8-async/src/main/java/io/swagger/api/FakeApiController.java
@@ -8,6 +8,7 @@ import javax.validation.Valid;
 
 @Controller
 public class FakeApiController implements FakeApi {
+
     private final ObjectMapper objectMapper;
 
     public FakeApiController(ObjectMapper objectMapper) {

--- a/samples/server/petstore/spring-mvc-j8-async/src/main/java/io/swagger/api/FakeApiController.java
+++ b/samples/server/petstore/spring-mvc-j8-async/src/main/java/io/swagger/api/FakeApiController.java
@@ -1,18 +1,8 @@
 package io.swagger.api;
 
 import org.springframework.stereotype.Controller;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import java.io.IOException;
-import javax.validation.constraints.*;
-import javax.validation.Valid;
 
 @Controller
 public class FakeApiController implements FakeApi {
-
-    private final ObjectMapper objectMapper;
-
-    public FakeApiController(ObjectMapper objectMapper) {
-        this.objectMapper = objectMapper;
-    }
 
 }

--- a/samples/server/petstore/spring-mvc-j8-async/src/main/java/io/swagger/api/FakeApiController.java
+++ b/samples/server/petstore/spring-mvc-j8-async/src/main/java/io/swagger/api/FakeApiController.java
@@ -1,8 +1,31 @@
 package io.swagger.api;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.springframework.stereotype.Controller;
+import javax.servlet.http.HttpServletRequest;
+import java.util.Optional;
 
 @Controller
 public class FakeApiController implements FakeApi {
+
+    private final ObjectMapper objectMapper;
+
+    private final HttpServletRequest request;
+
+    @org.springframework.beans.factory.annotation.Autowired
+    public FakeApiController(ObjectMapper objectMapper, HttpServletRequest request) {
+        this.objectMapper = objectMapper;
+        this.request = request;
+    }
+
+    @Override
+    public Optional<ObjectMapper> getObjectMapper() {
+        return Optional.ofNullable(objectMapper);
+    }
+
+    @Override
+    public Optional<HttpServletRequest> getRequest() {
+        return Optional.ofNullable(request);
+    }
 
 }

--- a/samples/server/petstore/spring-mvc-j8-async/src/main/java/io/swagger/api/FakeClassnameTestApi.java
+++ b/samples/server/petstore/spring-mvc-j8-async/src/main/java/io/swagger/api/FakeClassnameTestApi.java
@@ -6,10 +6,13 @@
 package io.swagger.api;
 
 import io.swagger.model.Client;
-
+import com.fasterxml.jackson.databind.ObjectMapper;
 import io.swagger.annotations.*;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
@@ -18,16 +21,31 @@ import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.multipart.MultipartFile;
-import java.io.IOException;
 
-import java.util.List;
-import java.util.concurrent.CompletableFuture;
-import org.springframework.validation.annotation.Validated;
-import javax.validation.constraints.*;
+import javax.servlet.http.HttpServletRequest;
 import javax.validation.Valid;
+import javax.validation.constraints.*;
+import java.io.IOException;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
 
 @Api(value = "fake_classname_test", description = "the fake_classname_test API")
 public interface FakeClassnameTestApi {
+
+    Logger log = LoggerFactory.getLogger(FakeClassnameTestApi.class);
+
+    default Optional<ObjectMapper> getObjectMapper() {
+        return Optional.empty();
+    }
+
+    default Optional<HttpServletRequest> getRequest() {
+        return Optional.empty();
+    }
+
+    default Optional<String> getAcceptHeader() {
+        return getRequest().map(r -> r.getHeader("Accept"));
+    }
 
     @ApiOperation(value = "To test class name in snake case", nickname = "testClassname", notes = "", response = Client.class, authorizations = {
         @Authorization(value = "api_key_query")
@@ -39,8 +57,19 @@ public interface FakeClassnameTestApi {
         consumes = { "application/json" },
         method = RequestMethod.PATCH)
     default CompletableFuture<ResponseEntity<Client>> testClassname(@ApiParam(value = "client model" ,required=true )  @Valid @RequestBody Client body) {
-        // do some magic!
-        return CompletableFuture.completedFuture(new ResponseEntity<Client>(HttpStatus.NOT_IMPLEMENTED));
+        if(getObjectMapper().isPresent() && getAcceptHeader().isPresent()) {
+            if (getAcceptHeader().get().contains("application/json")) {
+                try {
+                    return CompletableFuture.completedFuture(new ResponseEntity<>(getObjectMapper().get().readValue("{  \"client\" : \"client\"}", Client.class), HttpStatus.NOT_IMPLEMENTED));
+                } catch (IOException e) {
+                    log.error("Couldn't serialize response for content type application/json", e);
+                    return CompletableFuture.completedFuture(new ResponseEntity<>(HttpStatus.INTERNAL_SERVER_ERROR));
+                }
+            }
+        } else {
+            log.warn("ObjectMapper or HttpServletRequest not configured in default FakeClassnameTestApi interface so no example is generated");
+        }
+        return CompletableFuture.completedFuture(new ResponseEntity<>(HttpStatus.NOT_IMPLEMENTED));
     }
 
 }

--- a/samples/server/petstore/spring-mvc-j8-async/src/main/java/io/swagger/api/FakeClassnameTestApi.java
+++ b/samples/server/petstore/spring-mvc-j8-async/src/main/java/io/swagger/api/FakeClassnameTestApi.java
@@ -38,9 +38,9 @@ public interface FakeClassnameTestApi {
         produces = { "application/json" }, 
         consumes = { "application/json" },
         method = RequestMethod.PATCH)
-    default CompletableFuture<ResponseEntity<Client>> testClassname(@ApiParam(value = "client model" ,required=true )  @Valid @RequestBody Client body, @RequestHeader(value = "Accept", required = false) String accept) throws Exception {
+    default CompletableFuture<ResponseEntity<Client>> testClassname(@ApiParam(value = "client model" ,required=true )  @Valid @RequestBody Client body) {
         // do some magic!
-        return CompletableFuture.completedFuture(new ResponseEntity<Client>(HttpStatus.OK));
+        return CompletableFuture.completedFuture(new ResponseEntity<Client>(HttpStatus.NOT_IMPLEMENTED));
     }
 
 }

--- a/samples/server/petstore/spring-mvc-j8-async/src/main/java/io/swagger/api/FakeClassnameTestApiController.java
+++ b/samples/server/petstore/spring-mvc-j8-async/src/main/java/io/swagger/api/FakeClassnameTestApiController.java
@@ -1,18 +1,8 @@
 package io.swagger.api;
 
 import org.springframework.stereotype.Controller;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import java.io.IOException;
-import javax.validation.constraints.*;
-import javax.validation.Valid;
 
 @Controller
 public class FakeClassnameTestApiController implements FakeClassnameTestApi {
-
-    private final ObjectMapper objectMapper;
-
-    public FakeClassnameTestApiController(ObjectMapper objectMapper) {
-        this.objectMapper = objectMapper;
-    }
 
 }

--- a/samples/server/petstore/spring-mvc-j8-async/src/main/java/io/swagger/api/FakeClassnameTestApiController.java
+++ b/samples/server/petstore/spring-mvc-j8-async/src/main/java/io/swagger/api/FakeClassnameTestApiController.java
@@ -8,6 +8,7 @@ import javax.validation.Valid;
 
 @Controller
 public class FakeClassnameTestApiController implements FakeClassnameTestApi {
+
     private final ObjectMapper objectMapper;
 
     public FakeClassnameTestApiController(ObjectMapper objectMapper) {

--- a/samples/server/petstore/spring-mvc-j8-async/src/main/java/io/swagger/api/FakeClassnameTestApiController.java
+++ b/samples/server/petstore/spring-mvc-j8-async/src/main/java/io/swagger/api/FakeClassnameTestApiController.java
@@ -1,8 +1,31 @@
 package io.swagger.api;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.springframework.stereotype.Controller;
+import javax.servlet.http.HttpServletRequest;
+import java.util.Optional;
 
 @Controller
 public class FakeClassnameTestApiController implements FakeClassnameTestApi {
+
+    private final ObjectMapper objectMapper;
+
+    private final HttpServletRequest request;
+
+    @org.springframework.beans.factory.annotation.Autowired
+    public FakeClassnameTestApiController(ObjectMapper objectMapper, HttpServletRequest request) {
+        this.objectMapper = objectMapper;
+        this.request = request;
+    }
+
+    @Override
+    public Optional<ObjectMapper> getObjectMapper() {
+        return Optional.ofNullable(objectMapper);
+    }
+
+    @Override
+    public Optional<HttpServletRequest> getRequest() {
+        return Optional.ofNullable(request);
+    }
 
 }

--- a/samples/server/petstore/spring-mvc-j8-async/src/main/java/io/swagger/api/PetApi.java
+++ b/samples/server/petstore/spring-mvc-j8-async/src/main/java/io/swagger/api/PetApi.java
@@ -8,10 +8,13 @@ package io.swagger.api;
 import io.swagger.model.ModelApiResponse;
 import io.swagger.model.Pet;
 import org.springframework.core.io.Resource;
-
+import com.fasterxml.jackson.databind.ObjectMapper;
 import io.swagger.annotations.*;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
@@ -20,16 +23,31 @@ import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.multipart.MultipartFile;
-import java.io.IOException;
 
-import java.util.List;
-import java.util.concurrent.CompletableFuture;
-import org.springframework.validation.annotation.Validated;
-import javax.validation.constraints.*;
+import javax.servlet.http.HttpServletRequest;
 import javax.validation.Valid;
+import javax.validation.constraints.*;
+import java.io.IOException;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
 
 @Api(value = "pet", description = "the pet API")
 public interface PetApi {
+
+    Logger log = LoggerFactory.getLogger(PetApi.class);
+
+    default Optional<ObjectMapper> getObjectMapper() {
+        return Optional.empty();
+    }
+
+    default Optional<HttpServletRequest> getRequest() {
+        return Optional.empty();
+    }
+
+    default Optional<String> getAcceptHeader() {
+        return getRequest().map(r -> r.getHeader("Accept"));
+    }
 
     @ApiOperation(value = "Add a new pet to the store", nickname = "addPet", notes = "", authorizations = {
         @Authorization(value = "petstore_auth", scopes = {
@@ -44,8 +62,11 @@ public interface PetApi {
         consumes = { "application/json", "application/xml" },
         method = RequestMethod.POST)
     default CompletableFuture<ResponseEntity<Void>> addPet(@ApiParam(value = "Pet object that needs to be added to the store" ,required=true )  @Valid @RequestBody Pet body) {
-        // do some magic!
-        return CompletableFuture.completedFuture(new ResponseEntity<Void>(HttpStatus.NOT_IMPLEMENTED));
+        if(getObjectMapper().isPresent() && getAcceptHeader().isPresent()) {
+        } else {
+            log.warn("ObjectMapper or HttpServletRequest not configured in default PetApi interface so no example is generated");
+        }
+        return CompletableFuture.completedFuture(new ResponseEntity<>(HttpStatus.NOT_IMPLEMENTED));
     }
 
 
@@ -61,8 +82,11 @@ public interface PetApi {
         produces = { "application/xml", "application/json" }, 
         method = RequestMethod.DELETE)
     default CompletableFuture<ResponseEntity<Void>> deletePet(@ApiParam(value = "Pet id to delete",required=true) @PathVariable("petId") Long petId,@ApiParam(value = "" ) @RequestHeader(value="api_key", required=false) String apiKey) {
-        // do some magic!
-        return CompletableFuture.completedFuture(new ResponseEntity<Void>(HttpStatus.NOT_IMPLEMENTED));
+        if(getObjectMapper().isPresent() && getAcceptHeader().isPresent()) {
+        } else {
+            log.warn("ObjectMapper or HttpServletRequest not configured in default PetApi interface so no example is generated");
+        }
+        return CompletableFuture.completedFuture(new ResponseEntity<>(HttpStatus.NOT_IMPLEMENTED));
     }
 
 
@@ -79,8 +103,27 @@ public interface PetApi {
         produces = { "application/xml", "application/json" }, 
         method = RequestMethod.GET)
     default CompletableFuture<ResponseEntity<List<Pet>>> findPetsByStatus(@NotNull @ApiParam(value = "Status values that need to be considered for filter", required = true, allowableValues = "available, pending, sold") @Valid @RequestParam(value = "status", required = true) List<String> status) {
-        // do some magic!
-        return CompletableFuture.completedFuture(new ResponseEntity<List<Pet>>(HttpStatus.NOT_IMPLEMENTED));
+        if(getObjectMapper().isPresent() && getAcceptHeader().isPresent()) {
+            if (getAcceptHeader().get().contains("application/xml")) {
+                try {
+                    return CompletableFuture.completedFuture(new ResponseEntity<>(getObjectMapper().get().readValue("<Pet>  <id>123456789</id>  <name>doggie</name>  <photoUrls>    <photoUrls>aeiou</photoUrls>  </photoUrls>  <tags>  </tags>  <status>aeiou</status></Pet>", List.class), HttpStatus.NOT_IMPLEMENTED));
+                } catch (IOException e) {
+                    log.error("Couldn't serialize response for content type application/xml", e);
+                    return CompletableFuture.completedFuture(new ResponseEntity<>(HttpStatus.INTERNAL_SERVER_ERROR));
+                }
+            }
+            if (getAcceptHeader().get().contains("application/json")) {
+                try {
+                    return CompletableFuture.completedFuture(new ResponseEntity<>(getObjectMapper().get().readValue("[ {  \"photoUrls\" : [ \"photoUrls\", \"photoUrls\" ],  \"name\" : \"doggie\",  \"id\" : 0,  \"category\" : {    \"name\" : \"name\",    \"id\" : 6  },  \"tags\" : [ {    \"name\" : \"name\",    \"id\" : 1  }, {    \"name\" : \"name\",    \"id\" : 1  } ],  \"status\" : \"available\"}, {  \"photoUrls\" : [ \"photoUrls\", \"photoUrls\" ],  \"name\" : \"doggie\",  \"id\" : 0,  \"category\" : {    \"name\" : \"name\",    \"id\" : 6  },  \"tags\" : [ {    \"name\" : \"name\",    \"id\" : 1  }, {    \"name\" : \"name\",    \"id\" : 1  } ],  \"status\" : \"available\"} ]", List.class), HttpStatus.NOT_IMPLEMENTED));
+                } catch (IOException e) {
+                    log.error("Couldn't serialize response for content type application/json", e);
+                    return CompletableFuture.completedFuture(new ResponseEntity<>(HttpStatus.INTERNAL_SERVER_ERROR));
+                }
+            }
+        } else {
+            log.warn("ObjectMapper or HttpServletRequest not configured in default PetApi interface so no example is generated");
+        }
+        return CompletableFuture.completedFuture(new ResponseEntity<>(HttpStatus.NOT_IMPLEMENTED));
     }
 
 
@@ -97,8 +140,27 @@ public interface PetApi {
         produces = { "application/xml", "application/json" }, 
         method = RequestMethod.GET)
     default CompletableFuture<ResponseEntity<List<Pet>>> findPetsByTags(@NotNull @ApiParam(value = "Tags to filter by", required = true) @Valid @RequestParam(value = "tags", required = true) List<String> tags) {
-        // do some magic!
-        return CompletableFuture.completedFuture(new ResponseEntity<List<Pet>>(HttpStatus.NOT_IMPLEMENTED));
+        if(getObjectMapper().isPresent() && getAcceptHeader().isPresent()) {
+            if (getAcceptHeader().get().contains("application/xml")) {
+                try {
+                    return CompletableFuture.completedFuture(new ResponseEntity<>(getObjectMapper().get().readValue("<Pet>  <id>123456789</id>  <name>doggie</name>  <photoUrls>    <photoUrls>aeiou</photoUrls>  </photoUrls>  <tags>  </tags>  <status>aeiou</status></Pet>", List.class), HttpStatus.NOT_IMPLEMENTED));
+                } catch (IOException e) {
+                    log.error("Couldn't serialize response for content type application/xml", e);
+                    return CompletableFuture.completedFuture(new ResponseEntity<>(HttpStatus.INTERNAL_SERVER_ERROR));
+                }
+            }
+            if (getAcceptHeader().get().contains("application/json")) {
+                try {
+                    return CompletableFuture.completedFuture(new ResponseEntity<>(getObjectMapper().get().readValue("[ {  \"photoUrls\" : [ \"photoUrls\", \"photoUrls\" ],  \"name\" : \"doggie\",  \"id\" : 0,  \"category\" : {    \"name\" : \"name\",    \"id\" : 6  },  \"tags\" : [ {    \"name\" : \"name\",    \"id\" : 1  }, {    \"name\" : \"name\",    \"id\" : 1  } ],  \"status\" : \"available\"}, {  \"photoUrls\" : [ \"photoUrls\", \"photoUrls\" ],  \"name\" : \"doggie\",  \"id\" : 0,  \"category\" : {    \"name\" : \"name\",    \"id\" : 6  },  \"tags\" : [ {    \"name\" : \"name\",    \"id\" : 1  }, {    \"name\" : \"name\",    \"id\" : 1  } ],  \"status\" : \"available\"} ]", List.class), HttpStatus.NOT_IMPLEMENTED));
+                } catch (IOException e) {
+                    log.error("Couldn't serialize response for content type application/json", e);
+                    return CompletableFuture.completedFuture(new ResponseEntity<>(HttpStatus.INTERNAL_SERVER_ERROR));
+                }
+            }
+        } else {
+            log.warn("ObjectMapper or HttpServletRequest not configured in default PetApi interface so no example is generated");
+        }
+        return CompletableFuture.completedFuture(new ResponseEntity<>(HttpStatus.NOT_IMPLEMENTED));
     }
 
 
@@ -113,8 +175,27 @@ public interface PetApi {
         produces = { "application/xml", "application/json" }, 
         method = RequestMethod.GET)
     default CompletableFuture<ResponseEntity<Pet>> getPetById(@ApiParam(value = "ID of pet to return",required=true) @PathVariable("petId") Long petId) {
-        // do some magic!
-        return CompletableFuture.completedFuture(new ResponseEntity<Pet>(HttpStatus.NOT_IMPLEMENTED));
+        if(getObjectMapper().isPresent() && getAcceptHeader().isPresent()) {
+            if (getAcceptHeader().get().contains("application/xml")) {
+                try {
+                    return CompletableFuture.completedFuture(new ResponseEntity<>(getObjectMapper().get().readValue("<Pet>  <id>123456789</id>  <name>doggie</name>  <photoUrls>    <photoUrls>aeiou</photoUrls>  </photoUrls>  <tags>  </tags>  <status>aeiou</status></Pet>", Pet.class), HttpStatus.NOT_IMPLEMENTED));
+                } catch (IOException e) {
+                    log.error("Couldn't serialize response for content type application/xml", e);
+                    return CompletableFuture.completedFuture(new ResponseEntity<>(HttpStatus.INTERNAL_SERVER_ERROR));
+                }
+            }
+            if (getAcceptHeader().get().contains("application/json")) {
+                try {
+                    return CompletableFuture.completedFuture(new ResponseEntity<>(getObjectMapper().get().readValue("{  \"photoUrls\" : [ \"photoUrls\", \"photoUrls\" ],  \"name\" : \"doggie\",  \"id\" : 0,  \"category\" : {    \"name\" : \"name\",    \"id\" : 6  },  \"tags\" : [ {    \"name\" : \"name\",    \"id\" : 1  }, {    \"name\" : \"name\",    \"id\" : 1  } ],  \"status\" : \"available\"}", Pet.class), HttpStatus.NOT_IMPLEMENTED));
+                } catch (IOException e) {
+                    log.error("Couldn't serialize response for content type application/json", e);
+                    return CompletableFuture.completedFuture(new ResponseEntity<>(HttpStatus.INTERNAL_SERVER_ERROR));
+                }
+            }
+        } else {
+            log.warn("ObjectMapper or HttpServletRequest not configured in default PetApi interface so no example is generated");
+        }
+        return CompletableFuture.completedFuture(new ResponseEntity<>(HttpStatus.NOT_IMPLEMENTED));
     }
 
 
@@ -133,8 +214,11 @@ public interface PetApi {
         consumes = { "application/json", "application/xml" },
         method = RequestMethod.PUT)
     default CompletableFuture<ResponseEntity<Void>> updatePet(@ApiParam(value = "Pet object that needs to be added to the store" ,required=true )  @Valid @RequestBody Pet body) {
-        // do some magic!
-        return CompletableFuture.completedFuture(new ResponseEntity<Void>(HttpStatus.NOT_IMPLEMENTED));
+        if(getObjectMapper().isPresent() && getAcceptHeader().isPresent()) {
+        } else {
+            log.warn("ObjectMapper or HttpServletRequest not configured in default PetApi interface so no example is generated");
+        }
+        return CompletableFuture.completedFuture(new ResponseEntity<>(HttpStatus.NOT_IMPLEMENTED));
     }
 
 
@@ -151,8 +235,11 @@ public interface PetApi {
         consumes = { "application/x-www-form-urlencoded" },
         method = RequestMethod.POST)
     default CompletableFuture<ResponseEntity<Void>> updatePetWithForm(@ApiParam(value = "ID of pet that needs to be updated",required=true) @PathVariable("petId") Long petId,@ApiParam(value = "Updated name of the pet") @RequestPart(value="name", required=false)  String name,@ApiParam(value = "Updated status of the pet") @RequestPart(value="status", required=false)  String status) {
-        // do some magic!
-        return CompletableFuture.completedFuture(new ResponseEntity<Void>(HttpStatus.NOT_IMPLEMENTED));
+        if(getObjectMapper().isPresent() && getAcceptHeader().isPresent()) {
+        } else {
+            log.warn("ObjectMapper or HttpServletRequest not configured in default PetApi interface so no example is generated");
+        }
+        return CompletableFuture.completedFuture(new ResponseEntity<>(HttpStatus.NOT_IMPLEMENTED));
     }
 
 
@@ -169,8 +256,19 @@ public interface PetApi {
         consumes = { "multipart/form-data" },
         method = RequestMethod.POST)
     default CompletableFuture<ResponseEntity<ModelApiResponse>> uploadFile(@ApiParam(value = "ID of pet to update",required=true) @PathVariable("petId") Long petId,@ApiParam(value = "Additional data to pass to server") @RequestPart(value="additionalMetadata", required=false)  String additionalMetadata,@ApiParam(value = "file detail") @Valid @RequestPart("file") MultipartFile file) {
-        // do some magic!
-        return CompletableFuture.completedFuture(new ResponseEntity<ModelApiResponse>(HttpStatus.NOT_IMPLEMENTED));
+        if(getObjectMapper().isPresent() && getAcceptHeader().isPresent()) {
+            if (getAcceptHeader().get().contains("application/json")) {
+                try {
+                    return CompletableFuture.completedFuture(new ResponseEntity<>(getObjectMapper().get().readValue("{  \"code\" : 0,  \"type\" : \"type\",  \"message\" : \"message\"}", ModelApiResponse.class), HttpStatus.NOT_IMPLEMENTED));
+                } catch (IOException e) {
+                    log.error("Couldn't serialize response for content type application/json", e);
+                    return CompletableFuture.completedFuture(new ResponseEntity<>(HttpStatus.INTERNAL_SERVER_ERROR));
+                }
+            }
+        } else {
+            log.warn("ObjectMapper or HttpServletRequest not configured in default PetApi interface so no example is generated");
+        }
+        return CompletableFuture.completedFuture(new ResponseEntity<>(HttpStatus.NOT_IMPLEMENTED));
     }
 
 }

--- a/samples/server/petstore/spring-mvc-j8-async/src/main/java/io/swagger/api/PetApi.java
+++ b/samples/server/petstore/spring-mvc-j8-async/src/main/java/io/swagger/api/PetApi.java
@@ -43,9 +43,9 @@ public interface PetApi {
         produces = { "application/xml", "application/json" }, 
         consumes = { "application/json", "application/xml" },
         method = RequestMethod.POST)
-    default CompletableFuture<ResponseEntity<Void>> addPet(@ApiParam(value = "Pet object that needs to be added to the store" ,required=true )  @Valid @RequestBody Pet body, @RequestHeader(value = "Accept", required = false) String accept) throws Exception {
+    default CompletableFuture<ResponseEntity<Void>> addPet(@ApiParam(value = "Pet object that needs to be added to the store" ,required=true )  @Valid @RequestBody Pet body) {
         // do some magic!
-        return CompletableFuture.completedFuture(new ResponseEntity<Void>(HttpStatus.OK));
+        return CompletableFuture.completedFuture(new ResponseEntity<Void>(HttpStatus.NOT_IMPLEMENTED));
     }
 
 
@@ -60,9 +60,9 @@ public interface PetApi {
     @RequestMapping(value = "/pet/{petId}",
         produces = { "application/xml", "application/json" }, 
         method = RequestMethod.DELETE)
-    default CompletableFuture<ResponseEntity<Void>> deletePet(@ApiParam(value = "Pet id to delete",required=true) @PathVariable("petId") Long petId,@ApiParam(value = "" ) @RequestHeader(value="api_key", required=false) String apiKey, @RequestHeader(value = "Accept", required = false) String accept) throws Exception {
+    default CompletableFuture<ResponseEntity<Void>> deletePet(@ApiParam(value = "Pet id to delete",required=true) @PathVariable("petId") Long petId,@ApiParam(value = "" ) @RequestHeader(value="api_key", required=false) String apiKey) {
         // do some magic!
-        return CompletableFuture.completedFuture(new ResponseEntity<Void>(HttpStatus.OK));
+        return CompletableFuture.completedFuture(new ResponseEntity<Void>(HttpStatus.NOT_IMPLEMENTED));
     }
 
 
@@ -78,9 +78,9 @@ public interface PetApi {
     @RequestMapping(value = "/pet/findByStatus",
         produces = { "application/xml", "application/json" }, 
         method = RequestMethod.GET)
-    default CompletableFuture<ResponseEntity<List<Pet>>> findPetsByStatus( @NotNull@ApiParam(value = "Status values that need to be considered for filter", required = true, allowableValues = "available, pending, sold") @Valid @RequestParam(value = "status", required = true) List<String> status, @RequestHeader(value = "Accept", required = false) String accept) throws Exception {
+    default CompletableFuture<ResponseEntity<List<Pet>>> findPetsByStatus(@NotNull @ApiParam(value = "Status values that need to be considered for filter", required = true, allowableValues = "available, pending, sold") @Valid @RequestParam(value = "status", required = true) List<String> status) {
         // do some magic!
-        return CompletableFuture.completedFuture(new ResponseEntity<List<Pet>>(HttpStatus.OK));
+        return CompletableFuture.completedFuture(new ResponseEntity<List<Pet>>(HttpStatus.NOT_IMPLEMENTED));
     }
 
 
@@ -96,9 +96,9 @@ public interface PetApi {
     @RequestMapping(value = "/pet/findByTags",
         produces = { "application/xml", "application/json" }, 
         method = RequestMethod.GET)
-    default CompletableFuture<ResponseEntity<List<Pet>>> findPetsByTags( @NotNull@ApiParam(value = "Tags to filter by", required = true) @Valid @RequestParam(value = "tags", required = true) List<String> tags, @RequestHeader(value = "Accept", required = false) String accept) throws Exception {
+    default CompletableFuture<ResponseEntity<List<Pet>>> findPetsByTags(@NotNull @ApiParam(value = "Tags to filter by", required = true) @Valid @RequestParam(value = "tags", required = true) List<String> tags) {
         // do some magic!
-        return CompletableFuture.completedFuture(new ResponseEntity<List<Pet>>(HttpStatus.OK));
+        return CompletableFuture.completedFuture(new ResponseEntity<List<Pet>>(HttpStatus.NOT_IMPLEMENTED));
     }
 
 
@@ -112,9 +112,9 @@ public interface PetApi {
     @RequestMapping(value = "/pet/{petId}",
         produces = { "application/xml", "application/json" }, 
         method = RequestMethod.GET)
-    default CompletableFuture<ResponseEntity<Pet>> getPetById(@ApiParam(value = "ID of pet to return",required=true) @PathVariable("petId") Long petId, @RequestHeader(value = "Accept", required = false) String accept) throws Exception {
+    default CompletableFuture<ResponseEntity<Pet>> getPetById(@ApiParam(value = "ID of pet to return",required=true) @PathVariable("petId") Long petId) {
         // do some magic!
-        return CompletableFuture.completedFuture(new ResponseEntity<Pet>(HttpStatus.OK));
+        return CompletableFuture.completedFuture(new ResponseEntity<Pet>(HttpStatus.NOT_IMPLEMENTED));
     }
 
 
@@ -132,9 +132,9 @@ public interface PetApi {
         produces = { "application/xml", "application/json" }, 
         consumes = { "application/json", "application/xml" },
         method = RequestMethod.PUT)
-    default CompletableFuture<ResponseEntity<Void>> updatePet(@ApiParam(value = "Pet object that needs to be added to the store" ,required=true )  @Valid @RequestBody Pet body, @RequestHeader(value = "Accept", required = false) String accept) throws Exception {
+    default CompletableFuture<ResponseEntity<Void>> updatePet(@ApiParam(value = "Pet object that needs to be added to the store" ,required=true )  @Valid @RequestBody Pet body) {
         // do some magic!
-        return CompletableFuture.completedFuture(new ResponseEntity<Void>(HttpStatus.OK));
+        return CompletableFuture.completedFuture(new ResponseEntity<Void>(HttpStatus.NOT_IMPLEMENTED));
     }
 
 
@@ -150,9 +150,9 @@ public interface PetApi {
         produces = { "application/xml", "application/json" }, 
         consumes = { "application/x-www-form-urlencoded" },
         method = RequestMethod.POST)
-    default CompletableFuture<ResponseEntity<Void>> updatePetWithForm(@ApiParam(value = "ID of pet that needs to be updated",required=true) @PathVariable("petId") Long petId,@ApiParam(value = "Updated name of the pet") @RequestPart(value="name", required=false)  String name,@ApiParam(value = "Updated status of the pet") @RequestPart(value="status", required=false)  String status, @RequestHeader(value = "Accept", required = false) String accept) throws Exception {
+    default CompletableFuture<ResponseEntity<Void>> updatePetWithForm(@ApiParam(value = "ID of pet that needs to be updated",required=true) @PathVariable("petId") Long petId,@ApiParam(value = "Updated name of the pet") @RequestPart(value="name", required=false)  String name,@ApiParam(value = "Updated status of the pet") @RequestPart(value="status", required=false)  String status) {
         // do some magic!
-        return CompletableFuture.completedFuture(new ResponseEntity<Void>(HttpStatus.OK));
+        return CompletableFuture.completedFuture(new ResponseEntity<Void>(HttpStatus.NOT_IMPLEMENTED));
     }
 
 
@@ -168,9 +168,9 @@ public interface PetApi {
         produces = { "application/json" }, 
         consumes = { "multipart/form-data" },
         method = RequestMethod.POST)
-    default CompletableFuture<ResponseEntity<ModelApiResponse>> uploadFile(@ApiParam(value = "ID of pet to update",required=true) @PathVariable("petId") Long petId,@ApiParam(value = "Additional data to pass to server") @RequestPart(value="additionalMetadata", required=false)  String additionalMetadata,@ApiParam(value = "file detail") @Valid @RequestPart("file") MultipartFile file, @RequestHeader(value = "Accept", required = false) String accept) throws Exception {
+    default CompletableFuture<ResponseEntity<ModelApiResponse>> uploadFile(@ApiParam(value = "ID of pet to update",required=true) @PathVariable("petId") Long petId,@ApiParam(value = "Additional data to pass to server") @RequestPart(value="additionalMetadata", required=false)  String additionalMetadata,@ApiParam(value = "file detail") @Valid @RequestPart("file") MultipartFile file) {
         // do some magic!
-        return CompletableFuture.completedFuture(new ResponseEntity<ModelApiResponse>(HttpStatus.OK));
+        return CompletableFuture.completedFuture(new ResponseEntity<ModelApiResponse>(HttpStatus.NOT_IMPLEMENTED));
     }
 
 }

--- a/samples/server/petstore/spring-mvc-j8-async/src/main/java/io/swagger/api/PetApiController.java
+++ b/samples/server/petstore/spring-mvc-j8-async/src/main/java/io/swagger/api/PetApiController.java
@@ -8,6 +8,7 @@ import javax.validation.Valid;
 
 @Controller
 public class PetApiController implements PetApi {
+
     private final ObjectMapper objectMapper;
 
     public PetApiController(ObjectMapper objectMapper) {

--- a/samples/server/petstore/spring-mvc-j8-async/src/main/java/io/swagger/api/PetApiController.java
+++ b/samples/server/petstore/spring-mvc-j8-async/src/main/java/io/swagger/api/PetApiController.java
@@ -1,18 +1,8 @@
 package io.swagger.api;
 
 import org.springframework.stereotype.Controller;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import java.io.IOException;
-import javax.validation.constraints.*;
-import javax.validation.Valid;
 
 @Controller
 public class PetApiController implements PetApi {
-
-    private final ObjectMapper objectMapper;
-
-    public PetApiController(ObjectMapper objectMapper) {
-        this.objectMapper = objectMapper;
-    }
 
 }

--- a/samples/server/petstore/spring-mvc-j8-async/src/main/java/io/swagger/api/PetApiController.java
+++ b/samples/server/petstore/spring-mvc-j8-async/src/main/java/io/swagger/api/PetApiController.java
@@ -1,8 +1,31 @@
 package io.swagger.api;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.springframework.stereotype.Controller;
+import javax.servlet.http.HttpServletRequest;
+import java.util.Optional;
 
 @Controller
 public class PetApiController implements PetApi {
+
+    private final ObjectMapper objectMapper;
+
+    private final HttpServletRequest request;
+
+    @org.springframework.beans.factory.annotation.Autowired
+    public PetApiController(ObjectMapper objectMapper, HttpServletRequest request) {
+        this.objectMapper = objectMapper;
+        this.request = request;
+    }
+
+    @Override
+    public Optional<ObjectMapper> getObjectMapper() {
+        return Optional.ofNullable(objectMapper);
+    }
+
+    @Override
+    public Optional<HttpServletRequest> getRequest() {
+        return Optional.ofNullable(request);
+    }
 
 }

--- a/samples/server/petstore/spring-mvc-j8-async/src/main/java/io/swagger/api/StoreApi.java
+++ b/samples/server/petstore/spring-mvc-j8-async/src/main/java/io/swagger/api/StoreApi.java
@@ -7,10 +7,13 @@ package io.swagger.api;
 
 import java.util.Map;
 import io.swagger.model.Order;
-
+import com.fasterxml.jackson.databind.ObjectMapper;
 import io.swagger.annotations.*;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
@@ -19,16 +22,31 @@ import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.multipart.MultipartFile;
-import java.io.IOException;
 
-import java.util.List;
-import java.util.concurrent.CompletableFuture;
-import org.springframework.validation.annotation.Validated;
-import javax.validation.constraints.*;
+import javax.servlet.http.HttpServletRequest;
 import javax.validation.Valid;
+import javax.validation.constraints.*;
+import java.io.IOException;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
 
 @Api(value = "store", description = "the store API")
 public interface StoreApi {
+
+    Logger log = LoggerFactory.getLogger(StoreApi.class);
+
+    default Optional<ObjectMapper> getObjectMapper() {
+        return Optional.empty();
+    }
+
+    default Optional<HttpServletRequest> getRequest() {
+        return Optional.empty();
+    }
+
+    default Optional<String> getAcceptHeader() {
+        return getRequest().map(r -> r.getHeader("Accept"));
+    }
 
     @ApiOperation(value = "Delete purchase order by ID", nickname = "deleteOrder", notes = "For valid response try integer IDs with value < 1000. Anything above 1000 or nonintegers will generate API errors", tags={ "store", })
     @ApiResponses(value = { 
@@ -38,8 +56,11 @@ public interface StoreApi {
         produces = { "application/xml", "application/json" }, 
         method = RequestMethod.DELETE)
     default CompletableFuture<ResponseEntity<Void>> deleteOrder(@ApiParam(value = "ID of the order that needs to be deleted",required=true) @PathVariable("order_id") String orderId) {
-        // do some magic!
-        return CompletableFuture.completedFuture(new ResponseEntity<Void>(HttpStatus.NOT_IMPLEMENTED));
+        if(getObjectMapper().isPresent() && getAcceptHeader().isPresent()) {
+        } else {
+            log.warn("ObjectMapper or HttpServletRequest not configured in default StoreApi interface so no example is generated");
+        }
+        return CompletableFuture.completedFuture(new ResponseEntity<>(HttpStatus.NOT_IMPLEMENTED));
     }
 
 
@@ -52,8 +73,19 @@ public interface StoreApi {
         produces = { "application/json" }, 
         method = RequestMethod.GET)
     default CompletableFuture<ResponseEntity<Map<String, Integer>>> getInventory() {
-        // do some magic!
-        return CompletableFuture.completedFuture(new ResponseEntity<Map<String, Integer>>(HttpStatus.NOT_IMPLEMENTED));
+        if(getObjectMapper().isPresent() && getAcceptHeader().isPresent()) {
+            if (getAcceptHeader().get().contains("application/json")) {
+                try {
+                    return CompletableFuture.completedFuture(new ResponseEntity<>(getObjectMapper().get().readValue("{  \"key\" : 0}", Map.class), HttpStatus.NOT_IMPLEMENTED));
+                } catch (IOException e) {
+                    log.error("Couldn't serialize response for content type application/json", e);
+                    return CompletableFuture.completedFuture(new ResponseEntity<>(HttpStatus.INTERNAL_SERVER_ERROR));
+                }
+            }
+        } else {
+            log.warn("ObjectMapper or HttpServletRequest not configured in default StoreApi interface so no example is generated");
+        }
+        return CompletableFuture.completedFuture(new ResponseEntity<>(HttpStatus.NOT_IMPLEMENTED));
     }
 
 
@@ -66,8 +98,27 @@ public interface StoreApi {
         produces = { "application/xml", "application/json" }, 
         method = RequestMethod.GET)
     default CompletableFuture<ResponseEntity<Order>> getOrderById(@Min(1) @Max(5) @ApiParam(value = "ID of pet that needs to be fetched",required=true) @PathVariable("order_id") Long orderId) {
-        // do some magic!
-        return CompletableFuture.completedFuture(new ResponseEntity<Order>(HttpStatus.NOT_IMPLEMENTED));
+        if(getObjectMapper().isPresent() && getAcceptHeader().isPresent()) {
+            if (getAcceptHeader().get().contains("application/xml")) {
+                try {
+                    return CompletableFuture.completedFuture(new ResponseEntity<>(getObjectMapper().get().readValue("<Order>  <id>123456789</id>  <petId>123456789</petId>  <quantity>123</quantity>  <shipDate>2000-01-23T04:56:07.000Z</shipDate>  <status>aeiou</status>  <complete>true</complete></Order>", Order.class), HttpStatus.NOT_IMPLEMENTED));
+                } catch (IOException e) {
+                    log.error("Couldn't serialize response for content type application/xml", e);
+                    return CompletableFuture.completedFuture(new ResponseEntity<>(HttpStatus.INTERNAL_SERVER_ERROR));
+                }
+            }
+            if (getAcceptHeader().get().contains("application/json")) {
+                try {
+                    return CompletableFuture.completedFuture(new ResponseEntity<>(getObjectMapper().get().readValue("{  \"petId\" : 6,  \"quantity\" : 1,  \"id\" : 0,  \"shipDate\" : \"2000-01-23T04:56:07.000+00:00\",  \"complete\" : false,  \"status\" : \"placed\"}", Order.class), HttpStatus.NOT_IMPLEMENTED));
+                } catch (IOException e) {
+                    log.error("Couldn't serialize response for content type application/json", e);
+                    return CompletableFuture.completedFuture(new ResponseEntity<>(HttpStatus.INTERNAL_SERVER_ERROR));
+                }
+            }
+        } else {
+            log.warn("ObjectMapper or HttpServletRequest not configured in default StoreApi interface so no example is generated");
+        }
+        return CompletableFuture.completedFuture(new ResponseEntity<>(HttpStatus.NOT_IMPLEMENTED));
     }
 
 
@@ -79,8 +130,27 @@ public interface StoreApi {
         produces = { "application/xml", "application/json" }, 
         method = RequestMethod.POST)
     default CompletableFuture<ResponseEntity<Order>> placeOrder(@ApiParam(value = "order placed for purchasing the pet" ,required=true )  @Valid @RequestBody Order body) {
-        // do some magic!
-        return CompletableFuture.completedFuture(new ResponseEntity<Order>(HttpStatus.NOT_IMPLEMENTED));
+        if(getObjectMapper().isPresent() && getAcceptHeader().isPresent()) {
+            if (getAcceptHeader().get().contains("application/xml")) {
+                try {
+                    return CompletableFuture.completedFuture(new ResponseEntity<>(getObjectMapper().get().readValue("<Order>  <id>123456789</id>  <petId>123456789</petId>  <quantity>123</quantity>  <shipDate>2000-01-23T04:56:07.000Z</shipDate>  <status>aeiou</status>  <complete>true</complete></Order>", Order.class), HttpStatus.NOT_IMPLEMENTED));
+                } catch (IOException e) {
+                    log.error("Couldn't serialize response for content type application/xml", e);
+                    return CompletableFuture.completedFuture(new ResponseEntity<>(HttpStatus.INTERNAL_SERVER_ERROR));
+                }
+            }
+            if (getAcceptHeader().get().contains("application/json")) {
+                try {
+                    return CompletableFuture.completedFuture(new ResponseEntity<>(getObjectMapper().get().readValue("{  \"petId\" : 6,  \"quantity\" : 1,  \"id\" : 0,  \"shipDate\" : \"2000-01-23T04:56:07.000+00:00\",  \"complete\" : false,  \"status\" : \"placed\"}", Order.class), HttpStatus.NOT_IMPLEMENTED));
+                } catch (IOException e) {
+                    log.error("Couldn't serialize response for content type application/json", e);
+                    return CompletableFuture.completedFuture(new ResponseEntity<>(HttpStatus.INTERNAL_SERVER_ERROR));
+                }
+            }
+        } else {
+            log.warn("ObjectMapper or HttpServletRequest not configured in default StoreApi interface so no example is generated");
+        }
+        return CompletableFuture.completedFuture(new ResponseEntity<>(HttpStatus.NOT_IMPLEMENTED));
     }
 
 }

--- a/samples/server/petstore/spring-mvc-j8-async/src/main/java/io/swagger/api/StoreApi.java
+++ b/samples/server/petstore/spring-mvc-j8-async/src/main/java/io/swagger/api/StoreApi.java
@@ -37,9 +37,9 @@ public interface StoreApi {
     @RequestMapping(value = "/store/order/{order_id}",
         produces = { "application/xml", "application/json" }, 
         method = RequestMethod.DELETE)
-    default CompletableFuture<ResponseEntity<Void>> deleteOrder(@ApiParam(value = "ID of the order that needs to be deleted",required=true) @PathVariable("order_id") String orderId, @RequestHeader(value = "Accept", required = false) String accept) throws Exception {
+    default CompletableFuture<ResponseEntity<Void>> deleteOrder(@ApiParam(value = "ID of the order that needs to be deleted",required=true) @PathVariable("order_id") String orderId) {
         // do some magic!
-        return CompletableFuture.completedFuture(new ResponseEntity<Void>(HttpStatus.OK));
+        return CompletableFuture.completedFuture(new ResponseEntity<Void>(HttpStatus.NOT_IMPLEMENTED));
     }
 
 
@@ -51,9 +51,9 @@ public interface StoreApi {
     @RequestMapping(value = "/store/inventory",
         produces = { "application/json" }, 
         method = RequestMethod.GET)
-    default CompletableFuture<ResponseEntity<Map<String, Integer>>> getInventory( @RequestHeader(value = "Accept", required = false) String accept) throws Exception {
+    default CompletableFuture<ResponseEntity<Map<String, Integer>>> getInventory() {
         // do some magic!
-        return CompletableFuture.completedFuture(new ResponseEntity<Map<String, Integer>>(HttpStatus.OK));
+        return CompletableFuture.completedFuture(new ResponseEntity<Map<String, Integer>>(HttpStatus.NOT_IMPLEMENTED));
     }
 
 
@@ -65,9 +65,9 @@ public interface StoreApi {
     @RequestMapping(value = "/store/order/{order_id}",
         produces = { "application/xml", "application/json" }, 
         method = RequestMethod.GET)
-    default CompletableFuture<ResponseEntity<Order>> getOrderById( @Min(1) @Max(5)@ApiParam(value = "ID of pet that needs to be fetched",required=true) @PathVariable("order_id") Long orderId, @RequestHeader(value = "Accept", required = false) String accept) throws Exception {
+    default CompletableFuture<ResponseEntity<Order>> getOrderById(@Min(1) @Max(5) @ApiParam(value = "ID of pet that needs to be fetched",required=true) @PathVariable("order_id") Long orderId) {
         // do some magic!
-        return CompletableFuture.completedFuture(new ResponseEntity<Order>(HttpStatus.OK));
+        return CompletableFuture.completedFuture(new ResponseEntity<Order>(HttpStatus.NOT_IMPLEMENTED));
     }
 
 
@@ -78,9 +78,9 @@ public interface StoreApi {
     @RequestMapping(value = "/store/order",
         produces = { "application/xml", "application/json" }, 
         method = RequestMethod.POST)
-    default CompletableFuture<ResponseEntity<Order>> placeOrder(@ApiParam(value = "order placed for purchasing the pet" ,required=true )  @Valid @RequestBody Order body, @RequestHeader(value = "Accept", required = false) String accept) throws Exception {
+    default CompletableFuture<ResponseEntity<Order>> placeOrder(@ApiParam(value = "order placed for purchasing the pet" ,required=true )  @Valid @RequestBody Order body) {
         // do some magic!
-        return CompletableFuture.completedFuture(new ResponseEntity<Order>(HttpStatus.OK));
+        return CompletableFuture.completedFuture(new ResponseEntity<Order>(HttpStatus.NOT_IMPLEMENTED));
     }
 
 }

--- a/samples/server/petstore/spring-mvc-j8-async/src/main/java/io/swagger/api/StoreApiController.java
+++ b/samples/server/petstore/spring-mvc-j8-async/src/main/java/io/swagger/api/StoreApiController.java
@@ -8,6 +8,7 @@ import javax.validation.Valid;
 
 @Controller
 public class StoreApiController implements StoreApi {
+
     private final ObjectMapper objectMapper;
 
     public StoreApiController(ObjectMapper objectMapper) {

--- a/samples/server/petstore/spring-mvc-j8-async/src/main/java/io/swagger/api/StoreApiController.java
+++ b/samples/server/petstore/spring-mvc-j8-async/src/main/java/io/swagger/api/StoreApiController.java
@@ -1,18 +1,8 @@
 package io.swagger.api;
 
 import org.springframework.stereotype.Controller;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import java.io.IOException;
-import javax.validation.constraints.*;
-import javax.validation.Valid;
 
 @Controller
 public class StoreApiController implements StoreApi {
-
-    private final ObjectMapper objectMapper;
-
-    public StoreApiController(ObjectMapper objectMapper) {
-        this.objectMapper = objectMapper;
-    }
 
 }

--- a/samples/server/petstore/spring-mvc-j8-async/src/main/java/io/swagger/api/StoreApiController.java
+++ b/samples/server/petstore/spring-mvc-j8-async/src/main/java/io/swagger/api/StoreApiController.java
@@ -1,8 +1,31 @@
 package io.swagger.api;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.springframework.stereotype.Controller;
+import javax.servlet.http.HttpServletRequest;
+import java.util.Optional;
 
 @Controller
 public class StoreApiController implements StoreApi {
+
+    private final ObjectMapper objectMapper;
+
+    private final HttpServletRequest request;
+
+    @org.springframework.beans.factory.annotation.Autowired
+    public StoreApiController(ObjectMapper objectMapper, HttpServletRequest request) {
+        this.objectMapper = objectMapper;
+        this.request = request;
+    }
+
+    @Override
+    public Optional<ObjectMapper> getObjectMapper() {
+        return Optional.ofNullable(objectMapper);
+    }
+
+    @Override
+    public Optional<HttpServletRequest> getRequest() {
+        return Optional.ofNullable(request);
+    }
 
 }

--- a/samples/server/petstore/spring-mvc-j8-async/src/main/java/io/swagger/api/UserApi.java
+++ b/samples/server/petstore/spring-mvc-j8-async/src/main/java/io/swagger/api/UserApi.java
@@ -7,10 +7,13 @@ package io.swagger.api;
 
 import java.util.List;
 import io.swagger.model.User;
-
+import com.fasterxml.jackson.databind.ObjectMapper;
 import io.swagger.annotations.*;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
@@ -19,16 +22,31 @@ import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.multipart.MultipartFile;
-import java.io.IOException;
 
-import java.util.List;
-import java.util.concurrent.CompletableFuture;
-import org.springframework.validation.annotation.Validated;
-import javax.validation.constraints.*;
+import javax.servlet.http.HttpServletRequest;
 import javax.validation.Valid;
+import javax.validation.constraints.*;
+import java.io.IOException;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
 
 @Api(value = "user", description = "the user API")
 public interface UserApi {
+
+    Logger log = LoggerFactory.getLogger(UserApi.class);
+
+    default Optional<ObjectMapper> getObjectMapper() {
+        return Optional.empty();
+    }
+
+    default Optional<HttpServletRequest> getRequest() {
+        return Optional.empty();
+    }
+
+    default Optional<String> getAcceptHeader() {
+        return getRequest().map(r -> r.getHeader("Accept"));
+    }
 
     @ApiOperation(value = "Create user", nickname = "createUser", notes = "This can only be done by the logged in user.", tags={ "user", })
     @ApiResponses(value = { 
@@ -37,8 +55,11 @@ public interface UserApi {
         produces = { "application/xml", "application/json" }, 
         method = RequestMethod.POST)
     default CompletableFuture<ResponseEntity<Void>> createUser(@ApiParam(value = "Created user object" ,required=true )  @Valid @RequestBody User body) {
-        // do some magic!
-        return CompletableFuture.completedFuture(new ResponseEntity<Void>(HttpStatus.NOT_IMPLEMENTED));
+        if(getObjectMapper().isPresent() && getAcceptHeader().isPresent()) {
+        } else {
+            log.warn("ObjectMapper or HttpServletRequest not configured in default UserApi interface so no example is generated");
+        }
+        return CompletableFuture.completedFuture(new ResponseEntity<>(HttpStatus.NOT_IMPLEMENTED));
     }
 
 
@@ -49,8 +70,11 @@ public interface UserApi {
         produces = { "application/xml", "application/json" }, 
         method = RequestMethod.POST)
     default CompletableFuture<ResponseEntity<Void>> createUsersWithArrayInput(@ApiParam(value = "List of user object" ,required=true )  @Valid @RequestBody List<User> body) {
-        // do some magic!
-        return CompletableFuture.completedFuture(new ResponseEntity<Void>(HttpStatus.NOT_IMPLEMENTED));
+        if(getObjectMapper().isPresent() && getAcceptHeader().isPresent()) {
+        } else {
+            log.warn("ObjectMapper or HttpServletRequest not configured in default UserApi interface so no example is generated");
+        }
+        return CompletableFuture.completedFuture(new ResponseEntity<>(HttpStatus.NOT_IMPLEMENTED));
     }
 
 
@@ -61,8 +85,11 @@ public interface UserApi {
         produces = { "application/xml", "application/json" }, 
         method = RequestMethod.POST)
     default CompletableFuture<ResponseEntity<Void>> createUsersWithListInput(@ApiParam(value = "List of user object" ,required=true )  @Valid @RequestBody List<User> body) {
-        // do some magic!
-        return CompletableFuture.completedFuture(new ResponseEntity<Void>(HttpStatus.NOT_IMPLEMENTED));
+        if(getObjectMapper().isPresent() && getAcceptHeader().isPresent()) {
+        } else {
+            log.warn("ObjectMapper or HttpServletRequest not configured in default UserApi interface so no example is generated");
+        }
+        return CompletableFuture.completedFuture(new ResponseEntity<>(HttpStatus.NOT_IMPLEMENTED));
     }
 
 
@@ -74,8 +101,11 @@ public interface UserApi {
         produces = { "application/xml", "application/json" }, 
         method = RequestMethod.DELETE)
     default CompletableFuture<ResponseEntity<Void>> deleteUser(@ApiParam(value = "The name that needs to be deleted",required=true) @PathVariable("username") String username) {
-        // do some magic!
-        return CompletableFuture.completedFuture(new ResponseEntity<Void>(HttpStatus.NOT_IMPLEMENTED));
+        if(getObjectMapper().isPresent() && getAcceptHeader().isPresent()) {
+        } else {
+            log.warn("ObjectMapper or HttpServletRequest not configured in default UserApi interface so no example is generated");
+        }
+        return CompletableFuture.completedFuture(new ResponseEntity<>(HttpStatus.NOT_IMPLEMENTED));
     }
 
 
@@ -88,8 +118,27 @@ public interface UserApi {
         produces = { "application/xml", "application/json" }, 
         method = RequestMethod.GET)
     default CompletableFuture<ResponseEntity<User>> getUserByName(@ApiParam(value = "The name that needs to be fetched. Use user1 for testing. ",required=true) @PathVariable("username") String username) {
-        // do some magic!
-        return CompletableFuture.completedFuture(new ResponseEntity<User>(HttpStatus.NOT_IMPLEMENTED));
+        if(getObjectMapper().isPresent() && getAcceptHeader().isPresent()) {
+            if (getAcceptHeader().get().contains("application/xml")) {
+                try {
+                    return CompletableFuture.completedFuture(new ResponseEntity<>(getObjectMapper().get().readValue("<User>  <id>123456789</id>  <username>aeiou</username>  <firstName>aeiou</firstName>  <lastName>aeiou</lastName>  <email>aeiou</email>  <password>aeiou</password>  <phone>aeiou</phone>  <userStatus>123</userStatus></User>", User.class), HttpStatus.NOT_IMPLEMENTED));
+                } catch (IOException e) {
+                    log.error("Couldn't serialize response for content type application/xml", e);
+                    return CompletableFuture.completedFuture(new ResponseEntity<>(HttpStatus.INTERNAL_SERVER_ERROR));
+                }
+            }
+            if (getAcceptHeader().get().contains("application/json")) {
+                try {
+                    return CompletableFuture.completedFuture(new ResponseEntity<>(getObjectMapper().get().readValue("{  \"firstName\" : \"firstName\",  \"lastName\" : \"lastName\",  \"password\" : \"password\",  \"userStatus\" : 6,  \"phone\" : \"phone\",  \"id\" : 0,  \"email\" : \"email\",  \"username\" : \"username\"}", User.class), HttpStatus.NOT_IMPLEMENTED));
+                } catch (IOException e) {
+                    log.error("Couldn't serialize response for content type application/json", e);
+                    return CompletableFuture.completedFuture(new ResponseEntity<>(HttpStatus.INTERNAL_SERVER_ERROR));
+                }
+            }
+        } else {
+            log.warn("ObjectMapper or HttpServletRequest not configured in default UserApi interface so no example is generated");
+        }
+        return CompletableFuture.completedFuture(new ResponseEntity<>(HttpStatus.NOT_IMPLEMENTED));
     }
 
 
@@ -101,8 +150,27 @@ public interface UserApi {
         produces = { "application/xml", "application/json" }, 
         method = RequestMethod.GET)
     default CompletableFuture<ResponseEntity<String>> loginUser(@NotNull @ApiParam(value = "The user name for login", required = true) @Valid @RequestParam(value = "username", required = true) String username,@NotNull @ApiParam(value = "The password for login in clear text", required = true) @Valid @RequestParam(value = "password", required = true) String password) {
-        // do some magic!
-        return CompletableFuture.completedFuture(new ResponseEntity<String>(HttpStatus.NOT_IMPLEMENTED));
+        if(getObjectMapper().isPresent() && getAcceptHeader().isPresent()) {
+            if (getAcceptHeader().get().contains("application/xml")) {
+                try {
+                    return CompletableFuture.completedFuture(new ResponseEntity<>(getObjectMapper().get().readValue("aeiou", String.class), HttpStatus.NOT_IMPLEMENTED));
+                } catch (IOException e) {
+                    log.error("Couldn't serialize response for content type application/xml", e);
+                    return CompletableFuture.completedFuture(new ResponseEntity<>(HttpStatus.INTERNAL_SERVER_ERROR));
+                }
+            }
+            if (getAcceptHeader().get().contains("application/json")) {
+                try {
+                    return CompletableFuture.completedFuture(new ResponseEntity<>(getObjectMapper().get().readValue("\"\"", String.class), HttpStatus.NOT_IMPLEMENTED));
+                } catch (IOException e) {
+                    log.error("Couldn't serialize response for content type application/json", e);
+                    return CompletableFuture.completedFuture(new ResponseEntity<>(HttpStatus.INTERNAL_SERVER_ERROR));
+                }
+            }
+        } else {
+            log.warn("ObjectMapper or HttpServletRequest not configured in default UserApi interface so no example is generated");
+        }
+        return CompletableFuture.completedFuture(new ResponseEntity<>(HttpStatus.NOT_IMPLEMENTED));
     }
 
 
@@ -113,8 +181,11 @@ public interface UserApi {
         produces = { "application/xml", "application/json" }, 
         method = RequestMethod.GET)
     default CompletableFuture<ResponseEntity<Void>> logoutUser() {
-        // do some magic!
-        return CompletableFuture.completedFuture(new ResponseEntity<Void>(HttpStatus.NOT_IMPLEMENTED));
+        if(getObjectMapper().isPresent() && getAcceptHeader().isPresent()) {
+        } else {
+            log.warn("ObjectMapper or HttpServletRequest not configured in default UserApi interface so no example is generated");
+        }
+        return CompletableFuture.completedFuture(new ResponseEntity<>(HttpStatus.NOT_IMPLEMENTED));
     }
 
 
@@ -126,8 +197,11 @@ public interface UserApi {
         produces = { "application/xml", "application/json" }, 
         method = RequestMethod.PUT)
     default CompletableFuture<ResponseEntity<Void>> updateUser(@ApiParam(value = "name that need to be deleted",required=true) @PathVariable("username") String username,@ApiParam(value = "Updated user object" ,required=true )  @Valid @RequestBody User body) {
-        // do some magic!
-        return CompletableFuture.completedFuture(new ResponseEntity<Void>(HttpStatus.NOT_IMPLEMENTED));
+        if(getObjectMapper().isPresent() && getAcceptHeader().isPresent()) {
+        } else {
+            log.warn("ObjectMapper or HttpServletRequest not configured in default UserApi interface so no example is generated");
+        }
+        return CompletableFuture.completedFuture(new ResponseEntity<>(HttpStatus.NOT_IMPLEMENTED));
     }
 
 }

--- a/samples/server/petstore/spring-mvc-j8-async/src/main/java/io/swagger/api/UserApi.java
+++ b/samples/server/petstore/spring-mvc-j8-async/src/main/java/io/swagger/api/UserApi.java
@@ -36,9 +36,9 @@ public interface UserApi {
     @RequestMapping(value = "/user",
         produces = { "application/xml", "application/json" }, 
         method = RequestMethod.POST)
-    default CompletableFuture<ResponseEntity<Void>> createUser(@ApiParam(value = "Created user object" ,required=true )  @Valid @RequestBody User body, @RequestHeader(value = "Accept", required = false) String accept) throws Exception {
+    default CompletableFuture<ResponseEntity<Void>> createUser(@ApiParam(value = "Created user object" ,required=true )  @Valid @RequestBody User body) {
         // do some magic!
-        return CompletableFuture.completedFuture(new ResponseEntity<Void>(HttpStatus.OK));
+        return CompletableFuture.completedFuture(new ResponseEntity<Void>(HttpStatus.NOT_IMPLEMENTED));
     }
 
 
@@ -48,9 +48,9 @@ public interface UserApi {
     @RequestMapping(value = "/user/createWithArray",
         produces = { "application/xml", "application/json" }, 
         method = RequestMethod.POST)
-    default CompletableFuture<ResponseEntity<Void>> createUsersWithArrayInput(@ApiParam(value = "List of user object" ,required=true )  @Valid @RequestBody List<User> body, @RequestHeader(value = "Accept", required = false) String accept) throws Exception {
+    default CompletableFuture<ResponseEntity<Void>> createUsersWithArrayInput(@ApiParam(value = "List of user object" ,required=true )  @Valid @RequestBody List<User> body) {
         // do some magic!
-        return CompletableFuture.completedFuture(new ResponseEntity<Void>(HttpStatus.OK));
+        return CompletableFuture.completedFuture(new ResponseEntity<Void>(HttpStatus.NOT_IMPLEMENTED));
     }
 
 
@@ -60,9 +60,9 @@ public interface UserApi {
     @RequestMapping(value = "/user/createWithList",
         produces = { "application/xml", "application/json" }, 
         method = RequestMethod.POST)
-    default CompletableFuture<ResponseEntity<Void>> createUsersWithListInput(@ApiParam(value = "List of user object" ,required=true )  @Valid @RequestBody List<User> body, @RequestHeader(value = "Accept", required = false) String accept) throws Exception {
+    default CompletableFuture<ResponseEntity<Void>> createUsersWithListInput(@ApiParam(value = "List of user object" ,required=true )  @Valid @RequestBody List<User> body) {
         // do some magic!
-        return CompletableFuture.completedFuture(new ResponseEntity<Void>(HttpStatus.OK));
+        return CompletableFuture.completedFuture(new ResponseEntity<Void>(HttpStatus.NOT_IMPLEMENTED));
     }
 
 
@@ -73,9 +73,9 @@ public interface UserApi {
     @RequestMapping(value = "/user/{username}",
         produces = { "application/xml", "application/json" }, 
         method = RequestMethod.DELETE)
-    default CompletableFuture<ResponseEntity<Void>> deleteUser(@ApiParam(value = "The name that needs to be deleted",required=true) @PathVariable("username") String username, @RequestHeader(value = "Accept", required = false) String accept) throws Exception {
+    default CompletableFuture<ResponseEntity<Void>> deleteUser(@ApiParam(value = "The name that needs to be deleted",required=true) @PathVariable("username") String username) {
         // do some magic!
-        return CompletableFuture.completedFuture(new ResponseEntity<Void>(HttpStatus.OK));
+        return CompletableFuture.completedFuture(new ResponseEntity<Void>(HttpStatus.NOT_IMPLEMENTED));
     }
 
 
@@ -87,9 +87,9 @@ public interface UserApi {
     @RequestMapping(value = "/user/{username}",
         produces = { "application/xml", "application/json" }, 
         method = RequestMethod.GET)
-    default CompletableFuture<ResponseEntity<User>> getUserByName(@ApiParam(value = "The name that needs to be fetched. Use user1 for testing. ",required=true) @PathVariable("username") String username, @RequestHeader(value = "Accept", required = false) String accept) throws Exception {
+    default CompletableFuture<ResponseEntity<User>> getUserByName(@ApiParam(value = "The name that needs to be fetched. Use user1 for testing. ",required=true) @PathVariable("username") String username) {
         // do some magic!
-        return CompletableFuture.completedFuture(new ResponseEntity<User>(HttpStatus.OK));
+        return CompletableFuture.completedFuture(new ResponseEntity<User>(HttpStatus.NOT_IMPLEMENTED));
     }
 
 
@@ -100,9 +100,9 @@ public interface UserApi {
     @RequestMapping(value = "/user/login",
         produces = { "application/xml", "application/json" }, 
         method = RequestMethod.GET)
-    default CompletableFuture<ResponseEntity<String>> loginUser( @NotNull@ApiParam(value = "The user name for login", required = true) @Valid @RequestParam(value = "username", required = true) String username, @NotNull@ApiParam(value = "The password for login in clear text", required = true) @Valid @RequestParam(value = "password", required = true) String password, @RequestHeader(value = "Accept", required = false) String accept) throws Exception {
+    default CompletableFuture<ResponseEntity<String>> loginUser(@NotNull @ApiParam(value = "The user name for login", required = true) @Valid @RequestParam(value = "username", required = true) String username,@NotNull @ApiParam(value = "The password for login in clear text", required = true) @Valid @RequestParam(value = "password", required = true) String password) {
         // do some magic!
-        return CompletableFuture.completedFuture(new ResponseEntity<String>(HttpStatus.OK));
+        return CompletableFuture.completedFuture(new ResponseEntity<String>(HttpStatus.NOT_IMPLEMENTED));
     }
 
 
@@ -112,9 +112,9 @@ public interface UserApi {
     @RequestMapping(value = "/user/logout",
         produces = { "application/xml", "application/json" }, 
         method = RequestMethod.GET)
-    default CompletableFuture<ResponseEntity<Void>> logoutUser( @RequestHeader(value = "Accept", required = false) String accept) throws Exception {
+    default CompletableFuture<ResponseEntity<Void>> logoutUser() {
         // do some magic!
-        return CompletableFuture.completedFuture(new ResponseEntity<Void>(HttpStatus.OK));
+        return CompletableFuture.completedFuture(new ResponseEntity<Void>(HttpStatus.NOT_IMPLEMENTED));
     }
 
 
@@ -125,9 +125,9 @@ public interface UserApi {
     @RequestMapping(value = "/user/{username}",
         produces = { "application/xml", "application/json" }, 
         method = RequestMethod.PUT)
-    default CompletableFuture<ResponseEntity<Void>> updateUser(@ApiParam(value = "name that need to be deleted",required=true) @PathVariable("username") String username,@ApiParam(value = "Updated user object" ,required=true )  @Valid @RequestBody User body, @RequestHeader(value = "Accept", required = false) String accept) throws Exception {
+    default CompletableFuture<ResponseEntity<Void>> updateUser(@ApiParam(value = "name that need to be deleted",required=true) @PathVariable("username") String username,@ApiParam(value = "Updated user object" ,required=true )  @Valid @RequestBody User body) {
         // do some magic!
-        return CompletableFuture.completedFuture(new ResponseEntity<Void>(HttpStatus.OK));
+        return CompletableFuture.completedFuture(new ResponseEntity<Void>(HttpStatus.NOT_IMPLEMENTED));
     }
 
 }

--- a/samples/server/petstore/spring-mvc-j8-async/src/main/java/io/swagger/api/UserApiController.java
+++ b/samples/server/petstore/spring-mvc-j8-async/src/main/java/io/swagger/api/UserApiController.java
@@ -8,6 +8,7 @@ import javax.validation.Valid;
 
 @Controller
 public class UserApiController implements UserApi {
+
     private final ObjectMapper objectMapper;
 
     public UserApiController(ObjectMapper objectMapper) {

--- a/samples/server/petstore/spring-mvc-j8-async/src/main/java/io/swagger/api/UserApiController.java
+++ b/samples/server/petstore/spring-mvc-j8-async/src/main/java/io/swagger/api/UserApiController.java
@@ -1,18 +1,8 @@
 package io.swagger.api;
 
 import org.springframework.stereotype.Controller;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import java.io.IOException;
-import javax.validation.constraints.*;
-import javax.validation.Valid;
 
 @Controller
 public class UserApiController implements UserApi {
-
-    private final ObjectMapper objectMapper;
-
-    public UserApiController(ObjectMapper objectMapper) {
-        this.objectMapper = objectMapper;
-    }
 
 }

--- a/samples/server/petstore/spring-mvc-j8-async/src/main/java/io/swagger/api/UserApiController.java
+++ b/samples/server/petstore/spring-mvc-j8-async/src/main/java/io/swagger/api/UserApiController.java
@@ -1,8 +1,31 @@
 package io.swagger.api;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.springframework.stereotype.Controller;
+import javax.servlet.http.HttpServletRequest;
+import java.util.Optional;
 
 @Controller
 public class UserApiController implements UserApi {
+
+    private final ObjectMapper objectMapper;
+
+    private final HttpServletRequest request;
+
+    @org.springframework.beans.factory.annotation.Autowired
+    public UserApiController(ObjectMapper objectMapper, HttpServletRequest request) {
+        this.objectMapper = objectMapper;
+        this.request = request;
+    }
+
+    @Override
+    public Optional<ObjectMapper> getObjectMapper() {
+        return Optional.ofNullable(objectMapper);
+    }
+
+    @Override
+    public Optional<HttpServletRequest> getRequest() {
+        return Optional.ofNullable(request);
+    }
 
 }

--- a/samples/server/petstore/spring-mvc-j8-async/src/main/java/io/swagger/model/FormatTest.java
+++ b/samples/server/petstore/spring-mvc-j8-async/src/main/java/io/swagger/model/FormatTest.java
@@ -71,7 +71,7 @@ public class FormatTest   {
   **/
   @ApiModelProperty(value = "")
 
- @Min(10) @Max(100)
+@Min(10) @Max(100) 
   public Integer getInteger() {
     return integer;
   }
@@ -93,7 +93,7 @@ public class FormatTest   {
   **/
   @ApiModelProperty(value = "")
 
- @Min(20) @Max(200)
+@Min(20) @Max(200) 
   public Integer getInt32() {
     return int32;
   }
@@ -137,7 +137,7 @@ public class FormatTest   {
   @NotNull
 
   @Valid
- @DecimalMin("32.1") @DecimalMax("543.2")
+@DecimalMin("32.1") @DecimalMax("543.2") 
   public BigDecimal getNumber() {
     return number;
   }
@@ -159,7 +159,7 @@ public class FormatTest   {
   **/
   @ApiModelProperty(value = "")
 
- @DecimalMin("54.3") @DecimalMax("987.6")
+@DecimalMin("54.3") @DecimalMax("987.6") 
   public Float getFloat() {
     return _float;
   }
@@ -181,7 +181,7 @@ public class FormatTest   {
   **/
   @ApiModelProperty(value = "")
 
- @DecimalMin("67.8") @DecimalMax("123.4")
+@DecimalMin("67.8") @DecimalMax("123.4") 
   public Double getDouble() {
     return _double;
   }
@@ -201,7 +201,7 @@ public class FormatTest   {
   **/
   @ApiModelProperty(value = "")
 
- @Pattern(regexp="/[a-z]/i")
+@Pattern(regexp="/[a-z]/i") 
   public String getString() {
     return string;
   }
@@ -222,7 +222,7 @@ public class FormatTest   {
   @ApiModelProperty(required = true, value = "")
   @NotNull
 
- @Pattern(regexp="^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$")
+@Pattern(regexp="^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$") 
   public byte[] getByte() {
     return _byte;
   }
@@ -327,7 +327,7 @@ public class FormatTest   {
   @ApiModelProperty(required = true, value = "")
   @NotNull
 
- @Size(min=10,max=64)
+@Size(min=10,max=64) 
   public String getPassword() {
     return password;
   }

--- a/samples/server/petstore/spring-mvc/src/main/java/io/swagger/api/AnotherFakeApi.java
+++ b/samples/server/petstore/spring-mvc/src/main/java/io/swagger/api/AnotherFakeApi.java
@@ -34,6 +34,6 @@ public interface AnotherFakeApi {
         produces = { "application/json" }, 
         consumes = { "application/json" },
         method = RequestMethod.PATCH)
-    ResponseEntity<Client> testSpecialTags(@ApiParam(value = "client model" ,required=true )  @Valid @RequestBody Client body, @RequestHeader(value = "Accept", required = false) String accept) throws Exception;
+    ResponseEntity<Client> testSpecialTags(@ApiParam(value = "client model" ,required=true )  @Valid @RequestBody Client body);
 
 }

--- a/samples/server/petstore/spring-mvc/src/main/java/io/swagger/api/AnotherFakeApi.java
+++ b/samples/server/petstore/spring-mvc/src/main/java/io/swagger/api/AnotherFakeApi.java
@@ -6,9 +6,9 @@
 package io.swagger.api;
 
 import io.swagger.model.Client;
-
 import io.swagger.annotations.*;
 import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
@@ -17,12 +17,10 @@ import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.multipart.MultipartFile;
-import java.io.IOException;
 
-import java.util.List;
-import org.springframework.validation.annotation.Validated;
-import javax.validation.constraints.*;
 import javax.validation.Valid;
+import javax.validation.constraints.*;
+import java.util.List;
 
 @Api(value = "another-fake", description = "the another-fake API")
 public interface AnotherFakeApi {

--- a/samples/server/petstore/spring-mvc/src/main/java/io/swagger/api/AnotherFakeApiController.java
+++ b/samples/server/petstore/spring-mvc/src/main/java/io/swagger/api/AnotherFakeApiController.java
@@ -4,6 +4,8 @@ import io.swagger.model.Client;
 
 import io.swagger.annotations.*;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
@@ -12,6 +14,8 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RequestPart;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.util.List;
@@ -22,18 +26,25 @@ import javax.validation.Valid;
 
 @Controller
 public class AnotherFakeApiController implements AnotherFakeApi {
+
+    private final Logger log = LoggerFactory.getLogger(AnotherFakeApiController.class);
+
     private final ObjectMapper objectMapper;
 
     public AnotherFakeApiController(ObjectMapper objectMapper) {
         this.objectMapper = objectMapper;
     }
 
-    public ResponseEntity<Client> testSpecialTags(@ApiParam(value = "client model" ,required=true )  @Valid @RequestBody Client body,
-        @RequestHeader(value = "Accept", required = false) String accept) throws Exception {
+    public ResponseEntity<Client> testSpecialTags(@ApiParam(value = "client model" ,required=true )  @Valid @RequestBody Client body) {
         // do some magic!
-
+        String accept = ((ServletRequestAttributes)RequestContextHolder.getRequestAttributes()).getRequest().getHeader("Accept");
         if (accept != null && accept.contains("application/json")) {
-            return new ResponseEntity<Client>(objectMapper.readValue("{  \"client\" : \"client\"}", Client.class), HttpStatus.OK);
+            try {
+                return new ResponseEntity<Client>(objectMapper.readValue("{  \"client\" : \"client\"}", Client.class), HttpStatus.NOT_IMPLEMENTED);
+            } catch (IOException e) {
+                log.error("Couldn't serialize response for content type application/json", e);
+                return new ResponseEntity<Client>(HttpStatus.INTERNAL_SERVER_ERROR);
+            }
         }
 
         return new ResponseEntity<Client>(HttpStatus.OK);

--- a/samples/server/petstore/spring-mvc/src/main/java/io/swagger/api/AnotherFakeApiController.java
+++ b/samples/server/petstore/spring-mvc/src/main/java/io/swagger/api/AnotherFakeApiController.java
@@ -32,12 +32,12 @@ public class AnotherFakeApiController implements AnotherFakeApi {
 
     private final ObjectMapper objectMapper;
 
-    @org.springframework.beans.factory.annotation.Autowired
-    private HttpServletRequest request;
+    private final HttpServletRequest request;
 
     @org.springframework.beans.factory.annotation.Autowired
-    public AnotherFakeApiController(ObjectMapper objectMapper) {
+    public AnotherFakeApiController(ObjectMapper objectMapper, HttpServletRequest request) {
         this.objectMapper = objectMapper;
+        this.request = request;
     }
 
     public ResponseEntity<Client> testSpecialTags(@ApiParam(value = "client model" ,required=true )  @Valid @RequestBody Client body) {

--- a/samples/server/petstore/spring-mvc/src/main/java/io/swagger/api/AnotherFakeApiController.java
+++ b/samples/server/petstore/spring-mvc/src/main/java/io/swagger/api/AnotherFakeApiController.java
@@ -21,23 +21,28 @@ import org.springframework.web.multipart.MultipartFile;
 import java.util.List;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.IOException;
+import javax.servlet.http.HttpServletRequest;
 import javax.validation.constraints.*;
 import javax.validation.Valid;
 
 @Controller
 public class AnotherFakeApiController implements AnotherFakeApi {
 
-    private final Logger log = LoggerFactory.getLogger(AnotherFakeApiController.class);
+    private static final Logger log = LoggerFactory.getLogger(AnotherFakeApiController.class);
 
     private final ObjectMapper objectMapper;
 
+    @org.springframework.beans.factory.annotation.Autowired
+    private HttpServletRequest request;
+
+    @org.springframework.beans.factory.annotation.Autowired
     public AnotherFakeApiController(ObjectMapper objectMapper) {
         this.objectMapper = objectMapper;
     }
 
     public ResponseEntity<Client> testSpecialTags(@ApiParam(value = "client model" ,required=true )  @Valid @RequestBody Client body) {
         // do some magic!
-        String accept = ((ServletRequestAttributes)RequestContextHolder.getRequestAttributes()).getRequest().getHeader("Accept");
+        String accept = request.getHeader("Accept");
         if (accept != null && accept.contains("application/json")) {
             try {
                 return new ResponseEntity<Client>(objectMapper.readValue("{  \"client\" : \"client\"}", Client.class), HttpStatus.NOT_IMPLEMENTED);

--- a/samples/server/petstore/spring-mvc/src/main/java/io/swagger/api/AnotherFakeApiController.java
+++ b/samples/server/petstore/spring-mvc/src/main/java/io/swagger/api/AnotherFakeApiController.java
@@ -1,9 +1,8 @@
 package io.swagger.api;
 
 import io.swagger.model.Client;
-
+import com.fasterxml.jackson.databind.ObjectMapper;
 import io.swagger.annotations.*;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpStatus;
@@ -14,16 +13,13 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RequestPart;
-import org.springframework.web.context.request.RequestContextHolder;
-import org.springframework.web.context.request.ServletRequestAttributes;
 import org.springframework.web.multipart.MultipartFile;
 
-import java.util.List;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import java.io.IOException;
-import javax.servlet.http.HttpServletRequest;
 import javax.validation.constraints.*;
 import javax.validation.Valid;
+import javax.servlet.http.HttpServletRequest;
+import java.io.IOException;
+import java.util.List;
 
 @Controller
 public class AnotherFakeApiController implements AnotherFakeApi {
@@ -41,7 +37,6 @@ public class AnotherFakeApiController implements AnotherFakeApi {
     }
 
     public ResponseEntity<Client> testSpecialTags(@ApiParam(value = "client model" ,required=true )  @Valid @RequestBody Client body) {
-        // do some magic!
         String accept = request.getHeader("Accept");
         if (accept != null && accept.contains("application/json")) {
             try {
@@ -52,7 +47,7 @@ public class AnotherFakeApiController implements AnotherFakeApi {
             }
         }
 
-        return new ResponseEntity<Client>(HttpStatus.OK);
+        return new ResponseEntity<Client>(HttpStatus.NOT_IMPLEMENTED);
     }
 
 }

--- a/samples/server/petstore/spring-mvc/src/main/java/io/swagger/api/FakeApi.java
+++ b/samples/server/petstore/spring-mvc/src/main/java/io/swagger/api/FakeApi.java
@@ -10,9 +10,9 @@ import io.swagger.model.Client;
 import org.threeten.bp.LocalDate;
 import org.threeten.bp.OffsetDateTime;
 import io.swagger.model.OuterComposite;
-
 import io.swagger.annotations.*;
 import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
@@ -21,12 +21,10 @@ import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.multipart.MultipartFile;
-import java.io.IOException;
 
-import java.util.List;
-import org.springframework.validation.annotation.Validated;
-import javax.validation.constraints.*;
 import javax.validation.Valid;
+import javax.validation.constraints.*;
+import java.util.List;
 
 @Api(value = "fake", description = "the fake API")
 public interface FakeApi {

--- a/samples/server/petstore/spring-mvc/src/main/java/io/swagger/api/FakeApi.java
+++ b/samples/server/petstore/spring-mvc/src/main/java/io/swagger/api/FakeApi.java
@@ -36,7 +36,7 @@ public interface FakeApi {
         @ApiResponse(code = 200, message = "Output boolean", response = Boolean.class) })
     @RequestMapping(value = "/fake/outer/boolean",
         method = RequestMethod.POST)
-    ResponseEntity<Boolean> fakeOuterBooleanSerialize(@ApiParam(value = "Input boolean as post body"  )  @Valid @RequestBody Boolean body, @RequestHeader(value = "Accept", required = false) String accept) throws Exception;
+    ResponseEntity<Boolean> fakeOuterBooleanSerialize(@ApiParam(value = "Input boolean as post body"  )  @Valid @RequestBody Boolean body);
 
 
     @ApiOperation(value = "", nickname = "fakeOuterCompositeSerialize", notes = "Test serialization of object with outer number type", response = OuterComposite.class, tags={ "fake", })
@@ -44,7 +44,7 @@ public interface FakeApi {
         @ApiResponse(code = 200, message = "Output composite", response = OuterComposite.class) })
     @RequestMapping(value = "/fake/outer/composite",
         method = RequestMethod.POST)
-    ResponseEntity<OuterComposite> fakeOuterCompositeSerialize(@ApiParam(value = "Input composite as post body"  )  @Valid @RequestBody OuterComposite body, @RequestHeader(value = "Accept", required = false) String accept) throws Exception;
+    ResponseEntity<OuterComposite> fakeOuterCompositeSerialize(@ApiParam(value = "Input composite as post body"  )  @Valid @RequestBody OuterComposite body);
 
 
     @ApiOperation(value = "", nickname = "fakeOuterNumberSerialize", notes = "Test serialization of outer number types", response = BigDecimal.class, tags={ "fake", })
@@ -52,7 +52,7 @@ public interface FakeApi {
         @ApiResponse(code = 200, message = "Output number", response = BigDecimal.class) })
     @RequestMapping(value = "/fake/outer/number",
         method = RequestMethod.POST)
-    ResponseEntity<BigDecimal> fakeOuterNumberSerialize(@ApiParam(value = "Input number as post body"  )  @Valid @RequestBody BigDecimal body, @RequestHeader(value = "Accept", required = false) String accept) throws Exception;
+    ResponseEntity<BigDecimal> fakeOuterNumberSerialize(@ApiParam(value = "Input number as post body"  )  @Valid @RequestBody BigDecimal body);
 
 
     @ApiOperation(value = "", nickname = "fakeOuterStringSerialize", notes = "Test serialization of outer string types", response = String.class, tags={ "fake", })
@@ -60,7 +60,7 @@ public interface FakeApi {
         @ApiResponse(code = 200, message = "Output string", response = String.class) })
     @RequestMapping(value = "/fake/outer/string",
         method = RequestMethod.POST)
-    ResponseEntity<String> fakeOuterStringSerialize(@ApiParam(value = "Input string as post body"  )  @Valid @RequestBody String body, @RequestHeader(value = "Accept", required = false) String accept) throws Exception;
+    ResponseEntity<String> fakeOuterStringSerialize(@ApiParam(value = "Input string as post body"  )  @Valid @RequestBody String body);
 
 
     @ApiOperation(value = "To test \"client\" model", nickname = "testClientModel", notes = "To test \"client\" model", response = Client.class, tags={ "fake", })
@@ -70,7 +70,7 @@ public interface FakeApi {
         produces = { "application/json" }, 
         consumes = { "application/json" },
         method = RequestMethod.PATCH)
-    ResponseEntity<Client> testClientModel(@ApiParam(value = "client model" ,required=true )  @Valid @RequestBody Client body, @RequestHeader(value = "Accept", required = false) String accept) throws Exception;
+    ResponseEntity<Client> testClientModel(@ApiParam(value = "client model" ,required=true )  @Valid @RequestBody Client body);
 
 
     @ApiOperation(value = "Fake endpoint for testing various parameters 假端點 偽のエンドポイント 가짜 엔드 포인트 ", nickname = "testEndpointParameters", notes = "Fake endpoint for testing various parameters 假端點 偽のエンドポイント 가짜 엔드 포인트 ", authorizations = {
@@ -83,7 +83,7 @@ public interface FakeApi {
         produces = { "application/xml; charset=utf-8", "application/json; charset=utf-8" }, 
         consumes = { "application/xml; charset=utf-8", "application/json; charset=utf-8" },
         method = RequestMethod.POST)
-    ResponseEntity<Void> testEndpointParameters(@ApiParam(value = "None", required=true) @RequestPart(value="number", required=true)  BigDecimal number,@ApiParam(value = "None", required=true) @RequestPart(value="double", required=true)  Double _double,@ApiParam(value = "None", required=true) @RequestPart(value="pattern_without_delimiter", required=true)  String patternWithoutDelimiter,@ApiParam(value = "None", required=true) @RequestPart(value="byte", required=true)  byte[] _byte,@ApiParam(value = "None") @RequestPart(value="integer", required=false)  Integer integer,@ApiParam(value = "None") @RequestPart(value="int32", required=false)  Integer int32,@ApiParam(value = "None") @RequestPart(value="int64", required=false)  Long int64,@ApiParam(value = "None") @RequestPart(value="float", required=false)  Float _float,@ApiParam(value = "None") @RequestPart(value="string", required=false)  String string,@ApiParam(value = "None") @RequestPart(value="binary", required=false)  byte[] binary,@ApiParam(value = "None") @RequestPart(value="date", required=false)  LocalDate date,@ApiParam(value = "None") @RequestPart(value="dateTime", required=false)  OffsetDateTime dateTime,@ApiParam(value = "None") @RequestPart(value="password", required=false)  String password,@ApiParam(value = "None") @RequestPart(value="callback", required=false)  String paramCallback, @RequestHeader(value = "Accept", required = false) String accept) throws Exception;
+    ResponseEntity<Void> testEndpointParameters(@ApiParam(value = "None", required=true) @RequestPart(value="number", required=true)  BigDecimal number,@ApiParam(value = "None", required=true) @RequestPart(value="double", required=true)  Double _double,@ApiParam(value = "None", required=true) @RequestPart(value="pattern_without_delimiter", required=true)  String patternWithoutDelimiter,@ApiParam(value = "None", required=true) @RequestPart(value="byte", required=true)  byte[] _byte,@ApiParam(value = "None") @RequestPart(value="integer", required=false)  Integer integer,@ApiParam(value = "None") @RequestPart(value="int32", required=false)  Integer int32,@ApiParam(value = "None") @RequestPart(value="int64", required=false)  Long int64,@ApiParam(value = "None") @RequestPart(value="float", required=false)  Float _float,@ApiParam(value = "None") @RequestPart(value="string", required=false)  String string,@ApiParam(value = "None") @RequestPart(value="binary", required=false)  byte[] binary,@ApiParam(value = "None") @RequestPart(value="date", required=false)  LocalDate date,@ApiParam(value = "None") @RequestPart(value="dateTime", required=false)  OffsetDateTime dateTime,@ApiParam(value = "None") @RequestPart(value="password", required=false)  String password,@ApiParam(value = "None") @RequestPart(value="callback", required=false)  String paramCallback);
 
 
     @ApiOperation(value = "To test enum parameters", nickname = "testEnumParameters", notes = "To test enum parameters", tags={ "fake", })
@@ -94,7 +94,7 @@ public interface FakeApi {
         produces = { "*/*" }, 
         consumes = { "*/*" },
         method = RequestMethod.GET)
-    ResponseEntity<Void> testEnumParameters(@ApiParam(value = "Form parameter enum test (string array)", allowableValues=">, $") @RequestPart(value="enum_form_string_array", required=false)  List<String> enumFormStringArray,@ApiParam(value = "Form parameter enum test (string)", allowableValues="_abc, -efg, (xyz)", defaultValue="-efg") @RequestPart(value="enum_form_string", required=false)  String enumFormString,@ApiParam(value = "Header parameter enum test (string array)" , allowableValues=">, $") @RequestHeader(value="enum_header_string_array", required=false) List<String> enumHeaderStringArray,@ApiParam(value = "Header parameter enum test (string)" , allowableValues="_abc, -efg, (xyz)", defaultValue="-efg") @RequestHeader(value="enum_header_string", required=false) String enumHeaderString,@ApiParam(value = "Query parameter enum test (string array)", allowableValues = ">, $") @Valid @RequestParam(value = "enum_query_string_array", required = false) List<String> enumQueryStringArray,@ApiParam(value = "Query parameter enum test (string)", allowableValues = "_abc, -efg, (xyz)", defaultValue = "-efg") @Valid @RequestParam(value = "enum_query_string", required = false, defaultValue="-efg") String enumQueryString,@ApiParam(value = "Query parameter enum test (double)", allowableValues = "1, -2") @Valid @RequestParam(value = "enum_query_integer", required = false) Integer enumQueryInteger,@ApiParam(value = "Query parameter enum test (double)", allowableValues="1.1, -1.2") @RequestPart(value="enum_query_double", required=false)  Double enumQueryDouble, @RequestHeader(value = "Accept", required = false) String accept) throws Exception;
+    ResponseEntity<Void> testEnumParameters(@ApiParam(value = "Form parameter enum test (string array)", allowableValues=">, $") @RequestPart(value="enum_form_string_array", required=false)  List<String> enumFormStringArray,@ApiParam(value = "Form parameter enum test (string)", allowableValues="_abc, -efg, (xyz)", defaultValue="-efg") @RequestPart(value="enum_form_string", required=false)  String enumFormString,@ApiParam(value = "Header parameter enum test (string array)" , allowableValues=">, $") @RequestHeader(value="enum_header_string_array", required=false) List<String> enumHeaderStringArray,@ApiParam(value = "Header parameter enum test (string)" , allowableValues="_abc, -efg, (xyz)", defaultValue="-efg") @RequestHeader(value="enum_header_string", required=false) String enumHeaderString,@ApiParam(value = "Query parameter enum test (string array)", allowableValues = ">, $") @Valid @RequestParam(value = "enum_query_string_array", required = false) List<String> enumQueryStringArray,@ApiParam(value = "Query parameter enum test (string)", allowableValues = "_abc, -efg, (xyz)", defaultValue = "-efg") @Valid @RequestParam(value = "enum_query_string", required = false, defaultValue="-efg") String enumQueryString,@ApiParam(value = "Query parameter enum test (double)", allowableValues = "1, -2") @Valid @RequestParam(value = "enum_query_integer", required = false) Integer enumQueryInteger,@ApiParam(value = "Query parameter enum test (double)", allowableValues="1.1, -1.2") @RequestPart(value="enum_query_double", required=false)  Double enumQueryDouble);
 
 
     @ApiOperation(value = "test inline additionalProperties", nickname = "testInlineAdditionalProperties", notes = "", tags={ "fake", })
@@ -103,7 +103,7 @@ public interface FakeApi {
     @RequestMapping(value = "/fake/inline-additionalProperties",
         consumes = { "application/json" },
         method = RequestMethod.POST)
-    ResponseEntity<Void> testInlineAdditionalProperties(@ApiParam(value = "request body" ,required=true )  @Valid @RequestBody Object param, @RequestHeader(value = "Accept", required = false) String accept) throws Exception;
+    ResponseEntity<Void> testInlineAdditionalProperties(@ApiParam(value = "request body" ,required=true )  @Valid @RequestBody Object param);
 
 
     @ApiOperation(value = "test json serialization of form data", nickname = "testJsonFormData", notes = "", tags={ "fake", })
@@ -112,6 +112,6 @@ public interface FakeApi {
     @RequestMapping(value = "/fake/jsonFormData",
         consumes = { "application/json" },
         method = RequestMethod.GET)
-    ResponseEntity<Void> testJsonFormData(@ApiParam(value = "field1", required=true) @RequestPart(value="param", required=true)  String param,@ApiParam(value = "field2", required=true) @RequestPart(value="param2", required=true)  String param2, @RequestHeader(value = "Accept", required = false) String accept) throws Exception;
+    ResponseEntity<Void> testJsonFormData(@ApiParam(value = "field1", required=true) @RequestPart(value="param", required=true)  String param,@ApiParam(value = "field2", required=true) @RequestPart(value="param2", required=true)  String param2);
 
 }

--- a/samples/server/petstore/spring-mvc/src/main/java/io/swagger/api/FakeApiController.java
+++ b/samples/server/petstore/spring-mvc/src/main/java/io/swagger/api/FakeApiController.java
@@ -36,12 +36,12 @@ public class FakeApiController implements FakeApi {
 
     private final ObjectMapper objectMapper;
 
-    @org.springframework.beans.factory.annotation.Autowired
-    private HttpServletRequest request;
+    private final HttpServletRequest request;
 
     @org.springframework.beans.factory.annotation.Autowired
-    public FakeApiController(ObjectMapper objectMapper) {
+    public FakeApiController(ObjectMapper objectMapper, HttpServletRequest request) {
         this.objectMapper = objectMapper;
+        this.request = request;
     }
 
     public ResponseEntity<Boolean> fakeOuterBooleanSerialize(@ApiParam(value = "Input boolean as post body"  )  @Valid @RequestBody Boolean body) {

--- a/samples/server/petstore/spring-mvc/src/main/java/io/swagger/api/FakeApiController.java
+++ b/samples/server/petstore/spring-mvc/src/main/java/io/swagger/api/FakeApiController.java
@@ -25,23 +25,28 @@ import org.springframework.web.multipart.MultipartFile;
 import java.util.List;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.IOException;
+import javax.servlet.http.HttpServletRequest;
 import javax.validation.constraints.*;
 import javax.validation.Valid;
 
 @Controller
 public class FakeApiController implements FakeApi {
 
-    private final Logger log = LoggerFactory.getLogger(AnotherFakeApiController.class);
+    private static final Logger log = LoggerFactory.getLogger(FakeApiController.class);
 
     private final ObjectMapper objectMapper;
 
+    @org.springframework.beans.factory.annotation.Autowired
+    private HttpServletRequest request;
+
+    @org.springframework.beans.factory.annotation.Autowired
     public FakeApiController(ObjectMapper objectMapper) {
         this.objectMapper = objectMapper;
     }
 
     public ResponseEntity<Boolean> fakeOuterBooleanSerialize(@ApiParam(value = "Input boolean as post body"  )  @Valid @RequestBody Boolean body) {
         // do some magic!
-        String accept = ((ServletRequestAttributes)RequestContextHolder.getRequestAttributes()).getRequest().getHeader("Accept");
+        String accept = request.getHeader("Accept");
         if (accept != null && accept.contains("application/json")) {
             try {
                 return new ResponseEntity<Boolean>(objectMapper.readValue("{ }", Boolean.class), HttpStatus.NOT_IMPLEMENTED);
@@ -56,7 +61,7 @@ public class FakeApiController implements FakeApi {
 
     public ResponseEntity<OuterComposite> fakeOuterCompositeSerialize(@ApiParam(value = "Input composite as post body"  )  @Valid @RequestBody OuterComposite body) {
         // do some magic!
-        String accept = ((ServletRequestAttributes)RequestContextHolder.getRequestAttributes()).getRequest().getHeader("Accept");
+        String accept = request.getHeader("Accept");
         if (accept != null && accept.contains("application/json")) {
             try {
                 return new ResponseEntity<OuterComposite>(objectMapper.readValue("{  \"my_string\" : { },  \"my_number\" : { },  \"my_boolean\" : { }}", OuterComposite.class), HttpStatus.NOT_IMPLEMENTED);
@@ -71,7 +76,7 @@ public class FakeApiController implements FakeApi {
 
     public ResponseEntity<BigDecimal> fakeOuterNumberSerialize(@ApiParam(value = "Input number as post body"  )  @Valid @RequestBody BigDecimal body) {
         // do some magic!
-        String accept = ((ServletRequestAttributes)RequestContextHolder.getRequestAttributes()).getRequest().getHeader("Accept");
+        String accept = request.getHeader("Accept");
         if (accept != null && accept.contains("application/json")) {
             try {
                 return new ResponseEntity<BigDecimal>(objectMapper.readValue("{ }", BigDecimal.class), HttpStatus.NOT_IMPLEMENTED);
@@ -86,7 +91,7 @@ public class FakeApiController implements FakeApi {
 
     public ResponseEntity<String> fakeOuterStringSerialize(@ApiParam(value = "Input string as post body"  )  @Valid @RequestBody String body) {
         // do some magic!
-        String accept = ((ServletRequestAttributes)RequestContextHolder.getRequestAttributes()).getRequest().getHeader("Accept");
+        String accept = request.getHeader("Accept");
         if (accept != null && accept.contains("application/json")) {
             try {
                 return new ResponseEntity<String>(objectMapper.readValue("{ }", String.class), HttpStatus.NOT_IMPLEMENTED);
@@ -101,7 +106,7 @@ public class FakeApiController implements FakeApi {
 
     public ResponseEntity<Client> testClientModel(@ApiParam(value = "client model" ,required=true )  @Valid @RequestBody Client body) {
         // do some magic!
-        String accept = ((ServletRequestAttributes)RequestContextHolder.getRequestAttributes()).getRequest().getHeader("Accept");
+        String accept = request.getHeader("Accept");
         if (accept != null && accept.contains("application/json")) {
             try {
                 return new ResponseEntity<Client>(objectMapper.readValue("{  \"client\" : \"client\"}", Client.class), HttpStatus.NOT_IMPLEMENTED);
@@ -116,25 +121,25 @@ public class FakeApiController implements FakeApi {
 
     public ResponseEntity<Void> testEndpointParameters(@ApiParam(value = "None", required=true) @RequestPart(value="number", required=true)  BigDecimal number,@ApiParam(value = "None", required=true) @RequestPart(value="double", required=true)  Double _double,@ApiParam(value = "None", required=true) @RequestPart(value="pattern_without_delimiter", required=true)  String patternWithoutDelimiter,@ApiParam(value = "None", required=true) @RequestPart(value="byte", required=true)  byte[] _byte,@ApiParam(value = "None") @RequestPart(value="integer", required=false)  Integer integer,@ApiParam(value = "None") @RequestPart(value="int32", required=false)  Integer int32,@ApiParam(value = "None") @RequestPart(value="int64", required=false)  Long int64,@ApiParam(value = "None") @RequestPart(value="float", required=false)  Float _float,@ApiParam(value = "None") @RequestPart(value="string", required=false)  String string,@ApiParam(value = "None") @RequestPart(value="binary", required=false)  byte[] binary,@ApiParam(value = "None") @RequestPart(value="date", required=false)  LocalDate date,@ApiParam(value = "None") @RequestPart(value="dateTime", required=false)  OffsetDateTime dateTime,@ApiParam(value = "None") @RequestPart(value="password", required=false)  String password,@ApiParam(value = "None") @RequestPart(value="callback", required=false)  String paramCallback) {
         // do some magic!
-        String accept = ((ServletRequestAttributes)RequestContextHolder.getRequestAttributes()).getRequest().getHeader("Accept");
+        String accept = request.getHeader("Accept");
         return new ResponseEntity<Void>(HttpStatus.OK);
     }
 
     public ResponseEntity<Void> testEnumParameters(@ApiParam(value = "Form parameter enum test (string array)", allowableValues=">, $") @RequestPart(value="enum_form_string_array", required=false)  List<String> enumFormStringArray,@ApiParam(value = "Form parameter enum test (string)", allowableValues="_abc, -efg, (xyz)", defaultValue="-efg") @RequestPart(value="enum_form_string", required=false)  String enumFormString,@ApiParam(value = "Header parameter enum test (string array)" , allowableValues=">, $") @RequestHeader(value="enum_header_string_array", required=false) List<String> enumHeaderStringArray,@ApiParam(value = "Header parameter enum test (string)" , allowableValues="_abc, -efg, (xyz)", defaultValue="-efg") @RequestHeader(value="enum_header_string", required=false) String enumHeaderString,@ApiParam(value = "Query parameter enum test (string array)", allowableValues = ">, $") @Valid @RequestParam(value = "enum_query_string_array", required = false) List<String> enumQueryStringArray,@ApiParam(value = "Query parameter enum test (string)", allowableValues = "_abc, -efg, (xyz)", defaultValue = "-efg") @Valid @RequestParam(value = "enum_query_string", required = false, defaultValue="-efg") String enumQueryString,@ApiParam(value = "Query parameter enum test (double)", allowableValues = "1, -2") @Valid @RequestParam(value = "enum_query_integer", required = false) Integer enumQueryInteger,@ApiParam(value = "Query parameter enum test (double)", allowableValues="1.1, -1.2") @RequestPart(value="enum_query_double", required=false)  Double enumQueryDouble) {
         // do some magic!
-        String accept = ((ServletRequestAttributes)RequestContextHolder.getRequestAttributes()).getRequest().getHeader("Accept");
+        String accept = request.getHeader("Accept");
         return new ResponseEntity<Void>(HttpStatus.OK);
     }
 
     public ResponseEntity<Void> testInlineAdditionalProperties(@ApiParam(value = "request body" ,required=true )  @Valid @RequestBody Object param) {
         // do some magic!
-        String accept = ((ServletRequestAttributes)RequestContextHolder.getRequestAttributes()).getRequest().getHeader("Accept");
+        String accept = request.getHeader("Accept");
         return new ResponseEntity<Void>(HttpStatus.OK);
     }
 
     public ResponseEntity<Void> testJsonFormData(@ApiParam(value = "field1", required=true) @RequestPart(value="param", required=true)  String param,@ApiParam(value = "field2", required=true) @RequestPart(value="param2", required=true)  String param2) {
         // do some magic!
-        String accept = ((ServletRequestAttributes)RequestContextHolder.getRequestAttributes()).getRequest().getHeader("Accept");
+        String accept = request.getHeader("Accept");
         return new ResponseEntity<Void>(HttpStatus.OK);
     }
 

--- a/samples/server/petstore/spring-mvc/src/main/java/io/swagger/api/FakeApiController.java
+++ b/samples/server/petstore/spring-mvc/src/main/java/io/swagger/api/FakeApiController.java
@@ -8,6 +8,8 @@ import io.swagger.model.OuterComposite;
 
 import io.swagger.annotations.*;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
@@ -16,6 +18,8 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RequestPart;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.util.List;
@@ -26,109 +30,111 @@ import javax.validation.Valid;
 
 @Controller
 public class FakeApiController implements FakeApi {
+
+    private final Logger log = LoggerFactory.getLogger(AnotherFakeApiController.class);
+
     private final ObjectMapper objectMapper;
 
     public FakeApiController(ObjectMapper objectMapper) {
         this.objectMapper = objectMapper;
     }
 
-    public ResponseEntity<Boolean> fakeOuterBooleanSerialize(@ApiParam(value = "Input boolean as post body"  )  @Valid @RequestBody Boolean body,
-        @RequestHeader(value = "Accept", required = false) String accept) throws Exception {
+    public ResponseEntity<Boolean> fakeOuterBooleanSerialize(@ApiParam(value = "Input boolean as post body"  )  @Valid @RequestBody Boolean body) {
         // do some magic!
-
+        String accept = ((ServletRequestAttributes)RequestContextHolder.getRequestAttributes()).getRequest().getHeader("Accept");
         if (accept != null && accept.contains("application/json")) {
-            return new ResponseEntity<Boolean>(objectMapper.readValue("{ }", Boolean.class), HttpStatus.OK);
+            try {
+                return new ResponseEntity<Boolean>(objectMapper.readValue("{ }", Boolean.class), HttpStatus.NOT_IMPLEMENTED);
+            } catch (IOException e) {
+                log.error("Couldn't serialize response for content type application/json", e);
+                return new ResponseEntity<Boolean>(HttpStatus.INTERNAL_SERVER_ERROR);
+            }
         }
 
         return new ResponseEntity<Boolean>(HttpStatus.OK);
     }
 
-    public ResponseEntity<OuterComposite> fakeOuterCompositeSerialize(@ApiParam(value = "Input composite as post body"  )  @Valid @RequestBody OuterComposite body,
-        @RequestHeader(value = "Accept", required = false) String accept) throws Exception {
+    public ResponseEntity<OuterComposite> fakeOuterCompositeSerialize(@ApiParam(value = "Input composite as post body"  )  @Valid @RequestBody OuterComposite body) {
         // do some magic!
-
+        String accept = ((ServletRequestAttributes)RequestContextHolder.getRequestAttributes()).getRequest().getHeader("Accept");
         if (accept != null && accept.contains("application/json")) {
-            return new ResponseEntity<OuterComposite>(objectMapper.readValue("{  \"my_string\" : { },  \"my_number\" : { },  \"my_boolean\" : { }}", OuterComposite.class), HttpStatus.OK);
+            try {
+                return new ResponseEntity<OuterComposite>(objectMapper.readValue("{  \"my_string\" : { },  \"my_number\" : { },  \"my_boolean\" : { }}", OuterComposite.class), HttpStatus.NOT_IMPLEMENTED);
+            } catch (IOException e) {
+                log.error("Couldn't serialize response for content type application/json", e);
+                return new ResponseEntity<OuterComposite>(HttpStatus.INTERNAL_SERVER_ERROR);
+            }
         }
 
         return new ResponseEntity<OuterComposite>(HttpStatus.OK);
     }
 
-    public ResponseEntity<BigDecimal> fakeOuterNumberSerialize(@ApiParam(value = "Input number as post body"  )  @Valid @RequestBody BigDecimal body,
-        @RequestHeader(value = "Accept", required = false) String accept) throws Exception {
+    public ResponseEntity<BigDecimal> fakeOuterNumberSerialize(@ApiParam(value = "Input number as post body"  )  @Valid @RequestBody BigDecimal body) {
         // do some magic!
-
+        String accept = ((ServletRequestAttributes)RequestContextHolder.getRequestAttributes()).getRequest().getHeader("Accept");
         if (accept != null && accept.contains("application/json")) {
-            return new ResponseEntity<BigDecimal>(objectMapper.readValue("{ }", BigDecimal.class), HttpStatus.OK);
+            try {
+                return new ResponseEntity<BigDecimal>(objectMapper.readValue("{ }", BigDecimal.class), HttpStatus.NOT_IMPLEMENTED);
+            } catch (IOException e) {
+                log.error("Couldn't serialize response for content type application/json", e);
+                return new ResponseEntity<BigDecimal>(HttpStatus.INTERNAL_SERVER_ERROR);
+            }
         }
 
         return new ResponseEntity<BigDecimal>(HttpStatus.OK);
     }
 
-    public ResponseEntity<String> fakeOuterStringSerialize(@ApiParam(value = "Input string as post body"  )  @Valid @RequestBody String body,
-        @RequestHeader(value = "Accept", required = false) String accept) throws Exception {
+    public ResponseEntity<String> fakeOuterStringSerialize(@ApiParam(value = "Input string as post body"  )  @Valid @RequestBody String body) {
         // do some magic!
-
+        String accept = ((ServletRequestAttributes)RequestContextHolder.getRequestAttributes()).getRequest().getHeader("Accept");
         if (accept != null && accept.contains("application/json")) {
-            return new ResponseEntity<String>(objectMapper.readValue("{ }", String.class), HttpStatus.OK);
+            try {
+                return new ResponseEntity<String>(objectMapper.readValue("{ }", String.class), HttpStatus.NOT_IMPLEMENTED);
+            } catch (IOException e) {
+                log.error("Couldn't serialize response for content type application/json", e);
+                return new ResponseEntity<String>(HttpStatus.INTERNAL_SERVER_ERROR);
+            }
         }
 
         return new ResponseEntity<String>(HttpStatus.OK);
     }
 
-    public ResponseEntity<Client> testClientModel(@ApiParam(value = "client model" ,required=true )  @Valid @RequestBody Client body,
-        @RequestHeader(value = "Accept", required = false) String accept) throws Exception {
+    public ResponseEntity<Client> testClientModel(@ApiParam(value = "client model" ,required=true )  @Valid @RequestBody Client body) {
         // do some magic!
-
+        String accept = ((ServletRequestAttributes)RequestContextHolder.getRequestAttributes()).getRequest().getHeader("Accept");
         if (accept != null && accept.contains("application/json")) {
-            return new ResponseEntity<Client>(objectMapper.readValue("{  \"client\" : \"client\"}", Client.class), HttpStatus.OK);
+            try {
+                return new ResponseEntity<Client>(objectMapper.readValue("{  \"client\" : \"client\"}", Client.class), HttpStatus.NOT_IMPLEMENTED);
+            } catch (IOException e) {
+                log.error("Couldn't serialize response for content type application/json", e);
+                return new ResponseEntity<Client>(HttpStatus.INTERNAL_SERVER_ERROR);
+            }
         }
 
         return new ResponseEntity<Client>(HttpStatus.OK);
     }
 
-    public ResponseEntity<Void> testEndpointParameters(@ApiParam(value = "None", required=true) @RequestPart(value="number", required=true)  BigDecimal number,
-        @ApiParam(value = "None", required=true) @RequestPart(value="double", required=true)  Double _double,
-        @ApiParam(value = "None", required=true) @RequestPart(value="pattern_without_delimiter", required=true)  String patternWithoutDelimiter,
-        @ApiParam(value = "None", required=true) @RequestPart(value="byte", required=true)  byte[] _byte,
-        @ApiParam(value = "None") @RequestPart(value="integer", required=false)  Integer integer,
-        @ApiParam(value = "None") @RequestPart(value="int32", required=false)  Integer int32,
-        @ApiParam(value = "None") @RequestPart(value="int64", required=false)  Long int64,
-        @ApiParam(value = "None") @RequestPart(value="float", required=false)  Float _float,
-        @ApiParam(value = "None") @RequestPart(value="string", required=false)  String string,
-        @ApiParam(value = "None") @RequestPart(value="binary", required=false)  byte[] binary,
-        @ApiParam(value = "None") @RequestPart(value="date", required=false)  LocalDate date,
-        @ApiParam(value = "None") @RequestPart(value="dateTime", required=false)  OffsetDateTime dateTime,
-        @ApiParam(value = "None") @RequestPart(value="password", required=false)  String password,
-        @ApiParam(value = "None") @RequestPart(value="callback", required=false)  String paramCallback,
-        @RequestHeader(value = "Accept", required = false) String accept) throws Exception {
+    public ResponseEntity<Void> testEndpointParameters(@ApiParam(value = "None", required=true) @RequestPart(value="number", required=true)  BigDecimal number,@ApiParam(value = "None", required=true) @RequestPart(value="double", required=true)  Double _double,@ApiParam(value = "None", required=true) @RequestPart(value="pattern_without_delimiter", required=true)  String patternWithoutDelimiter,@ApiParam(value = "None", required=true) @RequestPart(value="byte", required=true)  byte[] _byte,@ApiParam(value = "None") @RequestPart(value="integer", required=false)  Integer integer,@ApiParam(value = "None") @RequestPart(value="int32", required=false)  Integer int32,@ApiParam(value = "None") @RequestPart(value="int64", required=false)  Long int64,@ApiParam(value = "None") @RequestPart(value="float", required=false)  Float _float,@ApiParam(value = "None") @RequestPart(value="string", required=false)  String string,@ApiParam(value = "None") @RequestPart(value="binary", required=false)  byte[] binary,@ApiParam(value = "None") @RequestPart(value="date", required=false)  LocalDate date,@ApiParam(value = "None") @RequestPart(value="dateTime", required=false)  OffsetDateTime dateTime,@ApiParam(value = "None") @RequestPart(value="password", required=false)  String password,@ApiParam(value = "None") @RequestPart(value="callback", required=false)  String paramCallback) {
         // do some magic!
+        String accept = ((ServletRequestAttributes)RequestContextHolder.getRequestAttributes()).getRequest().getHeader("Accept");
         return new ResponseEntity<Void>(HttpStatus.OK);
     }
 
-    public ResponseEntity<Void> testEnumParameters(@ApiParam(value = "Form parameter enum test (string array)", allowableValues=">, $") @RequestPart(value="enum_form_string_array", required=false)  List<String> enumFormStringArray,
-        @ApiParam(value = "Form parameter enum test (string)", allowableValues="_abc, -efg, (xyz)", defaultValue="-efg") @RequestPart(value="enum_form_string", required=false)  String enumFormString,
-        @ApiParam(value = "Header parameter enum test (string array)" , allowableValues=">, $") @RequestHeader(value="enum_header_string_array", required=false) List<String> enumHeaderStringArray,
-        @ApiParam(value = "Header parameter enum test (string)" , allowableValues="_abc, -efg, (xyz)", defaultValue="-efg") @RequestHeader(value="enum_header_string", required=false) String enumHeaderString,
-        @ApiParam(value = "Query parameter enum test (string array)", allowableValues = ">, $") @Valid @RequestParam(value = "enum_query_string_array", required = false) List<String> enumQueryStringArray,
-        @ApiParam(value = "Query parameter enum test (string)", allowableValues = "_abc, -efg, (xyz)", defaultValue = "-efg") @Valid @RequestParam(value = "enum_query_string", required = false, defaultValue="-efg") String enumQueryString,
-        @ApiParam(value = "Query parameter enum test (double)", allowableValues = "1, -2") @Valid @RequestParam(value = "enum_query_integer", required = false) Integer enumQueryInteger,
-        @ApiParam(value = "Query parameter enum test (double)", allowableValues="1.1, -1.2") @RequestPart(value="enum_query_double", required=false)  Double enumQueryDouble,
-        @RequestHeader(value = "Accept", required = false) String accept) throws Exception {
+    public ResponseEntity<Void> testEnumParameters(@ApiParam(value = "Form parameter enum test (string array)", allowableValues=">, $") @RequestPart(value="enum_form_string_array", required=false)  List<String> enumFormStringArray,@ApiParam(value = "Form parameter enum test (string)", allowableValues="_abc, -efg, (xyz)", defaultValue="-efg") @RequestPart(value="enum_form_string", required=false)  String enumFormString,@ApiParam(value = "Header parameter enum test (string array)" , allowableValues=">, $") @RequestHeader(value="enum_header_string_array", required=false) List<String> enumHeaderStringArray,@ApiParam(value = "Header parameter enum test (string)" , allowableValues="_abc, -efg, (xyz)", defaultValue="-efg") @RequestHeader(value="enum_header_string", required=false) String enumHeaderString,@ApiParam(value = "Query parameter enum test (string array)", allowableValues = ">, $") @Valid @RequestParam(value = "enum_query_string_array", required = false) List<String> enumQueryStringArray,@ApiParam(value = "Query parameter enum test (string)", allowableValues = "_abc, -efg, (xyz)", defaultValue = "-efg") @Valid @RequestParam(value = "enum_query_string", required = false, defaultValue="-efg") String enumQueryString,@ApiParam(value = "Query parameter enum test (double)", allowableValues = "1, -2") @Valid @RequestParam(value = "enum_query_integer", required = false) Integer enumQueryInteger,@ApiParam(value = "Query parameter enum test (double)", allowableValues="1.1, -1.2") @RequestPart(value="enum_query_double", required=false)  Double enumQueryDouble) {
         // do some magic!
+        String accept = ((ServletRequestAttributes)RequestContextHolder.getRequestAttributes()).getRequest().getHeader("Accept");
         return new ResponseEntity<Void>(HttpStatus.OK);
     }
 
-    public ResponseEntity<Void> testInlineAdditionalProperties(@ApiParam(value = "request body" ,required=true )  @Valid @RequestBody Object param,
-        @RequestHeader(value = "Accept", required = false) String accept) throws Exception {
+    public ResponseEntity<Void> testInlineAdditionalProperties(@ApiParam(value = "request body" ,required=true )  @Valid @RequestBody Object param) {
         // do some magic!
+        String accept = ((ServletRequestAttributes)RequestContextHolder.getRequestAttributes()).getRequest().getHeader("Accept");
         return new ResponseEntity<Void>(HttpStatus.OK);
     }
 
-    public ResponseEntity<Void> testJsonFormData(@ApiParam(value = "field1", required=true) @RequestPart(value="param", required=true)  String param,
-        @ApiParam(value = "field2", required=true) @RequestPart(value="param2", required=true)  String param2,
-        @RequestHeader(value = "Accept", required = false) String accept) throws Exception {
+    public ResponseEntity<Void> testJsonFormData(@ApiParam(value = "field1", required=true) @RequestPart(value="param", required=true)  String param,@ApiParam(value = "field2", required=true) @RequestPart(value="param2", required=true)  String param2) {
         // do some magic!
+        String accept = ((ServletRequestAttributes)RequestContextHolder.getRequestAttributes()).getRequest().getHeader("Accept");
         return new ResponseEntity<Void>(HttpStatus.OK);
     }
 

--- a/samples/server/petstore/spring-mvc/src/main/java/io/swagger/api/FakeApiController.java
+++ b/samples/server/petstore/spring-mvc/src/main/java/io/swagger/api/FakeApiController.java
@@ -5,9 +5,8 @@ import io.swagger.model.Client;
 import org.threeten.bp.LocalDate;
 import org.threeten.bp.OffsetDateTime;
 import io.swagger.model.OuterComposite;
-
+import com.fasterxml.jackson.databind.ObjectMapper;
 import io.swagger.annotations.*;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpStatus;
@@ -18,16 +17,13 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RequestPart;
-import org.springframework.web.context.request.RequestContextHolder;
-import org.springframework.web.context.request.ServletRequestAttributes;
 import org.springframework.web.multipart.MultipartFile;
 
-import java.util.List;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import java.io.IOException;
-import javax.servlet.http.HttpServletRequest;
 import javax.validation.constraints.*;
 import javax.validation.Valid;
+import javax.servlet.http.HttpServletRequest;
+import java.io.IOException;
+import java.util.List;
 
 @Controller
 public class FakeApiController implements FakeApi {
@@ -45,7 +41,6 @@ public class FakeApiController implements FakeApi {
     }
 
     public ResponseEntity<Boolean> fakeOuterBooleanSerialize(@ApiParam(value = "Input boolean as post body"  )  @Valid @RequestBody Boolean body) {
-        // do some magic!
         String accept = request.getHeader("Accept");
         if (accept != null && accept.contains("application/json")) {
             try {
@@ -56,11 +51,10 @@ public class FakeApiController implements FakeApi {
             }
         }
 
-        return new ResponseEntity<Boolean>(HttpStatus.OK);
+        return new ResponseEntity<Boolean>(HttpStatus.NOT_IMPLEMENTED);
     }
 
     public ResponseEntity<OuterComposite> fakeOuterCompositeSerialize(@ApiParam(value = "Input composite as post body"  )  @Valid @RequestBody OuterComposite body) {
-        // do some magic!
         String accept = request.getHeader("Accept");
         if (accept != null && accept.contains("application/json")) {
             try {
@@ -71,11 +65,10 @@ public class FakeApiController implements FakeApi {
             }
         }
 
-        return new ResponseEntity<OuterComposite>(HttpStatus.OK);
+        return new ResponseEntity<OuterComposite>(HttpStatus.NOT_IMPLEMENTED);
     }
 
     public ResponseEntity<BigDecimal> fakeOuterNumberSerialize(@ApiParam(value = "Input number as post body"  )  @Valid @RequestBody BigDecimal body) {
-        // do some magic!
         String accept = request.getHeader("Accept");
         if (accept != null && accept.contains("application/json")) {
             try {
@@ -86,11 +79,10 @@ public class FakeApiController implements FakeApi {
             }
         }
 
-        return new ResponseEntity<BigDecimal>(HttpStatus.OK);
+        return new ResponseEntity<BigDecimal>(HttpStatus.NOT_IMPLEMENTED);
     }
 
     public ResponseEntity<String> fakeOuterStringSerialize(@ApiParam(value = "Input string as post body"  )  @Valid @RequestBody String body) {
-        // do some magic!
         String accept = request.getHeader("Accept");
         if (accept != null && accept.contains("application/json")) {
             try {
@@ -101,11 +93,10 @@ public class FakeApiController implements FakeApi {
             }
         }
 
-        return new ResponseEntity<String>(HttpStatus.OK);
+        return new ResponseEntity<String>(HttpStatus.NOT_IMPLEMENTED);
     }
 
     public ResponseEntity<Client> testClientModel(@ApiParam(value = "client model" ,required=true )  @Valid @RequestBody Client body) {
-        // do some magic!
         String accept = request.getHeader("Accept");
         if (accept != null && accept.contains("application/json")) {
             try {
@@ -116,31 +107,27 @@ public class FakeApiController implements FakeApi {
             }
         }
 
-        return new ResponseEntity<Client>(HttpStatus.OK);
+        return new ResponseEntity<Client>(HttpStatus.NOT_IMPLEMENTED);
     }
 
     public ResponseEntity<Void> testEndpointParameters(@ApiParam(value = "None", required=true) @RequestPart(value="number", required=true)  BigDecimal number,@ApiParam(value = "None", required=true) @RequestPart(value="double", required=true)  Double _double,@ApiParam(value = "None", required=true) @RequestPart(value="pattern_without_delimiter", required=true)  String patternWithoutDelimiter,@ApiParam(value = "None", required=true) @RequestPart(value="byte", required=true)  byte[] _byte,@ApiParam(value = "None") @RequestPart(value="integer", required=false)  Integer integer,@ApiParam(value = "None") @RequestPart(value="int32", required=false)  Integer int32,@ApiParam(value = "None") @RequestPart(value="int64", required=false)  Long int64,@ApiParam(value = "None") @RequestPart(value="float", required=false)  Float _float,@ApiParam(value = "None") @RequestPart(value="string", required=false)  String string,@ApiParam(value = "None") @RequestPart(value="binary", required=false)  byte[] binary,@ApiParam(value = "None") @RequestPart(value="date", required=false)  LocalDate date,@ApiParam(value = "None") @RequestPart(value="dateTime", required=false)  OffsetDateTime dateTime,@ApiParam(value = "None") @RequestPart(value="password", required=false)  String password,@ApiParam(value = "None") @RequestPart(value="callback", required=false)  String paramCallback) {
-        // do some magic!
         String accept = request.getHeader("Accept");
-        return new ResponseEntity<Void>(HttpStatus.OK);
+        return new ResponseEntity<Void>(HttpStatus.NOT_IMPLEMENTED);
     }
 
     public ResponseEntity<Void> testEnumParameters(@ApiParam(value = "Form parameter enum test (string array)", allowableValues=">, $") @RequestPart(value="enum_form_string_array", required=false)  List<String> enumFormStringArray,@ApiParam(value = "Form parameter enum test (string)", allowableValues="_abc, -efg, (xyz)", defaultValue="-efg") @RequestPart(value="enum_form_string", required=false)  String enumFormString,@ApiParam(value = "Header parameter enum test (string array)" , allowableValues=">, $") @RequestHeader(value="enum_header_string_array", required=false) List<String> enumHeaderStringArray,@ApiParam(value = "Header parameter enum test (string)" , allowableValues="_abc, -efg, (xyz)", defaultValue="-efg") @RequestHeader(value="enum_header_string", required=false) String enumHeaderString,@ApiParam(value = "Query parameter enum test (string array)", allowableValues = ">, $") @Valid @RequestParam(value = "enum_query_string_array", required = false) List<String> enumQueryStringArray,@ApiParam(value = "Query parameter enum test (string)", allowableValues = "_abc, -efg, (xyz)", defaultValue = "-efg") @Valid @RequestParam(value = "enum_query_string", required = false, defaultValue="-efg") String enumQueryString,@ApiParam(value = "Query parameter enum test (double)", allowableValues = "1, -2") @Valid @RequestParam(value = "enum_query_integer", required = false) Integer enumQueryInteger,@ApiParam(value = "Query parameter enum test (double)", allowableValues="1.1, -1.2") @RequestPart(value="enum_query_double", required=false)  Double enumQueryDouble) {
-        // do some magic!
         String accept = request.getHeader("Accept");
-        return new ResponseEntity<Void>(HttpStatus.OK);
+        return new ResponseEntity<Void>(HttpStatus.NOT_IMPLEMENTED);
     }
 
     public ResponseEntity<Void> testInlineAdditionalProperties(@ApiParam(value = "request body" ,required=true )  @Valid @RequestBody Object param) {
-        // do some magic!
         String accept = request.getHeader("Accept");
-        return new ResponseEntity<Void>(HttpStatus.OK);
+        return new ResponseEntity<Void>(HttpStatus.NOT_IMPLEMENTED);
     }
 
     public ResponseEntity<Void> testJsonFormData(@ApiParam(value = "field1", required=true) @RequestPart(value="param", required=true)  String param,@ApiParam(value = "field2", required=true) @RequestPart(value="param2", required=true)  String param2) {
-        // do some magic!
         String accept = request.getHeader("Accept");
-        return new ResponseEntity<Void>(HttpStatus.OK);
+        return new ResponseEntity<Void>(HttpStatus.NOT_IMPLEMENTED);
     }
 
 }

--- a/samples/server/petstore/spring-mvc/src/main/java/io/swagger/api/FakeClassnameTestApi.java
+++ b/samples/server/petstore/spring-mvc/src/main/java/io/swagger/api/FakeClassnameTestApi.java
@@ -6,9 +6,9 @@
 package io.swagger.api;
 
 import io.swagger.model.Client;
-
 import io.swagger.annotations.*;
 import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
@@ -17,12 +17,10 @@ import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.multipart.MultipartFile;
-import java.io.IOException;
 
-import java.util.List;
-import org.springframework.validation.annotation.Validated;
-import javax.validation.constraints.*;
 import javax.validation.Valid;
+import javax.validation.constraints.*;
+import java.util.List;
 
 @Api(value = "fake_classname_test", description = "the fake_classname_test API")
 public interface FakeClassnameTestApi {

--- a/samples/server/petstore/spring-mvc/src/main/java/io/swagger/api/FakeClassnameTestApi.java
+++ b/samples/server/petstore/spring-mvc/src/main/java/io/swagger/api/FakeClassnameTestApi.java
@@ -36,6 +36,6 @@ public interface FakeClassnameTestApi {
         produces = { "application/json" }, 
         consumes = { "application/json" },
         method = RequestMethod.PATCH)
-    ResponseEntity<Client> testClassname(@ApiParam(value = "client model" ,required=true )  @Valid @RequestBody Client body, @RequestHeader(value = "Accept", required = false) String accept) throws Exception;
+    ResponseEntity<Client> testClassname(@ApiParam(value = "client model" ,required=true )  @Valid @RequestBody Client body);
 
 }

--- a/samples/server/petstore/spring-mvc/src/main/java/io/swagger/api/FakeClassnameTestApiController.java
+++ b/samples/server/petstore/spring-mvc/src/main/java/io/swagger/api/FakeClassnameTestApiController.java
@@ -4,6 +4,8 @@ import io.swagger.model.Client;
 
 import io.swagger.annotations.*;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
@@ -12,6 +14,8 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RequestPart;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.util.List;
@@ -22,18 +26,25 @@ import javax.validation.Valid;
 
 @Controller
 public class FakeClassnameTestApiController implements FakeClassnameTestApi {
+
+    private final Logger log = LoggerFactory.getLogger(AnotherFakeApiController.class);
+
     private final ObjectMapper objectMapper;
 
     public FakeClassnameTestApiController(ObjectMapper objectMapper) {
         this.objectMapper = objectMapper;
     }
 
-    public ResponseEntity<Client> testClassname(@ApiParam(value = "client model" ,required=true )  @Valid @RequestBody Client body,
-        @RequestHeader(value = "Accept", required = false) String accept) throws Exception {
+    public ResponseEntity<Client> testClassname(@ApiParam(value = "client model" ,required=true )  @Valid @RequestBody Client body) {
         // do some magic!
-
+        String accept = ((ServletRequestAttributes)RequestContextHolder.getRequestAttributes()).getRequest().getHeader("Accept");
         if (accept != null && accept.contains("application/json")) {
-            return new ResponseEntity<Client>(objectMapper.readValue("{  \"client\" : \"client\"}", Client.class), HttpStatus.OK);
+            try {
+                return new ResponseEntity<Client>(objectMapper.readValue("{  \"client\" : \"client\"}", Client.class), HttpStatus.NOT_IMPLEMENTED);
+            } catch (IOException e) {
+                log.error("Couldn't serialize response for content type application/json", e);
+                return new ResponseEntity<Client>(HttpStatus.INTERNAL_SERVER_ERROR);
+            }
         }
 
         return new ResponseEntity<Client>(HttpStatus.OK);

--- a/samples/server/petstore/spring-mvc/src/main/java/io/swagger/api/FakeClassnameTestApiController.java
+++ b/samples/server/petstore/spring-mvc/src/main/java/io/swagger/api/FakeClassnameTestApiController.java
@@ -21,23 +21,28 @@ import org.springframework.web.multipart.MultipartFile;
 import java.util.List;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.IOException;
+import javax.servlet.http.HttpServletRequest;
 import javax.validation.constraints.*;
 import javax.validation.Valid;
 
 @Controller
 public class FakeClassnameTestApiController implements FakeClassnameTestApi {
 
-    private final Logger log = LoggerFactory.getLogger(AnotherFakeApiController.class);
+    private static final Logger log = LoggerFactory.getLogger(FakeClassnameTestApiController.class);
 
     private final ObjectMapper objectMapper;
 
+    @org.springframework.beans.factory.annotation.Autowired
+    private HttpServletRequest request;
+
+    @org.springframework.beans.factory.annotation.Autowired
     public FakeClassnameTestApiController(ObjectMapper objectMapper) {
         this.objectMapper = objectMapper;
     }
 
     public ResponseEntity<Client> testClassname(@ApiParam(value = "client model" ,required=true )  @Valid @RequestBody Client body) {
         // do some magic!
-        String accept = ((ServletRequestAttributes)RequestContextHolder.getRequestAttributes()).getRequest().getHeader("Accept");
+        String accept = request.getHeader("Accept");
         if (accept != null && accept.contains("application/json")) {
             try {
                 return new ResponseEntity<Client>(objectMapper.readValue("{  \"client\" : \"client\"}", Client.class), HttpStatus.NOT_IMPLEMENTED);

--- a/samples/server/petstore/spring-mvc/src/main/java/io/swagger/api/FakeClassnameTestApiController.java
+++ b/samples/server/petstore/spring-mvc/src/main/java/io/swagger/api/FakeClassnameTestApiController.java
@@ -32,12 +32,12 @@ public class FakeClassnameTestApiController implements FakeClassnameTestApi {
 
     private final ObjectMapper objectMapper;
 
-    @org.springframework.beans.factory.annotation.Autowired
-    private HttpServletRequest request;
+    private final HttpServletRequest request;
 
     @org.springframework.beans.factory.annotation.Autowired
-    public FakeClassnameTestApiController(ObjectMapper objectMapper) {
+    public FakeClassnameTestApiController(ObjectMapper objectMapper, HttpServletRequest request) {
         this.objectMapper = objectMapper;
+        this.request = request;
     }
 
     public ResponseEntity<Client> testClassname(@ApiParam(value = "client model" ,required=true )  @Valid @RequestBody Client body) {

--- a/samples/server/petstore/spring-mvc/src/main/java/io/swagger/api/FakeClassnameTestApiController.java
+++ b/samples/server/petstore/spring-mvc/src/main/java/io/swagger/api/FakeClassnameTestApiController.java
@@ -1,9 +1,8 @@
 package io.swagger.api;
 
 import io.swagger.model.Client;
-
+import com.fasterxml.jackson.databind.ObjectMapper;
 import io.swagger.annotations.*;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpStatus;
@@ -14,16 +13,13 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RequestPart;
-import org.springframework.web.context.request.RequestContextHolder;
-import org.springframework.web.context.request.ServletRequestAttributes;
 import org.springframework.web.multipart.MultipartFile;
 
-import java.util.List;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import java.io.IOException;
-import javax.servlet.http.HttpServletRequest;
 import javax.validation.constraints.*;
 import javax.validation.Valid;
+import javax.servlet.http.HttpServletRequest;
+import java.io.IOException;
+import java.util.List;
 
 @Controller
 public class FakeClassnameTestApiController implements FakeClassnameTestApi {
@@ -41,7 +37,6 @@ public class FakeClassnameTestApiController implements FakeClassnameTestApi {
     }
 
     public ResponseEntity<Client> testClassname(@ApiParam(value = "client model" ,required=true )  @Valid @RequestBody Client body) {
-        // do some magic!
         String accept = request.getHeader("Accept");
         if (accept != null && accept.contains("application/json")) {
             try {
@@ -52,7 +47,7 @@ public class FakeClassnameTestApiController implements FakeClassnameTestApi {
             }
         }
 
-        return new ResponseEntity<Client>(HttpStatus.OK);
+        return new ResponseEntity<Client>(HttpStatus.NOT_IMPLEMENTED);
     }
 
 }

--- a/samples/server/petstore/spring-mvc/src/main/java/io/swagger/api/PetApi.java
+++ b/samples/server/petstore/spring-mvc/src/main/java/io/swagger/api/PetApi.java
@@ -8,9 +8,9 @@ package io.swagger.api;
 import io.swagger.model.ModelApiResponse;
 import io.swagger.model.Pet;
 import org.springframework.core.io.Resource;
-
 import io.swagger.annotations.*;
 import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
@@ -19,12 +19,10 @@ import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.multipart.MultipartFile;
-import java.io.IOException;
 
-import java.util.List;
-import org.springframework.validation.annotation.Validated;
-import javax.validation.constraints.*;
 import javax.validation.Valid;
+import javax.validation.constraints.*;
+import java.util.List;
 
 @Api(value = "pet", description = "the pet API")
 public interface PetApi {

--- a/samples/server/petstore/spring-mvc/src/main/java/io/swagger/api/PetApi.java
+++ b/samples/server/petstore/spring-mvc/src/main/java/io/swagger/api/PetApi.java
@@ -41,7 +41,7 @@ public interface PetApi {
         produces = { "application/xml", "application/json" }, 
         consumes = { "application/json", "application/xml" },
         method = RequestMethod.POST)
-    ResponseEntity<Void> addPet(@ApiParam(value = "Pet object that needs to be added to the store" ,required=true )  @Valid @RequestBody Pet body, @RequestHeader(value = "Accept", required = false) String accept) throws Exception;
+    ResponseEntity<Void> addPet(@ApiParam(value = "Pet object that needs to be added to the store" ,required=true )  @Valid @RequestBody Pet body);
 
 
     @ApiOperation(value = "Deletes a pet", nickname = "deletePet", notes = "", authorizations = {
@@ -55,7 +55,7 @@ public interface PetApi {
     @RequestMapping(value = "/pet/{petId}",
         produces = { "application/xml", "application/json" }, 
         method = RequestMethod.DELETE)
-    ResponseEntity<Void> deletePet(@ApiParam(value = "Pet id to delete",required=true) @PathVariable("petId") Long petId,@ApiParam(value = "" ) @RequestHeader(value="api_key", required=false) String apiKey, @RequestHeader(value = "Accept", required = false) String accept) throws Exception;
+    ResponseEntity<Void> deletePet(@ApiParam(value = "Pet id to delete",required=true) @PathVariable("petId") Long petId,@ApiParam(value = "" ) @RequestHeader(value="api_key", required=false) String apiKey);
 
 
     @ApiOperation(value = "Finds Pets by status", nickname = "findPetsByStatus", notes = "Multiple status values can be provided with comma separated strings", response = Pet.class, responseContainer = "List", authorizations = {
@@ -70,7 +70,7 @@ public interface PetApi {
     @RequestMapping(value = "/pet/findByStatus",
         produces = { "application/xml", "application/json" }, 
         method = RequestMethod.GET)
-    ResponseEntity<List<Pet>> findPetsByStatus( @NotNull@ApiParam(value = "Status values that need to be considered for filter", required = true, allowableValues = "available, pending, sold") @Valid @RequestParam(value = "status", required = true) List<String> status, @RequestHeader(value = "Accept", required = false) String accept) throws Exception;
+    ResponseEntity<List<Pet>> findPetsByStatus(@NotNull @ApiParam(value = "Status values that need to be considered for filter", required = true, allowableValues = "available, pending, sold") @Valid @RequestParam(value = "status", required = true) List<String> status);
 
 
     @ApiOperation(value = "Finds Pets by tags", nickname = "findPetsByTags", notes = "Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.", response = Pet.class, responseContainer = "List", authorizations = {
@@ -85,7 +85,7 @@ public interface PetApi {
     @RequestMapping(value = "/pet/findByTags",
         produces = { "application/xml", "application/json" }, 
         method = RequestMethod.GET)
-    ResponseEntity<List<Pet>> findPetsByTags( @NotNull@ApiParam(value = "Tags to filter by", required = true) @Valid @RequestParam(value = "tags", required = true) List<String> tags, @RequestHeader(value = "Accept", required = false) String accept) throws Exception;
+    ResponseEntity<List<Pet>> findPetsByTags(@NotNull @ApiParam(value = "Tags to filter by", required = true) @Valid @RequestParam(value = "tags", required = true) List<String> tags);
 
 
     @ApiOperation(value = "Find pet by ID", nickname = "getPetById", notes = "Returns a single pet", response = Pet.class, authorizations = {
@@ -98,7 +98,7 @@ public interface PetApi {
     @RequestMapping(value = "/pet/{petId}",
         produces = { "application/xml", "application/json" }, 
         method = RequestMethod.GET)
-    ResponseEntity<Pet> getPetById(@ApiParam(value = "ID of pet to return",required=true) @PathVariable("petId") Long petId, @RequestHeader(value = "Accept", required = false) String accept) throws Exception;
+    ResponseEntity<Pet> getPetById(@ApiParam(value = "ID of pet to return",required=true) @PathVariable("petId") Long petId);
 
 
     @ApiOperation(value = "Update an existing pet", nickname = "updatePet", notes = "", authorizations = {
@@ -115,7 +115,7 @@ public interface PetApi {
         produces = { "application/xml", "application/json" }, 
         consumes = { "application/json", "application/xml" },
         method = RequestMethod.PUT)
-    ResponseEntity<Void> updatePet(@ApiParam(value = "Pet object that needs to be added to the store" ,required=true )  @Valid @RequestBody Pet body, @RequestHeader(value = "Accept", required = false) String accept) throws Exception;
+    ResponseEntity<Void> updatePet(@ApiParam(value = "Pet object that needs to be added to the store" ,required=true )  @Valid @RequestBody Pet body);
 
 
     @ApiOperation(value = "Updates a pet in the store with form data", nickname = "updatePetWithForm", notes = "", authorizations = {
@@ -130,7 +130,7 @@ public interface PetApi {
         produces = { "application/xml", "application/json" }, 
         consumes = { "application/x-www-form-urlencoded" },
         method = RequestMethod.POST)
-    ResponseEntity<Void> updatePetWithForm(@ApiParam(value = "ID of pet that needs to be updated",required=true) @PathVariable("petId") Long petId,@ApiParam(value = "Updated name of the pet") @RequestPart(value="name", required=false)  String name,@ApiParam(value = "Updated status of the pet") @RequestPart(value="status", required=false)  String status, @RequestHeader(value = "Accept", required = false) String accept) throws Exception;
+    ResponseEntity<Void> updatePetWithForm(@ApiParam(value = "ID of pet that needs to be updated",required=true) @PathVariable("petId") Long petId,@ApiParam(value = "Updated name of the pet") @RequestPart(value="name", required=false)  String name,@ApiParam(value = "Updated status of the pet") @RequestPart(value="status", required=false)  String status);
 
 
     @ApiOperation(value = "uploads an image", nickname = "uploadFile", notes = "", response = ModelApiResponse.class, authorizations = {
@@ -145,6 +145,6 @@ public interface PetApi {
         produces = { "application/json" }, 
         consumes = { "multipart/form-data" },
         method = RequestMethod.POST)
-    ResponseEntity<ModelApiResponse> uploadFile(@ApiParam(value = "ID of pet to update",required=true) @PathVariable("petId") Long petId,@ApiParam(value = "Additional data to pass to server") @RequestPart(value="additionalMetadata", required=false)  String additionalMetadata,@ApiParam(value = "file detail") @Valid @RequestPart("file") MultipartFile file, @RequestHeader(value = "Accept", required = false) String accept) throws Exception;
+    ResponseEntity<ModelApiResponse> uploadFile(@ApiParam(value = "ID of pet to update",required=true) @PathVariable("petId") Long petId,@ApiParam(value = "Additional data to pass to server") @RequestPart(value="additionalMetadata", required=false)  String additionalMetadata,@ApiParam(value = "file detail") @Valid @RequestPart("file") MultipartFile file);
 
 }

--- a/samples/server/petstore/spring-mvc/src/main/java/io/swagger/api/PetApiController.java
+++ b/samples/server/petstore/spring-mvc/src/main/java/io/swagger/api/PetApiController.java
@@ -34,12 +34,12 @@ public class PetApiController implements PetApi {
 
     private final ObjectMapper objectMapper;
 
-    @org.springframework.beans.factory.annotation.Autowired
-    private HttpServletRequest request;
+    private final HttpServletRequest request;
 
     @org.springframework.beans.factory.annotation.Autowired
-    public PetApiController(ObjectMapper objectMapper) {
+    public PetApiController(ObjectMapper objectMapper, HttpServletRequest request) {
         this.objectMapper = objectMapper;
+        this.request = request;
     }
 
     public ResponseEntity<Void> addPet(@ApiParam(value = "Pet object that needs to be added to the store" ,required=true )  @Valid @RequestBody Pet body) {

--- a/samples/server/petstore/spring-mvc/src/main/java/io/swagger/api/PetApiController.java
+++ b/samples/server/petstore/spring-mvc/src/main/java/io/swagger/api/PetApiController.java
@@ -3,9 +3,8 @@ package io.swagger.api;
 import io.swagger.model.ModelApiResponse;
 import io.swagger.model.Pet;
 import org.springframework.core.io.Resource;
-
+import com.fasterxml.jackson.databind.ObjectMapper;
 import io.swagger.annotations.*;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpStatus;
@@ -16,16 +15,13 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RequestPart;
-import org.springframework.web.context.request.RequestContextHolder;
-import org.springframework.web.context.request.ServletRequestAttributes;
 import org.springframework.web.multipart.MultipartFile;
 
-import java.util.List;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import java.io.IOException;
-import javax.servlet.http.HttpServletRequest;
 import javax.validation.constraints.*;
 import javax.validation.Valid;
+import javax.servlet.http.HttpServletRequest;
+import java.io.IOException;
+import java.util.List;
 
 @Controller
 public class PetApiController implements PetApi {
@@ -43,19 +39,16 @@ public class PetApiController implements PetApi {
     }
 
     public ResponseEntity<Void> addPet(@ApiParam(value = "Pet object that needs to be added to the store" ,required=true )  @Valid @RequestBody Pet body) {
-        // do some magic!
         String accept = request.getHeader("Accept");
-        return new ResponseEntity<Void>(HttpStatus.OK);
+        return new ResponseEntity<Void>(HttpStatus.NOT_IMPLEMENTED);
     }
 
     public ResponseEntity<Void> deletePet(@ApiParam(value = "Pet id to delete",required=true) @PathVariable("petId") Long petId,@ApiParam(value = "" ) @RequestHeader(value="api_key", required=false) String apiKey) {
-        // do some magic!
         String accept = request.getHeader("Accept");
-        return new ResponseEntity<Void>(HttpStatus.OK);
+        return new ResponseEntity<Void>(HttpStatus.NOT_IMPLEMENTED);
     }
 
     public ResponseEntity<List<Pet>> findPetsByStatus(@NotNull @ApiParam(value = "Status values that need to be considered for filter", required = true, allowableValues = "available, pending, sold") @Valid @RequestParam(value = "status", required = true) List<String> status) {
-        // do some magic!
         String accept = request.getHeader("Accept");
         if (accept != null && accept.contains("application/xml")) {
             try {
@@ -75,11 +68,10 @@ public class PetApiController implements PetApi {
             }
         }
 
-        return new ResponseEntity<List<Pet>>(HttpStatus.OK);
+        return new ResponseEntity<List<Pet>>(HttpStatus.NOT_IMPLEMENTED);
     }
 
     public ResponseEntity<List<Pet>> findPetsByTags(@NotNull @ApiParam(value = "Tags to filter by", required = true) @Valid @RequestParam(value = "tags", required = true) List<String> tags) {
-        // do some magic!
         String accept = request.getHeader("Accept");
         if (accept != null && accept.contains("application/xml")) {
             try {
@@ -99,11 +91,10 @@ public class PetApiController implements PetApi {
             }
         }
 
-        return new ResponseEntity<List<Pet>>(HttpStatus.OK);
+        return new ResponseEntity<List<Pet>>(HttpStatus.NOT_IMPLEMENTED);
     }
 
     public ResponseEntity<Pet> getPetById(@ApiParam(value = "ID of pet to return",required=true) @PathVariable("petId") Long petId) {
-        // do some magic!
         String accept = request.getHeader("Accept");
         if (accept != null && accept.contains("application/xml")) {
             try {
@@ -123,23 +114,20 @@ public class PetApiController implements PetApi {
             }
         }
 
-        return new ResponseEntity<Pet>(HttpStatus.OK);
+        return new ResponseEntity<Pet>(HttpStatus.NOT_IMPLEMENTED);
     }
 
     public ResponseEntity<Void> updatePet(@ApiParam(value = "Pet object that needs to be added to the store" ,required=true )  @Valid @RequestBody Pet body) {
-        // do some magic!
         String accept = request.getHeader("Accept");
-        return new ResponseEntity<Void>(HttpStatus.OK);
+        return new ResponseEntity<Void>(HttpStatus.NOT_IMPLEMENTED);
     }
 
     public ResponseEntity<Void> updatePetWithForm(@ApiParam(value = "ID of pet that needs to be updated",required=true) @PathVariable("petId") Long petId,@ApiParam(value = "Updated name of the pet") @RequestPart(value="name", required=false)  String name,@ApiParam(value = "Updated status of the pet") @RequestPart(value="status", required=false)  String status) {
-        // do some magic!
         String accept = request.getHeader("Accept");
-        return new ResponseEntity<Void>(HttpStatus.OK);
+        return new ResponseEntity<Void>(HttpStatus.NOT_IMPLEMENTED);
     }
 
     public ResponseEntity<ModelApiResponse> uploadFile(@ApiParam(value = "ID of pet to update",required=true) @PathVariable("petId") Long petId,@ApiParam(value = "Additional data to pass to server") @RequestPart(value="additionalMetadata", required=false)  String additionalMetadata,@ApiParam(value = "file detail") @Valid @RequestPart("file") MultipartFile file) {
-        // do some magic!
         String accept = request.getHeader("Accept");
         if (accept != null && accept.contains("application/json")) {
             try {
@@ -150,7 +138,7 @@ public class PetApiController implements PetApi {
             }
         }
 
-        return new ResponseEntity<ModelApiResponse>(HttpStatus.OK);
+        return new ResponseEntity<ModelApiResponse>(HttpStatus.NOT_IMPLEMENTED);
     }
 
 }

--- a/samples/server/petstore/spring-mvc/src/main/java/io/swagger/api/PetApiController.java
+++ b/samples/server/petstore/spring-mvc/src/main/java/io/swagger/api/PetApiController.java
@@ -23,35 +23,40 @@ import org.springframework.web.multipart.MultipartFile;
 import java.util.List;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.IOException;
+import javax.servlet.http.HttpServletRequest;
 import javax.validation.constraints.*;
 import javax.validation.Valid;
 
 @Controller
 public class PetApiController implements PetApi {
 
-    private final Logger log = LoggerFactory.getLogger(AnotherFakeApiController.class);
+    private static final Logger log = LoggerFactory.getLogger(PetApiController.class);
 
     private final ObjectMapper objectMapper;
 
+    @org.springframework.beans.factory.annotation.Autowired
+    private HttpServletRequest request;
+
+    @org.springframework.beans.factory.annotation.Autowired
     public PetApiController(ObjectMapper objectMapper) {
         this.objectMapper = objectMapper;
     }
 
     public ResponseEntity<Void> addPet(@ApiParam(value = "Pet object that needs to be added to the store" ,required=true )  @Valid @RequestBody Pet body) {
         // do some magic!
-        String accept = ((ServletRequestAttributes)RequestContextHolder.getRequestAttributes()).getRequest().getHeader("Accept");
+        String accept = request.getHeader("Accept");
         return new ResponseEntity<Void>(HttpStatus.OK);
     }
 
     public ResponseEntity<Void> deletePet(@ApiParam(value = "Pet id to delete",required=true) @PathVariable("petId") Long petId,@ApiParam(value = "" ) @RequestHeader(value="api_key", required=false) String apiKey) {
         // do some magic!
-        String accept = ((ServletRequestAttributes)RequestContextHolder.getRequestAttributes()).getRequest().getHeader("Accept");
+        String accept = request.getHeader("Accept");
         return new ResponseEntity<Void>(HttpStatus.OK);
     }
 
     public ResponseEntity<List<Pet>> findPetsByStatus(@NotNull @ApiParam(value = "Status values that need to be considered for filter", required = true, allowableValues = "available, pending, sold") @Valid @RequestParam(value = "status", required = true) List<String> status) {
         // do some magic!
-        String accept = ((ServletRequestAttributes)RequestContextHolder.getRequestAttributes()).getRequest().getHeader("Accept");
+        String accept = request.getHeader("Accept");
         if (accept != null && accept.contains("application/xml")) {
             try {
                 return new ResponseEntity<List<Pet>>(objectMapper.readValue("<Pet>  <id>123456789</id>  <name>doggie</name>  <photoUrls>    <photoUrls>aeiou</photoUrls>  </photoUrls>  <tags>  </tags>  <status>aeiou</status></Pet>", List.class), HttpStatus.NOT_IMPLEMENTED);
@@ -75,7 +80,7 @@ public class PetApiController implements PetApi {
 
     public ResponseEntity<List<Pet>> findPetsByTags(@NotNull @ApiParam(value = "Tags to filter by", required = true) @Valid @RequestParam(value = "tags", required = true) List<String> tags) {
         // do some magic!
-        String accept = ((ServletRequestAttributes)RequestContextHolder.getRequestAttributes()).getRequest().getHeader("Accept");
+        String accept = request.getHeader("Accept");
         if (accept != null && accept.contains("application/xml")) {
             try {
                 return new ResponseEntity<List<Pet>>(objectMapper.readValue("<Pet>  <id>123456789</id>  <name>doggie</name>  <photoUrls>    <photoUrls>aeiou</photoUrls>  </photoUrls>  <tags>  </tags>  <status>aeiou</status></Pet>", List.class), HttpStatus.NOT_IMPLEMENTED);
@@ -99,7 +104,7 @@ public class PetApiController implements PetApi {
 
     public ResponseEntity<Pet> getPetById(@ApiParam(value = "ID of pet to return",required=true) @PathVariable("petId") Long petId) {
         // do some magic!
-        String accept = ((ServletRequestAttributes)RequestContextHolder.getRequestAttributes()).getRequest().getHeader("Accept");
+        String accept = request.getHeader("Accept");
         if (accept != null && accept.contains("application/xml")) {
             try {
                 return new ResponseEntity<Pet>(objectMapper.readValue("<Pet>  <id>123456789</id>  <name>doggie</name>  <photoUrls>    <photoUrls>aeiou</photoUrls>  </photoUrls>  <tags>  </tags>  <status>aeiou</status></Pet>", Pet.class), HttpStatus.NOT_IMPLEMENTED);
@@ -123,19 +128,19 @@ public class PetApiController implements PetApi {
 
     public ResponseEntity<Void> updatePet(@ApiParam(value = "Pet object that needs to be added to the store" ,required=true )  @Valid @RequestBody Pet body) {
         // do some magic!
-        String accept = ((ServletRequestAttributes)RequestContextHolder.getRequestAttributes()).getRequest().getHeader("Accept");
+        String accept = request.getHeader("Accept");
         return new ResponseEntity<Void>(HttpStatus.OK);
     }
 
     public ResponseEntity<Void> updatePetWithForm(@ApiParam(value = "ID of pet that needs to be updated",required=true) @PathVariable("petId") Long petId,@ApiParam(value = "Updated name of the pet") @RequestPart(value="name", required=false)  String name,@ApiParam(value = "Updated status of the pet") @RequestPart(value="status", required=false)  String status) {
         // do some magic!
-        String accept = ((ServletRequestAttributes)RequestContextHolder.getRequestAttributes()).getRequest().getHeader("Accept");
+        String accept = request.getHeader("Accept");
         return new ResponseEntity<Void>(HttpStatus.OK);
     }
 
     public ResponseEntity<ModelApiResponse> uploadFile(@ApiParam(value = "ID of pet to update",required=true) @PathVariable("petId") Long petId,@ApiParam(value = "Additional data to pass to server") @RequestPart(value="additionalMetadata", required=false)  String additionalMetadata,@ApiParam(value = "file detail") @Valid @RequestPart("file") MultipartFile file) {
         // do some magic!
-        String accept = ((ServletRequestAttributes)RequestContextHolder.getRequestAttributes()).getRequest().getHeader("Accept");
+        String accept = request.getHeader("Accept");
         if (accept != null && accept.contains("application/json")) {
             try {
                 return new ResponseEntity<ModelApiResponse>(objectMapper.readValue("{  \"code\" : 0,  \"type\" : \"type\",  \"message\" : \"message\"}", ModelApiResponse.class), HttpStatus.NOT_IMPLEMENTED);

--- a/samples/server/petstore/spring-mvc/src/main/java/io/swagger/api/PetApiController.java
+++ b/samples/server/petstore/spring-mvc/src/main/java/io/swagger/api/PetApiController.java
@@ -6,6 +6,8 @@ import org.springframework.core.io.Resource;
 
 import io.swagger.annotations.*;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
@@ -14,6 +16,8 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RequestPart;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.util.List;
@@ -24,95 +28,121 @@ import javax.validation.Valid;
 
 @Controller
 public class PetApiController implements PetApi {
+
+    private final Logger log = LoggerFactory.getLogger(AnotherFakeApiController.class);
+
     private final ObjectMapper objectMapper;
 
     public PetApiController(ObjectMapper objectMapper) {
         this.objectMapper = objectMapper;
     }
 
-    public ResponseEntity<Void> addPet(@ApiParam(value = "Pet object that needs to be added to the store" ,required=true )  @Valid @RequestBody Pet body,
-        @RequestHeader(value = "Accept", required = false) String accept) throws Exception {
+    public ResponseEntity<Void> addPet(@ApiParam(value = "Pet object that needs to be added to the store" ,required=true )  @Valid @RequestBody Pet body) {
         // do some magic!
+        String accept = ((ServletRequestAttributes)RequestContextHolder.getRequestAttributes()).getRequest().getHeader("Accept");
         return new ResponseEntity<Void>(HttpStatus.OK);
     }
 
-    public ResponseEntity<Void> deletePet(@ApiParam(value = "Pet id to delete",required=true) @PathVariable("petId") Long petId,
-        @ApiParam(value = "" ) @RequestHeader(value="api_key", required=false) String apiKey,
-        @RequestHeader(value = "Accept", required = false) String accept) throws Exception {
+    public ResponseEntity<Void> deletePet(@ApiParam(value = "Pet id to delete",required=true) @PathVariable("petId") Long petId,@ApiParam(value = "" ) @RequestHeader(value="api_key", required=false) String apiKey) {
         // do some magic!
+        String accept = ((ServletRequestAttributes)RequestContextHolder.getRequestAttributes()).getRequest().getHeader("Accept");
         return new ResponseEntity<Void>(HttpStatus.OK);
     }
 
-    public ResponseEntity<List<Pet>> findPetsByStatus( @NotNull@ApiParam(value = "Status values that need to be considered for filter", required = true, allowableValues = "available, pending, sold") @Valid @RequestParam(value = "status", required = true) List<String> status,
-        @RequestHeader(value = "Accept", required = false) String accept) throws Exception {
+    public ResponseEntity<List<Pet>> findPetsByStatus(@NotNull @ApiParam(value = "Status values that need to be considered for filter", required = true, allowableValues = "available, pending, sold") @Valid @RequestParam(value = "status", required = true) List<String> status) {
         // do some magic!
-
+        String accept = ((ServletRequestAttributes)RequestContextHolder.getRequestAttributes()).getRequest().getHeader("Accept");
         if (accept != null && accept.contains("application/xml")) {
-            return new ResponseEntity<List<Pet>>(objectMapper.readValue("<Pet>  <id>123456789</id>  <name>doggie</name>  <photoUrls>    <photoUrls>aeiou</photoUrls>  </photoUrls>  <tags>  </tags>  <status>aeiou</status></Pet>", List.class), HttpStatus.OK);
+            try {
+                return new ResponseEntity<List<Pet>>(objectMapper.readValue("<Pet>  <id>123456789</id>  <name>doggie</name>  <photoUrls>    <photoUrls>aeiou</photoUrls>  </photoUrls>  <tags>  </tags>  <status>aeiou</status></Pet>", List.class), HttpStatus.NOT_IMPLEMENTED);
+            } catch (IOException e) {
+                log.error("Couldn't serialize response for content type application/xml", e);
+                return new ResponseEntity<List<Pet>>(HttpStatus.INTERNAL_SERVER_ERROR);
+            }
         }
 
-
         if (accept != null && accept.contains("application/json")) {
-            return new ResponseEntity<List<Pet>>(objectMapper.readValue("[ {  \"photoUrls\" : [ \"photoUrls\", \"photoUrls\" ],  \"name\" : \"doggie\",  \"id\" : 0,  \"category\" : {    \"name\" : \"name\",    \"id\" : 6  },  \"tags\" : [ {    \"name\" : \"name\",    \"id\" : 1  }, {    \"name\" : \"name\",    \"id\" : 1  } ],  \"status\" : \"available\"}, {  \"photoUrls\" : [ \"photoUrls\", \"photoUrls\" ],  \"name\" : \"doggie\",  \"id\" : 0,  \"category\" : {    \"name\" : \"name\",    \"id\" : 6  },  \"tags\" : [ {    \"name\" : \"name\",    \"id\" : 1  }, {    \"name\" : \"name\",    \"id\" : 1  } ],  \"status\" : \"available\"} ]", List.class), HttpStatus.OK);
+            try {
+                return new ResponseEntity<List<Pet>>(objectMapper.readValue("[ {  \"photoUrls\" : [ \"photoUrls\", \"photoUrls\" ],  \"name\" : \"doggie\",  \"id\" : 0,  \"category\" : {    \"name\" : \"name\",    \"id\" : 6  },  \"tags\" : [ {    \"name\" : \"name\",    \"id\" : 1  }, {    \"name\" : \"name\",    \"id\" : 1  } ],  \"status\" : \"available\"}, {  \"photoUrls\" : [ \"photoUrls\", \"photoUrls\" ],  \"name\" : \"doggie\",  \"id\" : 0,  \"category\" : {    \"name\" : \"name\",    \"id\" : 6  },  \"tags\" : [ {    \"name\" : \"name\",    \"id\" : 1  }, {    \"name\" : \"name\",    \"id\" : 1  } ],  \"status\" : \"available\"} ]", List.class), HttpStatus.NOT_IMPLEMENTED);
+            } catch (IOException e) {
+                log.error("Couldn't serialize response for content type application/json", e);
+                return new ResponseEntity<List<Pet>>(HttpStatus.INTERNAL_SERVER_ERROR);
+            }
         }
 
         return new ResponseEntity<List<Pet>>(HttpStatus.OK);
     }
 
-    public ResponseEntity<List<Pet>> findPetsByTags( @NotNull@ApiParam(value = "Tags to filter by", required = true) @Valid @RequestParam(value = "tags", required = true) List<String> tags,
-        @RequestHeader(value = "Accept", required = false) String accept) throws Exception {
+    public ResponseEntity<List<Pet>> findPetsByTags(@NotNull @ApiParam(value = "Tags to filter by", required = true) @Valid @RequestParam(value = "tags", required = true) List<String> tags) {
         // do some magic!
-
+        String accept = ((ServletRequestAttributes)RequestContextHolder.getRequestAttributes()).getRequest().getHeader("Accept");
         if (accept != null && accept.contains("application/xml")) {
-            return new ResponseEntity<List<Pet>>(objectMapper.readValue("<Pet>  <id>123456789</id>  <name>doggie</name>  <photoUrls>    <photoUrls>aeiou</photoUrls>  </photoUrls>  <tags>  </tags>  <status>aeiou</status></Pet>", List.class), HttpStatus.OK);
+            try {
+                return new ResponseEntity<List<Pet>>(objectMapper.readValue("<Pet>  <id>123456789</id>  <name>doggie</name>  <photoUrls>    <photoUrls>aeiou</photoUrls>  </photoUrls>  <tags>  </tags>  <status>aeiou</status></Pet>", List.class), HttpStatus.NOT_IMPLEMENTED);
+            } catch (IOException e) {
+                log.error("Couldn't serialize response for content type application/xml", e);
+                return new ResponseEntity<List<Pet>>(HttpStatus.INTERNAL_SERVER_ERROR);
+            }
         }
 
-
         if (accept != null && accept.contains("application/json")) {
-            return new ResponseEntity<List<Pet>>(objectMapper.readValue("[ {  \"photoUrls\" : [ \"photoUrls\", \"photoUrls\" ],  \"name\" : \"doggie\",  \"id\" : 0,  \"category\" : {    \"name\" : \"name\",    \"id\" : 6  },  \"tags\" : [ {    \"name\" : \"name\",    \"id\" : 1  }, {    \"name\" : \"name\",    \"id\" : 1  } ],  \"status\" : \"available\"}, {  \"photoUrls\" : [ \"photoUrls\", \"photoUrls\" ],  \"name\" : \"doggie\",  \"id\" : 0,  \"category\" : {    \"name\" : \"name\",    \"id\" : 6  },  \"tags\" : [ {    \"name\" : \"name\",    \"id\" : 1  }, {    \"name\" : \"name\",    \"id\" : 1  } ],  \"status\" : \"available\"} ]", List.class), HttpStatus.OK);
+            try {
+                return new ResponseEntity<List<Pet>>(objectMapper.readValue("[ {  \"photoUrls\" : [ \"photoUrls\", \"photoUrls\" ],  \"name\" : \"doggie\",  \"id\" : 0,  \"category\" : {    \"name\" : \"name\",    \"id\" : 6  },  \"tags\" : [ {    \"name\" : \"name\",    \"id\" : 1  }, {    \"name\" : \"name\",    \"id\" : 1  } ],  \"status\" : \"available\"}, {  \"photoUrls\" : [ \"photoUrls\", \"photoUrls\" ],  \"name\" : \"doggie\",  \"id\" : 0,  \"category\" : {    \"name\" : \"name\",    \"id\" : 6  },  \"tags\" : [ {    \"name\" : \"name\",    \"id\" : 1  }, {    \"name\" : \"name\",    \"id\" : 1  } ],  \"status\" : \"available\"} ]", List.class), HttpStatus.NOT_IMPLEMENTED);
+            } catch (IOException e) {
+                log.error("Couldn't serialize response for content type application/json", e);
+                return new ResponseEntity<List<Pet>>(HttpStatus.INTERNAL_SERVER_ERROR);
+            }
         }
 
         return new ResponseEntity<List<Pet>>(HttpStatus.OK);
     }
 
-    public ResponseEntity<Pet> getPetById(@ApiParam(value = "ID of pet to return",required=true) @PathVariable("petId") Long petId,
-        @RequestHeader(value = "Accept", required = false) String accept) throws Exception {
+    public ResponseEntity<Pet> getPetById(@ApiParam(value = "ID of pet to return",required=true) @PathVariable("petId") Long petId) {
         // do some magic!
-
+        String accept = ((ServletRequestAttributes)RequestContextHolder.getRequestAttributes()).getRequest().getHeader("Accept");
         if (accept != null && accept.contains("application/xml")) {
-            return new ResponseEntity<Pet>(objectMapper.readValue("<Pet>  <id>123456789</id>  <name>doggie</name>  <photoUrls>    <photoUrls>aeiou</photoUrls>  </photoUrls>  <tags>  </tags>  <status>aeiou</status></Pet>", Pet.class), HttpStatus.OK);
+            try {
+                return new ResponseEntity<Pet>(objectMapper.readValue("<Pet>  <id>123456789</id>  <name>doggie</name>  <photoUrls>    <photoUrls>aeiou</photoUrls>  </photoUrls>  <tags>  </tags>  <status>aeiou</status></Pet>", Pet.class), HttpStatus.NOT_IMPLEMENTED);
+            } catch (IOException e) {
+                log.error("Couldn't serialize response for content type application/xml", e);
+                return new ResponseEntity<Pet>(HttpStatus.INTERNAL_SERVER_ERROR);
+            }
         }
 
-
         if (accept != null && accept.contains("application/json")) {
-            return new ResponseEntity<Pet>(objectMapper.readValue("{  \"photoUrls\" : [ \"photoUrls\", \"photoUrls\" ],  \"name\" : \"doggie\",  \"id\" : 0,  \"category\" : {    \"name\" : \"name\",    \"id\" : 6  },  \"tags\" : [ {    \"name\" : \"name\",    \"id\" : 1  }, {    \"name\" : \"name\",    \"id\" : 1  } ],  \"status\" : \"available\"}", Pet.class), HttpStatus.OK);
+            try {
+                return new ResponseEntity<Pet>(objectMapper.readValue("{  \"photoUrls\" : [ \"photoUrls\", \"photoUrls\" ],  \"name\" : \"doggie\",  \"id\" : 0,  \"category\" : {    \"name\" : \"name\",    \"id\" : 6  },  \"tags\" : [ {    \"name\" : \"name\",    \"id\" : 1  }, {    \"name\" : \"name\",    \"id\" : 1  } ],  \"status\" : \"available\"}", Pet.class), HttpStatus.NOT_IMPLEMENTED);
+            } catch (IOException e) {
+                log.error("Couldn't serialize response for content type application/json", e);
+                return new ResponseEntity<Pet>(HttpStatus.INTERNAL_SERVER_ERROR);
+            }
         }
 
         return new ResponseEntity<Pet>(HttpStatus.OK);
     }
 
-    public ResponseEntity<Void> updatePet(@ApiParam(value = "Pet object that needs to be added to the store" ,required=true )  @Valid @RequestBody Pet body,
-        @RequestHeader(value = "Accept", required = false) String accept) throws Exception {
+    public ResponseEntity<Void> updatePet(@ApiParam(value = "Pet object that needs to be added to the store" ,required=true )  @Valid @RequestBody Pet body) {
         // do some magic!
+        String accept = ((ServletRequestAttributes)RequestContextHolder.getRequestAttributes()).getRequest().getHeader("Accept");
         return new ResponseEntity<Void>(HttpStatus.OK);
     }
 
-    public ResponseEntity<Void> updatePetWithForm(@ApiParam(value = "ID of pet that needs to be updated",required=true) @PathVariable("petId") Long petId,
-        @ApiParam(value = "Updated name of the pet") @RequestPart(value="name", required=false)  String name,
-        @ApiParam(value = "Updated status of the pet") @RequestPart(value="status", required=false)  String status,
-        @RequestHeader(value = "Accept", required = false) String accept) throws Exception {
+    public ResponseEntity<Void> updatePetWithForm(@ApiParam(value = "ID of pet that needs to be updated",required=true) @PathVariable("petId") Long petId,@ApiParam(value = "Updated name of the pet") @RequestPart(value="name", required=false)  String name,@ApiParam(value = "Updated status of the pet") @RequestPart(value="status", required=false)  String status) {
         // do some magic!
+        String accept = ((ServletRequestAttributes)RequestContextHolder.getRequestAttributes()).getRequest().getHeader("Accept");
         return new ResponseEntity<Void>(HttpStatus.OK);
     }
 
-    public ResponseEntity<ModelApiResponse> uploadFile(@ApiParam(value = "ID of pet to update",required=true) @PathVariable("petId") Long petId,
-        @ApiParam(value = "Additional data to pass to server") @RequestPart(value="additionalMetadata", required=false)  String additionalMetadata,
-        @ApiParam(value = "file detail") @Valid @RequestPart("file") MultipartFile file,
-        @RequestHeader(value = "Accept", required = false) String accept) throws Exception {
+    public ResponseEntity<ModelApiResponse> uploadFile(@ApiParam(value = "ID of pet to update",required=true) @PathVariable("petId") Long petId,@ApiParam(value = "Additional data to pass to server") @RequestPart(value="additionalMetadata", required=false)  String additionalMetadata,@ApiParam(value = "file detail") @Valid @RequestPart("file") MultipartFile file) {
         // do some magic!
-
+        String accept = ((ServletRequestAttributes)RequestContextHolder.getRequestAttributes()).getRequest().getHeader("Accept");
         if (accept != null && accept.contains("application/json")) {
-            return new ResponseEntity<ModelApiResponse>(objectMapper.readValue("{  \"code\" : 0,  \"type\" : \"type\",  \"message\" : \"message\"}", ModelApiResponse.class), HttpStatus.OK);
+            try {
+                return new ResponseEntity<ModelApiResponse>(objectMapper.readValue("{  \"code\" : 0,  \"type\" : \"type\",  \"message\" : \"message\"}", ModelApiResponse.class), HttpStatus.NOT_IMPLEMENTED);
+            } catch (IOException e) {
+                log.error("Couldn't serialize response for content type application/json", e);
+                return new ResponseEntity<ModelApiResponse>(HttpStatus.INTERNAL_SERVER_ERROR);
+            }
         }
 
         return new ResponseEntity<ModelApiResponse>(HttpStatus.OK);

--- a/samples/server/petstore/spring-mvc/src/main/java/io/swagger/api/StoreApi.java
+++ b/samples/server/petstore/spring-mvc/src/main/java/io/swagger/api/StoreApi.java
@@ -7,9 +7,9 @@ package io.swagger.api;
 
 import java.util.Map;
 import io.swagger.model.Order;
-
 import io.swagger.annotations.*;
 import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
@@ -18,12 +18,10 @@ import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.multipart.MultipartFile;
-import java.io.IOException;
 
-import java.util.List;
-import org.springframework.validation.annotation.Validated;
-import javax.validation.constraints.*;
 import javax.validation.Valid;
+import javax.validation.constraints.*;
+import java.util.List;
 
 @Api(value = "store", description = "the store API")
 public interface StoreApi {

--- a/samples/server/petstore/spring-mvc/src/main/java/io/swagger/api/StoreApi.java
+++ b/samples/server/petstore/spring-mvc/src/main/java/io/swagger/api/StoreApi.java
@@ -35,7 +35,7 @@ public interface StoreApi {
     @RequestMapping(value = "/store/order/{order_id}",
         produces = { "application/xml", "application/json" }, 
         method = RequestMethod.DELETE)
-    ResponseEntity<Void> deleteOrder(@ApiParam(value = "ID of the order that needs to be deleted",required=true) @PathVariable("order_id") String orderId, @RequestHeader(value = "Accept", required = false) String accept) throws Exception;
+    ResponseEntity<Void> deleteOrder(@ApiParam(value = "ID of the order that needs to be deleted",required=true) @PathVariable("order_id") String orderId);
 
 
     @ApiOperation(value = "Returns pet inventories by status", nickname = "getInventory", notes = "Returns a map of status codes to quantities", response = Integer.class, responseContainer = "Map", authorizations = {
@@ -46,7 +46,7 @@ public interface StoreApi {
     @RequestMapping(value = "/store/inventory",
         produces = { "application/json" }, 
         method = RequestMethod.GET)
-    ResponseEntity<Map<String, Integer>> getInventory( @RequestHeader(value = "Accept", required = false) String accept) throws Exception;
+    ResponseEntity<Map<String, Integer>> getInventory();
 
 
     @ApiOperation(value = "Find purchase order by ID", nickname = "getOrderById", notes = "For valid response try integer IDs with value <= 5 or > 10. Other values will generated exceptions", response = Order.class, tags={ "store", })
@@ -57,7 +57,7 @@ public interface StoreApi {
     @RequestMapping(value = "/store/order/{order_id}",
         produces = { "application/xml", "application/json" }, 
         method = RequestMethod.GET)
-    ResponseEntity<Order> getOrderById( @Min(1) @Max(5)@ApiParam(value = "ID of pet that needs to be fetched",required=true) @PathVariable("order_id") Long orderId, @RequestHeader(value = "Accept", required = false) String accept) throws Exception;
+    ResponseEntity<Order> getOrderById(@Min(1) @Max(5) @ApiParam(value = "ID of pet that needs to be fetched",required=true) @PathVariable("order_id") Long orderId);
 
 
     @ApiOperation(value = "Place an order for a pet", nickname = "placeOrder", notes = "", response = Order.class, tags={ "store", })
@@ -67,6 +67,6 @@ public interface StoreApi {
     @RequestMapping(value = "/store/order",
         produces = { "application/xml", "application/json" }, 
         method = RequestMethod.POST)
-    ResponseEntity<Order> placeOrder(@ApiParam(value = "order placed for purchasing the pet" ,required=true )  @Valid @RequestBody Order body, @RequestHeader(value = "Accept", required = false) String accept) throws Exception;
+    ResponseEntity<Order> placeOrder(@ApiParam(value = "order placed for purchasing the pet" ,required=true )  @Valid @RequestBody Order body);
 
 }

--- a/samples/server/petstore/spring-mvc/src/main/java/io/swagger/api/StoreApiController.java
+++ b/samples/server/petstore/spring-mvc/src/main/java/io/swagger/api/StoreApiController.java
@@ -2,9 +2,8 @@ package io.swagger.api;
 
 import java.util.Map;
 import io.swagger.model.Order;
-
+import com.fasterxml.jackson.databind.ObjectMapper;
 import io.swagger.annotations.*;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpStatus;
@@ -15,16 +14,13 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RequestPart;
-import org.springframework.web.context.request.RequestContextHolder;
-import org.springframework.web.context.request.ServletRequestAttributes;
 import org.springframework.web.multipart.MultipartFile;
 
-import java.util.List;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import java.io.IOException;
-import javax.servlet.http.HttpServletRequest;
 import javax.validation.constraints.*;
 import javax.validation.Valid;
+import javax.servlet.http.HttpServletRequest;
+import java.io.IOException;
+import java.util.List;
 
 @Controller
 public class StoreApiController implements StoreApi {
@@ -42,13 +38,11 @@ public class StoreApiController implements StoreApi {
     }
 
     public ResponseEntity<Void> deleteOrder(@ApiParam(value = "ID of the order that needs to be deleted",required=true) @PathVariable("order_id") String orderId) {
-        // do some magic!
         String accept = request.getHeader("Accept");
-        return new ResponseEntity<Void>(HttpStatus.OK);
+        return new ResponseEntity<Void>(HttpStatus.NOT_IMPLEMENTED);
     }
 
     public ResponseEntity<Map<String, Integer>> getInventory() {
-        // do some magic!
         String accept = request.getHeader("Accept");
         if (accept != null && accept.contains("application/json")) {
             try {
@@ -59,11 +53,10 @@ public class StoreApiController implements StoreApi {
             }
         }
 
-        return new ResponseEntity<Map<String, Integer>>(HttpStatus.OK);
+        return new ResponseEntity<Map<String, Integer>>(HttpStatus.NOT_IMPLEMENTED);
     }
 
     public ResponseEntity<Order> getOrderById(@Min(1) @Max(5) @ApiParam(value = "ID of pet that needs to be fetched",required=true) @PathVariable("order_id") Long orderId) {
-        // do some magic!
         String accept = request.getHeader("Accept");
         if (accept != null && accept.contains("application/xml")) {
             try {
@@ -83,11 +76,10 @@ public class StoreApiController implements StoreApi {
             }
         }
 
-        return new ResponseEntity<Order>(HttpStatus.OK);
+        return new ResponseEntity<Order>(HttpStatus.NOT_IMPLEMENTED);
     }
 
     public ResponseEntity<Order> placeOrder(@ApiParam(value = "order placed for purchasing the pet" ,required=true )  @Valid @RequestBody Order body) {
-        // do some magic!
         String accept = request.getHeader("Accept");
         if (accept != null && accept.contains("application/xml")) {
             try {
@@ -107,7 +99,7 @@ public class StoreApiController implements StoreApi {
             }
         }
 
-        return new ResponseEntity<Order>(HttpStatus.OK);
+        return new ResponseEntity<Order>(HttpStatus.NOT_IMPLEMENTED);
     }
 
 }

--- a/samples/server/petstore/spring-mvc/src/main/java/io/swagger/api/StoreApiController.java
+++ b/samples/server/petstore/spring-mvc/src/main/java/io/swagger/api/StoreApiController.java
@@ -33,12 +33,12 @@ public class StoreApiController implements StoreApi {
 
     private final ObjectMapper objectMapper;
 
-    @org.springframework.beans.factory.annotation.Autowired
-    private HttpServletRequest request;
+    private final HttpServletRequest request;
 
     @org.springframework.beans.factory.annotation.Autowired
-    public StoreApiController(ObjectMapper objectMapper) {
+    public StoreApiController(ObjectMapper objectMapper, HttpServletRequest request) {
         this.objectMapper = objectMapper;
+        this.request = request;
     }
 
     public ResponseEntity<Void> deleteOrder(@ApiParam(value = "ID of the order that needs to be deleted",required=true) @PathVariable("order_id") String orderId) {

--- a/samples/server/petstore/spring-mvc/src/main/java/io/swagger/api/StoreApiController.java
+++ b/samples/server/petstore/spring-mvc/src/main/java/io/swagger/api/StoreApiController.java
@@ -5,6 +5,8 @@ import io.swagger.model.Order;
 
 import io.swagger.annotations.*;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
@@ -13,6 +15,8 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RequestPart;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.util.List;
@@ -23,55 +27,79 @@ import javax.validation.Valid;
 
 @Controller
 public class StoreApiController implements StoreApi {
+
+    private final Logger log = LoggerFactory.getLogger(AnotherFakeApiController.class);
+
     private final ObjectMapper objectMapper;
 
     public StoreApiController(ObjectMapper objectMapper) {
         this.objectMapper = objectMapper;
     }
 
-    public ResponseEntity<Void> deleteOrder(@ApiParam(value = "ID of the order that needs to be deleted",required=true) @PathVariable("order_id") String orderId,
-        @RequestHeader(value = "Accept", required = false) String accept) throws Exception {
+    public ResponseEntity<Void> deleteOrder(@ApiParam(value = "ID of the order that needs to be deleted",required=true) @PathVariable("order_id") String orderId) {
         // do some magic!
+        String accept = ((ServletRequestAttributes)RequestContextHolder.getRequestAttributes()).getRequest().getHeader("Accept");
         return new ResponseEntity<Void>(HttpStatus.OK);
     }
 
-    public ResponseEntity<Map<String, Integer>> getInventory(@RequestHeader(value = "Accept", required = false) String accept) throws Exception {
+    public ResponseEntity<Map<String, Integer>> getInventory() {
         // do some magic!
-
+        String accept = ((ServletRequestAttributes)RequestContextHolder.getRequestAttributes()).getRequest().getHeader("Accept");
         if (accept != null && accept.contains("application/json")) {
-            return new ResponseEntity<Map<String, Integer>>(objectMapper.readValue("{  \"key\" : 0}", Map.class), HttpStatus.OK);
+            try {
+                return new ResponseEntity<Map<String, Integer>>(objectMapper.readValue("{  \"key\" : 0}", Map.class), HttpStatus.NOT_IMPLEMENTED);
+            } catch (IOException e) {
+                log.error("Couldn't serialize response for content type application/json", e);
+                return new ResponseEntity<Map<String, Integer>>(HttpStatus.INTERNAL_SERVER_ERROR);
+            }
         }
 
         return new ResponseEntity<Map<String, Integer>>(HttpStatus.OK);
     }
 
-    public ResponseEntity<Order> getOrderById( @Min(1) @Max(5)@ApiParam(value = "ID of pet that needs to be fetched",required=true) @PathVariable("order_id") Long orderId,
-        @RequestHeader(value = "Accept", required = false) String accept) throws Exception {
+    public ResponseEntity<Order> getOrderById(@Min(1) @Max(5) @ApiParam(value = "ID of pet that needs to be fetched",required=true) @PathVariable("order_id") Long orderId) {
         // do some magic!
-
+        String accept = ((ServletRequestAttributes)RequestContextHolder.getRequestAttributes()).getRequest().getHeader("Accept");
         if (accept != null && accept.contains("application/xml")) {
-            return new ResponseEntity<Order>(objectMapper.readValue("<Order>  <id>123456789</id>  <petId>123456789</petId>  <quantity>123</quantity>  <shipDate>2000-01-23T04:56:07.000Z</shipDate>  <status>aeiou</status>  <complete>true</complete></Order>", Order.class), HttpStatus.OK);
+            try {
+                return new ResponseEntity<Order>(objectMapper.readValue("<Order>  <id>123456789</id>  <petId>123456789</petId>  <quantity>123</quantity>  <shipDate>2000-01-23T04:56:07.000Z</shipDate>  <status>aeiou</status>  <complete>true</complete></Order>", Order.class), HttpStatus.NOT_IMPLEMENTED);
+            } catch (IOException e) {
+                log.error("Couldn't serialize response for content type application/xml", e);
+                return new ResponseEntity<Order>(HttpStatus.INTERNAL_SERVER_ERROR);
+            }
         }
 
-
         if (accept != null && accept.contains("application/json")) {
-            return new ResponseEntity<Order>(objectMapper.readValue("{  \"petId\" : 6,  \"quantity\" : 1,  \"id\" : 0,  \"shipDate\" : \"2000-01-23T04:56:07.000+00:00\",  \"complete\" : false,  \"status\" : \"placed\"}", Order.class), HttpStatus.OK);
+            try {
+                return new ResponseEntity<Order>(objectMapper.readValue("{  \"petId\" : 6,  \"quantity\" : 1,  \"id\" : 0,  \"shipDate\" : \"2000-01-23T04:56:07.000+00:00\",  \"complete\" : false,  \"status\" : \"placed\"}", Order.class), HttpStatus.NOT_IMPLEMENTED);
+            } catch (IOException e) {
+                log.error("Couldn't serialize response for content type application/json", e);
+                return new ResponseEntity<Order>(HttpStatus.INTERNAL_SERVER_ERROR);
+            }
         }
 
         return new ResponseEntity<Order>(HttpStatus.OK);
     }
 
-    public ResponseEntity<Order> placeOrder(@ApiParam(value = "order placed for purchasing the pet" ,required=true )  @Valid @RequestBody Order body,
-        @RequestHeader(value = "Accept", required = false) String accept) throws Exception {
+    public ResponseEntity<Order> placeOrder(@ApiParam(value = "order placed for purchasing the pet" ,required=true )  @Valid @RequestBody Order body) {
         // do some magic!
-
+        String accept = ((ServletRequestAttributes)RequestContextHolder.getRequestAttributes()).getRequest().getHeader("Accept");
         if (accept != null && accept.contains("application/xml")) {
-            return new ResponseEntity<Order>(objectMapper.readValue("<Order>  <id>123456789</id>  <petId>123456789</petId>  <quantity>123</quantity>  <shipDate>2000-01-23T04:56:07.000Z</shipDate>  <status>aeiou</status>  <complete>true</complete></Order>", Order.class), HttpStatus.OK);
+            try {
+                return new ResponseEntity<Order>(objectMapper.readValue("<Order>  <id>123456789</id>  <petId>123456789</petId>  <quantity>123</quantity>  <shipDate>2000-01-23T04:56:07.000Z</shipDate>  <status>aeiou</status>  <complete>true</complete></Order>", Order.class), HttpStatus.NOT_IMPLEMENTED);
+            } catch (IOException e) {
+                log.error("Couldn't serialize response for content type application/xml", e);
+                return new ResponseEntity<Order>(HttpStatus.INTERNAL_SERVER_ERROR);
+            }
         }
 
-
         if (accept != null && accept.contains("application/json")) {
-            return new ResponseEntity<Order>(objectMapper.readValue("{  \"petId\" : 6,  \"quantity\" : 1,  \"id\" : 0,  \"shipDate\" : \"2000-01-23T04:56:07.000+00:00\",  \"complete\" : false,  \"status\" : \"placed\"}", Order.class), HttpStatus.OK);
+            try {
+                return new ResponseEntity<Order>(objectMapper.readValue("{  \"petId\" : 6,  \"quantity\" : 1,  \"id\" : 0,  \"shipDate\" : \"2000-01-23T04:56:07.000+00:00\",  \"complete\" : false,  \"status\" : \"placed\"}", Order.class), HttpStatus.NOT_IMPLEMENTED);
+            } catch (IOException e) {
+                log.error("Couldn't serialize response for content type application/json", e);
+                return new ResponseEntity<Order>(HttpStatus.INTERNAL_SERVER_ERROR);
+            }
         }
 
         return new ResponseEntity<Order>(HttpStatus.OK);

--- a/samples/server/petstore/spring-mvc/src/main/java/io/swagger/api/StoreApiController.java
+++ b/samples/server/petstore/spring-mvc/src/main/java/io/swagger/api/StoreApiController.java
@@ -22,29 +22,34 @@ import org.springframework.web.multipart.MultipartFile;
 import java.util.List;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.IOException;
+import javax.servlet.http.HttpServletRequest;
 import javax.validation.constraints.*;
 import javax.validation.Valid;
 
 @Controller
 public class StoreApiController implements StoreApi {
 
-    private final Logger log = LoggerFactory.getLogger(AnotherFakeApiController.class);
+    private static final Logger log = LoggerFactory.getLogger(StoreApiController.class);
 
     private final ObjectMapper objectMapper;
 
+    @org.springframework.beans.factory.annotation.Autowired
+    private HttpServletRequest request;
+
+    @org.springframework.beans.factory.annotation.Autowired
     public StoreApiController(ObjectMapper objectMapper) {
         this.objectMapper = objectMapper;
     }
 
     public ResponseEntity<Void> deleteOrder(@ApiParam(value = "ID of the order that needs to be deleted",required=true) @PathVariable("order_id") String orderId) {
         // do some magic!
-        String accept = ((ServletRequestAttributes)RequestContextHolder.getRequestAttributes()).getRequest().getHeader("Accept");
+        String accept = request.getHeader("Accept");
         return new ResponseEntity<Void>(HttpStatus.OK);
     }
 
     public ResponseEntity<Map<String, Integer>> getInventory() {
         // do some magic!
-        String accept = ((ServletRequestAttributes)RequestContextHolder.getRequestAttributes()).getRequest().getHeader("Accept");
+        String accept = request.getHeader("Accept");
         if (accept != null && accept.contains("application/json")) {
             try {
                 return new ResponseEntity<Map<String, Integer>>(objectMapper.readValue("{  \"key\" : 0}", Map.class), HttpStatus.NOT_IMPLEMENTED);
@@ -59,7 +64,7 @@ public class StoreApiController implements StoreApi {
 
     public ResponseEntity<Order> getOrderById(@Min(1) @Max(5) @ApiParam(value = "ID of pet that needs to be fetched",required=true) @PathVariable("order_id") Long orderId) {
         // do some magic!
-        String accept = ((ServletRequestAttributes)RequestContextHolder.getRequestAttributes()).getRequest().getHeader("Accept");
+        String accept = request.getHeader("Accept");
         if (accept != null && accept.contains("application/xml")) {
             try {
                 return new ResponseEntity<Order>(objectMapper.readValue("<Order>  <id>123456789</id>  <petId>123456789</petId>  <quantity>123</quantity>  <shipDate>2000-01-23T04:56:07.000Z</shipDate>  <status>aeiou</status>  <complete>true</complete></Order>", Order.class), HttpStatus.NOT_IMPLEMENTED);
@@ -83,7 +88,7 @@ public class StoreApiController implements StoreApi {
 
     public ResponseEntity<Order> placeOrder(@ApiParam(value = "order placed for purchasing the pet" ,required=true )  @Valid @RequestBody Order body) {
         // do some magic!
-        String accept = ((ServletRequestAttributes)RequestContextHolder.getRequestAttributes()).getRequest().getHeader("Accept");
+        String accept = request.getHeader("Accept");
         if (accept != null && accept.contains("application/xml")) {
             try {
                 return new ResponseEntity<Order>(objectMapper.readValue("<Order>  <id>123456789</id>  <petId>123456789</petId>  <quantity>123</quantity>  <shipDate>2000-01-23T04:56:07.000Z</shipDate>  <status>aeiou</status>  <complete>true</complete></Order>", Order.class), HttpStatus.NOT_IMPLEMENTED);

--- a/samples/server/petstore/spring-mvc/src/main/java/io/swagger/api/UserApi.java
+++ b/samples/server/petstore/spring-mvc/src/main/java/io/swagger/api/UserApi.java
@@ -7,9 +7,9 @@ package io.swagger.api;
 
 import java.util.List;
 import io.swagger.model.User;
-
 import io.swagger.annotations.*;
 import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
@@ -18,12 +18,10 @@ import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.multipart.MultipartFile;
-import java.io.IOException;
 
-import java.util.List;
-import org.springframework.validation.annotation.Validated;
-import javax.validation.constraints.*;
 import javax.validation.Valid;
+import javax.validation.constraints.*;
+import java.util.List;
 
 @Api(value = "user", description = "the user API")
 public interface UserApi {

--- a/samples/server/petstore/spring-mvc/src/main/java/io/swagger/api/UserApi.java
+++ b/samples/server/petstore/spring-mvc/src/main/java/io/swagger/api/UserApi.java
@@ -34,7 +34,7 @@ public interface UserApi {
     @RequestMapping(value = "/user",
         produces = { "application/xml", "application/json" }, 
         method = RequestMethod.POST)
-    ResponseEntity<Void> createUser(@ApiParam(value = "Created user object" ,required=true )  @Valid @RequestBody User body, @RequestHeader(value = "Accept", required = false) String accept) throws Exception;
+    ResponseEntity<Void> createUser(@ApiParam(value = "Created user object" ,required=true )  @Valid @RequestBody User body);
 
 
     @ApiOperation(value = "Creates list of users with given input array", nickname = "createUsersWithArrayInput", notes = "", tags={ "user", })
@@ -43,7 +43,7 @@ public interface UserApi {
     @RequestMapping(value = "/user/createWithArray",
         produces = { "application/xml", "application/json" }, 
         method = RequestMethod.POST)
-    ResponseEntity<Void> createUsersWithArrayInput(@ApiParam(value = "List of user object" ,required=true )  @Valid @RequestBody List<User> body, @RequestHeader(value = "Accept", required = false) String accept) throws Exception;
+    ResponseEntity<Void> createUsersWithArrayInput(@ApiParam(value = "List of user object" ,required=true )  @Valid @RequestBody List<User> body);
 
 
     @ApiOperation(value = "Creates list of users with given input array", nickname = "createUsersWithListInput", notes = "", tags={ "user", })
@@ -52,7 +52,7 @@ public interface UserApi {
     @RequestMapping(value = "/user/createWithList",
         produces = { "application/xml", "application/json" }, 
         method = RequestMethod.POST)
-    ResponseEntity<Void> createUsersWithListInput(@ApiParam(value = "List of user object" ,required=true )  @Valid @RequestBody List<User> body, @RequestHeader(value = "Accept", required = false) String accept) throws Exception;
+    ResponseEntity<Void> createUsersWithListInput(@ApiParam(value = "List of user object" ,required=true )  @Valid @RequestBody List<User> body);
 
 
     @ApiOperation(value = "Delete user", nickname = "deleteUser", notes = "This can only be done by the logged in user.", tags={ "user", })
@@ -62,7 +62,7 @@ public interface UserApi {
     @RequestMapping(value = "/user/{username}",
         produces = { "application/xml", "application/json" }, 
         method = RequestMethod.DELETE)
-    ResponseEntity<Void> deleteUser(@ApiParam(value = "The name that needs to be deleted",required=true) @PathVariable("username") String username, @RequestHeader(value = "Accept", required = false) String accept) throws Exception;
+    ResponseEntity<Void> deleteUser(@ApiParam(value = "The name that needs to be deleted",required=true) @PathVariable("username") String username);
 
 
     @ApiOperation(value = "Get user by user name", nickname = "getUserByName", notes = "", response = User.class, tags={ "user", })
@@ -73,7 +73,7 @@ public interface UserApi {
     @RequestMapping(value = "/user/{username}",
         produces = { "application/xml", "application/json" }, 
         method = RequestMethod.GET)
-    ResponseEntity<User> getUserByName(@ApiParam(value = "The name that needs to be fetched. Use user1 for testing. ",required=true) @PathVariable("username") String username, @RequestHeader(value = "Accept", required = false) String accept) throws Exception;
+    ResponseEntity<User> getUserByName(@ApiParam(value = "The name that needs to be fetched. Use user1 for testing. ",required=true) @PathVariable("username") String username);
 
 
     @ApiOperation(value = "Logs user into the system", nickname = "loginUser", notes = "", response = String.class, tags={ "user", })
@@ -83,7 +83,7 @@ public interface UserApi {
     @RequestMapping(value = "/user/login",
         produces = { "application/xml", "application/json" }, 
         method = RequestMethod.GET)
-    ResponseEntity<String> loginUser( @NotNull@ApiParam(value = "The user name for login", required = true) @Valid @RequestParam(value = "username", required = true) String username, @NotNull@ApiParam(value = "The password for login in clear text", required = true) @Valid @RequestParam(value = "password", required = true) String password, @RequestHeader(value = "Accept", required = false) String accept) throws Exception;
+    ResponseEntity<String> loginUser(@NotNull @ApiParam(value = "The user name for login", required = true) @Valid @RequestParam(value = "username", required = true) String username,@NotNull @ApiParam(value = "The password for login in clear text", required = true) @Valid @RequestParam(value = "password", required = true) String password);
 
 
     @ApiOperation(value = "Logs out current logged in user session", nickname = "logoutUser", notes = "", tags={ "user", })
@@ -92,7 +92,7 @@ public interface UserApi {
     @RequestMapping(value = "/user/logout",
         produces = { "application/xml", "application/json" }, 
         method = RequestMethod.GET)
-    ResponseEntity<Void> logoutUser( @RequestHeader(value = "Accept", required = false) String accept) throws Exception;
+    ResponseEntity<Void> logoutUser();
 
 
     @ApiOperation(value = "Updated user", nickname = "updateUser", notes = "This can only be done by the logged in user.", tags={ "user", })
@@ -102,6 +102,6 @@ public interface UserApi {
     @RequestMapping(value = "/user/{username}",
         produces = { "application/xml", "application/json" }, 
         method = RequestMethod.PUT)
-    ResponseEntity<Void> updateUser(@ApiParam(value = "name that need to be deleted",required=true) @PathVariable("username") String username,@ApiParam(value = "Updated user object" ,required=true )  @Valid @RequestBody User body, @RequestHeader(value = "Accept", required = false) String accept) throws Exception;
+    ResponseEntity<Void> updateUser(@ApiParam(value = "name that need to be deleted",required=true) @PathVariable("username") String username,@ApiParam(value = "Updated user object" ,required=true )  @Valid @RequestBody User body);
 
 }

--- a/samples/server/petstore/spring-mvc/src/main/java/io/swagger/api/UserApiController.java
+++ b/samples/server/petstore/spring-mvc/src/main/java/io/swagger/api/UserApiController.java
@@ -33,12 +33,12 @@ public class UserApiController implements UserApi {
 
     private final ObjectMapper objectMapper;
 
-    @org.springframework.beans.factory.annotation.Autowired
-    private HttpServletRequest request;
+    private final HttpServletRequest request;
 
     @org.springframework.beans.factory.annotation.Autowired
-    public UserApiController(ObjectMapper objectMapper) {
+    public UserApiController(ObjectMapper objectMapper, HttpServletRequest request) {
         this.objectMapper = objectMapper;
+        this.request = request;
     }
 
     public ResponseEntity<Void> createUser(@ApiParam(value = "Created user object" ,required=true )  @Valid @RequestBody User body) {

--- a/samples/server/petstore/spring-mvc/src/main/java/io/swagger/api/UserApiController.java
+++ b/samples/server/petstore/spring-mvc/src/main/java/io/swagger/api/UserApiController.java
@@ -2,9 +2,8 @@ package io.swagger.api;
 
 import java.util.List;
 import io.swagger.model.User;
-
+import com.fasterxml.jackson.databind.ObjectMapper;
 import io.swagger.annotations.*;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpStatus;
@@ -15,16 +14,13 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RequestPart;
-import org.springframework.web.context.request.RequestContextHolder;
-import org.springframework.web.context.request.ServletRequestAttributes;
 import org.springframework.web.multipart.MultipartFile;
 
-import java.util.List;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import java.io.IOException;
-import javax.servlet.http.HttpServletRequest;
 import javax.validation.constraints.*;
 import javax.validation.Valid;
+import javax.servlet.http.HttpServletRequest;
+import java.io.IOException;
+import java.util.List;
 
 @Controller
 public class UserApiController implements UserApi {
@@ -42,31 +38,26 @@ public class UserApiController implements UserApi {
     }
 
     public ResponseEntity<Void> createUser(@ApiParam(value = "Created user object" ,required=true )  @Valid @RequestBody User body) {
-        // do some magic!
         String accept = request.getHeader("Accept");
-        return new ResponseEntity<Void>(HttpStatus.OK);
+        return new ResponseEntity<Void>(HttpStatus.NOT_IMPLEMENTED);
     }
 
     public ResponseEntity<Void> createUsersWithArrayInput(@ApiParam(value = "List of user object" ,required=true )  @Valid @RequestBody List<User> body) {
-        // do some magic!
         String accept = request.getHeader("Accept");
-        return new ResponseEntity<Void>(HttpStatus.OK);
+        return new ResponseEntity<Void>(HttpStatus.NOT_IMPLEMENTED);
     }
 
     public ResponseEntity<Void> createUsersWithListInput(@ApiParam(value = "List of user object" ,required=true )  @Valid @RequestBody List<User> body) {
-        // do some magic!
         String accept = request.getHeader("Accept");
-        return new ResponseEntity<Void>(HttpStatus.OK);
+        return new ResponseEntity<Void>(HttpStatus.NOT_IMPLEMENTED);
     }
 
     public ResponseEntity<Void> deleteUser(@ApiParam(value = "The name that needs to be deleted",required=true) @PathVariable("username") String username) {
-        // do some magic!
         String accept = request.getHeader("Accept");
-        return new ResponseEntity<Void>(HttpStatus.OK);
+        return new ResponseEntity<Void>(HttpStatus.NOT_IMPLEMENTED);
     }
 
     public ResponseEntity<User> getUserByName(@ApiParam(value = "The name that needs to be fetched. Use user1 for testing. ",required=true) @PathVariable("username") String username) {
-        // do some magic!
         String accept = request.getHeader("Accept");
         if (accept != null && accept.contains("application/xml")) {
             try {
@@ -86,11 +77,10 @@ public class UserApiController implements UserApi {
             }
         }
 
-        return new ResponseEntity<User>(HttpStatus.OK);
+        return new ResponseEntity<User>(HttpStatus.NOT_IMPLEMENTED);
     }
 
     public ResponseEntity<String> loginUser(@NotNull @ApiParam(value = "The user name for login", required = true) @Valid @RequestParam(value = "username", required = true) String username,@NotNull @ApiParam(value = "The password for login in clear text", required = true) @Valid @RequestParam(value = "password", required = true) String password) {
-        // do some magic!
         String accept = request.getHeader("Accept");
         if (accept != null && accept.contains("application/xml")) {
             try {
@@ -110,19 +100,17 @@ public class UserApiController implements UserApi {
             }
         }
 
-        return new ResponseEntity<String>(HttpStatus.OK);
+        return new ResponseEntity<String>(HttpStatus.NOT_IMPLEMENTED);
     }
 
     public ResponseEntity<Void> logoutUser() {
-        // do some magic!
         String accept = request.getHeader("Accept");
-        return new ResponseEntity<Void>(HttpStatus.OK);
+        return new ResponseEntity<Void>(HttpStatus.NOT_IMPLEMENTED);
     }
 
     public ResponseEntity<Void> updateUser(@ApiParam(value = "name that need to be deleted",required=true) @PathVariable("username") String username,@ApiParam(value = "Updated user object" ,required=true )  @Valid @RequestBody User body) {
-        // do some magic!
         String accept = request.getHeader("Accept");
-        return new ResponseEntity<Void>(HttpStatus.OK);
+        return new ResponseEntity<Void>(HttpStatus.NOT_IMPLEMENTED);
     }
 
 }

--- a/samples/server/petstore/spring-mvc/src/main/java/io/swagger/api/UserApiController.java
+++ b/samples/server/petstore/spring-mvc/src/main/java/io/swagger/api/UserApiController.java
@@ -5,6 +5,8 @@ import io.swagger.model.User;
 
 import io.swagger.annotations.*;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
@@ -13,6 +15,8 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RequestPart;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.util.List;
@@ -23,78 +27,96 @@ import javax.validation.Valid;
 
 @Controller
 public class UserApiController implements UserApi {
+
+    private final Logger log = LoggerFactory.getLogger(AnotherFakeApiController.class);
+
     private final ObjectMapper objectMapper;
 
     public UserApiController(ObjectMapper objectMapper) {
         this.objectMapper = objectMapper;
     }
 
-    public ResponseEntity<Void> createUser(@ApiParam(value = "Created user object" ,required=true )  @Valid @RequestBody User body,
-        @RequestHeader(value = "Accept", required = false) String accept) throws Exception {
+    public ResponseEntity<Void> createUser(@ApiParam(value = "Created user object" ,required=true )  @Valid @RequestBody User body) {
         // do some magic!
+        String accept = ((ServletRequestAttributes)RequestContextHolder.getRequestAttributes()).getRequest().getHeader("Accept");
         return new ResponseEntity<Void>(HttpStatus.OK);
     }
 
-    public ResponseEntity<Void> createUsersWithArrayInput(@ApiParam(value = "List of user object" ,required=true )  @Valid @RequestBody List<User> body,
-        @RequestHeader(value = "Accept", required = false) String accept) throws Exception {
+    public ResponseEntity<Void> createUsersWithArrayInput(@ApiParam(value = "List of user object" ,required=true )  @Valid @RequestBody List<User> body) {
         // do some magic!
+        String accept = ((ServletRequestAttributes)RequestContextHolder.getRequestAttributes()).getRequest().getHeader("Accept");
         return new ResponseEntity<Void>(HttpStatus.OK);
     }
 
-    public ResponseEntity<Void> createUsersWithListInput(@ApiParam(value = "List of user object" ,required=true )  @Valid @RequestBody List<User> body,
-        @RequestHeader(value = "Accept", required = false) String accept) throws Exception {
+    public ResponseEntity<Void> createUsersWithListInput(@ApiParam(value = "List of user object" ,required=true )  @Valid @RequestBody List<User> body) {
         // do some magic!
+        String accept = ((ServletRequestAttributes)RequestContextHolder.getRequestAttributes()).getRequest().getHeader("Accept");
         return new ResponseEntity<Void>(HttpStatus.OK);
     }
 
-    public ResponseEntity<Void> deleteUser(@ApiParam(value = "The name that needs to be deleted",required=true) @PathVariable("username") String username,
-        @RequestHeader(value = "Accept", required = false) String accept) throws Exception {
+    public ResponseEntity<Void> deleteUser(@ApiParam(value = "The name that needs to be deleted",required=true) @PathVariable("username") String username) {
         // do some magic!
+        String accept = ((ServletRequestAttributes)RequestContextHolder.getRequestAttributes()).getRequest().getHeader("Accept");
         return new ResponseEntity<Void>(HttpStatus.OK);
     }
 
-    public ResponseEntity<User> getUserByName(@ApiParam(value = "The name that needs to be fetched. Use user1 for testing. ",required=true) @PathVariable("username") String username,
-        @RequestHeader(value = "Accept", required = false) String accept) throws Exception {
+    public ResponseEntity<User> getUserByName(@ApiParam(value = "The name that needs to be fetched. Use user1 for testing. ",required=true) @PathVariable("username") String username) {
         // do some magic!
-
+        String accept = ((ServletRequestAttributes)RequestContextHolder.getRequestAttributes()).getRequest().getHeader("Accept");
         if (accept != null && accept.contains("application/xml")) {
-            return new ResponseEntity<User>(objectMapper.readValue("<User>  <id>123456789</id>  <username>aeiou</username>  <firstName>aeiou</firstName>  <lastName>aeiou</lastName>  <email>aeiou</email>  <password>aeiou</password>  <phone>aeiou</phone>  <userStatus>123</userStatus></User>", User.class), HttpStatus.OK);
+            try {
+                return new ResponseEntity<User>(objectMapper.readValue("<User>  <id>123456789</id>  <username>aeiou</username>  <firstName>aeiou</firstName>  <lastName>aeiou</lastName>  <email>aeiou</email>  <password>aeiou</password>  <phone>aeiou</phone>  <userStatus>123</userStatus></User>", User.class), HttpStatus.NOT_IMPLEMENTED);
+            } catch (IOException e) {
+                log.error("Couldn't serialize response for content type application/xml", e);
+                return new ResponseEntity<User>(HttpStatus.INTERNAL_SERVER_ERROR);
+            }
         }
 
-
         if (accept != null && accept.contains("application/json")) {
-            return new ResponseEntity<User>(objectMapper.readValue("{  \"firstName\" : \"firstName\",  \"lastName\" : \"lastName\",  \"password\" : \"password\",  \"userStatus\" : 6,  \"phone\" : \"phone\",  \"id\" : 0,  \"email\" : \"email\",  \"username\" : \"username\"}", User.class), HttpStatus.OK);
+            try {
+                return new ResponseEntity<User>(objectMapper.readValue("{  \"firstName\" : \"firstName\",  \"lastName\" : \"lastName\",  \"password\" : \"password\",  \"userStatus\" : 6,  \"phone\" : \"phone\",  \"id\" : 0,  \"email\" : \"email\",  \"username\" : \"username\"}", User.class), HttpStatus.NOT_IMPLEMENTED);
+            } catch (IOException e) {
+                log.error("Couldn't serialize response for content type application/json", e);
+                return new ResponseEntity<User>(HttpStatus.INTERNAL_SERVER_ERROR);
+            }
         }
 
         return new ResponseEntity<User>(HttpStatus.OK);
     }
 
-    public ResponseEntity<String> loginUser( @NotNull@ApiParam(value = "The user name for login", required = true) @Valid @RequestParam(value = "username", required = true) String username,
-         @NotNull@ApiParam(value = "The password for login in clear text", required = true) @Valid @RequestParam(value = "password", required = true) String password,
-        @RequestHeader(value = "Accept", required = false) String accept) throws Exception {
+    public ResponseEntity<String> loginUser(@NotNull @ApiParam(value = "The user name for login", required = true) @Valid @RequestParam(value = "username", required = true) String username,@NotNull @ApiParam(value = "The password for login in clear text", required = true) @Valid @RequestParam(value = "password", required = true) String password) {
         // do some magic!
-
+        String accept = ((ServletRequestAttributes)RequestContextHolder.getRequestAttributes()).getRequest().getHeader("Accept");
         if (accept != null && accept.contains("application/xml")) {
-            return new ResponseEntity<String>(objectMapper.readValue("aeiou", String.class), HttpStatus.OK);
+            try {
+                return new ResponseEntity<String>(objectMapper.readValue("aeiou", String.class), HttpStatus.NOT_IMPLEMENTED);
+            } catch (IOException e) {
+                log.error("Couldn't serialize response for content type application/xml", e);
+                return new ResponseEntity<String>(HttpStatus.INTERNAL_SERVER_ERROR);
+            }
         }
 
-
         if (accept != null && accept.contains("application/json")) {
-            return new ResponseEntity<String>(objectMapper.readValue("\"\"", String.class), HttpStatus.OK);
+            try {
+                return new ResponseEntity<String>(objectMapper.readValue("\"\"", String.class), HttpStatus.NOT_IMPLEMENTED);
+            } catch (IOException e) {
+                log.error("Couldn't serialize response for content type application/json", e);
+                return new ResponseEntity<String>(HttpStatus.INTERNAL_SERVER_ERROR);
+            }
         }
 
         return new ResponseEntity<String>(HttpStatus.OK);
     }
 
-    public ResponseEntity<Void> logoutUser(@RequestHeader(value = "Accept", required = false) String accept) throws Exception {
+    public ResponseEntity<Void> logoutUser() {
         // do some magic!
+        String accept = ((ServletRequestAttributes)RequestContextHolder.getRequestAttributes()).getRequest().getHeader("Accept");
         return new ResponseEntity<Void>(HttpStatus.OK);
     }
 
-    public ResponseEntity<Void> updateUser(@ApiParam(value = "name that need to be deleted",required=true) @PathVariable("username") String username,
-        @ApiParam(value = "Updated user object" ,required=true )  @Valid @RequestBody User body,
-        @RequestHeader(value = "Accept", required = false) String accept) throws Exception {
+    public ResponseEntity<Void> updateUser(@ApiParam(value = "name that need to be deleted",required=true) @PathVariable("username") String username,@ApiParam(value = "Updated user object" ,required=true )  @Valid @RequestBody User body) {
         // do some magic!
+        String accept = ((ServletRequestAttributes)RequestContextHolder.getRequestAttributes()).getRequest().getHeader("Accept");
         return new ResponseEntity<Void>(HttpStatus.OK);
     }
 

--- a/samples/server/petstore/spring-mvc/src/main/java/io/swagger/api/UserApiController.java
+++ b/samples/server/petstore/spring-mvc/src/main/java/io/swagger/api/UserApiController.java
@@ -22,47 +22,52 @@ import org.springframework.web.multipart.MultipartFile;
 import java.util.List;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.IOException;
+import javax.servlet.http.HttpServletRequest;
 import javax.validation.constraints.*;
 import javax.validation.Valid;
 
 @Controller
 public class UserApiController implements UserApi {
 
-    private final Logger log = LoggerFactory.getLogger(AnotherFakeApiController.class);
+    private static final Logger log = LoggerFactory.getLogger(UserApiController.class);
 
     private final ObjectMapper objectMapper;
 
+    @org.springframework.beans.factory.annotation.Autowired
+    private HttpServletRequest request;
+
+    @org.springframework.beans.factory.annotation.Autowired
     public UserApiController(ObjectMapper objectMapper) {
         this.objectMapper = objectMapper;
     }
 
     public ResponseEntity<Void> createUser(@ApiParam(value = "Created user object" ,required=true )  @Valid @RequestBody User body) {
         // do some magic!
-        String accept = ((ServletRequestAttributes)RequestContextHolder.getRequestAttributes()).getRequest().getHeader("Accept");
+        String accept = request.getHeader("Accept");
         return new ResponseEntity<Void>(HttpStatus.OK);
     }
 
     public ResponseEntity<Void> createUsersWithArrayInput(@ApiParam(value = "List of user object" ,required=true )  @Valid @RequestBody List<User> body) {
         // do some magic!
-        String accept = ((ServletRequestAttributes)RequestContextHolder.getRequestAttributes()).getRequest().getHeader("Accept");
+        String accept = request.getHeader("Accept");
         return new ResponseEntity<Void>(HttpStatus.OK);
     }
 
     public ResponseEntity<Void> createUsersWithListInput(@ApiParam(value = "List of user object" ,required=true )  @Valid @RequestBody List<User> body) {
         // do some magic!
-        String accept = ((ServletRequestAttributes)RequestContextHolder.getRequestAttributes()).getRequest().getHeader("Accept");
+        String accept = request.getHeader("Accept");
         return new ResponseEntity<Void>(HttpStatus.OK);
     }
 
     public ResponseEntity<Void> deleteUser(@ApiParam(value = "The name that needs to be deleted",required=true) @PathVariable("username") String username) {
         // do some magic!
-        String accept = ((ServletRequestAttributes)RequestContextHolder.getRequestAttributes()).getRequest().getHeader("Accept");
+        String accept = request.getHeader("Accept");
         return new ResponseEntity<Void>(HttpStatus.OK);
     }
 
     public ResponseEntity<User> getUserByName(@ApiParam(value = "The name that needs to be fetched. Use user1 for testing. ",required=true) @PathVariable("username") String username) {
         // do some magic!
-        String accept = ((ServletRequestAttributes)RequestContextHolder.getRequestAttributes()).getRequest().getHeader("Accept");
+        String accept = request.getHeader("Accept");
         if (accept != null && accept.contains("application/xml")) {
             try {
                 return new ResponseEntity<User>(objectMapper.readValue("<User>  <id>123456789</id>  <username>aeiou</username>  <firstName>aeiou</firstName>  <lastName>aeiou</lastName>  <email>aeiou</email>  <password>aeiou</password>  <phone>aeiou</phone>  <userStatus>123</userStatus></User>", User.class), HttpStatus.NOT_IMPLEMENTED);
@@ -86,7 +91,7 @@ public class UserApiController implements UserApi {
 
     public ResponseEntity<String> loginUser(@NotNull @ApiParam(value = "The user name for login", required = true) @Valid @RequestParam(value = "username", required = true) String username,@NotNull @ApiParam(value = "The password for login in clear text", required = true) @Valid @RequestParam(value = "password", required = true) String password) {
         // do some magic!
-        String accept = ((ServletRequestAttributes)RequestContextHolder.getRequestAttributes()).getRequest().getHeader("Accept");
+        String accept = request.getHeader("Accept");
         if (accept != null && accept.contains("application/xml")) {
             try {
                 return new ResponseEntity<String>(objectMapper.readValue("aeiou", String.class), HttpStatus.NOT_IMPLEMENTED);
@@ -110,13 +115,13 @@ public class UserApiController implements UserApi {
 
     public ResponseEntity<Void> logoutUser() {
         // do some magic!
-        String accept = ((ServletRequestAttributes)RequestContextHolder.getRequestAttributes()).getRequest().getHeader("Accept");
+        String accept = request.getHeader("Accept");
         return new ResponseEntity<Void>(HttpStatus.OK);
     }
 
     public ResponseEntity<Void> updateUser(@ApiParam(value = "name that need to be deleted",required=true) @PathVariable("username") String username,@ApiParam(value = "Updated user object" ,required=true )  @Valid @RequestBody User body) {
         // do some magic!
-        String accept = ((ServletRequestAttributes)RequestContextHolder.getRequestAttributes()).getRequest().getHeader("Accept");
+        String accept = request.getHeader("Accept");
         return new ResponseEntity<Void>(HttpStatus.OK);
     }
 

--- a/samples/server/petstore/spring-mvc/src/main/java/io/swagger/model/FormatTest.java
+++ b/samples/server/petstore/spring-mvc/src/main/java/io/swagger/model/FormatTest.java
@@ -71,7 +71,7 @@ public class FormatTest   {
   **/
   @ApiModelProperty(value = "")
 
- @Min(10) @Max(100)
+@Min(10) @Max(100) 
   public Integer getInteger() {
     return integer;
   }
@@ -93,7 +93,7 @@ public class FormatTest   {
   **/
   @ApiModelProperty(value = "")
 
- @Min(20) @Max(200)
+@Min(20) @Max(200) 
   public Integer getInt32() {
     return int32;
   }
@@ -137,7 +137,7 @@ public class FormatTest   {
   @NotNull
 
   @Valid
- @DecimalMin("32.1") @DecimalMax("543.2")
+@DecimalMin("32.1") @DecimalMax("543.2") 
   public BigDecimal getNumber() {
     return number;
   }
@@ -159,7 +159,7 @@ public class FormatTest   {
   **/
   @ApiModelProperty(value = "")
 
- @DecimalMin("54.3") @DecimalMax("987.6")
+@DecimalMin("54.3") @DecimalMax("987.6") 
   public Float getFloat() {
     return _float;
   }
@@ -181,7 +181,7 @@ public class FormatTest   {
   **/
   @ApiModelProperty(value = "")
 
- @DecimalMin("67.8") @DecimalMax("123.4")
+@DecimalMin("67.8") @DecimalMax("123.4") 
   public Double getDouble() {
     return _double;
   }
@@ -201,7 +201,7 @@ public class FormatTest   {
   **/
   @ApiModelProperty(value = "")
 
- @Pattern(regexp="/[a-z]/i")
+@Pattern(regexp="/[a-z]/i") 
   public String getString() {
     return string;
   }
@@ -222,7 +222,7 @@ public class FormatTest   {
   @ApiModelProperty(required = true, value = "")
   @NotNull
 
- @Pattern(regexp="^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$")
+@Pattern(regexp="^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$") 
   public byte[] getByte() {
     return _byte;
   }
@@ -327,7 +327,7 @@ public class FormatTest   {
   @ApiModelProperty(required = true, value = "")
   @NotNull
 
- @Size(min=10,max=64)
+@Size(min=10,max=64) 
   public String getPassword() {
     return password;
   }

--- a/samples/server/petstore/springboot-beanvalidation/src/main/java/io/swagger/api/AnotherFakeApi.java
+++ b/samples/server/petstore/springboot-beanvalidation/src/main/java/io/swagger/api/AnotherFakeApi.java
@@ -34,6 +34,6 @@ public interface AnotherFakeApi {
         produces = { "application/json" }, 
         consumes = { "application/json" },
         method = RequestMethod.PATCH)
-    ResponseEntity<Client> testSpecialTags(@ApiParam(value = "client model" ,required=true )  @Valid @RequestBody Client body, @RequestHeader(value = "Accept", required = false) String accept) throws Exception;
+    ResponseEntity<Client> testSpecialTags(@ApiParam(value = "client model" ,required=true )  @Valid @RequestBody Client body);
 
 }

--- a/samples/server/petstore/springboot-beanvalidation/src/main/java/io/swagger/api/AnotherFakeApi.java
+++ b/samples/server/petstore/springboot-beanvalidation/src/main/java/io/swagger/api/AnotherFakeApi.java
@@ -6,9 +6,9 @@
 package io.swagger.api;
 
 import io.swagger.model.Client;
-
 import io.swagger.annotations.*;
 import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
@@ -17,12 +17,10 @@ import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.multipart.MultipartFile;
-import java.io.IOException;
 
-import java.util.List;
-import org.springframework.validation.annotation.Validated;
-import javax.validation.constraints.*;
 import javax.validation.Valid;
+import javax.validation.constraints.*;
+import java.util.List;
 
 @Api(value = "another-fake", description = "the another-fake API")
 public interface AnotherFakeApi {

--- a/samples/server/petstore/springboot-beanvalidation/src/main/java/io/swagger/api/AnotherFakeApiController.java
+++ b/samples/server/petstore/springboot-beanvalidation/src/main/java/io/swagger/api/AnotherFakeApiController.java
@@ -4,6 +4,8 @@ import io.swagger.model.Client;
 
 import io.swagger.annotations.*;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
@@ -12,6 +14,8 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RequestPart;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.util.List;
@@ -22,18 +26,25 @@ import javax.validation.Valid;
 
 @Controller
 public class AnotherFakeApiController implements AnotherFakeApi {
+
+    private final Logger log = LoggerFactory.getLogger(AnotherFakeApiController.class);
+
     private final ObjectMapper objectMapper;
 
     public AnotherFakeApiController(ObjectMapper objectMapper) {
         this.objectMapper = objectMapper;
     }
 
-    public ResponseEntity<Client> testSpecialTags(@ApiParam(value = "client model" ,required=true )  @Valid @RequestBody Client body,
-        @RequestHeader(value = "Accept", required = false) String accept) throws Exception {
+    public ResponseEntity<Client> testSpecialTags(@ApiParam(value = "client model" ,required=true )  @Valid @RequestBody Client body) {
         // do some magic!
-
+        String accept = ((ServletRequestAttributes)RequestContextHolder.getRequestAttributes()).getRequest().getHeader("Accept");
         if (accept != null && accept.contains("application/json")) {
-            return new ResponseEntity<Client>(objectMapper.readValue("{  \"client\" : \"client\"}", Client.class), HttpStatus.OK);
+            try {
+                return new ResponseEntity<Client>(objectMapper.readValue("{  \"client\" : \"client\"}", Client.class), HttpStatus.NOT_IMPLEMENTED);
+            } catch (IOException e) {
+                log.error("Couldn't serialize response for content type application/json", e);
+                return new ResponseEntity<Client>(HttpStatus.INTERNAL_SERVER_ERROR);
+            }
         }
 
         return new ResponseEntity<Client>(HttpStatus.OK);

--- a/samples/server/petstore/springboot-beanvalidation/src/main/java/io/swagger/api/AnotherFakeApiController.java
+++ b/samples/server/petstore/springboot-beanvalidation/src/main/java/io/swagger/api/AnotherFakeApiController.java
@@ -32,12 +32,12 @@ public class AnotherFakeApiController implements AnotherFakeApi {
 
     private final ObjectMapper objectMapper;
 
-    @org.springframework.beans.factory.annotation.Autowired
-    private HttpServletRequest request;
+    private final HttpServletRequest request;
 
     @org.springframework.beans.factory.annotation.Autowired
-    public AnotherFakeApiController(ObjectMapper objectMapper) {
+    public AnotherFakeApiController(ObjectMapper objectMapper, HttpServletRequest request) {
         this.objectMapper = objectMapper;
+        this.request = request;
     }
 
     public ResponseEntity<Client> testSpecialTags(@ApiParam(value = "client model" ,required=true )  @Valid @RequestBody Client body) {

--- a/samples/server/petstore/springboot-beanvalidation/src/main/java/io/swagger/api/AnotherFakeApiController.java
+++ b/samples/server/petstore/springboot-beanvalidation/src/main/java/io/swagger/api/AnotherFakeApiController.java
@@ -21,23 +21,28 @@ import org.springframework.web.multipart.MultipartFile;
 import java.util.List;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.IOException;
+import javax.servlet.http.HttpServletRequest;
 import javax.validation.constraints.*;
 import javax.validation.Valid;
 
 @Controller
 public class AnotherFakeApiController implements AnotherFakeApi {
 
-    private final Logger log = LoggerFactory.getLogger(AnotherFakeApiController.class);
+    private static final Logger log = LoggerFactory.getLogger(AnotherFakeApiController.class);
 
     private final ObjectMapper objectMapper;
 
+    @org.springframework.beans.factory.annotation.Autowired
+    private HttpServletRequest request;
+
+    @org.springframework.beans.factory.annotation.Autowired
     public AnotherFakeApiController(ObjectMapper objectMapper) {
         this.objectMapper = objectMapper;
     }
 
     public ResponseEntity<Client> testSpecialTags(@ApiParam(value = "client model" ,required=true )  @Valid @RequestBody Client body) {
         // do some magic!
-        String accept = ((ServletRequestAttributes)RequestContextHolder.getRequestAttributes()).getRequest().getHeader("Accept");
+        String accept = request.getHeader("Accept");
         if (accept != null && accept.contains("application/json")) {
             try {
                 return new ResponseEntity<Client>(objectMapper.readValue("{  \"client\" : \"client\"}", Client.class), HttpStatus.NOT_IMPLEMENTED);

--- a/samples/server/petstore/springboot-beanvalidation/src/main/java/io/swagger/api/AnotherFakeApiController.java
+++ b/samples/server/petstore/springboot-beanvalidation/src/main/java/io/swagger/api/AnotherFakeApiController.java
@@ -1,9 +1,8 @@
 package io.swagger.api;
 
 import io.swagger.model.Client;
-
+import com.fasterxml.jackson.databind.ObjectMapper;
 import io.swagger.annotations.*;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpStatus;
@@ -14,16 +13,13 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RequestPart;
-import org.springframework.web.context.request.RequestContextHolder;
-import org.springframework.web.context.request.ServletRequestAttributes;
 import org.springframework.web.multipart.MultipartFile;
 
-import java.util.List;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import java.io.IOException;
-import javax.servlet.http.HttpServletRequest;
 import javax.validation.constraints.*;
 import javax.validation.Valid;
+import javax.servlet.http.HttpServletRequest;
+import java.io.IOException;
+import java.util.List;
 
 @Controller
 public class AnotherFakeApiController implements AnotherFakeApi {
@@ -41,7 +37,6 @@ public class AnotherFakeApiController implements AnotherFakeApi {
     }
 
     public ResponseEntity<Client> testSpecialTags(@ApiParam(value = "client model" ,required=true )  @Valid @RequestBody Client body) {
-        // do some magic!
         String accept = request.getHeader("Accept");
         if (accept != null && accept.contains("application/json")) {
             try {
@@ -52,7 +47,7 @@ public class AnotherFakeApiController implements AnotherFakeApi {
             }
         }
 
-        return new ResponseEntity<Client>(HttpStatus.OK);
+        return new ResponseEntity<Client>(HttpStatus.NOT_IMPLEMENTED);
     }
 
 }

--- a/samples/server/petstore/springboot-beanvalidation/src/main/java/io/swagger/api/FakeApi.java
+++ b/samples/server/petstore/springboot-beanvalidation/src/main/java/io/swagger/api/FakeApi.java
@@ -10,9 +10,9 @@ import io.swagger.model.Client;
 import org.threeten.bp.LocalDate;
 import org.threeten.bp.OffsetDateTime;
 import io.swagger.model.OuterComposite;
-
 import io.swagger.annotations.*;
 import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
@@ -21,12 +21,10 @@ import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.multipart.MultipartFile;
-import java.io.IOException;
 
-import java.util.List;
-import org.springframework.validation.annotation.Validated;
-import javax.validation.constraints.*;
 import javax.validation.Valid;
+import javax.validation.constraints.*;
+import java.util.List;
 
 @Api(value = "fake", description = "the fake API")
 public interface FakeApi {

--- a/samples/server/petstore/springboot-beanvalidation/src/main/java/io/swagger/api/FakeApi.java
+++ b/samples/server/petstore/springboot-beanvalidation/src/main/java/io/swagger/api/FakeApi.java
@@ -36,7 +36,7 @@ public interface FakeApi {
         @ApiResponse(code = 200, message = "Output boolean", response = Boolean.class) })
     @RequestMapping(value = "/fake/outer/boolean",
         method = RequestMethod.POST)
-    ResponseEntity<Boolean> fakeOuterBooleanSerialize(@ApiParam(value = "Input boolean as post body"  )  @Valid @RequestBody Boolean body, @RequestHeader(value = "Accept", required = false) String accept) throws Exception;
+    ResponseEntity<Boolean> fakeOuterBooleanSerialize(@ApiParam(value = "Input boolean as post body"  )  @Valid @RequestBody Boolean body);
 
 
     @ApiOperation(value = "", nickname = "fakeOuterCompositeSerialize", notes = "Test serialization of object with outer number type", response = OuterComposite.class, tags={ "fake", })
@@ -44,7 +44,7 @@ public interface FakeApi {
         @ApiResponse(code = 200, message = "Output composite", response = OuterComposite.class) })
     @RequestMapping(value = "/fake/outer/composite",
         method = RequestMethod.POST)
-    ResponseEntity<OuterComposite> fakeOuterCompositeSerialize(@ApiParam(value = "Input composite as post body"  )  @Valid @RequestBody OuterComposite body, @RequestHeader(value = "Accept", required = false) String accept) throws Exception;
+    ResponseEntity<OuterComposite> fakeOuterCompositeSerialize(@ApiParam(value = "Input composite as post body"  )  @Valid @RequestBody OuterComposite body);
 
 
     @ApiOperation(value = "", nickname = "fakeOuterNumberSerialize", notes = "Test serialization of outer number types", response = BigDecimal.class, tags={ "fake", })
@@ -52,7 +52,7 @@ public interface FakeApi {
         @ApiResponse(code = 200, message = "Output number", response = BigDecimal.class) })
     @RequestMapping(value = "/fake/outer/number",
         method = RequestMethod.POST)
-    ResponseEntity<BigDecimal> fakeOuterNumberSerialize(@ApiParam(value = "Input number as post body"  )  @Valid @RequestBody BigDecimal body, @RequestHeader(value = "Accept", required = false) String accept) throws Exception;
+    ResponseEntity<BigDecimal> fakeOuterNumberSerialize(@ApiParam(value = "Input number as post body"  )  @Valid @RequestBody BigDecimal body);
 
 
     @ApiOperation(value = "", nickname = "fakeOuterStringSerialize", notes = "Test serialization of outer string types", response = String.class, tags={ "fake", })
@@ -60,7 +60,7 @@ public interface FakeApi {
         @ApiResponse(code = 200, message = "Output string", response = String.class) })
     @RequestMapping(value = "/fake/outer/string",
         method = RequestMethod.POST)
-    ResponseEntity<String> fakeOuterStringSerialize(@ApiParam(value = "Input string as post body"  )  @Valid @RequestBody String body, @RequestHeader(value = "Accept", required = false) String accept) throws Exception;
+    ResponseEntity<String> fakeOuterStringSerialize(@ApiParam(value = "Input string as post body"  )  @Valid @RequestBody String body);
 
 
     @ApiOperation(value = "To test \"client\" model", nickname = "testClientModel", notes = "To test \"client\" model", response = Client.class, tags={ "fake", })
@@ -70,7 +70,7 @@ public interface FakeApi {
         produces = { "application/json" }, 
         consumes = { "application/json" },
         method = RequestMethod.PATCH)
-    ResponseEntity<Client> testClientModel(@ApiParam(value = "client model" ,required=true )  @Valid @RequestBody Client body, @RequestHeader(value = "Accept", required = false) String accept) throws Exception;
+    ResponseEntity<Client> testClientModel(@ApiParam(value = "client model" ,required=true )  @Valid @RequestBody Client body);
 
 
     @ApiOperation(value = "Fake endpoint for testing various parameters 假端點 偽のエンドポイント 가짜 엔드 포인트 ", nickname = "testEndpointParameters", notes = "Fake endpoint for testing various parameters 假端點 偽のエンドポイント 가짜 엔드 포인트 ", authorizations = {
@@ -83,7 +83,7 @@ public interface FakeApi {
         produces = { "application/xml; charset=utf-8", "application/json; charset=utf-8" }, 
         consumes = { "application/xml; charset=utf-8", "application/json; charset=utf-8" },
         method = RequestMethod.POST)
-    ResponseEntity<Void> testEndpointParameters(@ApiParam(value = "None", required=true) @RequestPart(value="number", required=true)  BigDecimal number,@ApiParam(value = "None", required=true) @RequestPart(value="double", required=true)  Double _double,@ApiParam(value = "None", required=true) @RequestPart(value="pattern_without_delimiter", required=true)  String patternWithoutDelimiter,@ApiParam(value = "None", required=true) @RequestPart(value="byte", required=true)  byte[] _byte,@ApiParam(value = "None") @RequestPart(value="integer", required=false)  Integer integer,@ApiParam(value = "None") @RequestPart(value="int32", required=false)  Integer int32,@ApiParam(value = "None") @RequestPart(value="int64", required=false)  Long int64,@ApiParam(value = "None") @RequestPart(value="float", required=false)  Float _float,@ApiParam(value = "None") @RequestPart(value="string", required=false)  String string,@ApiParam(value = "None") @RequestPart(value="binary", required=false)  byte[] binary,@ApiParam(value = "None") @RequestPart(value="date", required=false)  LocalDate date,@ApiParam(value = "None") @RequestPart(value="dateTime", required=false)  OffsetDateTime dateTime,@ApiParam(value = "None") @RequestPart(value="password", required=false)  String password,@ApiParam(value = "None") @RequestPart(value="callback", required=false)  String paramCallback, @RequestHeader(value = "Accept", required = false) String accept) throws Exception;
+    ResponseEntity<Void> testEndpointParameters(@ApiParam(value = "None", required=true) @RequestPart(value="number", required=true)  BigDecimal number,@ApiParam(value = "None", required=true) @RequestPart(value="double", required=true)  Double _double,@ApiParam(value = "None", required=true) @RequestPart(value="pattern_without_delimiter", required=true)  String patternWithoutDelimiter,@ApiParam(value = "None", required=true) @RequestPart(value="byte", required=true)  byte[] _byte,@ApiParam(value = "None") @RequestPart(value="integer", required=false)  Integer integer,@ApiParam(value = "None") @RequestPart(value="int32", required=false)  Integer int32,@ApiParam(value = "None") @RequestPart(value="int64", required=false)  Long int64,@ApiParam(value = "None") @RequestPart(value="float", required=false)  Float _float,@ApiParam(value = "None") @RequestPart(value="string", required=false)  String string,@ApiParam(value = "None") @RequestPart(value="binary", required=false)  byte[] binary,@ApiParam(value = "None") @RequestPart(value="date", required=false)  LocalDate date,@ApiParam(value = "None") @RequestPart(value="dateTime", required=false)  OffsetDateTime dateTime,@ApiParam(value = "None") @RequestPart(value="password", required=false)  String password,@ApiParam(value = "None") @RequestPart(value="callback", required=false)  String paramCallback);
 
 
     @ApiOperation(value = "To test enum parameters", nickname = "testEnumParameters", notes = "To test enum parameters", tags={ "fake", })
@@ -94,7 +94,7 @@ public interface FakeApi {
         produces = { "*/*" }, 
         consumes = { "*/*" },
         method = RequestMethod.GET)
-    ResponseEntity<Void> testEnumParameters(@ApiParam(value = "Form parameter enum test (string array)", allowableValues=">, $") @RequestPart(value="enum_form_string_array", required=false)  List<String> enumFormStringArray,@ApiParam(value = "Form parameter enum test (string)", allowableValues="_abc, -efg, (xyz)", defaultValue="-efg") @RequestPart(value="enum_form_string", required=false)  String enumFormString,@ApiParam(value = "Header parameter enum test (string array)" , allowableValues=">, $") @RequestHeader(value="enum_header_string_array", required=false) List<String> enumHeaderStringArray,@ApiParam(value = "Header parameter enum test (string)" , allowableValues="_abc, -efg, (xyz)", defaultValue="-efg") @RequestHeader(value="enum_header_string", required=false) String enumHeaderString,@ApiParam(value = "Query parameter enum test (string array)", allowableValues = ">, $") @Valid @RequestParam(value = "enum_query_string_array", required = false) List<String> enumQueryStringArray,@ApiParam(value = "Query parameter enum test (string)", allowableValues = "_abc, -efg, (xyz)", defaultValue = "-efg") @Valid @RequestParam(value = "enum_query_string", required = false, defaultValue="-efg") String enumQueryString,@ApiParam(value = "Query parameter enum test (double)", allowableValues = "1, -2") @Valid @RequestParam(value = "enum_query_integer", required = false) Integer enumQueryInteger,@ApiParam(value = "Query parameter enum test (double)", allowableValues="1.1, -1.2") @RequestPart(value="enum_query_double", required=false)  Double enumQueryDouble, @RequestHeader(value = "Accept", required = false) String accept) throws Exception;
+    ResponseEntity<Void> testEnumParameters(@ApiParam(value = "Form parameter enum test (string array)", allowableValues=">, $") @RequestPart(value="enum_form_string_array", required=false)  List<String> enumFormStringArray,@ApiParam(value = "Form parameter enum test (string)", allowableValues="_abc, -efg, (xyz)", defaultValue="-efg") @RequestPart(value="enum_form_string", required=false)  String enumFormString,@ApiParam(value = "Header parameter enum test (string array)" , allowableValues=">, $") @RequestHeader(value="enum_header_string_array", required=false) List<String> enumHeaderStringArray,@ApiParam(value = "Header parameter enum test (string)" , allowableValues="_abc, -efg, (xyz)", defaultValue="-efg") @RequestHeader(value="enum_header_string", required=false) String enumHeaderString,@ApiParam(value = "Query parameter enum test (string array)", allowableValues = ">, $") @Valid @RequestParam(value = "enum_query_string_array", required = false) List<String> enumQueryStringArray,@ApiParam(value = "Query parameter enum test (string)", allowableValues = "_abc, -efg, (xyz)", defaultValue = "-efg") @Valid @RequestParam(value = "enum_query_string", required = false, defaultValue="-efg") String enumQueryString,@ApiParam(value = "Query parameter enum test (double)", allowableValues = "1, -2") @Valid @RequestParam(value = "enum_query_integer", required = false) Integer enumQueryInteger,@ApiParam(value = "Query parameter enum test (double)", allowableValues="1.1, -1.2") @RequestPart(value="enum_query_double", required=false)  Double enumQueryDouble);
 
 
     @ApiOperation(value = "test inline additionalProperties", nickname = "testInlineAdditionalProperties", notes = "", tags={ "fake", })
@@ -103,7 +103,7 @@ public interface FakeApi {
     @RequestMapping(value = "/fake/inline-additionalProperties",
         consumes = { "application/json" },
         method = RequestMethod.POST)
-    ResponseEntity<Void> testInlineAdditionalProperties(@ApiParam(value = "request body" ,required=true )  @Valid @RequestBody Object param, @RequestHeader(value = "Accept", required = false) String accept) throws Exception;
+    ResponseEntity<Void> testInlineAdditionalProperties(@ApiParam(value = "request body" ,required=true )  @Valid @RequestBody Object param);
 
 
     @ApiOperation(value = "test json serialization of form data", nickname = "testJsonFormData", notes = "", tags={ "fake", })
@@ -112,6 +112,6 @@ public interface FakeApi {
     @RequestMapping(value = "/fake/jsonFormData",
         consumes = { "application/json" },
         method = RequestMethod.GET)
-    ResponseEntity<Void> testJsonFormData(@ApiParam(value = "field1", required=true) @RequestPart(value="param", required=true)  String param,@ApiParam(value = "field2", required=true) @RequestPart(value="param2", required=true)  String param2, @RequestHeader(value = "Accept", required = false) String accept) throws Exception;
+    ResponseEntity<Void> testJsonFormData(@ApiParam(value = "field1", required=true) @RequestPart(value="param", required=true)  String param,@ApiParam(value = "field2", required=true) @RequestPart(value="param2", required=true)  String param2);
 
 }

--- a/samples/server/petstore/springboot-beanvalidation/src/main/java/io/swagger/api/FakeApiController.java
+++ b/samples/server/petstore/springboot-beanvalidation/src/main/java/io/swagger/api/FakeApiController.java
@@ -36,12 +36,12 @@ public class FakeApiController implements FakeApi {
 
     private final ObjectMapper objectMapper;
 
-    @org.springframework.beans.factory.annotation.Autowired
-    private HttpServletRequest request;
+    private final HttpServletRequest request;
 
     @org.springframework.beans.factory.annotation.Autowired
-    public FakeApiController(ObjectMapper objectMapper) {
+    public FakeApiController(ObjectMapper objectMapper, HttpServletRequest request) {
         this.objectMapper = objectMapper;
+        this.request = request;
     }
 
     public ResponseEntity<Boolean> fakeOuterBooleanSerialize(@ApiParam(value = "Input boolean as post body"  )  @Valid @RequestBody Boolean body) {

--- a/samples/server/petstore/springboot-beanvalidation/src/main/java/io/swagger/api/FakeApiController.java
+++ b/samples/server/petstore/springboot-beanvalidation/src/main/java/io/swagger/api/FakeApiController.java
@@ -25,23 +25,28 @@ import org.springframework.web.multipart.MultipartFile;
 import java.util.List;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.IOException;
+import javax.servlet.http.HttpServletRequest;
 import javax.validation.constraints.*;
 import javax.validation.Valid;
 
 @Controller
 public class FakeApiController implements FakeApi {
 
-    private final Logger log = LoggerFactory.getLogger(AnotherFakeApiController.class);
+    private static final Logger log = LoggerFactory.getLogger(FakeApiController.class);
 
     private final ObjectMapper objectMapper;
 
+    @org.springframework.beans.factory.annotation.Autowired
+    private HttpServletRequest request;
+
+    @org.springframework.beans.factory.annotation.Autowired
     public FakeApiController(ObjectMapper objectMapper) {
         this.objectMapper = objectMapper;
     }
 
     public ResponseEntity<Boolean> fakeOuterBooleanSerialize(@ApiParam(value = "Input boolean as post body"  )  @Valid @RequestBody Boolean body) {
         // do some magic!
-        String accept = ((ServletRequestAttributes)RequestContextHolder.getRequestAttributes()).getRequest().getHeader("Accept");
+        String accept = request.getHeader("Accept");
         if (accept != null && accept.contains("application/json")) {
             try {
                 return new ResponseEntity<Boolean>(objectMapper.readValue("{ }", Boolean.class), HttpStatus.NOT_IMPLEMENTED);
@@ -56,7 +61,7 @@ public class FakeApiController implements FakeApi {
 
     public ResponseEntity<OuterComposite> fakeOuterCompositeSerialize(@ApiParam(value = "Input composite as post body"  )  @Valid @RequestBody OuterComposite body) {
         // do some magic!
-        String accept = ((ServletRequestAttributes)RequestContextHolder.getRequestAttributes()).getRequest().getHeader("Accept");
+        String accept = request.getHeader("Accept");
         if (accept != null && accept.contains("application/json")) {
             try {
                 return new ResponseEntity<OuterComposite>(objectMapper.readValue("{  \"my_string\" : { },  \"my_number\" : { },  \"my_boolean\" : { }}", OuterComposite.class), HttpStatus.NOT_IMPLEMENTED);
@@ -71,7 +76,7 @@ public class FakeApiController implements FakeApi {
 
     public ResponseEntity<BigDecimal> fakeOuterNumberSerialize(@ApiParam(value = "Input number as post body"  )  @Valid @RequestBody BigDecimal body) {
         // do some magic!
-        String accept = ((ServletRequestAttributes)RequestContextHolder.getRequestAttributes()).getRequest().getHeader("Accept");
+        String accept = request.getHeader("Accept");
         if (accept != null && accept.contains("application/json")) {
             try {
                 return new ResponseEntity<BigDecimal>(objectMapper.readValue("{ }", BigDecimal.class), HttpStatus.NOT_IMPLEMENTED);
@@ -86,7 +91,7 @@ public class FakeApiController implements FakeApi {
 
     public ResponseEntity<String> fakeOuterStringSerialize(@ApiParam(value = "Input string as post body"  )  @Valid @RequestBody String body) {
         // do some magic!
-        String accept = ((ServletRequestAttributes)RequestContextHolder.getRequestAttributes()).getRequest().getHeader("Accept");
+        String accept = request.getHeader("Accept");
         if (accept != null && accept.contains("application/json")) {
             try {
                 return new ResponseEntity<String>(objectMapper.readValue("{ }", String.class), HttpStatus.NOT_IMPLEMENTED);
@@ -101,7 +106,7 @@ public class FakeApiController implements FakeApi {
 
     public ResponseEntity<Client> testClientModel(@ApiParam(value = "client model" ,required=true )  @Valid @RequestBody Client body) {
         // do some magic!
-        String accept = ((ServletRequestAttributes)RequestContextHolder.getRequestAttributes()).getRequest().getHeader("Accept");
+        String accept = request.getHeader("Accept");
         if (accept != null && accept.contains("application/json")) {
             try {
                 return new ResponseEntity<Client>(objectMapper.readValue("{  \"client\" : \"client\"}", Client.class), HttpStatus.NOT_IMPLEMENTED);
@@ -116,25 +121,25 @@ public class FakeApiController implements FakeApi {
 
     public ResponseEntity<Void> testEndpointParameters(@ApiParam(value = "None", required=true) @RequestPart(value="number", required=true)  BigDecimal number,@ApiParam(value = "None", required=true) @RequestPart(value="double", required=true)  Double _double,@ApiParam(value = "None", required=true) @RequestPart(value="pattern_without_delimiter", required=true)  String patternWithoutDelimiter,@ApiParam(value = "None", required=true) @RequestPart(value="byte", required=true)  byte[] _byte,@ApiParam(value = "None") @RequestPart(value="integer", required=false)  Integer integer,@ApiParam(value = "None") @RequestPart(value="int32", required=false)  Integer int32,@ApiParam(value = "None") @RequestPart(value="int64", required=false)  Long int64,@ApiParam(value = "None") @RequestPart(value="float", required=false)  Float _float,@ApiParam(value = "None") @RequestPart(value="string", required=false)  String string,@ApiParam(value = "None") @RequestPart(value="binary", required=false)  byte[] binary,@ApiParam(value = "None") @RequestPart(value="date", required=false)  LocalDate date,@ApiParam(value = "None") @RequestPart(value="dateTime", required=false)  OffsetDateTime dateTime,@ApiParam(value = "None") @RequestPart(value="password", required=false)  String password,@ApiParam(value = "None") @RequestPart(value="callback", required=false)  String paramCallback) {
         // do some magic!
-        String accept = ((ServletRequestAttributes)RequestContextHolder.getRequestAttributes()).getRequest().getHeader("Accept");
+        String accept = request.getHeader("Accept");
         return new ResponseEntity<Void>(HttpStatus.OK);
     }
 
     public ResponseEntity<Void> testEnumParameters(@ApiParam(value = "Form parameter enum test (string array)", allowableValues=">, $") @RequestPart(value="enum_form_string_array", required=false)  List<String> enumFormStringArray,@ApiParam(value = "Form parameter enum test (string)", allowableValues="_abc, -efg, (xyz)", defaultValue="-efg") @RequestPart(value="enum_form_string", required=false)  String enumFormString,@ApiParam(value = "Header parameter enum test (string array)" , allowableValues=">, $") @RequestHeader(value="enum_header_string_array", required=false) List<String> enumHeaderStringArray,@ApiParam(value = "Header parameter enum test (string)" , allowableValues="_abc, -efg, (xyz)", defaultValue="-efg") @RequestHeader(value="enum_header_string", required=false) String enumHeaderString,@ApiParam(value = "Query parameter enum test (string array)", allowableValues = ">, $") @Valid @RequestParam(value = "enum_query_string_array", required = false) List<String> enumQueryStringArray,@ApiParam(value = "Query parameter enum test (string)", allowableValues = "_abc, -efg, (xyz)", defaultValue = "-efg") @Valid @RequestParam(value = "enum_query_string", required = false, defaultValue="-efg") String enumQueryString,@ApiParam(value = "Query parameter enum test (double)", allowableValues = "1, -2") @Valid @RequestParam(value = "enum_query_integer", required = false) Integer enumQueryInteger,@ApiParam(value = "Query parameter enum test (double)", allowableValues="1.1, -1.2") @RequestPart(value="enum_query_double", required=false)  Double enumQueryDouble) {
         // do some magic!
-        String accept = ((ServletRequestAttributes)RequestContextHolder.getRequestAttributes()).getRequest().getHeader("Accept");
+        String accept = request.getHeader("Accept");
         return new ResponseEntity<Void>(HttpStatus.OK);
     }
 
     public ResponseEntity<Void> testInlineAdditionalProperties(@ApiParam(value = "request body" ,required=true )  @Valid @RequestBody Object param) {
         // do some magic!
-        String accept = ((ServletRequestAttributes)RequestContextHolder.getRequestAttributes()).getRequest().getHeader("Accept");
+        String accept = request.getHeader("Accept");
         return new ResponseEntity<Void>(HttpStatus.OK);
     }
 
     public ResponseEntity<Void> testJsonFormData(@ApiParam(value = "field1", required=true) @RequestPart(value="param", required=true)  String param,@ApiParam(value = "field2", required=true) @RequestPart(value="param2", required=true)  String param2) {
         // do some magic!
-        String accept = ((ServletRequestAttributes)RequestContextHolder.getRequestAttributes()).getRequest().getHeader("Accept");
+        String accept = request.getHeader("Accept");
         return new ResponseEntity<Void>(HttpStatus.OK);
     }
 

--- a/samples/server/petstore/springboot-beanvalidation/src/main/java/io/swagger/api/FakeApiController.java
+++ b/samples/server/petstore/springboot-beanvalidation/src/main/java/io/swagger/api/FakeApiController.java
@@ -8,6 +8,8 @@ import io.swagger.model.OuterComposite;
 
 import io.swagger.annotations.*;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
@@ -16,6 +18,8 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RequestPart;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.util.List;
@@ -26,109 +30,111 @@ import javax.validation.Valid;
 
 @Controller
 public class FakeApiController implements FakeApi {
+
+    private final Logger log = LoggerFactory.getLogger(AnotherFakeApiController.class);
+
     private final ObjectMapper objectMapper;
 
     public FakeApiController(ObjectMapper objectMapper) {
         this.objectMapper = objectMapper;
     }
 
-    public ResponseEntity<Boolean> fakeOuterBooleanSerialize(@ApiParam(value = "Input boolean as post body"  )  @Valid @RequestBody Boolean body,
-        @RequestHeader(value = "Accept", required = false) String accept) throws Exception {
+    public ResponseEntity<Boolean> fakeOuterBooleanSerialize(@ApiParam(value = "Input boolean as post body"  )  @Valid @RequestBody Boolean body) {
         // do some magic!
-
+        String accept = ((ServletRequestAttributes)RequestContextHolder.getRequestAttributes()).getRequest().getHeader("Accept");
         if (accept != null && accept.contains("application/json")) {
-            return new ResponseEntity<Boolean>(objectMapper.readValue("{ }", Boolean.class), HttpStatus.OK);
+            try {
+                return new ResponseEntity<Boolean>(objectMapper.readValue("{ }", Boolean.class), HttpStatus.NOT_IMPLEMENTED);
+            } catch (IOException e) {
+                log.error("Couldn't serialize response for content type application/json", e);
+                return new ResponseEntity<Boolean>(HttpStatus.INTERNAL_SERVER_ERROR);
+            }
         }
 
         return new ResponseEntity<Boolean>(HttpStatus.OK);
     }
 
-    public ResponseEntity<OuterComposite> fakeOuterCompositeSerialize(@ApiParam(value = "Input composite as post body"  )  @Valid @RequestBody OuterComposite body,
-        @RequestHeader(value = "Accept", required = false) String accept) throws Exception {
+    public ResponseEntity<OuterComposite> fakeOuterCompositeSerialize(@ApiParam(value = "Input composite as post body"  )  @Valid @RequestBody OuterComposite body) {
         // do some magic!
-
+        String accept = ((ServletRequestAttributes)RequestContextHolder.getRequestAttributes()).getRequest().getHeader("Accept");
         if (accept != null && accept.contains("application/json")) {
-            return new ResponseEntity<OuterComposite>(objectMapper.readValue("{  \"my_string\" : { },  \"my_number\" : { },  \"my_boolean\" : { }}", OuterComposite.class), HttpStatus.OK);
+            try {
+                return new ResponseEntity<OuterComposite>(objectMapper.readValue("{  \"my_string\" : { },  \"my_number\" : { },  \"my_boolean\" : { }}", OuterComposite.class), HttpStatus.NOT_IMPLEMENTED);
+            } catch (IOException e) {
+                log.error("Couldn't serialize response for content type application/json", e);
+                return new ResponseEntity<OuterComposite>(HttpStatus.INTERNAL_SERVER_ERROR);
+            }
         }
 
         return new ResponseEntity<OuterComposite>(HttpStatus.OK);
     }
 
-    public ResponseEntity<BigDecimal> fakeOuterNumberSerialize(@ApiParam(value = "Input number as post body"  )  @Valid @RequestBody BigDecimal body,
-        @RequestHeader(value = "Accept", required = false) String accept) throws Exception {
+    public ResponseEntity<BigDecimal> fakeOuterNumberSerialize(@ApiParam(value = "Input number as post body"  )  @Valid @RequestBody BigDecimal body) {
         // do some magic!
-
+        String accept = ((ServletRequestAttributes)RequestContextHolder.getRequestAttributes()).getRequest().getHeader("Accept");
         if (accept != null && accept.contains("application/json")) {
-            return new ResponseEntity<BigDecimal>(objectMapper.readValue("{ }", BigDecimal.class), HttpStatus.OK);
+            try {
+                return new ResponseEntity<BigDecimal>(objectMapper.readValue("{ }", BigDecimal.class), HttpStatus.NOT_IMPLEMENTED);
+            } catch (IOException e) {
+                log.error("Couldn't serialize response for content type application/json", e);
+                return new ResponseEntity<BigDecimal>(HttpStatus.INTERNAL_SERVER_ERROR);
+            }
         }
 
         return new ResponseEntity<BigDecimal>(HttpStatus.OK);
     }
 
-    public ResponseEntity<String> fakeOuterStringSerialize(@ApiParam(value = "Input string as post body"  )  @Valid @RequestBody String body,
-        @RequestHeader(value = "Accept", required = false) String accept) throws Exception {
+    public ResponseEntity<String> fakeOuterStringSerialize(@ApiParam(value = "Input string as post body"  )  @Valid @RequestBody String body) {
         // do some magic!
-
+        String accept = ((ServletRequestAttributes)RequestContextHolder.getRequestAttributes()).getRequest().getHeader("Accept");
         if (accept != null && accept.contains("application/json")) {
-            return new ResponseEntity<String>(objectMapper.readValue("{ }", String.class), HttpStatus.OK);
+            try {
+                return new ResponseEntity<String>(objectMapper.readValue("{ }", String.class), HttpStatus.NOT_IMPLEMENTED);
+            } catch (IOException e) {
+                log.error("Couldn't serialize response for content type application/json", e);
+                return new ResponseEntity<String>(HttpStatus.INTERNAL_SERVER_ERROR);
+            }
         }
 
         return new ResponseEntity<String>(HttpStatus.OK);
     }
 
-    public ResponseEntity<Client> testClientModel(@ApiParam(value = "client model" ,required=true )  @Valid @RequestBody Client body,
-        @RequestHeader(value = "Accept", required = false) String accept) throws Exception {
+    public ResponseEntity<Client> testClientModel(@ApiParam(value = "client model" ,required=true )  @Valid @RequestBody Client body) {
         // do some magic!
-
+        String accept = ((ServletRequestAttributes)RequestContextHolder.getRequestAttributes()).getRequest().getHeader("Accept");
         if (accept != null && accept.contains("application/json")) {
-            return new ResponseEntity<Client>(objectMapper.readValue("{  \"client\" : \"client\"}", Client.class), HttpStatus.OK);
+            try {
+                return new ResponseEntity<Client>(objectMapper.readValue("{  \"client\" : \"client\"}", Client.class), HttpStatus.NOT_IMPLEMENTED);
+            } catch (IOException e) {
+                log.error("Couldn't serialize response for content type application/json", e);
+                return new ResponseEntity<Client>(HttpStatus.INTERNAL_SERVER_ERROR);
+            }
         }
 
         return new ResponseEntity<Client>(HttpStatus.OK);
     }
 
-    public ResponseEntity<Void> testEndpointParameters(@ApiParam(value = "None", required=true) @RequestPart(value="number", required=true)  BigDecimal number,
-        @ApiParam(value = "None", required=true) @RequestPart(value="double", required=true)  Double _double,
-        @ApiParam(value = "None", required=true) @RequestPart(value="pattern_without_delimiter", required=true)  String patternWithoutDelimiter,
-        @ApiParam(value = "None", required=true) @RequestPart(value="byte", required=true)  byte[] _byte,
-        @ApiParam(value = "None") @RequestPart(value="integer", required=false)  Integer integer,
-        @ApiParam(value = "None") @RequestPart(value="int32", required=false)  Integer int32,
-        @ApiParam(value = "None") @RequestPart(value="int64", required=false)  Long int64,
-        @ApiParam(value = "None") @RequestPart(value="float", required=false)  Float _float,
-        @ApiParam(value = "None") @RequestPart(value="string", required=false)  String string,
-        @ApiParam(value = "None") @RequestPart(value="binary", required=false)  byte[] binary,
-        @ApiParam(value = "None") @RequestPart(value="date", required=false)  LocalDate date,
-        @ApiParam(value = "None") @RequestPart(value="dateTime", required=false)  OffsetDateTime dateTime,
-        @ApiParam(value = "None") @RequestPart(value="password", required=false)  String password,
-        @ApiParam(value = "None") @RequestPart(value="callback", required=false)  String paramCallback,
-        @RequestHeader(value = "Accept", required = false) String accept) throws Exception {
+    public ResponseEntity<Void> testEndpointParameters(@ApiParam(value = "None", required=true) @RequestPart(value="number", required=true)  BigDecimal number,@ApiParam(value = "None", required=true) @RequestPart(value="double", required=true)  Double _double,@ApiParam(value = "None", required=true) @RequestPart(value="pattern_without_delimiter", required=true)  String patternWithoutDelimiter,@ApiParam(value = "None", required=true) @RequestPart(value="byte", required=true)  byte[] _byte,@ApiParam(value = "None") @RequestPart(value="integer", required=false)  Integer integer,@ApiParam(value = "None") @RequestPart(value="int32", required=false)  Integer int32,@ApiParam(value = "None") @RequestPart(value="int64", required=false)  Long int64,@ApiParam(value = "None") @RequestPart(value="float", required=false)  Float _float,@ApiParam(value = "None") @RequestPart(value="string", required=false)  String string,@ApiParam(value = "None") @RequestPart(value="binary", required=false)  byte[] binary,@ApiParam(value = "None") @RequestPart(value="date", required=false)  LocalDate date,@ApiParam(value = "None") @RequestPart(value="dateTime", required=false)  OffsetDateTime dateTime,@ApiParam(value = "None") @RequestPart(value="password", required=false)  String password,@ApiParam(value = "None") @RequestPart(value="callback", required=false)  String paramCallback) {
         // do some magic!
+        String accept = ((ServletRequestAttributes)RequestContextHolder.getRequestAttributes()).getRequest().getHeader("Accept");
         return new ResponseEntity<Void>(HttpStatus.OK);
     }
 
-    public ResponseEntity<Void> testEnumParameters(@ApiParam(value = "Form parameter enum test (string array)", allowableValues=">, $") @RequestPart(value="enum_form_string_array", required=false)  List<String> enumFormStringArray,
-        @ApiParam(value = "Form parameter enum test (string)", allowableValues="_abc, -efg, (xyz)", defaultValue="-efg") @RequestPart(value="enum_form_string", required=false)  String enumFormString,
-        @ApiParam(value = "Header parameter enum test (string array)" , allowableValues=">, $") @RequestHeader(value="enum_header_string_array", required=false) List<String> enumHeaderStringArray,
-        @ApiParam(value = "Header parameter enum test (string)" , allowableValues="_abc, -efg, (xyz)", defaultValue="-efg") @RequestHeader(value="enum_header_string", required=false) String enumHeaderString,
-        @ApiParam(value = "Query parameter enum test (string array)", allowableValues = ">, $") @Valid @RequestParam(value = "enum_query_string_array", required = false) List<String> enumQueryStringArray,
-        @ApiParam(value = "Query parameter enum test (string)", allowableValues = "_abc, -efg, (xyz)", defaultValue = "-efg") @Valid @RequestParam(value = "enum_query_string", required = false, defaultValue="-efg") String enumQueryString,
-        @ApiParam(value = "Query parameter enum test (double)", allowableValues = "1, -2") @Valid @RequestParam(value = "enum_query_integer", required = false) Integer enumQueryInteger,
-        @ApiParam(value = "Query parameter enum test (double)", allowableValues="1.1, -1.2") @RequestPart(value="enum_query_double", required=false)  Double enumQueryDouble,
-        @RequestHeader(value = "Accept", required = false) String accept) throws Exception {
+    public ResponseEntity<Void> testEnumParameters(@ApiParam(value = "Form parameter enum test (string array)", allowableValues=">, $") @RequestPart(value="enum_form_string_array", required=false)  List<String> enumFormStringArray,@ApiParam(value = "Form parameter enum test (string)", allowableValues="_abc, -efg, (xyz)", defaultValue="-efg") @RequestPart(value="enum_form_string", required=false)  String enumFormString,@ApiParam(value = "Header parameter enum test (string array)" , allowableValues=">, $") @RequestHeader(value="enum_header_string_array", required=false) List<String> enumHeaderStringArray,@ApiParam(value = "Header parameter enum test (string)" , allowableValues="_abc, -efg, (xyz)", defaultValue="-efg") @RequestHeader(value="enum_header_string", required=false) String enumHeaderString,@ApiParam(value = "Query parameter enum test (string array)", allowableValues = ">, $") @Valid @RequestParam(value = "enum_query_string_array", required = false) List<String> enumQueryStringArray,@ApiParam(value = "Query parameter enum test (string)", allowableValues = "_abc, -efg, (xyz)", defaultValue = "-efg") @Valid @RequestParam(value = "enum_query_string", required = false, defaultValue="-efg") String enumQueryString,@ApiParam(value = "Query parameter enum test (double)", allowableValues = "1, -2") @Valid @RequestParam(value = "enum_query_integer", required = false) Integer enumQueryInteger,@ApiParam(value = "Query parameter enum test (double)", allowableValues="1.1, -1.2") @RequestPart(value="enum_query_double", required=false)  Double enumQueryDouble) {
         // do some magic!
+        String accept = ((ServletRequestAttributes)RequestContextHolder.getRequestAttributes()).getRequest().getHeader("Accept");
         return new ResponseEntity<Void>(HttpStatus.OK);
     }
 
-    public ResponseEntity<Void> testInlineAdditionalProperties(@ApiParam(value = "request body" ,required=true )  @Valid @RequestBody Object param,
-        @RequestHeader(value = "Accept", required = false) String accept) throws Exception {
+    public ResponseEntity<Void> testInlineAdditionalProperties(@ApiParam(value = "request body" ,required=true )  @Valid @RequestBody Object param) {
         // do some magic!
+        String accept = ((ServletRequestAttributes)RequestContextHolder.getRequestAttributes()).getRequest().getHeader("Accept");
         return new ResponseEntity<Void>(HttpStatus.OK);
     }
 
-    public ResponseEntity<Void> testJsonFormData(@ApiParam(value = "field1", required=true) @RequestPart(value="param", required=true)  String param,
-        @ApiParam(value = "field2", required=true) @RequestPart(value="param2", required=true)  String param2,
-        @RequestHeader(value = "Accept", required = false) String accept) throws Exception {
+    public ResponseEntity<Void> testJsonFormData(@ApiParam(value = "field1", required=true) @RequestPart(value="param", required=true)  String param,@ApiParam(value = "field2", required=true) @RequestPart(value="param2", required=true)  String param2) {
         // do some magic!
+        String accept = ((ServletRequestAttributes)RequestContextHolder.getRequestAttributes()).getRequest().getHeader("Accept");
         return new ResponseEntity<Void>(HttpStatus.OK);
     }
 

--- a/samples/server/petstore/springboot-beanvalidation/src/main/java/io/swagger/api/FakeApiController.java
+++ b/samples/server/petstore/springboot-beanvalidation/src/main/java/io/swagger/api/FakeApiController.java
@@ -5,9 +5,8 @@ import io.swagger.model.Client;
 import org.threeten.bp.LocalDate;
 import org.threeten.bp.OffsetDateTime;
 import io.swagger.model.OuterComposite;
-
+import com.fasterxml.jackson.databind.ObjectMapper;
 import io.swagger.annotations.*;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpStatus;
@@ -18,16 +17,13 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RequestPart;
-import org.springframework.web.context.request.RequestContextHolder;
-import org.springframework.web.context.request.ServletRequestAttributes;
 import org.springframework.web.multipart.MultipartFile;
 
-import java.util.List;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import java.io.IOException;
-import javax.servlet.http.HttpServletRequest;
 import javax.validation.constraints.*;
 import javax.validation.Valid;
+import javax.servlet.http.HttpServletRequest;
+import java.io.IOException;
+import java.util.List;
 
 @Controller
 public class FakeApiController implements FakeApi {
@@ -45,7 +41,6 @@ public class FakeApiController implements FakeApi {
     }
 
     public ResponseEntity<Boolean> fakeOuterBooleanSerialize(@ApiParam(value = "Input boolean as post body"  )  @Valid @RequestBody Boolean body) {
-        // do some magic!
         String accept = request.getHeader("Accept");
         if (accept != null && accept.contains("application/json")) {
             try {
@@ -56,11 +51,10 @@ public class FakeApiController implements FakeApi {
             }
         }
 
-        return new ResponseEntity<Boolean>(HttpStatus.OK);
+        return new ResponseEntity<Boolean>(HttpStatus.NOT_IMPLEMENTED);
     }
 
     public ResponseEntity<OuterComposite> fakeOuterCompositeSerialize(@ApiParam(value = "Input composite as post body"  )  @Valid @RequestBody OuterComposite body) {
-        // do some magic!
         String accept = request.getHeader("Accept");
         if (accept != null && accept.contains("application/json")) {
             try {
@@ -71,11 +65,10 @@ public class FakeApiController implements FakeApi {
             }
         }
 
-        return new ResponseEntity<OuterComposite>(HttpStatus.OK);
+        return new ResponseEntity<OuterComposite>(HttpStatus.NOT_IMPLEMENTED);
     }
 
     public ResponseEntity<BigDecimal> fakeOuterNumberSerialize(@ApiParam(value = "Input number as post body"  )  @Valid @RequestBody BigDecimal body) {
-        // do some magic!
         String accept = request.getHeader("Accept");
         if (accept != null && accept.contains("application/json")) {
             try {
@@ -86,11 +79,10 @@ public class FakeApiController implements FakeApi {
             }
         }
 
-        return new ResponseEntity<BigDecimal>(HttpStatus.OK);
+        return new ResponseEntity<BigDecimal>(HttpStatus.NOT_IMPLEMENTED);
     }
 
     public ResponseEntity<String> fakeOuterStringSerialize(@ApiParam(value = "Input string as post body"  )  @Valid @RequestBody String body) {
-        // do some magic!
         String accept = request.getHeader("Accept");
         if (accept != null && accept.contains("application/json")) {
             try {
@@ -101,11 +93,10 @@ public class FakeApiController implements FakeApi {
             }
         }
 
-        return new ResponseEntity<String>(HttpStatus.OK);
+        return new ResponseEntity<String>(HttpStatus.NOT_IMPLEMENTED);
     }
 
     public ResponseEntity<Client> testClientModel(@ApiParam(value = "client model" ,required=true )  @Valid @RequestBody Client body) {
-        // do some magic!
         String accept = request.getHeader("Accept");
         if (accept != null && accept.contains("application/json")) {
             try {
@@ -116,31 +107,27 @@ public class FakeApiController implements FakeApi {
             }
         }
 
-        return new ResponseEntity<Client>(HttpStatus.OK);
+        return new ResponseEntity<Client>(HttpStatus.NOT_IMPLEMENTED);
     }
 
     public ResponseEntity<Void> testEndpointParameters(@ApiParam(value = "None", required=true) @RequestPart(value="number", required=true)  BigDecimal number,@ApiParam(value = "None", required=true) @RequestPart(value="double", required=true)  Double _double,@ApiParam(value = "None", required=true) @RequestPart(value="pattern_without_delimiter", required=true)  String patternWithoutDelimiter,@ApiParam(value = "None", required=true) @RequestPart(value="byte", required=true)  byte[] _byte,@ApiParam(value = "None") @RequestPart(value="integer", required=false)  Integer integer,@ApiParam(value = "None") @RequestPart(value="int32", required=false)  Integer int32,@ApiParam(value = "None") @RequestPart(value="int64", required=false)  Long int64,@ApiParam(value = "None") @RequestPart(value="float", required=false)  Float _float,@ApiParam(value = "None") @RequestPart(value="string", required=false)  String string,@ApiParam(value = "None") @RequestPart(value="binary", required=false)  byte[] binary,@ApiParam(value = "None") @RequestPart(value="date", required=false)  LocalDate date,@ApiParam(value = "None") @RequestPart(value="dateTime", required=false)  OffsetDateTime dateTime,@ApiParam(value = "None") @RequestPart(value="password", required=false)  String password,@ApiParam(value = "None") @RequestPart(value="callback", required=false)  String paramCallback) {
-        // do some magic!
         String accept = request.getHeader("Accept");
-        return new ResponseEntity<Void>(HttpStatus.OK);
+        return new ResponseEntity<Void>(HttpStatus.NOT_IMPLEMENTED);
     }
 
     public ResponseEntity<Void> testEnumParameters(@ApiParam(value = "Form parameter enum test (string array)", allowableValues=">, $") @RequestPart(value="enum_form_string_array", required=false)  List<String> enumFormStringArray,@ApiParam(value = "Form parameter enum test (string)", allowableValues="_abc, -efg, (xyz)", defaultValue="-efg") @RequestPart(value="enum_form_string", required=false)  String enumFormString,@ApiParam(value = "Header parameter enum test (string array)" , allowableValues=">, $") @RequestHeader(value="enum_header_string_array", required=false) List<String> enumHeaderStringArray,@ApiParam(value = "Header parameter enum test (string)" , allowableValues="_abc, -efg, (xyz)", defaultValue="-efg") @RequestHeader(value="enum_header_string", required=false) String enumHeaderString,@ApiParam(value = "Query parameter enum test (string array)", allowableValues = ">, $") @Valid @RequestParam(value = "enum_query_string_array", required = false) List<String> enumQueryStringArray,@ApiParam(value = "Query parameter enum test (string)", allowableValues = "_abc, -efg, (xyz)", defaultValue = "-efg") @Valid @RequestParam(value = "enum_query_string", required = false, defaultValue="-efg") String enumQueryString,@ApiParam(value = "Query parameter enum test (double)", allowableValues = "1, -2") @Valid @RequestParam(value = "enum_query_integer", required = false) Integer enumQueryInteger,@ApiParam(value = "Query parameter enum test (double)", allowableValues="1.1, -1.2") @RequestPart(value="enum_query_double", required=false)  Double enumQueryDouble) {
-        // do some magic!
         String accept = request.getHeader("Accept");
-        return new ResponseEntity<Void>(HttpStatus.OK);
+        return new ResponseEntity<Void>(HttpStatus.NOT_IMPLEMENTED);
     }
 
     public ResponseEntity<Void> testInlineAdditionalProperties(@ApiParam(value = "request body" ,required=true )  @Valid @RequestBody Object param) {
-        // do some magic!
         String accept = request.getHeader("Accept");
-        return new ResponseEntity<Void>(HttpStatus.OK);
+        return new ResponseEntity<Void>(HttpStatus.NOT_IMPLEMENTED);
     }
 
     public ResponseEntity<Void> testJsonFormData(@ApiParam(value = "field1", required=true) @RequestPart(value="param", required=true)  String param,@ApiParam(value = "field2", required=true) @RequestPart(value="param2", required=true)  String param2) {
-        // do some magic!
         String accept = request.getHeader("Accept");
-        return new ResponseEntity<Void>(HttpStatus.OK);
+        return new ResponseEntity<Void>(HttpStatus.NOT_IMPLEMENTED);
     }
 
 }

--- a/samples/server/petstore/springboot-beanvalidation/src/main/java/io/swagger/api/FakeClassnameTestApi.java
+++ b/samples/server/petstore/springboot-beanvalidation/src/main/java/io/swagger/api/FakeClassnameTestApi.java
@@ -6,9 +6,9 @@
 package io.swagger.api;
 
 import io.swagger.model.Client;
-
 import io.swagger.annotations.*;
 import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
@@ -17,12 +17,10 @@ import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.multipart.MultipartFile;
-import java.io.IOException;
 
-import java.util.List;
-import org.springframework.validation.annotation.Validated;
-import javax.validation.constraints.*;
 import javax.validation.Valid;
+import javax.validation.constraints.*;
+import java.util.List;
 
 @Api(value = "fake_classname_test", description = "the fake_classname_test API")
 public interface FakeClassnameTestApi {

--- a/samples/server/petstore/springboot-beanvalidation/src/main/java/io/swagger/api/FakeClassnameTestApi.java
+++ b/samples/server/petstore/springboot-beanvalidation/src/main/java/io/swagger/api/FakeClassnameTestApi.java
@@ -36,6 +36,6 @@ public interface FakeClassnameTestApi {
         produces = { "application/json" }, 
         consumes = { "application/json" },
         method = RequestMethod.PATCH)
-    ResponseEntity<Client> testClassname(@ApiParam(value = "client model" ,required=true )  @Valid @RequestBody Client body, @RequestHeader(value = "Accept", required = false) String accept) throws Exception;
+    ResponseEntity<Client> testClassname(@ApiParam(value = "client model" ,required=true )  @Valid @RequestBody Client body);
 
 }

--- a/samples/server/petstore/springboot-beanvalidation/src/main/java/io/swagger/api/FakeClassnameTestApiController.java
+++ b/samples/server/petstore/springboot-beanvalidation/src/main/java/io/swagger/api/FakeClassnameTestApiController.java
@@ -4,6 +4,8 @@ import io.swagger.model.Client;
 
 import io.swagger.annotations.*;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
@@ -12,6 +14,8 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RequestPart;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.util.List;
@@ -22,18 +26,25 @@ import javax.validation.Valid;
 
 @Controller
 public class FakeClassnameTestApiController implements FakeClassnameTestApi {
+
+    private final Logger log = LoggerFactory.getLogger(AnotherFakeApiController.class);
+
     private final ObjectMapper objectMapper;
 
     public FakeClassnameTestApiController(ObjectMapper objectMapper) {
         this.objectMapper = objectMapper;
     }
 
-    public ResponseEntity<Client> testClassname(@ApiParam(value = "client model" ,required=true )  @Valid @RequestBody Client body,
-        @RequestHeader(value = "Accept", required = false) String accept) throws Exception {
+    public ResponseEntity<Client> testClassname(@ApiParam(value = "client model" ,required=true )  @Valid @RequestBody Client body) {
         // do some magic!
-
+        String accept = ((ServletRequestAttributes)RequestContextHolder.getRequestAttributes()).getRequest().getHeader("Accept");
         if (accept != null && accept.contains("application/json")) {
-            return new ResponseEntity<Client>(objectMapper.readValue("{  \"client\" : \"client\"}", Client.class), HttpStatus.OK);
+            try {
+                return new ResponseEntity<Client>(objectMapper.readValue("{  \"client\" : \"client\"}", Client.class), HttpStatus.NOT_IMPLEMENTED);
+            } catch (IOException e) {
+                log.error("Couldn't serialize response for content type application/json", e);
+                return new ResponseEntity<Client>(HttpStatus.INTERNAL_SERVER_ERROR);
+            }
         }
 
         return new ResponseEntity<Client>(HttpStatus.OK);

--- a/samples/server/petstore/springboot-beanvalidation/src/main/java/io/swagger/api/FakeClassnameTestApiController.java
+++ b/samples/server/petstore/springboot-beanvalidation/src/main/java/io/swagger/api/FakeClassnameTestApiController.java
@@ -21,23 +21,28 @@ import org.springframework.web.multipart.MultipartFile;
 import java.util.List;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.IOException;
+import javax.servlet.http.HttpServletRequest;
 import javax.validation.constraints.*;
 import javax.validation.Valid;
 
 @Controller
 public class FakeClassnameTestApiController implements FakeClassnameTestApi {
 
-    private final Logger log = LoggerFactory.getLogger(AnotherFakeApiController.class);
+    private static final Logger log = LoggerFactory.getLogger(FakeClassnameTestApiController.class);
 
     private final ObjectMapper objectMapper;
 
+    @org.springframework.beans.factory.annotation.Autowired
+    private HttpServletRequest request;
+
+    @org.springframework.beans.factory.annotation.Autowired
     public FakeClassnameTestApiController(ObjectMapper objectMapper) {
         this.objectMapper = objectMapper;
     }
 
     public ResponseEntity<Client> testClassname(@ApiParam(value = "client model" ,required=true )  @Valid @RequestBody Client body) {
         // do some magic!
-        String accept = ((ServletRequestAttributes)RequestContextHolder.getRequestAttributes()).getRequest().getHeader("Accept");
+        String accept = request.getHeader("Accept");
         if (accept != null && accept.contains("application/json")) {
             try {
                 return new ResponseEntity<Client>(objectMapper.readValue("{  \"client\" : \"client\"}", Client.class), HttpStatus.NOT_IMPLEMENTED);

--- a/samples/server/petstore/springboot-beanvalidation/src/main/java/io/swagger/api/FakeClassnameTestApiController.java
+++ b/samples/server/petstore/springboot-beanvalidation/src/main/java/io/swagger/api/FakeClassnameTestApiController.java
@@ -32,12 +32,12 @@ public class FakeClassnameTestApiController implements FakeClassnameTestApi {
 
     private final ObjectMapper objectMapper;
 
-    @org.springframework.beans.factory.annotation.Autowired
-    private HttpServletRequest request;
+    private final HttpServletRequest request;
 
     @org.springframework.beans.factory.annotation.Autowired
-    public FakeClassnameTestApiController(ObjectMapper objectMapper) {
+    public FakeClassnameTestApiController(ObjectMapper objectMapper, HttpServletRequest request) {
         this.objectMapper = objectMapper;
+        this.request = request;
     }
 
     public ResponseEntity<Client> testClassname(@ApiParam(value = "client model" ,required=true )  @Valid @RequestBody Client body) {

--- a/samples/server/petstore/springboot-beanvalidation/src/main/java/io/swagger/api/FakeClassnameTestApiController.java
+++ b/samples/server/petstore/springboot-beanvalidation/src/main/java/io/swagger/api/FakeClassnameTestApiController.java
@@ -1,9 +1,8 @@
 package io.swagger.api;
 
 import io.swagger.model.Client;
-
+import com.fasterxml.jackson.databind.ObjectMapper;
 import io.swagger.annotations.*;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpStatus;
@@ -14,16 +13,13 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RequestPart;
-import org.springframework.web.context.request.RequestContextHolder;
-import org.springframework.web.context.request.ServletRequestAttributes;
 import org.springframework.web.multipart.MultipartFile;
 
-import java.util.List;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import java.io.IOException;
-import javax.servlet.http.HttpServletRequest;
 import javax.validation.constraints.*;
 import javax.validation.Valid;
+import javax.servlet.http.HttpServletRequest;
+import java.io.IOException;
+import java.util.List;
 
 @Controller
 public class FakeClassnameTestApiController implements FakeClassnameTestApi {
@@ -41,7 +37,6 @@ public class FakeClassnameTestApiController implements FakeClassnameTestApi {
     }
 
     public ResponseEntity<Client> testClassname(@ApiParam(value = "client model" ,required=true )  @Valid @RequestBody Client body) {
-        // do some magic!
         String accept = request.getHeader("Accept");
         if (accept != null && accept.contains("application/json")) {
             try {
@@ -52,7 +47,7 @@ public class FakeClassnameTestApiController implements FakeClassnameTestApi {
             }
         }
 
-        return new ResponseEntity<Client>(HttpStatus.OK);
+        return new ResponseEntity<Client>(HttpStatus.NOT_IMPLEMENTED);
     }
 
 }

--- a/samples/server/petstore/springboot-beanvalidation/src/main/java/io/swagger/api/PetApi.java
+++ b/samples/server/petstore/springboot-beanvalidation/src/main/java/io/swagger/api/PetApi.java
@@ -8,9 +8,9 @@ package io.swagger.api;
 import io.swagger.model.ModelApiResponse;
 import io.swagger.model.Pet;
 import org.springframework.core.io.Resource;
-
 import io.swagger.annotations.*;
 import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
@@ -19,12 +19,10 @@ import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.multipart.MultipartFile;
-import java.io.IOException;
 
-import java.util.List;
-import org.springframework.validation.annotation.Validated;
-import javax.validation.constraints.*;
 import javax.validation.Valid;
+import javax.validation.constraints.*;
+import java.util.List;
 
 @Api(value = "pet", description = "the pet API")
 public interface PetApi {

--- a/samples/server/petstore/springboot-beanvalidation/src/main/java/io/swagger/api/PetApi.java
+++ b/samples/server/petstore/springboot-beanvalidation/src/main/java/io/swagger/api/PetApi.java
@@ -41,7 +41,7 @@ public interface PetApi {
         produces = { "application/xml", "application/json" }, 
         consumes = { "application/json", "application/xml" },
         method = RequestMethod.POST)
-    ResponseEntity<Void> addPet(@ApiParam(value = "Pet object that needs to be added to the store" ,required=true )  @Valid @RequestBody Pet body, @RequestHeader(value = "Accept", required = false) String accept) throws Exception;
+    ResponseEntity<Void> addPet(@ApiParam(value = "Pet object that needs to be added to the store" ,required=true )  @Valid @RequestBody Pet body);
 
 
     @ApiOperation(value = "Deletes a pet", nickname = "deletePet", notes = "", authorizations = {
@@ -55,7 +55,7 @@ public interface PetApi {
     @RequestMapping(value = "/pet/{petId}",
         produces = { "application/xml", "application/json" }, 
         method = RequestMethod.DELETE)
-    ResponseEntity<Void> deletePet(@ApiParam(value = "Pet id to delete",required=true) @PathVariable("petId") Long petId,@ApiParam(value = "" ) @RequestHeader(value="api_key", required=false) String apiKey, @RequestHeader(value = "Accept", required = false) String accept) throws Exception;
+    ResponseEntity<Void> deletePet(@ApiParam(value = "Pet id to delete",required=true) @PathVariable("petId") Long petId,@ApiParam(value = "" ) @RequestHeader(value="api_key", required=false) String apiKey);
 
 
     @ApiOperation(value = "Finds Pets by status", nickname = "findPetsByStatus", notes = "Multiple status values can be provided with comma separated strings", response = Pet.class, responseContainer = "List", authorizations = {
@@ -70,7 +70,7 @@ public interface PetApi {
     @RequestMapping(value = "/pet/findByStatus",
         produces = { "application/xml", "application/json" }, 
         method = RequestMethod.GET)
-    ResponseEntity<List<Pet>> findPetsByStatus( @NotNull@ApiParam(value = "Status values that need to be considered for filter", required = true, allowableValues = "available, pending, sold") @Valid @RequestParam(value = "status", required = true) List<String> status, @RequestHeader(value = "Accept", required = false) String accept) throws Exception;
+    ResponseEntity<List<Pet>> findPetsByStatus(@NotNull @ApiParam(value = "Status values that need to be considered for filter", required = true, allowableValues = "available, pending, sold") @Valid @RequestParam(value = "status", required = true) List<String> status);
 
 
     @ApiOperation(value = "Finds Pets by tags", nickname = "findPetsByTags", notes = "Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.", response = Pet.class, responseContainer = "List", authorizations = {
@@ -85,7 +85,7 @@ public interface PetApi {
     @RequestMapping(value = "/pet/findByTags",
         produces = { "application/xml", "application/json" }, 
         method = RequestMethod.GET)
-    ResponseEntity<List<Pet>> findPetsByTags( @NotNull@ApiParam(value = "Tags to filter by", required = true) @Valid @RequestParam(value = "tags", required = true) List<String> tags, @RequestHeader(value = "Accept", required = false) String accept) throws Exception;
+    ResponseEntity<List<Pet>> findPetsByTags(@NotNull @ApiParam(value = "Tags to filter by", required = true) @Valid @RequestParam(value = "tags", required = true) List<String> tags);
 
 
     @ApiOperation(value = "Find pet by ID", nickname = "getPetById", notes = "Returns a single pet", response = Pet.class, authorizations = {
@@ -98,7 +98,7 @@ public interface PetApi {
     @RequestMapping(value = "/pet/{petId}",
         produces = { "application/xml", "application/json" }, 
         method = RequestMethod.GET)
-    ResponseEntity<Pet> getPetById(@ApiParam(value = "ID of pet to return",required=true) @PathVariable("petId") Long petId, @RequestHeader(value = "Accept", required = false) String accept) throws Exception;
+    ResponseEntity<Pet> getPetById(@ApiParam(value = "ID of pet to return",required=true) @PathVariable("petId") Long petId);
 
 
     @ApiOperation(value = "Update an existing pet", nickname = "updatePet", notes = "", authorizations = {
@@ -115,7 +115,7 @@ public interface PetApi {
         produces = { "application/xml", "application/json" }, 
         consumes = { "application/json", "application/xml" },
         method = RequestMethod.PUT)
-    ResponseEntity<Void> updatePet(@ApiParam(value = "Pet object that needs to be added to the store" ,required=true )  @Valid @RequestBody Pet body, @RequestHeader(value = "Accept", required = false) String accept) throws Exception;
+    ResponseEntity<Void> updatePet(@ApiParam(value = "Pet object that needs to be added to the store" ,required=true )  @Valid @RequestBody Pet body);
 
 
     @ApiOperation(value = "Updates a pet in the store with form data", nickname = "updatePetWithForm", notes = "", authorizations = {
@@ -130,7 +130,7 @@ public interface PetApi {
         produces = { "application/xml", "application/json" }, 
         consumes = { "application/x-www-form-urlencoded" },
         method = RequestMethod.POST)
-    ResponseEntity<Void> updatePetWithForm(@ApiParam(value = "ID of pet that needs to be updated",required=true) @PathVariable("petId") Long petId,@ApiParam(value = "Updated name of the pet") @RequestPart(value="name", required=false)  String name,@ApiParam(value = "Updated status of the pet") @RequestPart(value="status", required=false)  String status, @RequestHeader(value = "Accept", required = false) String accept) throws Exception;
+    ResponseEntity<Void> updatePetWithForm(@ApiParam(value = "ID of pet that needs to be updated",required=true) @PathVariable("petId") Long petId,@ApiParam(value = "Updated name of the pet") @RequestPart(value="name", required=false)  String name,@ApiParam(value = "Updated status of the pet") @RequestPart(value="status", required=false)  String status);
 
 
     @ApiOperation(value = "uploads an image", nickname = "uploadFile", notes = "", response = ModelApiResponse.class, authorizations = {
@@ -145,6 +145,6 @@ public interface PetApi {
         produces = { "application/json" }, 
         consumes = { "multipart/form-data" },
         method = RequestMethod.POST)
-    ResponseEntity<ModelApiResponse> uploadFile(@ApiParam(value = "ID of pet to update",required=true) @PathVariable("petId") Long petId,@ApiParam(value = "Additional data to pass to server") @RequestPart(value="additionalMetadata", required=false)  String additionalMetadata,@ApiParam(value = "file detail") @Valid @RequestPart("file") MultipartFile file, @RequestHeader(value = "Accept", required = false) String accept) throws Exception;
+    ResponseEntity<ModelApiResponse> uploadFile(@ApiParam(value = "ID of pet to update",required=true) @PathVariable("petId") Long petId,@ApiParam(value = "Additional data to pass to server") @RequestPart(value="additionalMetadata", required=false)  String additionalMetadata,@ApiParam(value = "file detail") @Valid @RequestPart("file") MultipartFile file);
 
 }

--- a/samples/server/petstore/springboot-beanvalidation/src/main/java/io/swagger/api/PetApiController.java
+++ b/samples/server/petstore/springboot-beanvalidation/src/main/java/io/swagger/api/PetApiController.java
@@ -34,12 +34,12 @@ public class PetApiController implements PetApi {
 
     private final ObjectMapper objectMapper;
 
-    @org.springframework.beans.factory.annotation.Autowired
-    private HttpServletRequest request;
+    private final HttpServletRequest request;
 
     @org.springframework.beans.factory.annotation.Autowired
-    public PetApiController(ObjectMapper objectMapper) {
+    public PetApiController(ObjectMapper objectMapper, HttpServletRequest request) {
         this.objectMapper = objectMapper;
+        this.request = request;
     }
 
     public ResponseEntity<Void> addPet(@ApiParam(value = "Pet object that needs to be added to the store" ,required=true )  @Valid @RequestBody Pet body) {

--- a/samples/server/petstore/springboot-beanvalidation/src/main/java/io/swagger/api/PetApiController.java
+++ b/samples/server/petstore/springboot-beanvalidation/src/main/java/io/swagger/api/PetApiController.java
@@ -3,9 +3,8 @@ package io.swagger.api;
 import io.swagger.model.ModelApiResponse;
 import io.swagger.model.Pet;
 import org.springframework.core.io.Resource;
-
+import com.fasterxml.jackson.databind.ObjectMapper;
 import io.swagger.annotations.*;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpStatus;
@@ -16,16 +15,13 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RequestPart;
-import org.springframework.web.context.request.RequestContextHolder;
-import org.springframework.web.context.request.ServletRequestAttributes;
 import org.springframework.web.multipart.MultipartFile;
 
-import java.util.List;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import java.io.IOException;
-import javax.servlet.http.HttpServletRequest;
 import javax.validation.constraints.*;
 import javax.validation.Valid;
+import javax.servlet.http.HttpServletRequest;
+import java.io.IOException;
+import java.util.List;
 
 @Controller
 public class PetApiController implements PetApi {
@@ -43,19 +39,16 @@ public class PetApiController implements PetApi {
     }
 
     public ResponseEntity<Void> addPet(@ApiParam(value = "Pet object that needs to be added to the store" ,required=true )  @Valid @RequestBody Pet body) {
-        // do some magic!
         String accept = request.getHeader("Accept");
-        return new ResponseEntity<Void>(HttpStatus.OK);
+        return new ResponseEntity<Void>(HttpStatus.NOT_IMPLEMENTED);
     }
 
     public ResponseEntity<Void> deletePet(@ApiParam(value = "Pet id to delete",required=true) @PathVariable("petId") Long petId,@ApiParam(value = "" ) @RequestHeader(value="api_key", required=false) String apiKey) {
-        // do some magic!
         String accept = request.getHeader("Accept");
-        return new ResponseEntity<Void>(HttpStatus.OK);
+        return new ResponseEntity<Void>(HttpStatus.NOT_IMPLEMENTED);
     }
 
     public ResponseEntity<List<Pet>> findPetsByStatus(@NotNull @ApiParam(value = "Status values that need to be considered for filter", required = true, allowableValues = "available, pending, sold") @Valid @RequestParam(value = "status", required = true) List<String> status) {
-        // do some magic!
         String accept = request.getHeader("Accept");
         if (accept != null && accept.contains("application/xml")) {
             try {
@@ -75,11 +68,10 @@ public class PetApiController implements PetApi {
             }
         }
 
-        return new ResponseEntity<List<Pet>>(HttpStatus.OK);
+        return new ResponseEntity<List<Pet>>(HttpStatus.NOT_IMPLEMENTED);
     }
 
     public ResponseEntity<List<Pet>> findPetsByTags(@NotNull @ApiParam(value = "Tags to filter by", required = true) @Valid @RequestParam(value = "tags", required = true) List<String> tags) {
-        // do some magic!
         String accept = request.getHeader("Accept");
         if (accept != null && accept.contains("application/xml")) {
             try {
@@ -99,11 +91,10 @@ public class PetApiController implements PetApi {
             }
         }
 
-        return new ResponseEntity<List<Pet>>(HttpStatus.OK);
+        return new ResponseEntity<List<Pet>>(HttpStatus.NOT_IMPLEMENTED);
     }
 
     public ResponseEntity<Pet> getPetById(@ApiParam(value = "ID of pet to return",required=true) @PathVariable("petId") Long petId) {
-        // do some magic!
         String accept = request.getHeader("Accept");
         if (accept != null && accept.contains("application/xml")) {
             try {
@@ -123,23 +114,20 @@ public class PetApiController implements PetApi {
             }
         }
 
-        return new ResponseEntity<Pet>(HttpStatus.OK);
+        return new ResponseEntity<Pet>(HttpStatus.NOT_IMPLEMENTED);
     }
 
     public ResponseEntity<Void> updatePet(@ApiParam(value = "Pet object that needs to be added to the store" ,required=true )  @Valid @RequestBody Pet body) {
-        // do some magic!
         String accept = request.getHeader("Accept");
-        return new ResponseEntity<Void>(HttpStatus.OK);
+        return new ResponseEntity<Void>(HttpStatus.NOT_IMPLEMENTED);
     }
 
     public ResponseEntity<Void> updatePetWithForm(@ApiParam(value = "ID of pet that needs to be updated",required=true) @PathVariable("petId") Long petId,@ApiParam(value = "Updated name of the pet") @RequestPart(value="name", required=false)  String name,@ApiParam(value = "Updated status of the pet") @RequestPart(value="status", required=false)  String status) {
-        // do some magic!
         String accept = request.getHeader("Accept");
-        return new ResponseEntity<Void>(HttpStatus.OK);
+        return new ResponseEntity<Void>(HttpStatus.NOT_IMPLEMENTED);
     }
 
     public ResponseEntity<ModelApiResponse> uploadFile(@ApiParam(value = "ID of pet to update",required=true) @PathVariable("petId") Long petId,@ApiParam(value = "Additional data to pass to server") @RequestPart(value="additionalMetadata", required=false)  String additionalMetadata,@ApiParam(value = "file detail") @Valid @RequestPart("file") MultipartFile file) {
-        // do some magic!
         String accept = request.getHeader("Accept");
         if (accept != null && accept.contains("application/json")) {
             try {
@@ -150,7 +138,7 @@ public class PetApiController implements PetApi {
             }
         }
 
-        return new ResponseEntity<ModelApiResponse>(HttpStatus.OK);
+        return new ResponseEntity<ModelApiResponse>(HttpStatus.NOT_IMPLEMENTED);
     }
 
 }

--- a/samples/server/petstore/springboot-beanvalidation/src/main/java/io/swagger/api/PetApiController.java
+++ b/samples/server/petstore/springboot-beanvalidation/src/main/java/io/swagger/api/PetApiController.java
@@ -23,35 +23,40 @@ import org.springframework.web.multipart.MultipartFile;
 import java.util.List;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.IOException;
+import javax.servlet.http.HttpServletRequest;
 import javax.validation.constraints.*;
 import javax.validation.Valid;
 
 @Controller
 public class PetApiController implements PetApi {
 
-    private final Logger log = LoggerFactory.getLogger(AnotherFakeApiController.class);
+    private static final Logger log = LoggerFactory.getLogger(PetApiController.class);
 
     private final ObjectMapper objectMapper;
 
+    @org.springframework.beans.factory.annotation.Autowired
+    private HttpServletRequest request;
+
+    @org.springframework.beans.factory.annotation.Autowired
     public PetApiController(ObjectMapper objectMapper) {
         this.objectMapper = objectMapper;
     }
 
     public ResponseEntity<Void> addPet(@ApiParam(value = "Pet object that needs to be added to the store" ,required=true )  @Valid @RequestBody Pet body) {
         // do some magic!
-        String accept = ((ServletRequestAttributes)RequestContextHolder.getRequestAttributes()).getRequest().getHeader("Accept");
+        String accept = request.getHeader("Accept");
         return new ResponseEntity<Void>(HttpStatus.OK);
     }
 
     public ResponseEntity<Void> deletePet(@ApiParam(value = "Pet id to delete",required=true) @PathVariable("petId") Long petId,@ApiParam(value = "" ) @RequestHeader(value="api_key", required=false) String apiKey) {
         // do some magic!
-        String accept = ((ServletRequestAttributes)RequestContextHolder.getRequestAttributes()).getRequest().getHeader("Accept");
+        String accept = request.getHeader("Accept");
         return new ResponseEntity<Void>(HttpStatus.OK);
     }
 
     public ResponseEntity<List<Pet>> findPetsByStatus(@NotNull @ApiParam(value = "Status values that need to be considered for filter", required = true, allowableValues = "available, pending, sold") @Valid @RequestParam(value = "status", required = true) List<String> status) {
         // do some magic!
-        String accept = ((ServletRequestAttributes)RequestContextHolder.getRequestAttributes()).getRequest().getHeader("Accept");
+        String accept = request.getHeader("Accept");
         if (accept != null && accept.contains("application/xml")) {
             try {
                 return new ResponseEntity<List<Pet>>(objectMapper.readValue("<Pet>  <id>123456789</id>  <name>doggie</name>  <photoUrls>    <photoUrls>aeiou</photoUrls>  </photoUrls>  <tags>  </tags>  <status>aeiou</status></Pet>", List.class), HttpStatus.NOT_IMPLEMENTED);
@@ -75,7 +80,7 @@ public class PetApiController implements PetApi {
 
     public ResponseEntity<List<Pet>> findPetsByTags(@NotNull @ApiParam(value = "Tags to filter by", required = true) @Valid @RequestParam(value = "tags", required = true) List<String> tags) {
         // do some magic!
-        String accept = ((ServletRequestAttributes)RequestContextHolder.getRequestAttributes()).getRequest().getHeader("Accept");
+        String accept = request.getHeader("Accept");
         if (accept != null && accept.contains("application/xml")) {
             try {
                 return new ResponseEntity<List<Pet>>(objectMapper.readValue("<Pet>  <id>123456789</id>  <name>doggie</name>  <photoUrls>    <photoUrls>aeiou</photoUrls>  </photoUrls>  <tags>  </tags>  <status>aeiou</status></Pet>", List.class), HttpStatus.NOT_IMPLEMENTED);
@@ -99,7 +104,7 @@ public class PetApiController implements PetApi {
 
     public ResponseEntity<Pet> getPetById(@ApiParam(value = "ID of pet to return",required=true) @PathVariable("petId") Long petId) {
         // do some magic!
-        String accept = ((ServletRequestAttributes)RequestContextHolder.getRequestAttributes()).getRequest().getHeader("Accept");
+        String accept = request.getHeader("Accept");
         if (accept != null && accept.contains("application/xml")) {
             try {
                 return new ResponseEntity<Pet>(objectMapper.readValue("<Pet>  <id>123456789</id>  <name>doggie</name>  <photoUrls>    <photoUrls>aeiou</photoUrls>  </photoUrls>  <tags>  </tags>  <status>aeiou</status></Pet>", Pet.class), HttpStatus.NOT_IMPLEMENTED);
@@ -123,19 +128,19 @@ public class PetApiController implements PetApi {
 
     public ResponseEntity<Void> updatePet(@ApiParam(value = "Pet object that needs to be added to the store" ,required=true )  @Valid @RequestBody Pet body) {
         // do some magic!
-        String accept = ((ServletRequestAttributes)RequestContextHolder.getRequestAttributes()).getRequest().getHeader("Accept");
+        String accept = request.getHeader("Accept");
         return new ResponseEntity<Void>(HttpStatus.OK);
     }
 
     public ResponseEntity<Void> updatePetWithForm(@ApiParam(value = "ID of pet that needs to be updated",required=true) @PathVariable("petId") Long petId,@ApiParam(value = "Updated name of the pet") @RequestPart(value="name", required=false)  String name,@ApiParam(value = "Updated status of the pet") @RequestPart(value="status", required=false)  String status) {
         // do some magic!
-        String accept = ((ServletRequestAttributes)RequestContextHolder.getRequestAttributes()).getRequest().getHeader("Accept");
+        String accept = request.getHeader("Accept");
         return new ResponseEntity<Void>(HttpStatus.OK);
     }
 
     public ResponseEntity<ModelApiResponse> uploadFile(@ApiParam(value = "ID of pet to update",required=true) @PathVariable("petId") Long petId,@ApiParam(value = "Additional data to pass to server") @RequestPart(value="additionalMetadata", required=false)  String additionalMetadata,@ApiParam(value = "file detail") @Valid @RequestPart("file") MultipartFile file) {
         // do some magic!
-        String accept = ((ServletRequestAttributes)RequestContextHolder.getRequestAttributes()).getRequest().getHeader("Accept");
+        String accept = request.getHeader("Accept");
         if (accept != null && accept.contains("application/json")) {
             try {
                 return new ResponseEntity<ModelApiResponse>(objectMapper.readValue("{  \"code\" : 0,  \"type\" : \"type\",  \"message\" : \"message\"}", ModelApiResponse.class), HttpStatus.NOT_IMPLEMENTED);

--- a/samples/server/petstore/springboot-beanvalidation/src/main/java/io/swagger/api/PetApiController.java
+++ b/samples/server/petstore/springboot-beanvalidation/src/main/java/io/swagger/api/PetApiController.java
@@ -6,6 +6,8 @@ import org.springframework.core.io.Resource;
 
 import io.swagger.annotations.*;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
@@ -14,6 +16,8 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RequestPart;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.util.List;
@@ -24,95 +28,121 @@ import javax.validation.Valid;
 
 @Controller
 public class PetApiController implements PetApi {
+
+    private final Logger log = LoggerFactory.getLogger(AnotherFakeApiController.class);
+
     private final ObjectMapper objectMapper;
 
     public PetApiController(ObjectMapper objectMapper) {
         this.objectMapper = objectMapper;
     }
 
-    public ResponseEntity<Void> addPet(@ApiParam(value = "Pet object that needs to be added to the store" ,required=true )  @Valid @RequestBody Pet body,
-        @RequestHeader(value = "Accept", required = false) String accept) throws Exception {
+    public ResponseEntity<Void> addPet(@ApiParam(value = "Pet object that needs to be added to the store" ,required=true )  @Valid @RequestBody Pet body) {
         // do some magic!
+        String accept = ((ServletRequestAttributes)RequestContextHolder.getRequestAttributes()).getRequest().getHeader("Accept");
         return new ResponseEntity<Void>(HttpStatus.OK);
     }
 
-    public ResponseEntity<Void> deletePet(@ApiParam(value = "Pet id to delete",required=true) @PathVariable("petId") Long petId,
-        @ApiParam(value = "" ) @RequestHeader(value="api_key", required=false) String apiKey,
-        @RequestHeader(value = "Accept", required = false) String accept) throws Exception {
+    public ResponseEntity<Void> deletePet(@ApiParam(value = "Pet id to delete",required=true) @PathVariable("petId") Long petId,@ApiParam(value = "" ) @RequestHeader(value="api_key", required=false) String apiKey) {
         // do some magic!
+        String accept = ((ServletRequestAttributes)RequestContextHolder.getRequestAttributes()).getRequest().getHeader("Accept");
         return new ResponseEntity<Void>(HttpStatus.OK);
     }
 
-    public ResponseEntity<List<Pet>> findPetsByStatus( @NotNull@ApiParam(value = "Status values that need to be considered for filter", required = true, allowableValues = "available, pending, sold") @Valid @RequestParam(value = "status", required = true) List<String> status,
-        @RequestHeader(value = "Accept", required = false) String accept) throws Exception {
+    public ResponseEntity<List<Pet>> findPetsByStatus(@NotNull @ApiParam(value = "Status values that need to be considered for filter", required = true, allowableValues = "available, pending, sold") @Valid @RequestParam(value = "status", required = true) List<String> status) {
         // do some magic!
-
+        String accept = ((ServletRequestAttributes)RequestContextHolder.getRequestAttributes()).getRequest().getHeader("Accept");
         if (accept != null && accept.contains("application/xml")) {
-            return new ResponseEntity<List<Pet>>(objectMapper.readValue("<Pet>  <id>123456789</id>  <name>doggie</name>  <photoUrls>    <photoUrls>aeiou</photoUrls>  </photoUrls>  <tags>  </tags>  <status>aeiou</status></Pet>", List.class), HttpStatus.OK);
+            try {
+                return new ResponseEntity<List<Pet>>(objectMapper.readValue("<Pet>  <id>123456789</id>  <name>doggie</name>  <photoUrls>    <photoUrls>aeiou</photoUrls>  </photoUrls>  <tags>  </tags>  <status>aeiou</status></Pet>", List.class), HttpStatus.NOT_IMPLEMENTED);
+            } catch (IOException e) {
+                log.error("Couldn't serialize response for content type application/xml", e);
+                return new ResponseEntity<List<Pet>>(HttpStatus.INTERNAL_SERVER_ERROR);
+            }
         }
 
-
         if (accept != null && accept.contains("application/json")) {
-            return new ResponseEntity<List<Pet>>(objectMapper.readValue("[ {  \"photoUrls\" : [ \"photoUrls\", \"photoUrls\" ],  \"name\" : \"doggie\",  \"id\" : 0,  \"category\" : {    \"name\" : \"name\",    \"id\" : 6  },  \"tags\" : [ {    \"name\" : \"name\",    \"id\" : 1  }, {    \"name\" : \"name\",    \"id\" : 1  } ],  \"status\" : \"available\"}, {  \"photoUrls\" : [ \"photoUrls\", \"photoUrls\" ],  \"name\" : \"doggie\",  \"id\" : 0,  \"category\" : {    \"name\" : \"name\",    \"id\" : 6  },  \"tags\" : [ {    \"name\" : \"name\",    \"id\" : 1  }, {    \"name\" : \"name\",    \"id\" : 1  } ],  \"status\" : \"available\"} ]", List.class), HttpStatus.OK);
+            try {
+                return new ResponseEntity<List<Pet>>(objectMapper.readValue("[ {  \"photoUrls\" : [ \"photoUrls\", \"photoUrls\" ],  \"name\" : \"doggie\",  \"id\" : 0,  \"category\" : {    \"name\" : \"name\",    \"id\" : 6  },  \"tags\" : [ {    \"name\" : \"name\",    \"id\" : 1  }, {    \"name\" : \"name\",    \"id\" : 1  } ],  \"status\" : \"available\"}, {  \"photoUrls\" : [ \"photoUrls\", \"photoUrls\" ],  \"name\" : \"doggie\",  \"id\" : 0,  \"category\" : {    \"name\" : \"name\",    \"id\" : 6  },  \"tags\" : [ {    \"name\" : \"name\",    \"id\" : 1  }, {    \"name\" : \"name\",    \"id\" : 1  } ],  \"status\" : \"available\"} ]", List.class), HttpStatus.NOT_IMPLEMENTED);
+            } catch (IOException e) {
+                log.error("Couldn't serialize response for content type application/json", e);
+                return new ResponseEntity<List<Pet>>(HttpStatus.INTERNAL_SERVER_ERROR);
+            }
         }
 
         return new ResponseEntity<List<Pet>>(HttpStatus.OK);
     }
 
-    public ResponseEntity<List<Pet>> findPetsByTags( @NotNull@ApiParam(value = "Tags to filter by", required = true) @Valid @RequestParam(value = "tags", required = true) List<String> tags,
-        @RequestHeader(value = "Accept", required = false) String accept) throws Exception {
+    public ResponseEntity<List<Pet>> findPetsByTags(@NotNull @ApiParam(value = "Tags to filter by", required = true) @Valid @RequestParam(value = "tags", required = true) List<String> tags) {
         // do some magic!
-
+        String accept = ((ServletRequestAttributes)RequestContextHolder.getRequestAttributes()).getRequest().getHeader("Accept");
         if (accept != null && accept.contains("application/xml")) {
-            return new ResponseEntity<List<Pet>>(objectMapper.readValue("<Pet>  <id>123456789</id>  <name>doggie</name>  <photoUrls>    <photoUrls>aeiou</photoUrls>  </photoUrls>  <tags>  </tags>  <status>aeiou</status></Pet>", List.class), HttpStatus.OK);
+            try {
+                return new ResponseEntity<List<Pet>>(objectMapper.readValue("<Pet>  <id>123456789</id>  <name>doggie</name>  <photoUrls>    <photoUrls>aeiou</photoUrls>  </photoUrls>  <tags>  </tags>  <status>aeiou</status></Pet>", List.class), HttpStatus.NOT_IMPLEMENTED);
+            } catch (IOException e) {
+                log.error("Couldn't serialize response for content type application/xml", e);
+                return new ResponseEntity<List<Pet>>(HttpStatus.INTERNAL_SERVER_ERROR);
+            }
         }
 
-
         if (accept != null && accept.contains("application/json")) {
-            return new ResponseEntity<List<Pet>>(objectMapper.readValue("[ {  \"photoUrls\" : [ \"photoUrls\", \"photoUrls\" ],  \"name\" : \"doggie\",  \"id\" : 0,  \"category\" : {    \"name\" : \"name\",    \"id\" : 6  },  \"tags\" : [ {    \"name\" : \"name\",    \"id\" : 1  }, {    \"name\" : \"name\",    \"id\" : 1  } ],  \"status\" : \"available\"}, {  \"photoUrls\" : [ \"photoUrls\", \"photoUrls\" ],  \"name\" : \"doggie\",  \"id\" : 0,  \"category\" : {    \"name\" : \"name\",    \"id\" : 6  },  \"tags\" : [ {    \"name\" : \"name\",    \"id\" : 1  }, {    \"name\" : \"name\",    \"id\" : 1  } ],  \"status\" : \"available\"} ]", List.class), HttpStatus.OK);
+            try {
+                return new ResponseEntity<List<Pet>>(objectMapper.readValue("[ {  \"photoUrls\" : [ \"photoUrls\", \"photoUrls\" ],  \"name\" : \"doggie\",  \"id\" : 0,  \"category\" : {    \"name\" : \"name\",    \"id\" : 6  },  \"tags\" : [ {    \"name\" : \"name\",    \"id\" : 1  }, {    \"name\" : \"name\",    \"id\" : 1  } ],  \"status\" : \"available\"}, {  \"photoUrls\" : [ \"photoUrls\", \"photoUrls\" ],  \"name\" : \"doggie\",  \"id\" : 0,  \"category\" : {    \"name\" : \"name\",    \"id\" : 6  },  \"tags\" : [ {    \"name\" : \"name\",    \"id\" : 1  }, {    \"name\" : \"name\",    \"id\" : 1  } ],  \"status\" : \"available\"} ]", List.class), HttpStatus.NOT_IMPLEMENTED);
+            } catch (IOException e) {
+                log.error("Couldn't serialize response for content type application/json", e);
+                return new ResponseEntity<List<Pet>>(HttpStatus.INTERNAL_SERVER_ERROR);
+            }
         }
 
         return new ResponseEntity<List<Pet>>(HttpStatus.OK);
     }
 
-    public ResponseEntity<Pet> getPetById(@ApiParam(value = "ID of pet to return",required=true) @PathVariable("petId") Long petId,
-        @RequestHeader(value = "Accept", required = false) String accept) throws Exception {
+    public ResponseEntity<Pet> getPetById(@ApiParam(value = "ID of pet to return",required=true) @PathVariable("petId") Long petId) {
         // do some magic!
-
+        String accept = ((ServletRequestAttributes)RequestContextHolder.getRequestAttributes()).getRequest().getHeader("Accept");
         if (accept != null && accept.contains("application/xml")) {
-            return new ResponseEntity<Pet>(objectMapper.readValue("<Pet>  <id>123456789</id>  <name>doggie</name>  <photoUrls>    <photoUrls>aeiou</photoUrls>  </photoUrls>  <tags>  </tags>  <status>aeiou</status></Pet>", Pet.class), HttpStatus.OK);
+            try {
+                return new ResponseEntity<Pet>(objectMapper.readValue("<Pet>  <id>123456789</id>  <name>doggie</name>  <photoUrls>    <photoUrls>aeiou</photoUrls>  </photoUrls>  <tags>  </tags>  <status>aeiou</status></Pet>", Pet.class), HttpStatus.NOT_IMPLEMENTED);
+            } catch (IOException e) {
+                log.error("Couldn't serialize response for content type application/xml", e);
+                return new ResponseEntity<Pet>(HttpStatus.INTERNAL_SERVER_ERROR);
+            }
         }
 
-
         if (accept != null && accept.contains("application/json")) {
-            return new ResponseEntity<Pet>(objectMapper.readValue("{  \"photoUrls\" : [ \"photoUrls\", \"photoUrls\" ],  \"name\" : \"doggie\",  \"id\" : 0,  \"category\" : {    \"name\" : \"name\",    \"id\" : 6  },  \"tags\" : [ {    \"name\" : \"name\",    \"id\" : 1  }, {    \"name\" : \"name\",    \"id\" : 1  } ],  \"status\" : \"available\"}", Pet.class), HttpStatus.OK);
+            try {
+                return new ResponseEntity<Pet>(objectMapper.readValue("{  \"photoUrls\" : [ \"photoUrls\", \"photoUrls\" ],  \"name\" : \"doggie\",  \"id\" : 0,  \"category\" : {    \"name\" : \"name\",    \"id\" : 6  },  \"tags\" : [ {    \"name\" : \"name\",    \"id\" : 1  }, {    \"name\" : \"name\",    \"id\" : 1  } ],  \"status\" : \"available\"}", Pet.class), HttpStatus.NOT_IMPLEMENTED);
+            } catch (IOException e) {
+                log.error("Couldn't serialize response for content type application/json", e);
+                return new ResponseEntity<Pet>(HttpStatus.INTERNAL_SERVER_ERROR);
+            }
         }
 
         return new ResponseEntity<Pet>(HttpStatus.OK);
     }
 
-    public ResponseEntity<Void> updatePet(@ApiParam(value = "Pet object that needs to be added to the store" ,required=true )  @Valid @RequestBody Pet body,
-        @RequestHeader(value = "Accept", required = false) String accept) throws Exception {
+    public ResponseEntity<Void> updatePet(@ApiParam(value = "Pet object that needs to be added to the store" ,required=true )  @Valid @RequestBody Pet body) {
         // do some magic!
+        String accept = ((ServletRequestAttributes)RequestContextHolder.getRequestAttributes()).getRequest().getHeader("Accept");
         return new ResponseEntity<Void>(HttpStatus.OK);
     }
 
-    public ResponseEntity<Void> updatePetWithForm(@ApiParam(value = "ID of pet that needs to be updated",required=true) @PathVariable("petId") Long petId,
-        @ApiParam(value = "Updated name of the pet") @RequestPart(value="name", required=false)  String name,
-        @ApiParam(value = "Updated status of the pet") @RequestPart(value="status", required=false)  String status,
-        @RequestHeader(value = "Accept", required = false) String accept) throws Exception {
+    public ResponseEntity<Void> updatePetWithForm(@ApiParam(value = "ID of pet that needs to be updated",required=true) @PathVariable("petId") Long petId,@ApiParam(value = "Updated name of the pet") @RequestPart(value="name", required=false)  String name,@ApiParam(value = "Updated status of the pet") @RequestPart(value="status", required=false)  String status) {
         // do some magic!
+        String accept = ((ServletRequestAttributes)RequestContextHolder.getRequestAttributes()).getRequest().getHeader("Accept");
         return new ResponseEntity<Void>(HttpStatus.OK);
     }
 
-    public ResponseEntity<ModelApiResponse> uploadFile(@ApiParam(value = "ID of pet to update",required=true) @PathVariable("petId") Long petId,
-        @ApiParam(value = "Additional data to pass to server") @RequestPart(value="additionalMetadata", required=false)  String additionalMetadata,
-        @ApiParam(value = "file detail") @Valid @RequestPart("file") MultipartFile file,
-        @RequestHeader(value = "Accept", required = false) String accept) throws Exception {
+    public ResponseEntity<ModelApiResponse> uploadFile(@ApiParam(value = "ID of pet to update",required=true) @PathVariable("petId") Long petId,@ApiParam(value = "Additional data to pass to server") @RequestPart(value="additionalMetadata", required=false)  String additionalMetadata,@ApiParam(value = "file detail") @Valid @RequestPart("file") MultipartFile file) {
         // do some magic!
-
+        String accept = ((ServletRequestAttributes)RequestContextHolder.getRequestAttributes()).getRequest().getHeader("Accept");
         if (accept != null && accept.contains("application/json")) {
-            return new ResponseEntity<ModelApiResponse>(objectMapper.readValue("{  \"code\" : 0,  \"type\" : \"type\",  \"message\" : \"message\"}", ModelApiResponse.class), HttpStatus.OK);
+            try {
+                return new ResponseEntity<ModelApiResponse>(objectMapper.readValue("{  \"code\" : 0,  \"type\" : \"type\",  \"message\" : \"message\"}", ModelApiResponse.class), HttpStatus.NOT_IMPLEMENTED);
+            } catch (IOException e) {
+                log.error("Couldn't serialize response for content type application/json", e);
+                return new ResponseEntity<ModelApiResponse>(HttpStatus.INTERNAL_SERVER_ERROR);
+            }
         }
 
         return new ResponseEntity<ModelApiResponse>(HttpStatus.OK);

--- a/samples/server/petstore/springboot-beanvalidation/src/main/java/io/swagger/api/StoreApi.java
+++ b/samples/server/petstore/springboot-beanvalidation/src/main/java/io/swagger/api/StoreApi.java
@@ -7,9 +7,9 @@ package io.swagger.api;
 
 import java.util.Map;
 import io.swagger.model.Order;
-
 import io.swagger.annotations.*;
 import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
@@ -18,12 +18,10 @@ import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.multipart.MultipartFile;
-import java.io.IOException;
 
-import java.util.List;
-import org.springframework.validation.annotation.Validated;
-import javax.validation.constraints.*;
 import javax.validation.Valid;
+import javax.validation.constraints.*;
+import java.util.List;
 
 @Api(value = "store", description = "the store API")
 public interface StoreApi {

--- a/samples/server/petstore/springboot-beanvalidation/src/main/java/io/swagger/api/StoreApi.java
+++ b/samples/server/petstore/springboot-beanvalidation/src/main/java/io/swagger/api/StoreApi.java
@@ -35,7 +35,7 @@ public interface StoreApi {
     @RequestMapping(value = "/store/order/{order_id}",
         produces = { "application/xml", "application/json" }, 
         method = RequestMethod.DELETE)
-    ResponseEntity<Void> deleteOrder(@ApiParam(value = "ID of the order that needs to be deleted",required=true) @PathVariable("order_id") String orderId, @RequestHeader(value = "Accept", required = false) String accept) throws Exception;
+    ResponseEntity<Void> deleteOrder(@ApiParam(value = "ID of the order that needs to be deleted",required=true) @PathVariable("order_id") String orderId);
 
 
     @ApiOperation(value = "Returns pet inventories by status", nickname = "getInventory", notes = "Returns a map of status codes to quantities", response = Integer.class, responseContainer = "Map", authorizations = {
@@ -46,7 +46,7 @@ public interface StoreApi {
     @RequestMapping(value = "/store/inventory",
         produces = { "application/json" }, 
         method = RequestMethod.GET)
-    ResponseEntity<Map<String, Integer>> getInventory( @RequestHeader(value = "Accept", required = false) String accept) throws Exception;
+    ResponseEntity<Map<String, Integer>> getInventory();
 
 
     @ApiOperation(value = "Find purchase order by ID", nickname = "getOrderById", notes = "For valid response try integer IDs with value <= 5 or > 10. Other values will generated exceptions", response = Order.class, tags={ "store", })
@@ -57,7 +57,7 @@ public interface StoreApi {
     @RequestMapping(value = "/store/order/{order_id}",
         produces = { "application/xml", "application/json" }, 
         method = RequestMethod.GET)
-    ResponseEntity<Order> getOrderById( @Min(1) @Max(5)@ApiParam(value = "ID of pet that needs to be fetched",required=true) @PathVariable("order_id") Long orderId, @RequestHeader(value = "Accept", required = false) String accept) throws Exception;
+    ResponseEntity<Order> getOrderById(@Min(1) @Max(5) @ApiParam(value = "ID of pet that needs to be fetched",required=true) @PathVariable("order_id") Long orderId);
 
 
     @ApiOperation(value = "Place an order for a pet", nickname = "placeOrder", notes = "", response = Order.class, tags={ "store", })
@@ -67,6 +67,6 @@ public interface StoreApi {
     @RequestMapping(value = "/store/order",
         produces = { "application/xml", "application/json" }, 
         method = RequestMethod.POST)
-    ResponseEntity<Order> placeOrder(@ApiParam(value = "order placed for purchasing the pet" ,required=true )  @Valid @RequestBody Order body, @RequestHeader(value = "Accept", required = false) String accept) throws Exception;
+    ResponseEntity<Order> placeOrder(@ApiParam(value = "order placed for purchasing the pet" ,required=true )  @Valid @RequestBody Order body);
 
 }

--- a/samples/server/petstore/springboot-beanvalidation/src/main/java/io/swagger/api/StoreApiController.java
+++ b/samples/server/petstore/springboot-beanvalidation/src/main/java/io/swagger/api/StoreApiController.java
@@ -2,9 +2,8 @@ package io.swagger.api;
 
 import java.util.Map;
 import io.swagger.model.Order;
-
+import com.fasterxml.jackson.databind.ObjectMapper;
 import io.swagger.annotations.*;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpStatus;
@@ -15,16 +14,13 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RequestPart;
-import org.springframework.web.context.request.RequestContextHolder;
-import org.springframework.web.context.request.ServletRequestAttributes;
 import org.springframework.web.multipart.MultipartFile;
 
-import java.util.List;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import java.io.IOException;
-import javax.servlet.http.HttpServletRequest;
 import javax.validation.constraints.*;
 import javax.validation.Valid;
+import javax.servlet.http.HttpServletRequest;
+import java.io.IOException;
+import java.util.List;
 
 @Controller
 public class StoreApiController implements StoreApi {
@@ -42,13 +38,11 @@ public class StoreApiController implements StoreApi {
     }
 
     public ResponseEntity<Void> deleteOrder(@ApiParam(value = "ID of the order that needs to be deleted",required=true) @PathVariable("order_id") String orderId) {
-        // do some magic!
         String accept = request.getHeader("Accept");
-        return new ResponseEntity<Void>(HttpStatus.OK);
+        return new ResponseEntity<Void>(HttpStatus.NOT_IMPLEMENTED);
     }
 
     public ResponseEntity<Map<String, Integer>> getInventory() {
-        // do some magic!
         String accept = request.getHeader("Accept");
         if (accept != null && accept.contains("application/json")) {
             try {
@@ -59,11 +53,10 @@ public class StoreApiController implements StoreApi {
             }
         }
 
-        return new ResponseEntity<Map<String, Integer>>(HttpStatus.OK);
+        return new ResponseEntity<Map<String, Integer>>(HttpStatus.NOT_IMPLEMENTED);
     }
 
     public ResponseEntity<Order> getOrderById(@Min(1) @Max(5) @ApiParam(value = "ID of pet that needs to be fetched",required=true) @PathVariable("order_id") Long orderId) {
-        // do some magic!
         String accept = request.getHeader("Accept");
         if (accept != null && accept.contains("application/xml")) {
             try {
@@ -83,11 +76,10 @@ public class StoreApiController implements StoreApi {
             }
         }
 
-        return new ResponseEntity<Order>(HttpStatus.OK);
+        return new ResponseEntity<Order>(HttpStatus.NOT_IMPLEMENTED);
     }
 
     public ResponseEntity<Order> placeOrder(@ApiParam(value = "order placed for purchasing the pet" ,required=true )  @Valid @RequestBody Order body) {
-        // do some magic!
         String accept = request.getHeader("Accept");
         if (accept != null && accept.contains("application/xml")) {
             try {
@@ -107,7 +99,7 @@ public class StoreApiController implements StoreApi {
             }
         }
 
-        return new ResponseEntity<Order>(HttpStatus.OK);
+        return new ResponseEntity<Order>(HttpStatus.NOT_IMPLEMENTED);
     }
 
 }

--- a/samples/server/petstore/springboot-beanvalidation/src/main/java/io/swagger/api/StoreApiController.java
+++ b/samples/server/petstore/springboot-beanvalidation/src/main/java/io/swagger/api/StoreApiController.java
@@ -33,12 +33,12 @@ public class StoreApiController implements StoreApi {
 
     private final ObjectMapper objectMapper;
 
-    @org.springframework.beans.factory.annotation.Autowired
-    private HttpServletRequest request;
+    private final HttpServletRequest request;
 
     @org.springframework.beans.factory.annotation.Autowired
-    public StoreApiController(ObjectMapper objectMapper) {
+    public StoreApiController(ObjectMapper objectMapper, HttpServletRequest request) {
         this.objectMapper = objectMapper;
+        this.request = request;
     }
 
     public ResponseEntity<Void> deleteOrder(@ApiParam(value = "ID of the order that needs to be deleted",required=true) @PathVariable("order_id") String orderId) {

--- a/samples/server/petstore/springboot-beanvalidation/src/main/java/io/swagger/api/StoreApiController.java
+++ b/samples/server/petstore/springboot-beanvalidation/src/main/java/io/swagger/api/StoreApiController.java
@@ -5,6 +5,8 @@ import io.swagger.model.Order;
 
 import io.swagger.annotations.*;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
@@ -13,6 +15,8 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RequestPart;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.util.List;
@@ -23,55 +27,79 @@ import javax.validation.Valid;
 
 @Controller
 public class StoreApiController implements StoreApi {
+
+    private final Logger log = LoggerFactory.getLogger(AnotherFakeApiController.class);
+
     private final ObjectMapper objectMapper;
 
     public StoreApiController(ObjectMapper objectMapper) {
         this.objectMapper = objectMapper;
     }
 
-    public ResponseEntity<Void> deleteOrder(@ApiParam(value = "ID of the order that needs to be deleted",required=true) @PathVariable("order_id") String orderId,
-        @RequestHeader(value = "Accept", required = false) String accept) throws Exception {
+    public ResponseEntity<Void> deleteOrder(@ApiParam(value = "ID of the order that needs to be deleted",required=true) @PathVariable("order_id") String orderId) {
         // do some magic!
+        String accept = ((ServletRequestAttributes)RequestContextHolder.getRequestAttributes()).getRequest().getHeader("Accept");
         return new ResponseEntity<Void>(HttpStatus.OK);
     }
 
-    public ResponseEntity<Map<String, Integer>> getInventory(@RequestHeader(value = "Accept", required = false) String accept) throws Exception {
+    public ResponseEntity<Map<String, Integer>> getInventory() {
         // do some magic!
-
+        String accept = ((ServletRequestAttributes)RequestContextHolder.getRequestAttributes()).getRequest().getHeader("Accept");
         if (accept != null && accept.contains("application/json")) {
-            return new ResponseEntity<Map<String, Integer>>(objectMapper.readValue("{  \"key\" : 0}", Map.class), HttpStatus.OK);
+            try {
+                return new ResponseEntity<Map<String, Integer>>(objectMapper.readValue("{  \"key\" : 0}", Map.class), HttpStatus.NOT_IMPLEMENTED);
+            } catch (IOException e) {
+                log.error("Couldn't serialize response for content type application/json", e);
+                return new ResponseEntity<Map<String, Integer>>(HttpStatus.INTERNAL_SERVER_ERROR);
+            }
         }
 
         return new ResponseEntity<Map<String, Integer>>(HttpStatus.OK);
     }
 
-    public ResponseEntity<Order> getOrderById( @Min(1) @Max(5)@ApiParam(value = "ID of pet that needs to be fetched",required=true) @PathVariable("order_id") Long orderId,
-        @RequestHeader(value = "Accept", required = false) String accept) throws Exception {
+    public ResponseEntity<Order> getOrderById(@Min(1) @Max(5) @ApiParam(value = "ID of pet that needs to be fetched",required=true) @PathVariable("order_id") Long orderId) {
         // do some magic!
-
+        String accept = ((ServletRequestAttributes)RequestContextHolder.getRequestAttributes()).getRequest().getHeader("Accept");
         if (accept != null && accept.contains("application/xml")) {
-            return new ResponseEntity<Order>(objectMapper.readValue("<Order>  <id>123456789</id>  <petId>123456789</petId>  <quantity>123</quantity>  <shipDate>2000-01-23T04:56:07.000Z</shipDate>  <status>aeiou</status>  <complete>true</complete></Order>", Order.class), HttpStatus.OK);
+            try {
+                return new ResponseEntity<Order>(objectMapper.readValue("<Order>  <id>123456789</id>  <petId>123456789</petId>  <quantity>123</quantity>  <shipDate>2000-01-23T04:56:07.000Z</shipDate>  <status>aeiou</status>  <complete>true</complete></Order>", Order.class), HttpStatus.NOT_IMPLEMENTED);
+            } catch (IOException e) {
+                log.error("Couldn't serialize response for content type application/xml", e);
+                return new ResponseEntity<Order>(HttpStatus.INTERNAL_SERVER_ERROR);
+            }
         }
 
-
         if (accept != null && accept.contains("application/json")) {
-            return new ResponseEntity<Order>(objectMapper.readValue("{  \"petId\" : 6,  \"quantity\" : 1,  \"id\" : 0,  \"shipDate\" : \"2000-01-23T04:56:07.000+00:00\",  \"complete\" : false,  \"status\" : \"placed\"}", Order.class), HttpStatus.OK);
+            try {
+                return new ResponseEntity<Order>(objectMapper.readValue("{  \"petId\" : 6,  \"quantity\" : 1,  \"id\" : 0,  \"shipDate\" : \"2000-01-23T04:56:07.000+00:00\",  \"complete\" : false,  \"status\" : \"placed\"}", Order.class), HttpStatus.NOT_IMPLEMENTED);
+            } catch (IOException e) {
+                log.error("Couldn't serialize response for content type application/json", e);
+                return new ResponseEntity<Order>(HttpStatus.INTERNAL_SERVER_ERROR);
+            }
         }
 
         return new ResponseEntity<Order>(HttpStatus.OK);
     }
 
-    public ResponseEntity<Order> placeOrder(@ApiParam(value = "order placed for purchasing the pet" ,required=true )  @Valid @RequestBody Order body,
-        @RequestHeader(value = "Accept", required = false) String accept) throws Exception {
+    public ResponseEntity<Order> placeOrder(@ApiParam(value = "order placed for purchasing the pet" ,required=true )  @Valid @RequestBody Order body) {
         // do some magic!
-
+        String accept = ((ServletRequestAttributes)RequestContextHolder.getRequestAttributes()).getRequest().getHeader("Accept");
         if (accept != null && accept.contains("application/xml")) {
-            return new ResponseEntity<Order>(objectMapper.readValue("<Order>  <id>123456789</id>  <petId>123456789</petId>  <quantity>123</quantity>  <shipDate>2000-01-23T04:56:07.000Z</shipDate>  <status>aeiou</status>  <complete>true</complete></Order>", Order.class), HttpStatus.OK);
+            try {
+                return new ResponseEntity<Order>(objectMapper.readValue("<Order>  <id>123456789</id>  <petId>123456789</petId>  <quantity>123</quantity>  <shipDate>2000-01-23T04:56:07.000Z</shipDate>  <status>aeiou</status>  <complete>true</complete></Order>", Order.class), HttpStatus.NOT_IMPLEMENTED);
+            } catch (IOException e) {
+                log.error("Couldn't serialize response for content type application/xml", e);
+                return new ResponseEntity<Order>(HttpStatus.INTERNAL_SERVER_ERROR);
+            }
         }
 
-
         if (accept != null && accept.contains("application/json")) {
-            return new ResponseEntity<Order>(objectMapper.readValue("{  \"petId\" : 6,  \"quantity\" : 1,  \"id\" : 0,  \"shipDate\" : \"2000-01-23T04:56:07.000+00:00\",  \"complete\" : false,  \"status\" : \"placed\"}", Order.class), HttpStatus.OK);
+            try {
+                return new ResponseEntity<Order>(objectMapper.readValue("{  \"petId\" : 6,  \"quantity\" : 1,  \"id\" : 0,  \"shipDate\" : \"2000-01-23T04:56:07.000+00:00\",  \"complete\" : false,  \"status\" : \"placed\"}", Order.class), HttpStatus.NOT_IMPLEMENTED);
+            } catch (IOException e) {
+                log.error("Couldn't serialize response for content type application/json", e);
+                return new ResponseEntity<Order>(HttpStatus.INTERNAL_SERVER_ERROR);
+            }
         }
 
         return new ResponseEntity<Order>(HttpStatus.OK);

--- a/samples/server/petstore/springboot-beanvalidation/src/main/java/io/swagger/api/StoreApiController.java
+++ b/samples/server/petstore/springboot-beanvalidation/src/main/java/io/swagger/api/StoreApiController.java
@@ -22,29 +22,34 @@ import org.springframework.web.multipart.MultipartFile;
 import java.util.List;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.IOException;
+import javax.servlet.http.HttpServletRequest;
 import javax.validation.constraints.*;
 import javax.validation.Valid;
 
 @Controller
 public class StoreApiController implements StoreApi {
 
-    private final Logger log = LoggerFactory.getLogger(AnotherFakeApiController.class);
+    private static final Logger log = LoggerFactory.getLogger(StoreApiController.class);
 
     private final ObjectMapper objectMapper;
 
+    @org.springframework.beans.factory.annotation.Autowired
+    private HttpServletRequest request;
+
+    @org.springframework.beans.factory.annotation.Autowired
     public StoreApiController(ObjectMapper objectMapper) {
         this.objectMapper = objectMapper;
     }
 
     public ResponseEntity<Void> deleteOrder(@ApiParam(value = "ID of the order that needs to be deleted",required=true) @PathVariable("order_id") String orderId) {
         // do some magic!
-        String accept = ((ServletRequestAttributes)RequestContextHolder.getRequestAttributes()).getRequest().getHeader("Accept");
+        String accept = request.getHeader("Accept");
         return new ResponseEntity<Void>(HttpStatus.OK);
     }
 
     public ResponseEntity<Map<String, Integer>> getInventory() {
         // do some magic!
-        String accept = ((ServletRequestAttributes)RequestContextHolder.getRequestAttributes()).getRequest().getHeader("Accept");
+        String accept = request.getHeader("Accept");
         if (accept != null && accept.contains("application/json")) {
             try {
                 return new ResponseEntity<Map<String, Integer>>(objectMapper.readValue("{  \"key\" : 0}", Map.class), HttpStatus.NOT_IMPLEMENTED);
@@ -59,7 +64,7 @@ public class StoreApiController implements StoreApi {
 
     public ResponseEntity<Order> getOrderById(@Min(1) @Max(5) @ApiParam(value = "ID of pet that needs to be fetched",required=true) @PathVariable("order_id") Long orderId) {
         // do some magic!
-        String accept = ((ServletRequestAttributes)RequestContextHolder.getRequestAttributes()).getRequest().getHeader("Accept");
+        String accept = request.getHeader("Accept");
         if (accept != null && accept.contains("application/xml")) {
             try {
                 return new ResponseEntity<Order>(objectMapper.readValue("<Order>  <id>123456789</id>  <petId>123456789</petId>  <quantity>123</quantity>  <shipDate>2000-01-23T04:56:07.000Z</shipDate>  <status>aeiou</status>  <complete>true</complete></Order>", Order.class), HttpStatus.NOT_IMPLEMENTED);
@@ -83,7 +88,7 @@ public class StoreApiController implements StoreApi {
 
     public ResponseEntity<Order> placeOrder(@ApiParam(value = "order placed for purchasing the pet" ,required=true )  @Valid @RequestBody Order body) {
         // do some magic!
-        String accept = ((ServletRequestAttributes)RequestContextHolder.getRequestAttributes()).getRequest().getHeader("Accept");
+        String accept = request.getHeader("Accept");
         if (accept != null && accept.contains("application/xml")) {
             try {
                 return new ResponseEntity<Order>(objectMapper.readValue("<Order>  <id>123456789</id>  <petId>123456789</petId>  <quantity>123</quantity>  <shipDate>2000-01-23T04:56:07.000Z</shipDate>  <status>aeiou</status>  <complete>true</complete></Order>", Order.class), HttpStatus.NOT_IMPLEMENTED);

--- a/samples/server/petstore/springboot-beanvalidation/src/main/java/io/swagger/api/UserApi.java
+++ b/samples/server/petstore/springboot-beanvalidation/src/main/java/io/swagger/api/UserApi.java
@@ -7,9 +7,9 @@ package io.swagger.api;
 
 import java.util.List;
 import io.swagger.model.User;
-
 import io.swagger.annotations.*;
 import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
@@ -18,12 +18,10 @@ import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.multipart.MultipartFile;
-import java.io.IOException;
 
-import java.util.List;
-import org.springframework.validation.annotation.Validated;
-import javax.validation.constraints.*;
 import javax.validation.Valid;
+import javax.validation.constraints.*;
+import java.util.List;
 
 @Api(value = "user", description = "the user API")
 public interface UserApi {

--- a/samples/server/petstore/springboot-beanvalidation/src/main/java/io/swagger/api/UserApi.java
+++ b/samples/server/petstore/springboot-beanvalidation/src/main/java/io/swagger/api/UserApi.java
@@ -34,7 +34,7 @@ public interface UserApi {
     @RequestMapping(value = "/user",
         produces = { "application/xml", "application/json" }, 
         method = RequestMethod.POST)
-    ResponseEntity<Void> createUser(@ApiParam(value = "Created user object" ,required=true )  @Valid @RequestBody User body, @RequestHeader(value = "Accept", required = false) String accept) throws Exception;
+    ResponseEntity<Void> createUser(@ApiParam(value = "Created user object" ,required=true )  @Valid @RequestBody User body);
 
 
     @ApiOperation(value = "Creates list of users with given input array", nickname = "createUsersWithArrayInput", notes = "", tags={ "user", })
@@ -43,7 +43,7 @@ public interface UserApi {
     @RequestMapping(value = "/user/createWithArray",
         produces = { "application/xml", "application/json" }, 
         method = RequestMethod.POST)
-    ResponseEntity<Void> createUsersWithArrayInput(@ApiParam(value = "List of user object" ,required=true )  @Valid @RequestBody List<User> body, @RequestHeader(value = "Accept", required = false) String accept) throws Exception;
+    ResponseEntity<Void> createUsersWithArrayInput(@ApiParam(value = "List of user object" ,required=true )  @Valid @RequestBody List<User> body);
 
 
     @ApiOperation(value = "Creates list of users with given input array", nickname = "createUsersWithListInput", notes = "", tags={ "user", })
@@ -52,7 +52,7 @@ public interface UserApi {
     @RequestMapping(value = "/user/createWithList",
         produces = { "application/xml", "application/json" }, 
         method = RequestMethod.POST)
-    ResponseEntity<Void> createUsersWithListInput(@ApiParam(value = "List of user object" ,required=true )  @Valid @RequestBody List<User> body, @RequestHeader(value = "Accept", required = false) String accept) throws Exception;
+    ResponseEntity<Void> createUsersWithListInput(@ApiParam(value = "List of user object" ,required=true )  @Valid @RequestBody List<User> body);
 
 
     @ApiOperation(value = "Delete user", nickname = "deleteUser", notes = "This can only be done by the logged in user.", tags={ "user", })
@@ -62,7 +62,7 @@ public interface UserApi {
     @RequestMapping(value = "/user/{username}",
         produces = { "application/xml", "application/json" }, 
         method = RequestMethod.DELETE)
-    ResponseEntity<Void> deleteUser(@ApiParam(value = "The name that needs to be deleted",required=true) @PathVariable("username") String username, @RequestHeader(value = "Accept", required = false) String accept) throws Exception;
+    ResponseEntity<Void> deleteUser(@ApiParam(value = "The name that needs to be deleted",required=true) @PathVariable("username") String username);
 
 
     @ApiOperation(value = "Get user by user name", nickname = "getUserByName", notes = "", response = User.class, tags={ "user", })
@@ -73,7 +73,7 @@ public interface UserApi {
     @RequestMapping(value = "/user/{username}",
         produces = { "application/xml", "application/json" }, 
         method = RequestMethod.GET)
-    ResponseEntity<User> getUserByName(@ApiParam(value = "The name that needs to be fetched. Use user1 for testing. ",required=true) @PathVariable("username") String username, @RequestHeader(value = "Accept", required = false) String accept) throws Exception;
+    ResponseEntity<User> getUserByName(@ApiParam(value = "The name that needs to be fetched. Use user1 for testing. ",required=true) @PathVariable("username") String username);
 
 
     @ApiOperation(value = "Logs user into the system", nickname = "loginUser", notes = "", response = String.class, tags={ "user", })
@@ -83,7 +83,7 @@ public interface UserApi {
     @RequestMapping(value = "/user/login",
         produces = { "application/xml", "application/json" }, 
         method = RequestMethod.GET)
-    ResponseEntity<String> loginUser( @NotNull@ApiParam(value = "The user name for login", required = true) @Valid @RequestParam(value = "username", required = true) String username, @NotNull@ApiParam(value = "The password for login in clear text", required = true) @Valid @RequestParam(value = "password", required = true) String password, @RequestHeader(value = "Accept", required = false) String accept) throws Exception;
+    ResponseEntity<String> loginUser(@NotNull @ApiParam(value = "The user name for login", required = true) @Valid @RequestParam(value = "username", required = true) String username,@NotNull @ApiParam(value = "The password for login in clear text", required = true) @Valid @RequestParam(value = "password", required = true) String password);
 
 
     @ApiOperation(value = "Logs out current logged in user session", nickname = "logoutUser", notes = "", tags={ "user", })
@@ -92,7 +92,7 @@ public interface UserApi {
     @RequestMapping(value = "/user/logout",
         produces = { "application/xml", "application/json" }, 
         method = RequestMethod.GET)
-    ResponseEntity<Void> logoutUser( @RequestHeader(value = "Accept", required = false) String accept) throws Exception;
+    ResponseEntity<Void> logoutUser();
 
 
     @ApiOperation(value = "Updated user", nickname = "updateUser", notes = "This can only be done by the logged in user.", tags={ "user", })
@@ -102,6 +102,6 @@ public interface UserApi {
     @RequestMapping(value = "/user/{username}",
         produces = { "application/xml", "application/json" }, 
         method = RequestMethod.PUT)
-    ResponseEntity<Void> updateUser(@ApiParam(value = "name that need to be deleted",required=true) @PathVariable("username") String username,@ApiParam(value = "Updated user object" ,required=true )  @Valid @RequestBody User body, @RequestHeader(value = "Accept", required = false) String accept) throws Exception;
+    ResponseEntity<Void> updateUser(@ApiParam(value = "name that need to be deleted",required=true) @PathVariable("username") String username,@ApiParam(value = "Updated user object" ,required=true )  @Valid @RequestBody User body);
 
 }

--- a/samples/server/petstore/springboot-beanvalidation/src/main/java/io/swagger/api/UserApiController.java
+++ b/samples/server/petstore/springboot-beanvalidation/src/main/java/io/swagger/api/UserApiController.java
@@ -33,12 +33,12 @@ public class UserApiController implements UserApi {
 
     private final ObjectMapper objectMapper;
 
-    @org.springframework.beans.factory.annotation.Autowired
-    private HttpServletRequest request;
+    private final HttpServletRequest request;
 
     @org.springframework.beans.factory.annotation.Autowired
-    public UserApiController(ObjectMapper objectMapper) {
+    public UserApiController(ObjectMapper objectMapper, HttpServletRequest request) {
         this.objectMapper = objectMapper;
+        this.request = request;
     }
 
     public ResponseEntity<Void> createUser(@ApiParam(value = "Created user object" ,required=true )  @Valid @RequestBody User body) {

--- a/samples/server/petstore/springboot-beanvalidation/src/main/java/io/swagger/api/UserApiController.java
+++ b/samples/server/petstore/springboot-beanvalidation/src/main/java/io/swagger/api/UserApiController.java
@@ -2,9 +2,8 @@ package io.swagger.api;
 
 import java.util.List;
 import io.swagger.model.User;
-
+import com.fasterxml.jackson.databind.ObjectMapper;
 import io.swagger.annotations.*;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpStatus;
@@ -15,16 +14,13 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RequestPart;
-import org.springframework.web.context.request.RequestContextHolder;
-import org.springframework.web.context.request.ServletRequestAttributes;
 import org.springframework.web.multipart.MultipartFile;
 
-import java.util.List;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import java.io.IOException;
-import javax.servlet.http.HttpServletRequest;
 import javax.validation.constraints.*;
 import javax.validation.Valid;
+import javax.servlet.http.HttpServletRequest;
+import java.io.IOException;
+import java.util.List;
 
 @Controller
 public class UserApiController implements UserApi {
@@ -42,31 +38,26 @@ public class UserApiController implements UserApi {
     }
 
     public ResponseEntity<Void> createUser(@ApiParam(value = "Created user object" ,required=true )  @Valid @RequestBody User body) {
-        // do some magic!
         String accept = request.getHeader("Accept");
-        return new ResponseEntity<Void>(HttpStatus.OK);
+        return new ResponseEntity<Void>(HttpStatus.NOT_IMPLEMENTED);
     }
 
     public ResponseEntity<Void> createUsersWithArrayInput(@ApiParam(value = "List of user object" ,required=true )  @Valid @RequestBody List<User> body) {
-        // do some magic!
         String accept = request.getHeader("Accept");
-        return new ResponseEntity<Void>(HttpStatus.OK);
+        return new ResponseEntity<Void>(HttpStatus.NOT_IMPLEMENTED);
     }
 
     public ResponseEntity<Void> createUsersWithListInput(@ApiParam(value = "List of user object" ,required=true )  @Valid @RequestBody List<User> body) {
-        // do some magic!
         String accept = request.getHeader("Accept");
-        return new ResponseEntity<Void>(HttpStatus.OK);
+        return new ResponseEntity<Void>(HttpStatus.NOT_IMPLEMENTED);
     }
 
     public ResponseEntity<Void> deleteUser(@ApiParam(value = "The name that needs to be deleted",required=true) @PathVariable("username") String username) {
-        // do some magic!
         String accept = request.getHeader("Accept");
-        return new ResponseEntity<Void>(HttpStatus.OK);
+        return new ResponseEntity<Void>(HttpStatus.NOT_IMPLEMENTED);
     }
 
     public ResponseEntity<User> getUserByName(@ApiParam(value = "The name that needs to be fetched. Use user1 for testing. ",required=true) @PathVariable("username") String username) {
-        // do some magic!
         String accept = request.getHeader("Accept");
         if (accept != null && accept.contains("application/xml")) {
             try {
@@ -86,11 +77,10 @@ public class UserApiController implements UserApi {
             }
         }
 
-        return new ResponseEntity<User>(HttpStatus.OK);
+        return new ResponseEntity<User>(HttpStatus.NOT_IMPLEMENTED);
     }
 
     public ResponseEntity<String> loginUser(@NotNull @ApiParam(value = "The user name for login", required = true) @Valid @RequestParam(value = "username", required = true) String username,@NotNull @ApiParam(value = "The password for login in clear text", required = true) @Valid @RequestParam(value = "password", required = true) String password) {
-        // do some magic!
         String accept = request.getHeader("Accept");
         if (accept != null && accept.contains("application/xml")) {
             try {
@@ -110,19 +100,17 @@ public class UserApiController implements UserApi {
             }
         }
 
-        return new ResponseEntity<String>(HttpStatus.OK);
+        return new ResponseEntity<String>(HttpStatus.NOT_IMPLEMENTED);
     }
 
     public ResponseEntity<Void> logoutUser() {
-        // do some magic!
         String accept = request.getHeader("Accept");
-        return new ResponseEntity<Void>(HttpStatus.OK);
+        return new ResponseEntity<Void>(HttpStatus.NOT_IMPLEMENTED);
     }
 
     public ResponseEntity<Void> updateUser(@ApiParam(value = "name that need to be deleted",required=true) @PathVariable("username") String username,@ApiParam(value = "Updated user object" ,required=true )  @Valid @RequestBody User body) {
-        // do some magic!
         String accept = request.getHeader("Accept");
-        return new ResponseEntity<Void>(HttpStatus.OK);
+        return new ResponseEntity<Void>(HttpStatus.NOT_IMPLEMENTED);
     }
 
 }

--- a/samples/server/petstore/springboot-beanvalidation/src/main/java/io/swagger/api/UserApiController.java
+++ b/samples/server/petstore/springboot-beanvalidation/src/main/java/io/swagger/api/UserApiController.java
@@ -5,6 +5,8 @@ import io.swagger.model.User;
 
 import io.swagger.annotations.*;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
@@ -13,6 +15,8 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RequestPart;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.util.List;
@@ -23,78 +27,96 @@ import javax.validation.Valid;
 
 @Controller
 public class UserApiController implements UserApi {
+
+    private final Logger log = LoggerFactory.getLogger(AnotherFakeApiController.class);
+
     private final ObjectMapper objectMapper;
 
     public UserApiController(ObjectMapper objectMapper) {
         this.objectMapper = objectMapper;
     }
 
-    public ResponseEntity<Void> createUser(@ApiParam(value = "Created user object" ,required=true )  @Valid @RequestBody User body,
-        @RequestHeader(value = "Accept", required = false) String accept) throws Exception {
+    public ResponseEntity<Void> createUser(@ApiParam(value = "Created user object" ,required=true )  @Valid @RequestBody User body) {
         // do some magic!
+        String accept = ((ServletRequestAttributes)RequestContextHolder.getRequestAttributes()).getRequest().getHeader("Accept");
         return new ResponseEntity<Void>(HttpStatus.OK);
     }
 
-    public ResponseEntity<Void> createUsersWithArrayInput(@ApiParam(value = "List of user object" ,required=true )  @Valid @RequestBody List<User> body,
-        @RequestHeader(value = "Accept", required = false) String accept) throws Exception {
+    public ResponseEntity<Void> createUsersWithArrayInput(@ApiParam(value = "List of user object" ,required=true )  @Valid @RequestBody List<User> body) {
         // do some magic!
+        String accept = ((ServletRequestAttributes)RequestContextHolder.getRequestAttributes()).getRequest().getHeader("Accept");
         return new ResponseEntity<Void>(HttpStatus.OK);
     }
 
-    public ResponseEntity<Void> createUsersWithListInput(@ApiParam(value = "List of user object" ,required=true )  @Valid @RequestBody List<User> body,
-        @RequestHeader(value = "Accept", required = false) String accept) throws Exception {
+    public ResponseEntity<Void> createUsersWithListInput(@ApiParam(value = "List of user object" ,required=true )  @Valid @RequestBody List<User> body) {
         // do some magic!
+        String accept = ((ServletRequestAttributes)RequestContextHolder.getRequestAttributes()).getRequest().getHeader("Accept");
         return new ResponseEntity<Void>(HttpStatus.OK);
     }
 
-    public ResponseEntity<Void> deleteUser(@ApiParam(value = "The name that needs to be deleted",required=true) @PathVariable("username") String username,
-        @RequestHeader(value = "Accept", required = false) String accept) throws Exception {
+    public ResponseEntity<Void> deleteUser(@ApiParam(value = "The name that needs to be deleted",required=true) @PathVariable("username") String username) {
         // do some magic!
+        String accept = ((ServletRequestAttributes)RequestContextHolder.getRequestAttributes()).getRequest().getHeader("Accept");
         return new ResponseEntity<Void>(HttpStatus.OK);
     }
 
-    public ResponseEntity<User> getUserByName(@ApiParam(value = "The name that needs to be fetched. Use user1 for testing. ",required=true) @PathVariable("username") String username,
-        @RequestHeader(value = "Accept", required = false) String accept) throws Exception {
+    public ResponseEntity<User> getUserByName(@ApiParam(value = "The name that needs to be fetched. Use user1 for testing. ",required=true) @PathVariable("username") String username) {
         // do some magic!
-
+        String accept = ((ServletRequestAttributes)RequestContextHolder.getRequestAttributes()).getRequest().getHeader("Accept");
         if (accept != null && accept.contains("application/xml")) {
-            return new ResponseEntity<User>(objectMapper.readValue("<User>  <id>123456789</id>  <username>aeiou</username>  <firstName>aeiou</firstName>  <lastName>aeiou</lastName>  <email>aeiou</email>  <password>aeiou</password>  <phone>aeiou</phone>  <userStatus>123</userStatus></User>", User.class), HttpStatus.OK);
+            try {
+                return new ResponseEntity<User>(objectMapper.readValue("<User>  <id>123456789</id>  <username>aeiou</username>  <firstName>aeiou</firstName>  <lastName>aeiou</lastName>  <email>aeiou</email>  <password>aeiou</password>  <phone>aeiou</phone>  <userStatus>123</userStatus></User>", User.class), HttpStatus.NOT_IMPLEMENTED);
+            } catch (IOException e) {
+                log.error("Couldn't serialize response for content type application/xml", e);
+                return new ResponseEntity<User>(HttpStatus.INTERNAL_SERVER_ERROR);
+            }
         }
 
-
         if (accept != null && accept.contains("application/json")) {
-            return new ResponseEntity<User>(objectMapper.readValue("{  \"firstName\" : \"firstName\",  \"lastName\" : \"lastName\",  \"password\" : \"password\",  \"userStatus\" : 6,  \"phone\" : \"phone\",  \"id\" : 0,  \"email\" : \"email\",  \"username\" : \"username\"}", User.class), HttpStatus.OK);
+            try {
+                return new ResponseEntity<User>(objectMapper.readValue("{  \"firstName\" : \"firstName\",  \"lastName\" : \"lastName\",  \"password\" : \"password\",  \"userStatus\" : 6,  \"phone\" : \"phone\",  \"id\" : 0,  \"email\" : \"email\",  \"username\" : \"username\"}", User.class), HttpStatus.NOT_IMPLEMENTED);
+            } catch (IOException e) {
+                log.error("Couldn't serialize response for content type application/json", e);
+                return new ResponseEntity<User>(HttpStatus.INTERNAL_SERVER_ERROR);
+            }
         }
 
         return new ResponseEntity<User>(HttpStatus.OK);
     }
 
-    public ResponseEntity<String> loginUser( @NotNull@ApiParam(value = "The user name for login", required = true) @Valid @RequestParam(value = "username", required = true) String username,
-         @NotNull@ApiParam(value = "The password for login in clear text", required = true) @Valid @RequestParam(value = "password", required = true) String password,
-        @RequestHeader(value = "Accept", required = false) String accept) throws Exception {
+    public ResponseEntity<String> loginUser(@NotNull @ApiParam(value = "The user name for login", required = true) @Valid @RequestParam(value = "username", required = true) String username,@NotNull @ApiParam(value = "The password for login in clear text", required = true) @Valid @RequestParam(value = "password", required = true) String password) {
         // do some magic!
-
+        String accept = ((ServletRequestAttributes)RequestContextHolder.getRequestAttributes()).getRequest().getHeader("Accept");
         if (accept != null && accept.contains("application/xml")) {
-            return new ResponseEntity<String>(objectMapper.readValue("aeiou", String.class), HttpStatus.OK);
+            try {
+                return new ResponseEntity<String>(objectMapper.readValue("aeiou", String.class), HttpStatus.NOT_IMPLEMENTED);
+            } catch (IOException e) {
+                log.error("Couldn't serialize response for content type application/xml", e);
+                return new ResponseEntity<String>(HttpStatus.INTERNAL_SERVER_ERROR);
+            }
         }
 
-
         if (accept != null && accept.contains("application/json")) {
-            return new ResponseEntity<String>(objectMapper.readValue("\"\"", String.class), HttpStatus.OK);
+            try {
+                return new ResponseEntity<String>(objectMapper.readValue("\"\"", String.class), HttpStatus.NOT_IMPLEMENTED);
+            } catch (IOException e) {
+                log.error("Couldn't serialize response for content type application/json", e);
+                return new ResponseEntity<String>(HttpStatus.INTERNAL_SERVER_ERROR);
+            }
         }
 
         return new ResponseEntity<String>(HttpStatus.OK);
     }
 
-    public ResponseEntity<Void> logoutUser(@RequestHeader(value = "Accept", required = false) String accept) throws Exception {
+    public ResponseEntity<Void> logoutUser() {
         // do some magic!
+        String accept = ((ServletRequestAttributes)RequestContextHolder.getRequestAttributes()).getRequest().getHeader("Accept");
         return new ResponseEntity<Void>(HttpStatus.OK);
     }
 
-    public ResponseEntity<Void> updateUser(@ApiParam(value = "name that need to be deleted",required=true) @PathVariable("username") String username,
-        @ApiParam(value = "Updated user object" ,required=true )  @Valid @RequestBody User body,
-        @RequestHeader(value = "Accept", required = false) String accept) throws Exception {
+    public ResponseEntity<Void> updateUser(@ApiParam(value = "name that need to be deleted",required=true) @PathVariable("username") String username,@ApiParam(value = "Updated user object" ,required=true )  @Valid @RequestBody User body) {
         // do some magic!
+        String accept = ((ServletRequestAttributes)RequestContextHolder.getRequestAttributes()).getRequest().getHeader("Accept");
         return new ResponseEntity<Void>(HttpStatus.OK);
     }
 

--- a/samples/server/petstore/springboot-beanvalidation/src/main/java/io/swagger/api/UserApiController.java
+++ b/samples/server/petstore/springboot-beanvalidation/src/main/java/io/swagger/api/UserApiController.java
@@ -22,47 +22,52 @@ import org.springframework.web.multipart.MultipartFile;
 import java.util.List;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.IOException;
+import javax.servlet.http.HttpServletRequest;
 import javax.validation.constraints.*;
 import javax.validation.Valid;
 
 @Controller
 public class UserApiController implements UserApi {
 
-    private final Logger log = LoggerFactory.getLogger(AnotherFakeApiController.class);
+    private static final Logger log = LoggerFactory.getLogger(UserApiController.class);
 
     private final ObjectMapper objectMapper;
 
+    @org.springframework.beans.factory.annotation.Autowired
+    private HttpServletRequest request;
+
+    @org.springframework.beans.factory.annotation.Autowired
     public UserApiController(ObjectMapper objectMapper) {
         this.objectMapper = objectMapper;
     }
 
     public ResponseEntity<Void> createUser(@ApiParam(value = "Created user object" ,required=true )  @Valid @RequestBody User body) {
         // do some magic!
-        String accept = ((ServletRequestAttributes)RequestContextHolder.getRequestAttributes()).getRequest().getHeader("Accept");
+        String accept = request.getHeader("Accept");
         return new ResponseEntity<Void>(HttpStatus.OK);
     }
 
     public ResponseEntity<Void> createUsersWithArrayInput(@ApiParam(value = "List of user object" ,required=true )  @Valid @RequestBody List<User> body) {
         // do some magic!
-        String accept = ((ServletRequestAttributes)RequestContextHolder.getRequestAttributes()).getRequest().getHeader("Accept");
+        String accept = request.getHeader("Accept");
         return new ResponseEntity<Void>(HttpStatus.OK);
     }
 
     public ResponseEntity<Void> createUsersWithListInput(@ApiParam(value = "List of user object" ,required=true )  @Valid @RequestBody List<User> body) {
         // do some magic!
-        String accept = ((ServletRequestAttributes)RequestContextHolder.getRequestAttributes()).getRequest().getHeader("Accept");
+        String accept = request.getHeader("Accept");
         return new ResponseEntity<Void>(HttpStatus.OK);
     }
 
     public ResponseEntity<Void> deleteUser(@ApiParam(value = "The name that needs to be deleted",required=true) @PathVariable("username") String username) {
         // do some magic!
-        String accept = ((ServletRequestAttributes)RequestContextHolder.getRequestAttributes()).getRequest().getHeader("Accept");
+        String accept = request.getHeader("Accept");
         return new ResponseEntity<Void>(HttpStatus.OK);
     }
 
     public ResponseEntity<User> getUserByName(@ApiParam(value = "The name that needs to be fetched. Use user1 for testing. ",required=true) @PathVariable("username") String username) {
         // do some magic!
-        String accept = ((ServletRequestAttributes)RequestContextHolder.getRequestAttributes()).getRequest().getHeader("Accept");
+        String accept = request.getHeader("Accept");
         if (accept != null && accept.contains("application/xml")) {
             try {
                 return new ResponseEntity<User>(objectMapper.readValue("<User>  <id>123456789</id>  <username>aeiou</username>  <firstName>aeiou</firstName>  <lastName>aeiou</lastName>  <email>aeiou</email>  <password>aeiou</password>  <phone>aeiou</phone>  <userStatus>123</userStatus></User>", User.class), HttpStatus.NOT_IMPLEMENTED);
@@ -86,7 +91,7 @@ public class UserApiController implements UserApi {
 
     public ResponseEntity<String> loginUser(@NotNull @ApiParam(value = "The user name for login", required = true) @Valid @RequestParam(value = "username", required = true) String username,@NotNull @ApiParam(value = "The password for login in clear text", required = true) @Valid @RequestParam(value = "password", required = true) String password) {
         // do some magic!
-        String accept = ((ServletRequestAttributes)RequestContextHolder.getRequestAttributes()).getRequest().getHeader("Accept");
+        String accept = request.getHeader("Accept");
         if (accept != null && accept.contains("application/xml")) {
             try {
                 return new ResponseEntity<String>(objectMapper.readValue("aeiou", String.class), HttpStatus.NOT_IMPLEMENTED);
@@ -110,13 +115,13 @@ public class UserApiController implements UserApi {
 
     public ResponseEntity<Void> logoutUser() {
         // do some magic!
-        String accept = ((ServletRequestAttributes)RequestContextHolder.getRequestAttributes()).getRequest().getHeader("Accept");
+        String accept = request.getHeader("Accept");
         return new ResponseEntity<Void>(HttpStatus.OK);
     }
 
     public ResponseEntity<Void> updateUser(@ApiParam(value = "name that need to be deleted",required=true) @PathVariable("username") String username,@ApiParam(value = "Updated user object" ,required=true )  @Valid @RequestBody User body) {
         // do some magic!
-        String accept = ((ServletRequestAttributes)RequestContextHolder.getRequestAttributes()).getRequest().getHeader("Accept");
+        String accept = request.getHeader("Accept");
         return new ResponseEntity<Void>(HttpStatus.OK);
     }
 

--- a/samples/server/petstore/springboot-beanvalidation/src/main/java/io/swagger/model/FormatTest.java
+++ b/samples/server/petstore/springboot-beanvalidation/src/main/java/io/swagger/model/FormatTest.java
@@ -71,7 +71,7 @@ public class FormatTest   {
   **/
   @ApiModelProperty(value = "")
 
- @Min(10) @Max(100)
+@Min(10) @Max(100) 
   public Integer getInteger() {
     return integer;
   }
@@ -93,7 +93,7 @@ public class FormatTest   {
   **/
   @ApiModelProperty(value = "")
 
- @Min(20) @Max(200)
+@Min(20) @Max(200) 
   public Integer getInt32() {
     return int32;
   }
@@ -137,7 +137,7 @@ public class FormatTest   {
   @NotNull
 
   @Valid
- @DecimalMin("32.1") @DecimalMax("543.2")
+@DecimalMin("32.1") @DecimalMax("543.2") 
   public BigDecimal getNumber() {
     return number;
   }
@@ -159,7 +159,7 @@ public class FormatTest   {
   **/
   @ApiModelProperty(value = "")
 
- @DecimalMin("54.3") @DecimalMax("987.6")
+@DecimalMin("54.3") @DecimalMax("987.6") 
   public Float getFloat() {
     return _float;
   }
@@ -181,7 +181,7 @@ public class FormatTest   {
   **/
   @ApiModelProperty(value = "")
 
- @DecimalMin("67.8") @DecimalMax("123.4")
+@DecimalMin("67.8") @DecimalMax("123.4") 
   public Double getDouble() {
     return _double;
   }
@@ -201,7 +201,7 @@ public class FormatTest   {
   **/
   @ApiModelProperty(value = "")
 
- @Pattern(regexp="/[a-z]/i")
+@Pattern(regexp="/[a-z]/i") 
   public String getString() {
     return string;
   }
@@ -222,7 +222,7 @@ public class FormatTest   {
   @ApiModelProperty(required = true, value = "")
   @NotNull
 
- @Pattern(regexp="^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$")
+@Pattern(regexp="^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$") 
   public byte[] getByte() {
     return _byte;
   }
@@ -327,7 +327,7 @@ public class FormatTest   {
   @ApiModelProperty(required = true, value = "")
   @NotNull
 
- @Size(min=10,max=64)
+@Size(min=10,max=64) 
   public String getPassword() {
     return password;
   }

--- a/samples/server/petstore/springboot-delegate-j8/src/main/java/io/swagger/api/AnotherFakeApi.java
+++ b/samples/server/petstore/springboot-delegate-j8/src/main/java/io/swagger/api/AnotherFakeApi.java
@@ -6,10 +6,9 @@
 package io.swagger.api;
 
 import io.swagger.model.Client;
-
 import io.swagger.annotations.*;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
@@ -18,15 +17,15 @@ import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.multipart.MultipartFile;
-import java.io.IOException;
 
-import java.util.List;
-import org.springframework.validation.annotation.Validated;
-import javax.validation.constraints.*;
 import javax.validation.Valid;
+import javax.validation.constraints.*;
+import java.util.List;
 
 @Api(value = "another-fake", description = "the another-fake API")
 public interface AnotherFakeApi {
+
+    AnotherFakeApiDelegate getDelegate();
 
     @ApiOperation(value = "To test special tags", nickname = "testSpecialTags", notes = "To test special tags", response = Client.class, tags={ "$another-fake?", })
     @ApiResponses(value = { 
@@ -36,8 +35,7 @@ public interface AnotherFakeApi {
         consumes = { "application/json" },
         method = RequestMethod.PATCH)
     default ResponseEntity<Client> testSpecialTags(@ApiParam(value = "client model" ,required=true )  @Valid @RequestBody Client body) {
-        // do some magic!
-        return new ResponseEntity<Client>(HttpStatus.NOT_IMPLEMENTED);
+        return getDelegate().testSpecialTags(body);
     }
 
 }

--- a/samples/server/petstore/springboot-delegate-j8/src/main/java/io/swagger/api/AnotherFakeApi.java
+++ b/samples/server/petstore/springboot-delegate-j8/src/main/java/io/swagger/api/AnotherFakeApi.java
@@ -35,9 +35,9 @@ public interface AnotherFakeApi {
         produces = { "application/json" }, 
         consumes = { "application/json" },
         method = RequestMethod.PATCH)
-    default ResponseEntity<Client> testSpecialTags(@ApiParam(value = "client model" ,required=true )  @Valid @RequestBody Client body, @RequestHeader(value = "Accept", required = false) String accept) throws Exception {
+    default ResponseEntity<Client> testSpecialTags(@ApiParam(value = "client model" ,required=true )  @Valid @RequestBody Client body) {
         // do some magic!
-        return new ResponseEntity<Client>(HttpStatus.OK);
+        return new ResponseEntity<Client>(HttpStatus.NOT_IMPLEMENTED);
     }
 
 }

--- a/samples/server/petstore/springboot-delegate-j8/src/main/java/io/swagger/api/AnotherFakeApiController.java
+++ b/samples/server/petstore/springboot-delegate-j8/src/main/java/io/swagger/api/AnotherFakeApiController.java
@@ -4,6 +4,8 @@ import io.swagger.model.Client;
 
 import io.swagger.annotations.*;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
@@ -12,6 +14,8 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RequestPart;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.util.List;
@@ -22,6 +26,9 @@ import javax.validation.Valid;
 
 @Controller
 public class AnotherFakeApiController implements AnotherFakeApi {
+
+    private final Logger log = LoggerFactory.getLogger(AnotherFakeApiController.class);
+
     private final ObjectMapper objectMapper;
 
     public AnotherFakeApiController(ObjectMapper objectMapper) {
@@ -35,8 +42,7 @@ public class AnotherFakeApiController implements AnotherFakeApi {
         this.delegate = delegate;
     }
 
-    public ResponseEntity<Client> testSpecialTags(@ApiParam(value = "client model" ,required=true )  @Valid @RequestBody Client body,
-        @RequestHeader(value = "Accept", required = false) String accept) throws Exception {
+    public ResponseEntity<Client> testSpecialTags(@ApiParam(value = "client model" ,required=true )  @Valid @RequestBody Client body) {
         // do some magic!
         return delegate.testSpecialTags(body);
     }

--- a/samples/server/petstore/springboot-delegate-j8/src/main/java/io/swagger/api/AnotherFakeApiController.java
+++ b/samples/server/petstore/springboot-delegate-j8/src/main/java/io/swagger/api/AnotherFakeApiController.java
@@ -21,19 +21,12 @@ import org.springframework.web.multipart.MultipartFile;
 import java.util.List;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.IOException;
+import javax.servlet.http.HttpServletRequest;
 import javax.validation.constraints.*;
 import javax.validation.Valid;
 
 @Controller
 public class AnotherFakeApiController implements AnotherFakeApi {
-
-    private final Logger log = LoggerFactory.getLogger(AnotherFakeApiController.class);
-
-    private final ObjectMapper objectMapper;
-
-    public AnotherFakeApiController(ObjectMapper objectMapper) {
-        this.objectMapper = objectMapper;
-    }
 
     private final AnotherFakeApiDelegate delegate;
 

--- a/samples/server/petstore/springboot-delegate-j8/src/main/java/io/swagger/api/AnotherFakeApiController.java
+++ b/samples/server/petstore/springboot-delegate-j8/src/main/java/io/swagger/api/AnotherFakeApiController.java
@@ -1,29 +1,6 @@
 package io.swagger.api;
 
-import io.swagger.model.Client;
-
-import io.swagger.annotations.*;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import org.springframework.http.HttpStatus;
-import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestHeader;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RequestPart;
-import org.springframework.web.context.request.RequestContextHolder;
-import org.springframework.web.context.request.ServletRequestAttributes;
-import org.springframework.web.multipart.MultipartFile;
-
-import java.util.List;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import java.io.IOException;
-import javax.servlet.http.HttpServletRequest;
-import javax.validation.constraints.*;
-import javax.validation.Valid;
 
 @Controller
 public class AnotherFakeApiController implements AnotherFakeApi {
@@ -35,9 +12,8 @@ public class AnotherFakeApiController implements AnotherFakeApi {
         this.delegate = delegate;
     }
 
-    public ResponseEntity<Client> testSpecialTags(@ApiParam(value = "client model" ,required=true )  @Valid @RequestBody Client body) {
-        // do some magic!
-        return delegate.testSpecialTags(body);
+    @Override
+    public AnotherFakeApiDelegate getDelegate() {
+        return delegate;
     }
-
 }

--- a/samples/server/petstore/springboot-delegate-j8/src/main/java/io/swagger/api/AnotherFakeApiDelegate.java
+++ b/samples/server/petstore/springboot-delegate-j8/src/main/java/io/swagger/api/AnotherFakeApiDelegate.java
@@ -1,28 +1,57 @@
 package io.swagger.api;
 
 import io.swagger.model.Client;
-
+import com.fasterxml.jackson.databind.ObjectMapper;
 import io.swagger.annotations.*;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.multipart.MultipartFile;
+import java.io.IOException;
 
+import javax.servlet.http.HttpServletRequest;
 import java.util.List;
+import java.util.Optional;
 
 /**
  * A delegate to be called by the {@link AnotherFakeApiController}}.
- * Should be implemented as a controller but without the {@link org.springframework.stereotype.Controller} annotation.
- * Instead, use spring to autowire this class into the {@link AnotherFakeApiController}.
+ * Implement this interface with a {@link org.springframework.stereotype.Service} annotated class.
  */
 
 public interface AnotherFakeApiDelegate {
+
+    Logger log = LoggerFactory.getLogger(AnotherFakeApi.class);
+
+    default Optional<ObjectMapper> getObjectMapper() {
+        return Optional.empty();
+    }
+
+    default Optional<HttpServletRequest> getRequest() {
+        return Optional.empty();
+    }
+
+    default Optional<String> getAcceptHeader() {
+        return getRequest().map(r -> r.getHeader("Accept"));
+    }
 
     /**
      * @see AnotherFakeApi#testSpecialTags
      */
     default ResponseEntity<Client> testSpecialTags(Client body) {
-        // do some magic!
-        return new ResponseEntity<Client>(HttpStatus.NOT_IMPLEMENTED);
+        if(getObjectMapper().isPresent() && getAcceptHeader().isPresent()) {
+            if (getAcceptHeader().get().contains("application/json")) {
+                try {
+                    return new ResponseEntity<>(getObjectMapper().get().readValue("{  \"client\" : \"client\"}", Client.class), HttpStatus.NOT_IMPLEMENTED);
+                } catch (IOException e) {
+                    log.error("Couldn't serialize response for content type application/json", e);
+                    return new ResponseEntity<>(HttpStatus.INTERNAL_SERVER_ERROR);
+                }
+            }
+        } else {
+            log.warn("ObjectMapper or HttpServletRequest not configured in default AnotherFakeApi interface so no example is generated");
+        }
+        return new ResponseEntity<>(HttpStatus.NOT_IMPLEMENTED);
     }
 
 }

--- a/samples/server/petstore/springboot-delegate-j8/src/main/java/io/swagger/api/AnotherFakeApiDelegate.java
+++ b/samples/server/petstore/springboot-delegate-j8/src/main/java/io/swagger/api/AnotherFakeApiDelegate.java
@@ -22,7 +22,7 @@ public interface AnotherFakeApiDelegate {
      */
     default ResponseEntity<Client> testSpecialTags(Client body) {
     // do some magic!
-    return new ResponseEntity<Client>(HttpStatus.OK);
+    return new ResponseEntity<Client>(HttpStatus.NOT_IMPLEMENTED);
     }
 
 }

--- a/samples/server/petstore/springboot-delegate-j8/src/main/java/io/swagger/api/AnotherFakeApiDelegate.java
+++ b/samples/server/petstore/springboot-delegate-j8/src/main/java/io/swagger/api/AnotherFakeApiDelegate.java
@@ -21,8 +21,8 @@ public interface AnotherFakeApiDelegate {
      * @see AnotherFakeApi#testSpecialTags
      */
     default ResponseEntity<Client> testSpecialTags(Client body) {
-    // do some magic!
-    return new ResponseEntity<Client>(HttpStatus.NOT_IMPLEMENTED);
+        // do some magic!
+        return new ResponseEntity<Client>(HttpStatus.NOT_IMPLEMENTED);
     }
 
 }

--- a/samples/server/petstore/springboot-delegate-j8/src/main/java/io/swagger/api/FakeApi.java
+++ b/samples/server/petstore/springboot-delegate-j8/src/main/java/io/swagger/api/FakeApi.java
@@ -10,10 +10,9 @@ import io.swagger.model.Client;
 import java.time.LocalDate;
 import java.time.OffsetDateTime;
 import io.swagger.model.OuterComposite;
-
 import io.swagger.annotations.*;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
@@ -22,15 +21,15 @@ import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.multipart.MultipartFile;
-import java.io.IOException;
 
-import java.util.List;
-import org.springframework.validation.annotation.Validated;
-import javax.validation.constraints.*;
 import javax.validation.Valid;
+import javax.validation.constraints.*;
+import java.util.List;
 
 @Api(value = "fake", description = "the fake API")
 public interface FakeApi {
+
+    FakeApiDelegate getDelegate();
 
     @ApiOperation(value = "", nickname = "fakeOuterBooleanSerialize", notes = "Test serialization of outer boolean types", response = Boolean.class, tags={ "fake", })
     @ApiResponses(value = { 
@@ -38,8 +37,7 @@ public interface FakeApi {
     @RequestMapping(value = "/fake/outer/boolean",
         method = RequestMethod.POST)
     default ResponseEntity<Boolean> fakeOuterBooleanSerialize(@ApiParam(value = "Input boolean as post body"  )  @Valid @RequestBody Boolean body) {
-        // do some magic!
-        return new ResponseEntity<Boolean>(HttpStatus.NOT_IMPLEMENTED);
+        return getDelegate().fakeOuterBooleanSerialize(body);
     }
 
 
@@ -49,8 +47,7 @@ public interface FakeApi {
     @RequestMapping(value = "/fake/outer/composite",
         method = RequestMethod.POST)
     default ResponseEntity<OuterComposite> fakeOuterCompositeSerialize(@ApiParam(value = "Input composite as post body"  )  @Valid @RequestBody OuterComposite body) {
-        // do some magic!
-        return new ResponseEntity<OuterComposite>(HttpStatus.NOT_IMPLEMENTED);
+        return getDelegate().fakeOuterCompositeSerialize(body);
     }
 
 
@@ -60,8 +57,7 @@ public interface FakeApi {
     @RequestMapping(value = "/fake/outer/number",
         method = RequestMethod.POST)
     default ResponseEntity<BigDecimal> fakeOuterNumberSerialize(@ApiParam(value = "Input number as post body"  )  @Valid @RequestBody BigDecimal body) {
-        // do some magic!
-        return new ResponseEntity<BigDecimal>(HttpStatus.NOT_IMPLEMENTED);
+        return getDelegate().fakeOuterNumberSerialize(body);
     }
 
 
@@ -71,8 +67,7 @@ public interface FakeApi {
     @RequestMapping(value = "/fake/outer/string",
         method = RequestMethod.POST)
     default ResponseEntity<String> fakeOuterStringSerialize(@ApiParam(value = "Input string as post body"  )  @Valid @RequestBody String body) {
-        // do some magic!
-        return new ResponseEntity<String>(HttpStatus.NOT_IMPLEMENTED);
+        return getDelegate().fakeOuterStringSerialize(body);
     }
 
 
@@ -84,8 +79,7 @@ public interface FakeApi {
         consumes = { "application/json" },
         method = RequestMethod.PATCH)
     default ResponseEntity<Client> testClientModel(@ApiParam(value = "client model" ,required=true )  @Valid @RequestBody Client body) {
-        // do some magic!
-        return new ResponseEntity<Client>(HttpStatus.NOT_IMPLEMENTED);
+        return getDelegate().testClientModel(body);
     }
 
 
@@ -100,8 +94,7 @@ public interface FakeApi {
         consumes = { "application/xml; charset=utf-8", "application/json; charset=utf-8" },
         method = RequestMethod.POST)
     default ResponseEntity<Void> testEndpointParameters(@ApiParam(value = "None", required=true) @RequestPart(value="number", required=true)  BigDecimal number,@ApiParam(value = "None", required=true) @RequestPart(value="double", required=true)  Double _double,@ApiParam(value = "None", required=true) @RequestPart(value="pattern_without_delimiter", required=true)  String patternWithoutDelimiter,@ApiParam(value = "None", required=true) @RequestPart(value="byte", required=true)  byte[] _byte,@ApiParam(value = "None") @RequestPart(value="integer", required=false)  Integer integer,@ApiParam(value = "None") @RequestPart(value="int32", required=false)  Integer int32,@ApiParam(value = "None") @RequestPart(value="int64", required=false)  Long int64,@ApiParam(value = "None") @RequestPart(value="float", required=false)  Float _float,@ApiParam(value = "None") @RequestPart(value="string", required=false)  String string,@ApiParam(value = "None") @RequestPart(value="binary", required=false)  byte[] binary,@ApiParam(value = "None") @RequestPart(value="date", required=false)  LocalDate date,@ApiParam(value = "None") @RequestPart(value="dateTime", required=false)  OffsetDateTime dateTime,@ApiParam(value = "None") @RequestPart(value="password", required=false)  String password,@ApiParam(value = "None") @RequestPart(value="callback", required=false)  String paramCallback) {
-        // do some magic!
-        return new ResponseEntity<Void>(HttpStatus.NOT_IMPLEMENTED);
+        return getDelegate().testEndpointParameters(number, _double, patternWithoutDelimiter, _byte, integer, int32, int64, _float, string, binary, date, dateTime, password, paramCallback);
     }
 
 
@@ -114,8 +107,7 @@ public interface FakeApi {
         consumes = { "*/*" },
         method = RequestMethod.GET)
     default ResponseEntity<Void> testEnumParameters(@ApiParam(value = "Form parameter enum test (string array)", allowableValues=">, $") @RequestPart(value="enum_form_string_array", required=false)  List<String> enumFormStringArray,@ApiParam(value = "Form parameter enum test (string)", allowableValues="_abc, -efg, (xyz)", defaultValue="-efg") @RequestPart(value="enum_form_string", required=false)  String enumFormString,@ApiParam(value = "Header parameter enum test (string array)" , allowableValues=">, $") @RequestHeader(value="enum_header_string_array", required=false) List<String> enumHeaderStringArray,@ApiParam(value = "Header parameter enum test (string)" , allowableValues="_abc, -efg, (xyz)", defaultValue="-efg") @RequestHeader(value="enum_header_string", required=false) String enumHeaderString,@ApiParam(value = "Query parameter enum test (string array)", allowableValues = ">, $") @Valid @RequestParam(value = "enum_query_string_array", required = false) List<String> enumQueryStringArray,@ApiParam(value = "Query parameter enum test (string)", allowableValues = "_abc, -efg, (xyz)", defaultValue = "-efg") @Valid @RequestParam(value = "enum_query_string", required = false, defaultValue="-efg") String enumQueryString,@ApiParam(value = "Query parameter enum test (double)", allowableValues = "1, -2") @Valid @RequestParam(value = "enum_query_integer", required = false) Integer enumQueryInteger,@ApiParam(value = "Query parameter enum test (double)", allowableValues="1.1, -1.2") @RequestPart(value="enum_query_double", required=false)  Double enumQueryDouble) {
-        // do some magic!
-        return new ResponseEntity<Void>(HttpStatus.NOT_IMPLEMENTED);
+        return getDelegate().testEnumParameters(enumFormStringArray, enumFormString, enumHeaderStringArray, enumHeaderString, enumQueryStringArray, enumQueryString, enumQueryInteger, enumQueryDouble);
     }
 
 
@@ -126,8 +118,7 @@ public interface FakeApi {
         consumes = { "application/json" },
         method = RequestMethod.POST)
     default ResponseEntity<Void> testInlineAdditionalProperties(@ApiParam(value = "request body" ,required=true )  @Valid @RequestBody Object param) {
-        // do some magic!
-        return new ResponseEntity<Void>(HttpStatus.NOT_IMPLEMENTED);
+        return getDelegate().testInlineAdditionalProperties(param);
     }
 
 
@@ -138,8 +129,7 @@ public interface FakeApi {
         consumes = { "application/json" },
         method = RequestMethod.GET)
     default ResponseEntity<Void> testJsonFormData(@ApiParam(value = "field1", required=true) @RequestPart(value="param", required=true)  String param,@ApiParam(value = "field2", required=true) @RequestPart(value="param2", required=true)  String param2) {
-        // do some magic!
-        return new ResponseEntity<Void>(HttpStatus.NOT_IMPLEMENTED);
+        return getDelegate().testJsonFormData(param, param2);
     }
 
 }

--- a/samples/server/petstore/springboot-delegate-j8/src/main/java/io/swagger/api/FakeApi.java
+++ b/samples/server/petstore/springboot-delegate-j8/src/main/java/io/swagger/api/FakeApi.java
@@ -37,9 +37,9 @@ public interface FakeApi {
         @ApiResponse(code = 200, message = "Output boolean", response = Boolean.class) })
     @RequestMapping(value = "/fake/outer/boolean",
         method = RequestMethod.POST)
-    default ResponseEntity<Boolean> fakeOuterBooleanSerialize(@ApiParam(value = "Input boolean as post body"  )  @Valid @RequestBody Boolean body, @RequestHeader(value = "Accept", required = false) String accept) throws Exception {
+    default ResponseEntity<Boolean> fakeOuterBooleanSerialize(@ApiParam(value = "Input boolean as post body"  )  @Valid @RequestBody Boolean body) {
         // do some magic!
-        return new ResponseEntity<Boolean>(HttpStatus.OK);
+        return new ResponseEntity<Boolean>(HttpStatus.NOT_IMPLEMENTED);
     }
 
 
@@ -48,9 +48,9 @@ public interface FakeApi {
         @ApiResponse(code = 200, message = "Output composite", response = OuterComposite.class) })
     @RequestMapping(value = "/fake/outer/composite",
         method = RequestMethod.POST)
-    default ResponseEntity<OuterComposite> fakeOuterCompositeSerialize(@ApiParam(value = "Input composite as post body"  )  @Valid @RequestBody OuterComposite body, @RequestHeader(value = "Accept", required = false) String accept) throws Exception {
+    default ResponseEntity<OuterComposite> fakeOuterCompositeSerialize(@ApiParam(value = "Input composite as post body"  )  @Valid @RequestBody OuterComposite body) {
         // do some magic!
-        return new ResponseEntity<OuterComposite>(HttpStatus.OK);
+        return new ResponseEntity<OuterComposite>(HttpStatus.NOT_IMPLEMENTED);
     }
 
 
@@ -59,9 +59,9 @@ public interface FakeApi {
         @ApiResponse(code = 200, message = "Output number", response = BigDecimal.class) })
     @RequestMapping(value = "/fake/outer/number",
         method = RequestMethod.POST)
-    default ResponseEntity<BigDecimal> fakeOuterNumberSerialize(@ApiParam(value = "Input number as post body"  )  @Valid @RequestBody BigDecimal body, @RequestHeader(value = "Accept", required = false) String accept) throws Exception {
+    default ResponseEntity<BigDecimal> fakeOuterNumberSerialize(@ApiParam(value = "Input number as post body"  )  @Valid @RequestBody BigDecimal body) {
         // do some magic!
-        return new ResponseEntity<BigDecimal>(HttpStatus.OK);
+        return new ResponseEntity<BigDecimal>(HttpStatus.NOT_IMPLEMENTED);
     }
 
 
@@ -70,9 +70,9 @@ public interface FakeApi {
         @ApiResponse(code = 200, message = "Output string", response = String.class) })
     @RequestMapping(value = "/fake/outer/string",
         method = RequestMethod.POST)
-    default ResponseEntity<String> fakeOuterStringSerialize(@ApiParam(value = "Input string as post body"  )  @Valid @RequestBody String body, @RequestHeader(value = "Accept", required = false) String accept) throws Exception {
+    default ResponseEntity<String> fakeOuterStringSerialize(@ApiParam(value = "Input string as post body"  )  @Valid @RequestBody String body) {
         // do some magic!
-        return new ResponseEntity<String>(HttpStatus.OK);
+        return new ResponseEntity<String>(HttpStatus.NOT_IMPLEMENTED);
     }
 
 
@@ -83,9 +83,9 @@ public interface FakeApi {
         produces = { "application/json" }, 
         consumes = { "application/json" },
         method = RequestMethod.PATCH)
-    default ResponseEntity<Client> testClientModel(@ApiParam(value = "client model" ,required=true )  @Valid @RequestBody Client body, @RequestHeader(value = "Accept", required = false) String accept) throws Exception {
+    default ResponseEntity<Client> testClientModel(@ApiParam(value = "client model" ,required=true )  @Valid @RequestBody Client body) {
         // do some magic!
-        return new ResponseEntity<Client>(HttpStatus.OK);
+        return new ResponseEntity<Client>(HttpStatus.NOT_IMPLEMENTED);
     }
 
 
@@ -99,9 +99,9 @@ public interface FakeApi {
         produces = { "application/xml; charset=utf-8", "application/json; charset=utf-8" }, 
         consumes = { "application/xml; charset=utf-8", "application/json; charset=utf-8" },
         method = RequestMethod.POST)
-    default ResponseEntity<Void> testEndpointParameters(@ApiParam(value = "None", required=true) @RequestPart(value="number", required=true)  BigDecimal number,@ApiParam(value = "None", required=true) @RequestPart(value="double", required=true)  Double _double,@ApiParam(value = "None", required=true) @RequestPart(value="pattern_without_delimiter", required=true)  String patternWithoutDelimiter,@ApiParam(value = "None", required=true) @RequestPart(value="byte", required=true)  byte[] _byte,@ApiParam(value = "None") @RequestPart(value="integer", required=false)  Integer integer,@ApiParam(value = "None") @RequestPart(value="int32", required=false)  Integer int32,@ApiParam(value = "None") @RequestPart(value="int64", required=false)  Long int64,@ApiParam(value = "None") @RequestPart(value="float", required=false)  Float _float,@ApiParam(value = "None") @RequestPart(value="string", required=false)  String string,@ApiParam(value = "None") @RequestPart(value="binary", required=false)  byte[] binary,@ApiParam(value = "None") @RequestPart(value="date", required=false)  LocalDate date,@ApiParam(value = "None") @RequestPart(value="dateTime", required=false)  OffsetDateTime dateTime,@ApiParam(value = "None") @RequestPart(value="password", required=false)  String password,@ApiParam(value = "None") @RequestPart(value="callback", required=false)  String paramCallback, @RequestHeader(value = "Accept", required = false) String accept) throws Exception {
+    default ResponseEntity<Void> testEndpointParameters(@ApiParam(value = "None", required=true) @RequestPart(value="number", required=true)  BigDecimal number,@ApiParam(value = "None", required=true) @RequestPart(value="double", required=true)  Double _double,@ApiParam(value = "None", required=true) @RequestPart(value="pattern_without_delimiter", required=true)  String patternWithoutDelimiter,@ApiParam(value = "None", required=true) @RequestPart(value="byte", required=true)  byte[] _byte,@ApiParam(value = "None") @RequestPart(value="integer", required=false)  Integer integer,@ApiParam(value = "None") @RequestPart(value="int32", required=false)  Integer int32,@ApiParam(value = "None") @RequestPart(value="int64", required=false)  Long int64,@ApiParam(value = "None") @RequestPart(value="float", required=false)  Float _float,@ApiParam(value = "None") @RequestPart(value="string", required=false)  String string,@ApiParam(value = "None") @RequestPart(value="binary", required=false)  byte[] binary,@ApiParam(value = "None") @RequestPart(value="date", required=false)  LocalDate date,@ApiParam(value = "None") @RequestPart(value="dateTime", required=false)  OffsetDateTime dateTime,@ApiParam(value = "None") @RequestPart(value="password", required=false)  String password,@ApiParam(value = "None") @RequestPart(value="callback", required=false)  String paramCallback) {
         // do some magic!
-        return new ResponseEntity<Void>(HttpStatus.OK);
+        return new ResponseEntity<Void>(HttpStatus.NOT_IMPLEMENTED);
     }
 
 
@@ -113,9 +113,9 @@ public interface FakeApi {
         produces = { "*/*" }, 
         consumes = { "*/*" },
         method = RequestMethod.GET)
-    default ResponseEntity<Void> testEnumParameters(@ApiParam(value = "Form parameter enum test (string array)", allowableValues=">, $") @RequestPart(value="enum_form_string_array", required=false)  List<String> enumFormStringArray,@ApiParam(value = "Form parameter enum test (string)", allowableValues="_abc, -efg, (xyz)", defaultValue="-efg") @RequestPart(value="enum_form_string", required=false)  String enumFormString,@ApiParam(value = "Header parameter enum test (string array)" , allowableValues=">, $") @RequestHeader(value="enum_header_string_array", required=false) List<String> enumHeaderStringArray,@ApiParam(value = "Header parameter enum test (string)" , allowableValues="_abc, -efg, (xyz)", defaultValue="-efg") @RequestHeader(value="enum_header_string", required=false) String enumHeaderString,@ApiParam(value = "Query parameter enum test (string array)", allowableValues = ">, $") @Valid @RequestParam(value = "enum_query_string_array", required = false) List<String> enumQueryStringArray,@ApiParam(value = "Query parameter enum test (string)", allowableValues = "_abc, -efg, (xyz)", defaultValue = "-efg") @Valid @RequestParam(value = "enum_query_string", required = false, defaultValue="-efg") String enumQueryString,@ApiParam(value = "Query parameter enum test (double)", allowableValues = "1, -2") @Valid @RequestParam(value = "enum_query_integer", required = false) Integer enumQueryInteger,@ApiParam(value = "Query parameter enum test (double)", allowableValues="1.1, -1.2") @RequestPart(value="enum_query_double", required=false)  Double enumQueryDouble, @RequestHeader(value = "Accept", required = false) String accept) throws Exception {
+    default ResponseEntity<Void> testEnumParameters(@ApiParam(value = "Form parameter enum test (string array)", allowableValues=">, $") @RequestPart(value="enum_form_string_array", required=false)  List<String> enumFormStringArray,@ApiParam(value = "Form parameter enum test (string)", allowableValues="_abc, -efg, (xyz)", defaultValue="-efg") @RequestPart(value="enum_form_string", required=false)  String enumFormString,@ApiParam(value = "Header parameter enum test (string array)" , allowableValues=">, $") @RequestHeader(value="enum_header_string_array", required=false) List<String> enumHeaderStringArray,@ApiParam(value = "Header parameter enum test (string)" , allowableValues="_abc, -efg, (xyz)", defaultValue="-efg") @RequestHeader(value="enum_header_string", required=false) String enumHeaderString,@ApiParam(value = "Query parameter enum test (string array)", allowableValues = ">, $") @Valid @RequestParam(value = "enum_query_string_array", required = false) List<String> enumQueryStringArray,@ApiParam(value = "Query parameter enum test (string)", allowableValues = "_abc, -efg, (xyz)", defaultValue = "-efg") @Valid @RequestParam(value = "enum_query_string", required = false, defaultValue="-efg") String enumQueryString,@ApiParam(value = "Query parameter enum test (double)", allowableValues = "1, -2") @Valid @RequestParam(value = "enum_query_integer", required = false) Integer enumQueryInteger,@ApiParam(value = "Query parameter enum test (double)", allowableValues="1.1, -1.2") @RequestPart(value="enum_query_double", required=false)  Double enumQueryDouble) {
         // do some magic!
-        return new ResponseEntity<Void>(HttpStatus.OK);
+        return new ResponseEntity<Void>(HttpStatus.NOT_IMPLEMENTED);
     }
 
 
@@ -125,9 +125,9 @@ public interface FakeApi {
     @RequestMapping(value = "/fake/inline-additionalProperties",
         consumes = { "application/json" },
         method = RequestMethod.POST)
-    default ResponseEntity<Void> testInlineAdditionalProperties(@ApiParam(value = "request body" ,required=true )  @Valid @RequestBody Object param, @RequestHeader(value = "Accept", required = false) String accept) throws Exception {
+    default ResponseEntity<Void> testInlineAdditionalProperties(@ApiParam(value = "request body" ,required=true )  @Valid @RequestBody Object param) {
         // do some magic!
-        return new ResponseEntity<Void>(HttpStatus.OK);
+        return new ResponseEntity<Void>(HttpStatus.NOT_IMPLEMENTED);
     }
 
 
@@ -137,9 +137,9 @@ public interface FakeApi {
     @RequestMapping(value = "/fake/jsonFormData",
         consumes = { "application/json" },
         method = RequestMethod.GET)
-    default ResponseEntity<Void> testJsonFormData(@ApiParam(value = "field1", required=true) @RequestPart(value="param", required=true)  String param,@ApiParam(value = "field2", required=true) @RequestPart(value="param2", required=true)  String param2, @RequestHeader(value = "Accept", required = false) String accept) throws Exception {
+    default ResponseEntity<Void> testJsonFormData(@ApiParam(value = "field1", required=true) @RequestPart(value="param", required=true)  String param,@ApiParam(value = "field2", required=true) @RequestPart(value="param2", required=true)  String param2) {
         // do some magic!
-        return new ResponseEntity<Void>(HttpStatus.OK);
+        return new ResponseEntity<Void>(HttpStatus.NOT_IMPLEMENTED);
     }
 
 }

--- a/samples/server/petstore/springboot-delegate-j8/src/main/java/io/swagger/api/FakeApiController.java
+++ b/samples/server/petstore/springboot-delegate-j8/src/main/java/io/swagger/api/FakeApiController.java
@@ -25,19 +25,12 @@ import org.springframework.web.multipart.MultipartFile;
 import java.util.List;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.IOException;
+import javax.servlet.http.HttpServletRequest;
 import javax.validation.constraints.*;
 import javax.validation.Valid;
 
 @Controller
 public class FakeApiController implements FakeApi {
-
-    private final Logger log = LoggerFactory.getLogger(AnotherFakeApiController.class);
-
-    private final ObjectMapper objectMapper;
-
-    public FakeApiController(ObjectMapper objectMapper) {
-        this.objectMapper = objectMapper;
-    }
 
     private final FakeApiDelegate delegate;
 

--- a/samples/server/petstore/springboot-delegate-j8/src/main/java/io/swagger/api/FakeApiController.java
+++ b/samples/server/petstore/springboot-delegate-j8/src/main/java/io/swagger/api/FakeApiController.java
@@ -1,33 +1,6 @@
 package io.swagger.api;
 
-import java.math.BigDecimal;
-import io.swagger.model.Client;
-import java.time.LocalDate;
-import java.time.OffsetDateTime;
-import io.swagger.model.OuterComposite;
-
-import io.swagger.annotations.*;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import org.springframework.http.HttpStatus;
-import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestHeader;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RequestPart;
-import org.springframework.web.context.request.RequestContextHolder;
-import org.springframework.web.context.request.ServletRequestAttributes;
-import org.springframework.web.multipart.MultipartFile;
-
-import java.util.List;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import java.io.IOException;
-import javax.servlet.http.HttpServletRequest;
-import javax.validation.constraints.*;
-import javax.validation.Valid;
 
 @Controller
 public class FakeApiController implements FakeApi {
@@ -39,49 +12,8 @@ public class FakeApiController implements FakeApi {
         this.delegate = delegate;
     }
 
-    public ResponseEntity<Boolean> fakeOuterBooleanSerialize(@ApiParam(value = "Input boolean as post body"  )  @Valid @RequestBody Boolean body) {
-        // do some magic!
-        return delegate.fakeOuterBooleanSerialize(body);
+    @Override
+    public FakeApiDelegate getDelegate() {
+        return delegate;
     }
-
-    public ResponseEntity<OuterComposite> fakeOuterCompositeSerialize(@ApiParam(value = "Input composite as post body"  )  @Valid @RequestBody OuterComposite body) {
-        // do some magic!
-        return delegate.fakeOuterCompositeSerialize(body);
-    }
-
-    public ResponseEntity<BigDecimal> fakeOuterNumberSerialize(@ApiParam(value = "Input number as post body"  )  @Valid @RequestBody BigDecimal body) {
-        // do some magic!
-        return delegate.fakeOuterNumberSerialize(body);
-    }
-
-    public ResponseEntity<String> fakeOuterStringSerialize(@ApiParam(value = "Input string as post body"  )  @Valid @RequestBody String body) {
-        // do some magic!
-        return delegate.fakeOuterStringSerialize(body);
-    }
-
-    public ResponseEntity<Client> testClientModel(@ApiParam(value = "client model" ,required=true )  @Valid @RequestBody Client body) {
-        // do some magic!
-        return delegate.testClientModel(body);
-    }
-
-    public ResponseEntity<Void> testEndpointParameters(@ApiParam(value = "None", required=true) @RequestPart(value="number", required=true)  BigDecimal number,@ApiParam(value = "None", required=true) @RequestPart(value="double", required=true)  Double _double,@ApiParam(value = "None", required=true) @RequestPart(value="pattern_without_delimiter", required=true)  String patternWithoutDelimiter,@ApiParam(value = "None", required=true) @RequestPart(value="byte", required=true)  byte[] _byte,@ApiParam(value = "None") @RequestPart(value="integer", required=false)  Integer integer,@ApiParam(value = "None") @RequestPart(value="int32", required=false)  Integer int32,@ApiParam(value = "None") @RequestPart(value="int64", required=false)  Long int64,@ApiParam(value = "None") @RequestPart(value="float", required=false)  Float _float,@ApiParam(value = "None") @RequestPart(value="string", required=false)  String string,@ApiParam(value = "None") @RequestPart(value="binary", required=false)  byte[] binary,@ApiParam(value = "None") @RequestPart(value="date", required=false)  LocalDate date,@ApiParam(value = "None") @RequestPart(value="dateTime", required=false)  OffsetDateTime dateTime,@ApiParam(value = "None") @RequestPart(value="password", required=false)  String password,@ApiParam(value = "None") @RequestPart(value="callback", required=false)  String paramCallback) {
-        // do some magic!
-        return delegate.testEndpointParameters(number, _double, patternWithoutDelimiter, _byte, integer, int32, int64, _float, string, binary, date, dateTime, password, paramCallback);
-    }
-
-    public ResponseEntity<Void> testEnumParameters(@ApiParam(value = "Form parameter enum test (string array)", allowableValues=">, $") @RequestPart(value="enum_form_string_array", required=false)  List<String> enumFormStringArray,@ApiParam(value = "Form parameter enum test (string)", allowableValues="_abc, -efg, (xyz)", defaultValue="-efg") @RequestPart(value="enum_form_string", required=false)  String enumFormString,@ApiParam(value = "Header parameter enum test (string array)" , allowableValues=">, $") @RequestHeader(value="enum_header_string_array", required=false) List<String> enumHeaderStringArray,@ApiParam(value = "Header parameter enum test (string)" , allowableValues="_abc, -efg, (xyz)", defaultValue="-efg") @RequestHeader(value="enum_header_string", required=false) String enumHeaderString,@ApiParam(value = "Query parameter enum test (string array)", allowableValues = ">, $") @Valid @RequestParam(value = "enum_query_string_array", required = false) List<String> enumQueryStringArray,@ApiParam(value = "Query parameter enum test (string)", allowableValues = "_abc, -efg, (xyz)", defaultValue = "-efg") @Valid @RequestParam(value = "enum_query_string", required = false, defaultValue="-efg") String enumQueryString,@ApiParam(value = "Query parameter enum test (double)", allowableValues = "1, -2") @Valid @RequestParam(value = "enum_query_integer", required = false) Integer enumQueryInteger,@ApiParam(value = "Query parameter enum test (double)", allowableValues="1.1, -1.2") @RequestPart(value="enum_query_double", required=false)  Double enumQueryDouble) {
-        // do some magic!
-        return delegate.testEnumParameters(enumFormStringArray, enumFormString, enumHeaderStringArray, enumHeaderString, enumQueryStringArray, enumQueryString, enumQueryInteger, enumQueryDouble);
-    }
-
-    public ResponseEntity<Void> testInlineAdditionalProperties(@ApiParam(value = "request body" ,required=true )  @Valid @RequestBody Object param) {
-        // do some magic!
-        return delegate.testInlineAdditionalProperties(param);
-    }
-
-    public ResponseEntity<Void> testJsonFormData(@ApiParam(value = "field1", required=true) @RequestPart(value="param", required=true)  String param,@ApiParam(value = "field2", required=true) @RequestPart(value="param2", required=true)  String param2) {
-        // do some magic!
-        return delegate.testJsonFormData(param, param2);
-    }
-
 }

--- a/samples/server/petstore/springboot-delegate-j8/src/main/java/io/swagger/api/FakeApiController.java
+++ b/samples/server/petstore/springboot-delegate-j8/src/main/java/io/swagger/api/FakeApiController.java
@@ -8,6 +8,8 @@ import io.swagger.model.OuterComposite;
 
 import io.swagger.annotations.*;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
@@ -16,6 +18,8 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RequestPart;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.util.List;
@@ -26,6 +30,9 @@ import javax.validation.Valid;
 
 @Controller
 public class FakeApiController implements FakeApi {
+
+    private final Logger log = LoggerFactory.getLogger(AnotherFakeApiController.class);
+
     private final ObjectMapper objectMapper;
 
     public FakeApiController(ObjectMapper objectMapper) {
@@ -39,77 +46,47 @@ public class FakeApiController implements FakeApi {
         this.delegate = delegate;
     }
 
-    public ResponseEntity<Boolean> fakeOuterBooleanSerialize(@ApiParam(value = "Input boolean as post body"  )  @Valid @RequestBody Boolean body,
-        @RequestHeader(value = "Accept", required = false) String accept) throws Exception {
+    public ResponseEntity<Boolean> fakeOuterBooleanSerialize(@ApiParam(value = "Input boolean as post body"  )  @Valid @RequestBody Boolean body) {
         // do some magic!
         return delegate.fakeOuterBooleanSerialize(body);
     }
 
-    public ResponseEntity<OuterComposite> fakeOuterCompositeSerialize(@ApiParam(value = "Input composite as post body"  )  @Valid @RequestBody OuterComposite body,
-        @RequestHeader(value = "Accept", required = false) String accept) throws Exception {
+    public ResponseEntity<OuterComposite> fakeOuterCompositeSerialize(@ApiParam(value = "Input composite as post body"  )  @Valid @RequestBody OuterComposite body) {
         // do some magic!
         return delegate.fakeOuterCompositeSerialize(body);
     }
 
-    public ResponseEntity<BigDecimal> fakeOuterNumberSerialize(@ApiParam(value = "Input number as post body"  )  @Valid @RequestBody BigDecimal body,
-        @RequestHeader(value = "Accept", required = false) String accept) throws Exception {
+    public ResponseEntity<BigDecimal> fakeOuterNumberSerialize(@ApiParam(value = "Input number as post body"  )  @Valid @RequestBody BigDecimal body) {
         // do some magic!
         return delegate.fakeOuterNumberSerialize(body);
     }
 
-    public ResponseEntity<String> fakeOuterStringSerialize(@ApiParam(value = "Input string as post body"  )  @Valid @RequestBody String body,
-        @RequestHeader(value = "Accept", required = false) String accept) throws Exception {
+    public ResponseEntity<String> fakeOuterStringSerialize(@ApiParam(value = "Input string as post body"  )  @Valid @RequestBody String body) {
         // do some magic!
         return delegate.fakeOuterStringSerialize(body);
     }
 
-    public ResponseEntity<Client> testClientModel(@ApiParam(value = "client model" ,required=true )  @Valid @RequestBody Client body,
-        @RequestHeader(value = "Accept", required = false) String accept) throws Exception {
+    public ResponseEntity<Client> testClientModel(@ApiParam(value = "client model" ,required=true )  @Valid @RequestBody Client body) {
         // do some magic!
         return delegate.testClientModel(body);
     }
 
-    public ResponseEntity<Void> testEndpointParameters(@ApiParam(value = "None", required=true) @RequestPart(value="number", required=true)  BigDecimal number,
-        @ApiParam(value = "None", required=true) @RequestPart(value="double", required=true)  Double _double,
-        @ApiParam(value = "None", required=true) @RequestPart(value="pattern_without_delimiter", required=true)  String patternWithoutDelimiter,
-        @ApiParam(value = "None", required=true) @RequestPart(value="byte", required=true)  byte[] _byte,
-        @ApiParam(value = "None") @RequestPart(value="integer", required=false)  Integer integer,
-        @ApiParam(value = "None") @RequestPart(value="int32", required=false)  Integer int32,
-        @ApiParam(value = "None") @RequestPart(value="int64", required=false)  Long int64,
-        @ApiParam(value = "None") @RequestPart(value="float", required=false)  Float _float,
-        @ApiParam(value = "None") @RequestPart(value="string", required=false)  String string,
-        @ApiParam(value = "None") @RequestPart(value="binary", required=false)  byte[] binary,
-        @ApiParam(value = "None") @RequestPart(value="date", required=false)  LocalDate date,
-        @ApiParam(value = "None") @RequestPart(value="dateTime", required=false)  OffsetDateTime dateTime,
-        @ApiParam(value = "None") @RequestPart(value="password", required=false)  String password,
-        @ApiParam(value = "None") @RequestPart(value="callback", required=false)  String paramCallback,
-        @RequestHeader(value = "Accept", required = false) String accept) throws Exception {
+    public ResponseEntity<Void> testEndpointParameters(@ApiParam(value = "None", required=true) @RequestPart(value="number", required=true)  BigDecimal number,@ApiParam(value = "None", required=true) @RequestPart(value="double", required=true)  Double _double,@ApiParam(value = "None", required=true) @RequestPart(value="pattern_without_delimiter", required=true)  String patternWithoutDelimiter,@ApiParam(value = "None", required=true) @RequestPart(value="byte", required=true)  byte[] _byte,@ApiParam(value = "None") @RequestPart(value="integer", required=false)  Integer integer,@ApiParam(value = "None") @RequestPart(value="int32", required=false)  Integer int32,@ApiParam(value = "None") @RequestPart(value="int64", required=false)  Long int64,@ApiParam(value = "None") @RequestPart(value="float", required=false)  Float _float,@ApiParam(value = "None") @RequestPart(value="string", required=false)  String string,@ApiParam(value = "None") @RequestPart(value="binary", required=false)  byte[] binary,@ApiParam(value = "None") @RequestPart(value="date", required=false)  LocalDate date,@ApiParam(value = "None") @RequestPart(value="dateTime", required=false)  OffsetDateTime dateTime,@ApiParam(value = "None") @RequestPart(value="password", required=false)  String password,@ApiParam(value = "None") @RequestPart(value="callback", required=false)  String paramCallback) {
         // do some magic!
         return delegate.testEndpointParameters(number, _double, patternWithoutDelimiter, _byte, integer, int32, int64, _float, string, binary, date, dateTime, password, paramCallback);
     }
 
-    public ResponseEntity<Void> testEnumParameters(@ApiParam(value = "Form parameter enum test (string array)", allowableValues=">, $") @RequestPart(value="enum_form_string_array", required=false)  List<String> enumFormStringArray,
-        @ApiParam(value = "Form parameter enum test (string)", allowableValues="_abc, -efg, (xyz)", defaultValue="-efg") @RequestPart(value="enum_form_string", required=false)  String enumFormString,
-        @ApiParam(value = "Header parameter enum test (string array)" , allowableValues=">, $") @RequestHeader(value="enum_header_string_array", required=false) List<String> enumHeaderStringArray,
-        @ApiParam(value = "Header parameter enum test (string)" , allowableValues="_abc, -efg, (xyz)", defaultValue="-efg") @RequestHeader(value="enum_header_string", required=false) String enumHeaderString,
-        @ApiParam(value = "Query parameter enum test (string array)", allowableValues = ">, $") @Valid @RequestParam(value = "enum_query_string_array", required = false) List<String> enumQueryStringArray,
-        @ApiParam(value = "Query parameter enum test (string)", allowableValues = "_abc, -efg, (xyz)", defaultValue = "-efg") @Valid @RequestParam(value = "enum_query_string", required = false, defaultValue="-efg") String enumQueryString,
-        @ApiParam(value = "Query parameter enum test (double)", allowableValues = "1, -2") @Valid @RequestParam(value = "enum_query_integer", required = false) Integer enumQueryInteger,
-        @ApiParam(value = "Query parameter enum test (double)", allowableValues="1.1, -1.2") @RequestPart(value="enum_query_double", required=false)  Double enumQueryDouble,
-        @RequestHeader(value = "Accept", required = false) String accept) throws Exception {
+    public ResponseEntity<Void> testEnumParameters(@ApiParam(value = "Form parameter enum test (string array)", allowableValues=">, $") @RequestPart(value="enum_form_string_array", required=false)  List<String> enumFormStringArray,@ApiParam(value = "Form parameter enum test (string)", allowableValues="_abc, -efg, (xyz)", defaultValue="-efg") @RequestPart(value="enum_form_string", required=false)  String enumFormString,@ApiParam(value = "Header parameter enum test (string array)" , allowableValues=">, $") @RequestHeader(value="enum_header_string_array", required=false) List<String> enumHeaderStringArray,@ApiParam(value = "Header parameter enum test (string)" , allowableValues="_abc, -efg, (xyz)", defaultValue="-efg") @RequestHeader(value="enum_header_string", required=false) String enumHeaderString,@ApiParam(value = "Query parameter enum test (string array)", allowableValues = ">, $") @Valid @RequestParam(value = "enum_query_string_array", required = false) List<String> enumQueryStringArray,@ApiParam(value = "Query parameter enum test (string)", allowableValues = "_abc, -efg, (xyz)", defaultValue = "-efg") @Valid @RequestParam(value = "enum_query_string", required = false, defaultValue="-efg") String enumQueryString,@ApiParam(value = "Query parameter enum test (double)", allowableValues = "1, -2") @Valid @RequestParam(value = "enum_query_integer", required = false) Integer enumQueryInteger,@ApiParam(value = "Query parameter enum test (double)", allowableValues="1.1, -1.2") @RequestPart(value="enum_query_double", required=false)  Double enumQueryDouble) {
         // do some magic!
         return delegate.testEnumParameters(enumFormStringArray, enumFormString, enumHeaderStringArray, enumHeaderString, enumQueryStringArray, enumQueryString, enumQueryInteger, enumQueryDouble);
     }
 
-    public ResponseEntity<Void> testInlineAdditionalProperties(@ApiParam(value = "request body" ,required=true )  @Valid @RequestBody Object param,
-        @RequestHeader(value = "Accept", required = false) String accept) throws Exception {
+    public ResponseEntity<Void> testInlineAdditionalProperties(@ApiParam(value = "request body" ,required=true )  @Valid @RequestBody Object param) {
         // do some magic!
         return delegate.testInlineAdditionalProperties(param);
     }
 
-    public ResponseEntity<Void> testJsonFormData(@ApiParam(value = "field1", required=true) @RequestPart(value="param", required=true)  String param,
-        @ApiParam(value = "field2", required=true) @RequestPart(value="param2", required=true)  String param2,
-        @RequestHeader(value = "Accept", required = false) String accept) throws Exception {
+    public ResponseEntity<Void> testJsonFormData(@ApiParam(value = "field1", required=true) @RequestPart(value="param", required=true)  String param,@ApiParam(value = "field2", required=true) @RequestPart(value="param2", required=true)  String param2) {
         // do some magic!
         return delegate.testJsonFormData(param, param2);
     }

--- a/samples/server/petstore/springboot-delegate-j8/src/main/java/io/swagger/api/FakeApiDelegate.java
+++ b/samples/server/petstore/springboot-delegate-j8/src/main/java/io/swagger/api/FakeApiDelegate.java
@@ -5,60 +5,133 @@ import io.swagger.model.Client;
 import java.time.LocalDate;
 import java.time.OffsetDateTime;
 import io.swagger.model.OuterComposite;
-
+import com.fasterxml.jackson.databind.ObjectMapper;
 import io.swagger.annotations.*;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.multipart.MultipartFile;
+import java.io.IOException;
 
+import javax.servlet.http.HttpServletRequest;
 import java.util.List;
+import java.util.Optional;
 
 /**
  * A delegate to be called by the {@link FakeApiController}}.
- * Should be implemented as a controller but without the {@link org.springframework.stereotype.Controller} annotation.
- * Instead, use spring to autowire this class into the {@link FakeApiController}.
+ * Implement this interface with a {@link org.springframework.stereotype.Service} annotated class.
  */
 
 public interface FakeApiDelegate {
+
+    Logger log = LoggerFactory.getLogger(FakeApi.class);
+
+    default Optional<ObjectMapper> getObjectMapper() {
+        return Optional.empty();
+    }
+
+    default Optional<HttpServletRequest> getRequest() {
+        return Optional.empty();
+    }
+
+    default Optional<String> getAcceptHeader() {
+        return getRequest().map(r -> r.getHeader("Accept"));
+    }
 
     /**
      * @see FakeApi#fakeOuterBooleanSerialize
      */
     default ResponseEntity<Boolean> fakeOuterBooleanSerialize(Boolean body) {
-        // do some magic!
-        return new ResponseEntity<Boolean>(HttpStatus.NOT_IMPLEMENTED);
+        if(getObjectMapper().isPresent() && getAcceptHeader().isPresent()) {
+            if (getAcceptHeader().get().contains("application/json")) {
+                try {
+                    return new ResponseEntity<>(getObjectMapper().get().readValue("{ }", Boolean.class), HttpStatus.NOT_IMPLEMENTED);
+                } catch (IOException e) {
+                    log.error("Couldn't serialize response for content type application/json", e);
+                    return new ResponseEntity<>(HttpStatus.INTERNAL_SERVER_ERROR);
+                }
+            }
+        } else {
+            log.warn("ObjectMapper or HttpServletRequest not configured in default FakeApi interface so no example is generated");
+        }
+        return new ResponseEntity<>(HttpStatus.NOT_IMPLEMENTED);
     }
 
     /**
      * @see FakeApi#fakeOuterCompositeSerialize
      */
     default ResponseEntity<OuterComposite> fakeOuterCompositeSerialize(OuterComposite body) {
-        // do some magic!
-        return new ResponseEntity<OuterComposite>(HttpStatus.NOT_IMPLEMENTED);
+        if(getObjectMapper().isPresent() && getAcceptHeader().isPresent()) {
+            if (getAcceptHeader().get().contains("application/json")) {
+                try {
+                    return new ResponseEntity<>(getObjectMapper().get().readValue("{  \"my_string\" : { },  \"my_number\" : { },  \"my_boolean\" : { }}", OuterComposite.class), HttpStatus.NOT_IMPLEMENTED);
+                } catch (IOException e) {
+                    log.error("Couldn't serialize response for content type application/json", e);
+                    return new ResponseEntity<>(HttpStatus.INTERNAL_SERVER_ERROR);
+                }
+            }
+        } else {
+            log.warn("ObjectMapper or HttpServletRequest not configured in default FakeApi interface so no example is generated");
+        }
+        return new ResponseEntity<>(HttpStatus.NOT_IMPLEMENTED);
     }
 
     /**
      * @see FakeApi#fakeOuterNumberSerialize
      */
     default ResponseEntity<BigDecimal> fakeOuterNumberSerialize(BigDecimal body) {
-        // do some magic!
-        return new ResponseEntity<BigDecimal>(HttpStatus.NOT_IMPLEMENTED);
+        if(getObjectMapper().isPresent() && getAcceptHeader().isPresent()) {
+            if (getAcceptHeader().get().contains("application/json")) {
+                try {
+                    return new ResponseEntity<>(getObjectMapper().get().readValue("{ }", BigDecimal.class), HttpStatus.NOT_IMPLEMENTED);
+                } catch (IOException e) {
+                    log.error("Couldn't serialize response for content type application/json", e);
+                    return new ResponseEntity<>(HttpStatus.INTERNAL_SERVER_ERROR);
+                }
+            }
+        } else {
+            log.warn("ObjectMapper or HttpServletRequest not configured in default FakeApi interface so no example is generated");
+        }
+        return new ResponseEntity<>(HttpStatus.NOT_IMPLEMENTED);
     }
 
     /**
      * @see FakeApi#fakeOuterStringSerialize
      */
     default ResponseEntity<String> fakeOuterStringSerialize(String body) {
-        // do some magic!
-        return new ResponseEntity<String>(HttpStatus.NOT_IMPLEMENTED);
+        if(getObjectMapper().isPresent() && getAcceptHeader().isPresent()) {
+            if (getAcceptHeader().get().contains("application/json")) {
+                try {
+                    return new ResponseEntity<>(getObjectMapper().get().readValue("{ }", String.class), HttpStatus.NOT_IMPLEMENTED);
+                } catch (IOException e) {
+                    log.error("Couldn't serialize response for content type application/json", e);
+                    return new ResponseEntity<>(HttpStatus.INTERNAL_SERVER_ERROR);
+                }
+            }
+        } else {
+            log.warn("ObjectMapper or HttpServletRequest not configured in default FakeApi interface so no example is generated");
+        }
+        return new ResponseEntity<>(HttpStatus.NOT_IMPLEMENTED);
     }
 
     /**
      * @see FakeApi#testClientModel
      */
     default ResponseEntity<Client> testClientModel(Client body) {
-        // do some magic!
-        return new ResponseEntity<Client>(HttpStatus.NOT_IMPLEMENTED);
+        if(getObjectMapper().isPresent() && getAcceptHeader().isPresent()) {
+            if (getAcceptHeader().get().contains("application/json")) {
+                try {
+                    return new ResponseEntity<>(getObjectMapper().get().readValue("{  \"client\" : \"client\"}", Client.class), HttpStatus.NOT_IMPLEMENTED);
+                } catch (IOException e) {
+                    log.error("Couldn't serialize response for content type application/json", e);
+                    return new ResponseEntity<>(HttpStatus.INTERNAL_SERVER_ERROR);
+                }
+            }
+        } else {
+            log.warn("ObjectMapper or HttpServletRequest not configured in default FakeApi interface so no example is generated");
+        }
+        return new ResponseEntity<>(HttpStatus.NOT_IMPLEMENTED);
     }
 
     /**
@@ -78,8 +151,11 @@ public interface FakeApiDelegate {
         OffsetDateTime dateTime,
         String password,
         String paramCallback) {
-        // do some magic!
-        return new ResponseEntity<Void>(HttpStatus.NOT_IMPLEMENTED);
+        if(getObjectMapper().isPresent() && getAcceptHeader().isPresent()) {
+        } else {
+            log.warn("ObjectMapper or HttpServletRequest not configured in default FakeApi interface so no example is generated");
+        }
+        return new ResponseEntity<>(HttpStatus.NOT_IMPLEMENTED);
     }
 
     /**
@@ -93,16 +169,22 @@ public interface FakeApiDelegate {
         String enumQueryString,
         Integer enumQueryInteger,
         Double enumQueryDouble) {
-        // do some magic!
-        return new ResponseEntity<Void>(HttpStatus.NOT_IMPLEMENTED);
+        if(getObjectMapper().isPresent() && getAcceptHeader().isPresent()) {
+        } else {
+            log.warn("ObjectMapper or HttpServletRequest not configured in default FakeApi interface so no example is generated");
+        }
+        return new ResponseEntity<>(HttpStatus.NOT_IMPLEMENTED);
     }
 
     /**
      * @see FakeApi#testInlineAdditionalProperties
      */
     default ResponseEntity<Void> testInlineAdditionalProperties(Object param) {
-        // do some magic!
-        return new ResponseEntity<Void>(HttpStatus.NOT_IMPLEMENTED);
+        if(getObjectMapper().isPresent() && getAcceptHeader().isPresent()) {
+        } else {
+            log.warn("ObjectMapper or HttpServletRequest not configured in default FakeApi interface so no example is generated");
+        }
+        return new ResponseEntity<>(HttpStatus.NOT_IMPLEMENTED);
     }
 
     /**
@@ -110,8 +192,11 @@ public interface FakeApiDelegate {
      */
     default ResponseEntity<Void> testJsonFormData(String param,
         String param2) {
-        // do some magic!
-        return new ResponseEntity<Void>(HttpStatus.NOT_IMPLEMENTED);
+        if(getObjectMapper().isPresent() && getAcceptHeader().isPresent()) {
+        } else {
+            log.warn("ObjectMapper or HttpServletRequest not configured in default FakeApi interface so no example is generated");
+        }
+        return new ResponseEntity<>(HttpStatus.NOT_IMPLEMENTED);
     }
 
 }

--- a/samples/server/petstore/springboot-delegate-j8/src/main/java/io/swagger/api/FakeApiDelegate.java
+++ b/samples/server/petstore/springboot-delegate-j8/src/main/java/io/swagger/api/FakeApiDelegate.java
@@ -26,7 +26,7 @@ public interface FakeApiDelegate {
      */
     default ResponseEntity<Boolean> fakeOuterBooleanSerialize(Boolean body) {
     // do some magic!
-    return new ResponseEntity<Boolean>(HttpStatus.OK);
+    return new ResponseEntity<Boolean>(HttpStatus.NOT_IMPLEMENTED);
     }
 
     /**
@@ -34,7 +34,7 @@ public interface FakeApiDelegate {
      */
     default ResponseEntity<OuterComposite> fakeOuterCompositeSerialize(OuterComposite body) {
     // do some magic!
-    return new ResponseEntity<OuterComposite>(HttpStatus.OK);
+    return new ResponseEntity<OuterComposite>(HttpStatus.NOT_IMPLEMENTED);
     }
 
     /**
@@ -42,7 +42,7 @@ public interface FakeApiDelegate {
      */
     default ResponseEntity<BigDecimal> fakeOuterNumberSerialize(BigDecimal body) {
     // do some magic!
-    return new ResponseEntity<BigDecimal>(HttpStatus.OK);
+    return new ResponseEntity<BigDecimal>(HttpStatus.NOT_IMPLEMENTED);
     }
 
     /**
@@ -50,7 +50,7 @@ public interface FakeApiDelegate {
      */
     default ResponseEntity<String> fakeOuterStringSerialize(String body) {
     // do some magic!
-    return new ResponseEntity<String>(HttpStatus.OK);
+    return new ResponseEntity<String>(HttpStatus.NOT_IMPLEMENTED);
     }
 
     /**
@@ -58,7 +58,7 @@ public interface FakeApiDelegate {
      */
     default ResponseEntity<Client> testClientModel(Client body) {
     // do some magic!
-    return new ResponseEntity<Client>(HttpStatus.OK);
+    return new ResponseEntity<Client>(HttpStatus.NOT_IMPLEMENTED);
     }
 
     /**
@@ -79,7 +79,7 @@ public interface FakeApiDelegate {
         String password,
         String paramCallback) {
     // do some magic!
-    return new ResponseEntity<Void>(HttpStatus.OK);
+    return new ResponseEntity<Void>(HttpStatus.NOT_IMPLEMENTED);
     }
 
     /**
@@ -94,7 +94,7 @@ public interface FakeApiDelegate {
         Integer enumQueryInteger,
         Double enumQueryDouble) {
     // do some magic!
-    return new ResponseEntity<Void>(HttpStatus.OK);
+    return new ResponseEntity<Void>(HttpStatus.NOT_IMPLEMENTED);
     }
 
     /**
@@ -102,7 +102,7 @@ public interface FakeApiDelegate {
      */
     default ResponseEntity<Void> testInlineAdditionalProperties(Object param) {
     // do some magic!
-    return new ResponseEntity<Void>(HttpStatus.OK);
+    return new ResponseEntity<Void>(HttpStatus.NOT_IMPLEMENTED);
     }
 
     /**
@@ -111,7 +111,7 @@ public interface FakeApiDelegate {
     default ResponseEntity<Void> testJsonFormData(String param,
         String param2) {
     // do some magic!
-    return new ResponseEntity<Void>(HttpStatus.OK);
+    return new ResponseEntity<Void>(HttpStatus.NOT_IMPLEMENTED);
     }
 
 }

--- a/samples/server/petstore/springboot-delegate-j8/src/main/java/io/swagger/api/FakeApiDelegate.java
+++ b/samples/server/petstore/springboot-delegate-j8/src/main/java/io/swagger/api/FakeApiDelegate.java
@@ -25,40 +25,40 @@ public interface FakeApiDelegate {
      * @see FakeApi#fakeOuterBooleanSerialize
      */
     default ResponseEntity<Boolean> fakeOuterBooleanSerialize(Boolean body) {
-    // do some magic!
-    return new ResponseEntity<Boolean>(HttpStatus.NOT_IMPLEMENTED);
+        // do some magic!
+        return new ResponseEntity<Boolean>(HttpStatus.NOT_IMPLEMENTED);
     }
 
     /**
      * @see FakeApi#fakeOuterCompositeSerialize
      */
     default ResponseEntity<OuterComposite> fakeOuterCompositeSerialize(OuterComposite body) {
-    // do some magic!
-    return new ResponseEntity<OuterComposite>(HttpStatus.NOT_IMPLEMENTED);
+        // do some magic!
+        return new ResponseEntity<OuterComposite>(HttpStatus.NOT_IMPLEMENTED);
     }
 
     /**
      * @see FakeApi#fakeOuterNumberSerialize
      */
     default ResponseEntity<BigDecimal> fakeOuterNumberSerialize(BigDecimal body) {
-    // do some magic!
-    return new ResponseEntity<BigDecimal>(HttpStatus.NOT_IMPLEMENTED);
+        // do some magic!
+        return new ResponseEntity<BigDecimal>(HttpStatus.NOT_IMPLEMENTED);
     }
 
     /**
      * @see FakeApi#fakeOuterStringSerialize
      */
     default ResponseEntity<String> fakeOuterStringSerialize(String body) {
-    // do some magic!
-    return new ResponseEntity<String>(HttpStatus.NOT_IMPLEMENTED);
+        // do some magic!
+        return new ResponseEntity<String>(HttpStatus.NOT_IMPLEMENTED);
     }
 
     /**
      * @see FakeApi#testClientModel
      */
     default ResponseEntity<Client> testClientModel(Client body) {
-    // do some magic!
-    return new ResponseEntity<Client>(HttpStatus.NOT_IMPLEMENTED);
+        // do some magic!
+        return new ResponseEntity<Client>(HttpStatus.NOT_IMPLEMENTED);
     }
 
     /**
@@ -78,8 +78,8 @@ public interface FakeApiDelegate {
         OffsetDateTime dateTime,
         String password,
         String paramCallback) {
-    // do some magic!
-    return new ResponseEntity<Void>(HttpStatus.NOT_IMPLEMENTED);
+        // do some magic!
+        return new ResponseEntity<Void>(HttpStatus.NOT_IMPLEMENTED);
     }
 
     /**
@@ -93,16 +93,16 @@ public interface FakeApiDelegate {
         String enumQueryString,
         Integer enumQueryInteger,
         Double enumQueryDouble) {
-    // do some magic!
-    return new ResponseEntity<Void>(HttpStatus.NOT_IMPLEMENTED);
+        // do some magic!
+        return new ResponseEntity<Void>(HttpStatus.NOT_IMPLEMENTED);
     }
 
     /**
      * @see FakeApi#testInlineAdditionalProperties
      */
     default ResponseEntity<Void> testInlineAdditionalProperties(Object param) {
-    // do some magic!
-    return new ResponseEntity<Void>(HttpStatus.NOT_IMPLEMENTED);
+        // do some magic!
+        return new ResponseEntity<Void>(HttpStatus.NOT_IMPLEMENTED);
     }
 
     /**
@@ -110,8 +110,8 @@ public interface FakeApiDelegate {
      */
     default ResponseEntity<Void> testJsonFormData(String param,
         String param2) {
-    // do some magic!
-    return new ResponseEntity<Void>(HttpStatus.NOT_IMPLEMENTED);
+        // do some magic!
+        return new ResponseEntity<Void>(HttpStatus.NOT_IMPLEMENTED);
     }
 
 }

--- a/samples/server/petstore/springboot-delegate-j8/src/main/java/io/swagger/api/FakeClassnameTestApi.java
+++ b/samples/server/petstore/springboot-delegate-j8/src/main/java/io/swagger/api/FakeClassnameTestApi.java
@@ -6,10 +6,9 @@
 package io.swagger.api;
 
 import io.swagger.model.Client;
-
 import io.swagger.annotations.*;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
@@ -18,15 +17,15 @@ import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.multipart.MultipartFile;
-import java.io.IOException;
 
-import java.util.List;
-import org.springframework.validation.annotation.Validated;
-import javax.validation.constraints.*;
 import javax.validation.Valid;
+import javax.validation.constraints.*;
+import java.util.List;
 
 @Api(value = "fake_classname_test", description = "the fake_classname_test API")
 public interface FakeClassnameTestApi {
+
+    FakeClassnameTestApiDelegate getDelegate();
 
     @ApiOperation(value = "To test class name in snake case", nickname = "testClassname", notes = "", response = Client.class, authorizations = {
         @Authorization(value = "api_key_query")
@@ -38,8 +37,7 @@ public interface FakeClassnameTestApi {
         consumes = { "application/json" },
         method = RequestMethod.PATCH)
     default ResponseEntity<Client> testClassname(@ApiParam(value = "client model" ,required=true )  @Valid @RequestBody Client body) {
-        // do some magic!
-        return new ResponseEntity<Client>(HttpStatus.NOT_IMPLEMENTED);
+        return getDelegate().testClassname(body);
     }
 
 }

--- a/samples/server/petstore/springboot-delegate-j8/src/main/java/io/swagger/api/FakeClassnameTestApi.java
+++ b/samples/server/petstore/springboot-delegate-j8/src/main/java/io/swagger/api/FakeClassnameTestApi.java
@@ -37,9 +37,9 @@ public interface FakeClassnameTestApi {
         produces = { "application/json" }, 
         consumes = { "application/json" },
         method = RequestMethod.PATCH)
-    default ResponseEntity<Client> testClassname(@ApiParam(value = "client model" ,required=true )  @Valid @RequestBody Client body, @RequestHeader(value = "Accept", required = false) String accept) throws Exception {
+    default ResponseEntity<Client> testClassname(@ApiParam(value = "client model" ,required=true )  @Valid @RequestBody Client body) {
         // do some magic!
-        return new ResponseEntity<Client>(HttpStatus.OK);
+        return new ResponseEntity<Client>(HttpStatus.NOT_IMPLEMENTED);
     }
 
 }

--- a/samples/server/petstore/springboot-delegate-j8/src/main/java/io/swagger/api/FakeClassnameTestApiController.java
+++ b/samples/server/petstore/springboot-delegate-j8/src/main/java/io/swagger/api/FakeClassnameTestApiController.java
@@ -21,19 +21,12 @@ import org.springframework.web.multipart.MultipartFile;
 import java.util.List;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.IOException;
+import javax.servlet.http.HttpServletRequest;
 import javax.validation.constraints.*;
 import javax.validation.Valid;
 
 @Controller
 public class FakeClassnameTestApiController implements FakeClassnameTestApi {
-
-    private final Logger log = LoggerFactory.getLogger(AnotherFakeApiController.class);
-
-    private final ObjectMapper objectMapper;
-
-    public FakeClassnameTestApiController(ObjectMapper objectMapper) {
-        this.objectMapper = objectMapper;
-    }
 
     private final FakeClassnameTestApiDelegate delegate;
 

--- a/samples/server/petstore/springboot-delegate-j8/src/main/java/io/swagger/api/FakeClassnameTestApiController.java
+++ b/samples/server/petstore/springboot-delegate-j8/src/main/java/io/swagger/api/FakeClassnameTestApiController.java
@@ -4,6 +4,8 @@ import io.swagger.model.Client;
 
 import io.swagger.annotations.*;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
@@ -12,6 +14,8 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RequestPart;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.util.List;
@@ -22,6 +26,9 @@ import javax.validation.Valid;
 
 @Controller
 public class FakeClassnameTestApiController implements FakeClassnameTestApi {
+
+    private final Logger log = LoggerFactory.getLogger(AnotherFakeApiController.class);
+
     private final ObjectMapper objectMapper;
 
     public FakeClassnameTestApiController(ObjectMapper objectMapper) {
@@ -35,8 +42,7 @@ public class FakeClassnameTestApiController implements FakeClassnameTestApi {
         this.delegate = delegate;
     }
 
-    public ResponseEntity<Client> testClassname(@ApiParam(value = "client model" ,required=true )  @Valid @RequestBody Client body,
-        @RequestHeader(value = "Accept", required = false) String accept) throws Exception {
+    public ResponseEntity<Client> testClassname(@ApiParam(value = "client model" ,required=true )  @Valid @RequestBody Client body) {
         // do some magic!
         return delegate.testClassname(body);
     }

--- a/samples/server/petstore/springboot-delegate-j8/src/main/java/io/swagger/api/FakeClassnameTestApiController.java
+++ b/samples/server/petstore/springboot-delegate-j8/src/main/java/io/swagger/api/FakeClassnameTestApiController.java
@@ -1,29 +1,6 @@
 package io.swagger.api;
 
-import io.swagger.model.Client;
-
-import io.swagger.annotations.*;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import org.springframework.http.HttpStatus;
-import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestHeader;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RequestPart;
-import org.springframework.web.context.request.RequestContextHolder;
-import org.springframework.web.context.request.ServletRequestAttributes;
-import org.springframework.web.multipart.MultipartFile;
-
-import java.util.List;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import java.io.IOException;
-import javax.servlet.http.HttpServletRequest;
-import javax.validation.constraints.*;
-import javax.validation.Valid;
 
 @Controller
 public class FakeClassnameTestApiController implements FakeClassnameTestApi {
@@ -35,9 +12,8 @@ public class FakeClassnameTestApiController implements FakeClassnameTestApi {
         this.delegate = delegate;
     }
 
-    public ResponseEntity<Client> testClassname(@ApiParam(value = "client model" ,required=true )  @Valid @RequestBody Client body) {
-        // do some magic!
-        return delegate.testClassname(body);
+    @Override
+    public FakeClassnameTestApiDelegate getDelegate() {
+        return delegate;
     }
-
 }

--- a/samples/server/petstore/springboot-delegate-j8/src/main/java/io/swagger/api/FakeClassnameTestApiDelegate.java
+++ b/samples/server/petstore/springboot-delegate-j8/src/main/java/io/swagger/api/FakeClassnameTestApiDelegate.java
@@ -1,28 +1,57 @@
 package io.swagger.api;
 
 import io.swagger.model.Client;
-
+import com.fasterxml.jackson.databind.ObjectMapper;
 import io.swagger.annotations.*;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.multipart.MultipartFile;
+import java.io.IOException;
 
+import javax.servlet.http.HttpServletRequest;
 import java.util.List;
+import java.util.Optional;
 
 /**
  * A delegate to be called by the {@link FakeClassnameTestApiController}}.
- * Should be implemented as a controller but without the {@link org.springframework.stereotype.Controller} annotation.
- * Instead, use spring to autowire this class into the {@link FakeClassnameTestApiController}.
+ * Implement this interface with a {@link org.springframework.stereotype.Service} annotated class.
  */
 
 public interface FakeClassnameTestApiDelegate {
+
+    Logger log = LoggerFactory.getLogger(FakeClassnameTestApi.class);
+
+    default Optional<ObjectMapper> getObjectMapper() {
+        return Optional.empty();
+    }
+
+    default Optional<HttpServletRequest> getRequest() {
+        return Optional.empty();
+    }
+
+    default Optional<String> getAcceptHeader() {
+        return getRequest().map(r -> r.getHeader("Accept"));
+    }
 
     /**
      * @see FakeClassnameTestApi#testClassname
      */
     default ResponseEntity<Client> testClassname(Client body) {
-        // do some magic!
-        return new ResponseEntity<Client>(HttpStatus.NOT_IMPLEMENTED);
+        if(getObjectMapper().isPresent() && getAcceptHeader().isPresent()) {
+            if (getAcceptHeader().get().contains("application/json")) {
+                try {
+                    return new ResponseEntity<>(getObjectMapper().get().readValue("{  \"client\" : \"client\"}", Client.class), HttpStatus.NOT_IMPLEMENTED);
+                } catch (IOException e) {
+                    log.error("Couldn't serialize response for content type application/json", e);
+                    return new ResponseEntity<>(HttpStatus.INTERNAL_SERVER_ERROR);
+                }
+            }
+        } else {
+            log.warn("ObjectMapper or HttpServletRequest not configured in default FakeClassnameTestApi interface so no example is generated");
+        }
+        return new ResponseEntity<>(HttpStatus.NOT_IMPLEMENTED);
     }
 
 }

--- a/samples/server/petstore/springboot-delegate-j8/src/main/java/io/swagger/api/FakeClassnameTestApiDelegate.java
+++ b/samples/server/petstore/springboot-delegate-j8/src/main/java/io/swagger/api/FakeClassnameTestApiDelegate.java
@@ -22,7 +22,7 @@ public interface FakeClassnameTestApiDelegate {
      */
     default ResponseEntity<Client> testClassname(Client body) {
     // do some magic!
-    return new ResponseEntity<Client>(HttpStatus.OK);
+    return new ResponseEntity<Client>(HttpStatus.NOT_IMPLEMENTED);
     }
 
 }

--- a/samples/server/petstore/springboot-delegate-j8/src/main/java/io/swagger/api/FakeClassnameTestApiDelegate.java
+++ b/samples/server/petstore/springboot-delegate-j8/src/main/java/io/swagger/api/FakeClassnameTestApiDelegate.java
@@ -21,8 +21,8 @@ public interface FakeClassnameTestApiDelegate {
      * @see FakeClassnameTestApi#testClassname
      */
     default ResponseEntity<Client> testClassname(Client body) {
-    // do some magic!
-    return new ResponseEntity<Client>(HttpStatus.NOT_IMPLEMENTED);
+        // do some magic!
+        return new ResponseEntity<Client>(HttpStatus.NOT_IMPLEMENTED);
     }
 
 }

--- a/samples/server/petstore/springboot-delegate-j8/src/main/java/io/swagger/api/PetApi.java
+++ b/samples/server/petstore/springboot-delegate-j8/src/main/java/io/swagger/api/PetApi.java
@@ -8,10 +8,9 @@ package io.swagger.api;
 import io.swagger.model.ModelApiResponse;
 import io.swagger.model.Pet;
 import org.springframework.core.io.Resource;
-
 import io.swagger.annotations.*;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
@@ -20,15 +19,15 @@ import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.multipart.MultipartFile;
-import java.io.IOException;
 
-import java.util.List;
-import org.springframework.validation.annotation.Validated;
-import javax.validation.constraints.*;
 import javax.validation.Valid;
+import javax.validation.constraints.*;
+import java.util.List;
 
 @Api(value = "pet", description = "the pet API")
 public interface PetApi {
+
+    PetApiDelegate getDelegate();
 
     @ApiOperation(value = "Add a new pet to the store", nickname = "addPet", notes = "", authorizations = {
         @Authorization(value = "petstore_auth", scopes = {
@@ -43,8 +42,7 @@ public interface PetApi {
         consumes = { "application/json", "application/xml" },
         method = RequestMethod.POST)
     default ResponseEntity<Void> addPet(@ApiParam(value = "Pet object that needs to be added to the store" ,required=true )  @Valid @RequestBody Pet body) {
-        // do some magic!
-        return new ResponseEntity<Void>(HttpStatus.NOT_IMPLEMENTED);
+        return getDelegate().addPet(body);
     }
 
 
@@ -60,8 +58,7 @@ public interface PetApi {
         produces = { "application/xml", "application/json" }, 
         method = RequestMethod.DELETE)
     default ResponseEntity<Void> deletePet(@ApiParam(value = "Pet id to delete",required=true) @PathVariable("petId") Long petId,@ApiParam(value = "" ) @RequestHeader(value="api_key", required=false) String apiKey) {
-        // do some magic!
-        return new ResponseEntity<Void>(HttpStatus.NOT_IMPLEMENTED);
+        return getDelegate().deletePet(petId, apiKey);
     }
 
 
@@ -78,8 +75,7 @@ public interface PetApi {
         produces = { "application/xml", "application/json" }, 
         method = RequestMethod.GET)
     default ResponseEntity<List<Pet>> findPetsByStatus(@NotNull @ApiParam(value = "Status values that need to be considered for filter", required = true, allowableValues = "available, pending, sold") @Valid @RequestParam(value = "status", required = true) List<String> status) {
-        // do some magic!
-        return new ResponseEntity<List<Pet>>(HttpStatus.NOT_IMPLEMENTED);
+        return getDelegate().findPetsByStatus(status);
     }
 
 
@@ -96,8 +92,7 @@ public interface PetApi {
         produces = { "application/xml", "application/json" }, 
         method = RequestMethod.GET)
     default ResponseEntity<List<Pet>> findPetsByTags(@NotNull @ApiParam(value = "Tags to filter by", required = true) @Valid @RequestParam(value = "tags", required = true) List<String> tags) {
-        // do some magic!
-        return new ResponseEntity<List<Pet>>(HttpStatus.NOT_IMPLEMENTED);
+        return getDelegate().findPetsByTags(tags);
     }
 
 
@@ -112,8 +107,7 @@ public interface PetApi {
         produces = { "application/xml", "application/json" }, 
         method = RequestMethod.GET)
     default ResponseEntity<Pet> getPetById(@ApiParam(value = "ID of pet to return",required=true) @PathVariable("petId") Long petId) {
-        // do some magic!
-        return new ResponseEntity<Pet>(HttpStatus.NOT_IMPLEMENTED);
+        return getDelegate().getPetById(petId);
     }
 
 
@@ -132,8 +126,7 @@ public interface PetApi {
         consumes = { "application/json", "application/xml" },
         method = RequestMethod.PUT)
     default ResponseEntity<Void> updatePet(@ApiParam(value = "Pet object that needs to be added to the store" ,required=true )  @Valid @RequestBody Pet body) {
-        // do some magic!
-        return new ResponseEntity<Void>(HttpStatus.NOT_IMPLEMENTED);
+        return getDelegate().updatePet(body);
     }
 
 
@@ -150,8 +143,7 @@ public interface PetApi {
         consumes = { "application/x-www-form-urlencoded" },
         method = RequestMethod.POST)
     default ResponseEntity<Void> updatePetWithForm(@ApiParam(value = "ID of pet that needs to be updated",required=true) @PathVariable("petId") Long petId,@ApiParam(value = "Updated name of the pet") @RequestPart(value="name", required=false)  String name,@ApiParam(value = "Updated status of the pet") @RequestPart(value="status", required=false)  String status) {
-        // do some magic!
-        return new ResponseEntity<Void>(HttpStatus.NOT_IMPLEMENTED);
+        return getDelegate().updatePetWithForm(petId, name, status);
     }
 
 
@@ -168,8 +160,7 @@ public interface PetApi {
         consumes = { "multipart/form-data" },
         method = RequestMethod.POST)
     default ResponseEntity<ModelApiResponse> uploadFile(@ApiParam(value = "ID of pet to update",required=true) @PathVariable("petId") Long petId,@ApiParam(value = "Additional data to pass to server") @RequestPart(value="additionalMetadata", required=false)  String additionalMetadata,@ApiParam(value = "file detail") @Valid @RequestPart("file") MultipartFile file) {
-        // do some magic!
-        return new ResponseEntity<ModelApiResponse>(HttpStatus.NOT_IMPLEMENTED);
+        return getDelegate().uploadFile(petId, additionalMetadata, file);
     }
 
 }

--- a/samples/server/petstore/springboot-delegate-j8/src/main/java/io/swagger/api/PetApi.java
+++ b/samples/server/petstore/springboot-delegate-j8/src/main/java/io/swagger/api/PetApi.java
@@ -42,9 +42,9 @@ public interface PetApi {
         produces = { "application/xml", "application/json" }, 
         consumes = { "application/json", "application/xml" },
         method = RequestMethod.POST)
-    default ResponseEntity<Void> addPet(@ApiParam(value = "Pet object that needs to be added to the store" ,required=true )  @Valid @RequestBody Pet body, @RequestHeader(value = "Accept", required = false) String accept) throws Exception {
+    default ResponseEntity<Void> addPet(@ApiParam(value = "Pet object that needs to be added to the store" ,required=true )  @Valid @RequestBody Pet body) {
         // do some magic!
-        return new ResponseEntity<Void>(HttpStatus.OK);
+        return new ResponseEntity<Void>(HttpStatus.NOT_IMPLEMENTED);
     }
 
 
@@ -59,9 +59,9 @@ public interface PetApi {
     @RequestMapping(value = "/pet/{petId}",
         produces = { "application/xml", "application/json" }, 
         method = RequestMethod.DELETE)
-    default ResponseEntity<Void> deletePet(@ApiParam(value = "Pet id to delete",required=true) @PathVariable("petId") Long petId,@ApiParam(value = "" ) @RequestHeader(value="api_key", required=false) String apiKey, @RequestHeader(value = "Accept", required = false) String accept) throws Exception {
+    default ResponseEntity<Void> deletePet(@ApiParam(value = "Pet id to delete",required=true) @PathVariable("petId") Long petId,@ApiParam(value = "" ) @RequestHeader(value="api_key", required=false) String apiKey) {
         // do some magic!
-        return new ResponseEntity<Void>(HttpStatus.OK);
+        return new ResponseEntity<Void>(HttpStatus.NOT_IMPLEMENTED);
     }
 
 
@@ -77,9 +77,9 @@ public interface PetApi {
     @RequestMapping(value = "/pet/findByStatus",
         produces = { "application/xml", "application/json" }, 
         method = RequestMethod.GET)
-    default ResponseEntity<List<Pet>> findPetsByStatus( @NotNull@ApiParam(value = "Status values that need to be considered for filter", required = true, allowableValues = "available, pending, sold") @Valid @RequestParam(value = "status", required = true) List<String> status, @RequestHeader(value = "Accept", required = false) String accept) throws Exception {
+    default ResponseEntity<List<Pet>> findPetsByStatus(@NotNull @ApiParam(value = "Status values that need to be considered for filter", required = true, allowableValues = "available, pending, sold") @Valid @RequestParam(value = "status", required = true) List<String> status) {
         // do some magic!
-        return new ResponseEntity<List<Pet>>(HttpStatus.OK);
+        return new ResponseEntity<List<Pet>>(HttpStatus.NOT_IMPLEMENTED);
     }
 
 
@@ -95,9 +95,9 @@ public interface PetApi {
     @RequestMapping(value = "/pet/findByTags",
         produces = { "application/xml", "application/json" }, 
         method = RequestMethod.GET)
-    default ResponseEntity<List<Pet>> findPetsByTags( @NotNull@ApiParam(value = "Tags to filter by", required = true) @Valid @RequestParam(value = "tags", required = true) List<String> tags, @RequestHeader(value = "Accept", required = false) String accept) throws Exception {
+    default ResponseEntity<List<Pet>> findPetsByTags(@NotNull @ApiParam(value = "Tags to filter by", required = true) @Valid @RequestParam(value = "tags", required = true) List<String> tags) {
         // do some magic!
-        return new ResponseEntity<List<Pet>>(HttpStatus.OK);
+        return new ResponseEntity<List<Pet>>(HttpStatus.NOT_IMPLEMENTED);
     }
 
 
@@ -111,9 +111,9 @@ public interface PetApi {
     @RequestMapping(value = "/pet/{petId}",
         produces = { "application/xml", "application/json" }, 
         method = RequestMethod.GET)
-    default ResponseEntity<Pet> getPetById(@ApiParam(value = "ID of pet to return",required=true) @PathVariable("petId") Long petId, @RequestHeader(value = "Accept", required = false) String accept) throws Exception {
+    default ResponseEntity<Pet> getPetById(@ApiParam(value = "ID of pet to return",required=true) @PathVariable("petId") Long petId) {
         // do some magic!
-        return new ResponseEntity<Pet>(HttpStatus.OK);
+        return new ResponseEntity<Pet>(HttpStatus.NOT_IMPLEMENTED);
     }
 
 
@@ -131,9 +131,9 @@ public interface PetApi {
         produces = { "application/xml", "application/json" }, 
         consumes = { "application/json", "application/xml" },
         method = RequestMethod.PUT)
-    default ResponseEntity<Void> updatePet(@ApiParam(value = "Pet object that needs to be added to the store" ,required=true )  @Valid @RequestBody Pet body, @RequestHeader(value = "Accept", required = false) String accept) throws Exception {
+    default ResponseEntity<Void> updatePet(@ApiParam(value = "Pet object that needs to be added to the store" ,required=true )  @Valid @RequestBody Pet body) {
         // do some magic!
-        return new ResponseEntity<Void>(HttpStatus.OK);
+        return new ResponseEntity<Void>(HttpStatus.NOT_IMPLEMENTED);
     }
 
 
@@ -149,9 +149,9 @@ public interface PetApi {
         produces = { "application/xml", "application/json" }, 
         consumes = { "application/x-www-form-urlencoded" },
         method = RequestMethod.POST)
-    default ResponseEntity<Void> updatePetWithForm(@ApiParam(value = "ID of pet that needs to be updated",required=true) @PathVariable("petId") Long petId,@ApiParam(value = "Updated name of the pet") @RequestPart(value="name", required=false)  String name,@ApiParam(value = "Updated status of the pet") @RequestPart(value="status", required=false)  String status, @RequestHeader(value = "Accept", required = false) String accept) throws Exception {
+    default ResponseEntity<Void> updatePetWithForm(@ApiParam(value = "ID of pet that needs to be updated",required=true) @PathVariable("petId") Long petId,@ApiParam(value = "Updated name of the pet") @RequestPart(value="name", required=false)  String name,@ApiParam(value = "Updated status of the pet") @RequestPart(value="status", required=false)  String status) {
         // do some magic!
-        return new ResponseEntity<Void>(HttpStatus.OK);
+        return new ResponseEntity<Void>(HttpStatus.NOT_IMPLEMENTED);
     }
 
 
@@ -167,9 +167,9 @@ public interface PetApi {
         produces = { "application/json" }, 
         consumes = { "multipart/form-data" },
         method = RequestMethod.POST)
-    default ResponseEntity<ModelApiResponse> uploadFile(@ApiParam(value = "ID of pet to update",required=true) @PathVariable("petId") Long petId,@ApiParam(value = "Additional data to pass to server") @RequestPart(value="additionalMetadata", required=false)  String additionalMetadata,@ApiParam(value = "file detail") @Valid @RequestPart("file") MultipartFile file, @RequestHeader(value = "Accept", required = false) String accept) throws Exception {
+    default ResponseEntity<ModelApiResponse> uploadFile(@ApiParam(value = "ID of pet to update",required=true) @PathVariable("petId") Long petId,@ApiParam(value = "Additional data to pass to server") @RequestPart(value="additionalMetadata", required=false)  String additionalMetadata,@ApiParam(value = "file detail") @Valid @RequestPart("file") MultipartFile file) {
         // do some magic!
-        return new ResponseEntity<ModelApiResponse>(HttpStatus.OK);
+        return new ResponseEntity<ModelApiResponse>(HttpStatus.NOT_IMPLEMENTED);
     }
 
 }

--- a/samples/server/petstore/springboot-delegate-j8/src/main/java/io/swagger/api/PetApiController.java
+++ b/samples/server/petstore/springboot-delegate-j8/src/main/java/io/swagger/api/PetApiController.java
@@ -23,19 +23,12 @@ import org.springframework.web.multipart.MultipartFile;
 import java.util.List;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.IOException;
+import javax.servlet.http.HttpServletRequest;
 import javax.validation.constraints.*;
 import javax.validation.Valid;
 
 @Controller
 public class PetApiController implements PetApi {
-
-    private final Logger log = LoggerFactory.getLogger(AnotherFakeApiController.class);
-
-    private final ObjectMapper objectMapper;
-
-    public PetApiController(ObjectMapper objectMapper) {
-        this.objectMapper = objectMapper;
-    }
 
     private final PetApiDelegate delegate;
 

--- a/samples/server/petstore/springboot-delegate-j8/src/main/java/io/swagger/api/PetApiController.java
+++ b/samples/server/petstore/springboot-delegate-j8/src/main/java/io/swagger/api/PetApiController.java
@@ -1,31 +1,6 @@
 package io.swagger.api;
 
-import io.swagger.model.ModelApiResponse;
-import io.swagger.model.Pet;
-import org.springframework.core.io.Resource;
-
-import io.swagger.annotations.*;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import org.springframework.http.HttpStatus;
-import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestHeader;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RequestPart;
-import org.springframework.web.context.request.RequestContextHolder;
-import org.springframework.web.context.request.ServletRequestAttributes;
-import org.springframework.web.multipart.MultipartFile;
-
-import java.util.List;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import java.io.IOException;
-import javax.servlet.http.HttpServletRequest;
-import javax.validation.constraints.*;
-import javax.validation.Valid;
 
 @Controller
 public class PetApiController implements PetApi {
@@ -37,44 +12,8 @@ public class PetApiController implements PetApi {
         this.delegate = delegate;
     }
 
-    public ResponseEntity<Void> addPet(@ApiParam(value = "Pet object that needs to be added to the store" ,required=true )  @Valid @RequestBody Pet body) {
-        // do some magic!
-        return delegate.addPet(body);
+    @Override
+    public PetApiDelegate getDelegate() {
+        return delegate;
     }
-
-    public ResponseEntity<Void> deletePet(@ApiParam(value = "Pet id to delete",required=true) @PathVariable("petId") Long petId,@ApiParam(value = "" ) @RequestHeader(value="api_key", required=false) String apiKey) {
-        // do some magic!
-        return delegate.deletePet(petId, apiKey);
-    }
-
-    public ResponseEntity<List<Pet>> findPetsByStatus(@NotNull @ApiParam(value = "Status values that need to be considered for filter", required = true, allowableValues = "available, pending, sold") @Valid @RequestParam(value = "status", required = true) List<String> status) {
-        // do some magic!
-        return delegate.findPetsByStatus(status);
-    }
-
-    public ResponseEntity<List<Pet>> findPetsByTags(@NotNull @ApiParam(value = "Tags to filter by", required = true) @Valid @RequestParam(value = "tags", required = true) List<String> tags) {
-        // do some magic!
-        return delegate.findPetsByTags(tags);
-    }
-
-    public ResponseEntity<Pet> getPetById(@ApiParam(value = "ID of pet to return",required=true) @PathVariable("petId") Long petId) {
-        // do some magic!
-        return delegate.getPetById(petId);
-    }
-
-    public ResponseEntity<Void> updatePet(@ApiParam(value = "Pet object that needs to be added to the store" ,required=true )  @Valid @RequestBody Pet body) {
-        // do some magic!
-        return delegate.updatePet(body);
-    }
-
-    public ResponseEntity<Void> updatePetWithForm(@ApiParam(value = "ID of pet that needs to be updated",required=true) @PathVariable("petId") Long petId,@ApiParam(value = "Updated name of the pet") @RequestPart(value="name", required=false)  String name,@ApiParam(value = "Updated status of the pet") @RequestPart(value="status", required=false)  String status) {
-        // do some magic!
-        return delegate.updatePetWithForm(petId, name, status);
-    }
-
-    public ResponseEntity<ModelApiResponse> uploadFile(@ApiParam(value = "ID of pet to update",required=true) @PathVariable("petId") Long petId,@ApiParam(value = "Additional data to pass to server") @RequestPart(value="additionalMetadata", required=false)  String additionalMetadata,@ApiParam(value = "file detail") @Valid @RequestPart("file") MultipartFile file) {
-        // do some magic!
-        return delegate.uploadFile(petId, additionalMetadata, file);
-    }
-
 }

--- a/samples/server/petstore/springboot-delegate-j8/src/main/java/io/swagger/api/PetApiController.java
+++ b/samples/server/petstore/springboot-delegate-j8/src/main/java/io/swagger/api/PetApiController.java
@@ -6,6 +6,8 @@ import org.springframework.core.io.Resource;
 
 import io.swagger.annotations.*;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
@@ -14,6 +16,8 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RequestPart;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.util.List;
@@ -24,6 +28,9 @@ import javax.validation.Valid;
 
 @Controller
 public class PetApiController implements PetApi {
+
+    private final Logger log = LoggerFactory.getLogger(AnotherFakeApiController.class);
+
     private final ObjectMapper objectMapper;
 
     public PetApiController(ObjectMapper objectMapper) {
@@ -37,55 +44,42 @@ public class PetApiController implements PetApi {
         this.delegate = delegate;
     }
 
-    public ResponseEntity<Void> addPet(@ApiParam(value = "Pet object that needs to be added to the store" ,required=true )  @Valid @RequestBody Pet body,
-        @RequestHeader(value = "Accept", required = false) String accept) throws Exception {
+    public ResponseEntity<Void> addPet(@ApiParam(value = "Pet object that needs to be added to the store" ,required=true )  @Valid @RequestBody Pet body) {
         // do some magic!
         return delegate.addPet(body);
     }
 
-    public ResponseEntity<Void> deletePet(@ApiParam(value = "Pet id to delete",required=true) @PathVariable("petId") Long petId,
-        @ApiParam(value = "" ) @RequestHeader(value="api_key", required=false) String apiKey,
-        @RequestHeader(value = "Accept", required = false) String accept) throws Exception {
+    public ResponseEntity<Void> deletePet(@ApiParam(value = "Pet id to delete",required=true) @PathVariable("petId") Long petId,@ApiParam(value = "" ) @RequestHeader(value="api_key", required=false) String apiKey) {
         // do some magic!
         return delegate.deletePet(petId, apiKey);
     }
 
-    public ResponseEntity<List<Pet>> findPetsByStatus( @NotNull@ApiParam(value = "Status values that need to be considered for filter", required = true, allowableValues = "available, pending, sold") @Valid @RequestParam(value = "status", required = true) List<String> status,
-        @RequestHeader(value = "Accept", required = false) String accept) throws Exception {
+    public ResponseEntity<List<Pet>> findPetsByStatus(@NotNull @ApiParam(value = "Status values that need to be considered for filter", required = true, allowableValues = "available, pending, sold") @Valid @RequestParam(value = "status", required = true) List<String> status) {
         // do some magic!
         return delegate.findPetsByStatus(status);
     }
 
-    public ResponseEntity<List<Pet>> findPetsByTags( @NotNull@ApiParam(value = "Tags to filter by", required = true) @Valid @RequestParam(value = "tags", required = true) List<String> tags,
-        @RequestHeader(value = "Accept", required = false) String accept) throws Exception {
+    public ResponseEntity<List<Pet>> findPetsByTags(@NotNull @ApiParam(value = "Tags to filter by", required = true) @Valid @RequestParam(value = "tags", required = true) List<String> tags) {
         // do some magic!
         return delegate.findPetsByTags(tags);
     }
 
-    public ResponseEntity<Pet> getPetById(@ApiParam(value = "ID of pet to return",required=true) @PathVariable("petId") Long petId,
-        @RequestHeader(value = "Accept", required = false) String accept) throws Exception {
+    public ResponseEntity<Pet> getPetById(@ApiParam(value = "ID of pet to return",required=true) @PathVariable("petId") Long petId) {
         // do some magic!
         return delegate.getPetById(petId);
     }
 
-    public ResponseEntity<Void> updatePet(@ApiParam(value = "Pet object that needs to be added to the store" ,required=true )  @Valid @RequestBody Pet body,
-        @RequestHeader(value = "Accept", required = false) String accept) throws Exception {
+    public ResponseEntity<Void> updatePet(@ApiParam(value = "Pet object that needs to be added to the store" ,required=true )  @Valid @RequestBody Pet body) {
         // do some magic!
         return delegate.updatePet(body);
     }
 
-    public ResponseEntity<Void> updatePetWithForm(@ApiParam(value = "ID of pet that needs to be updated",required=true) @PathVariable("petId") Long petId,
-        @ApiParam(value = "Updated name of the pet") @RequestPart(value="name", required=false)  String name,
-        @ApiParam(value = "Updated status of the pet") @RequestPart(value="status", required=false)  String status,
-        @RequestHeader(value = "Accept", required = false) String accept) throws Exception {
+    public ResponseEntity<Void> updatePetWithForm(@ApiParam(value = "ID of pet that needs to be updated",required=true) @PathVariable("petId") Long petId,@ApiParam(value = "Updated name of the pet") @RequestPart(value="name", required=false)  String name,@ApiParam(value = "Updated status of the pet") @RequestPart(value="status", required=false)  String status) {
         // do some magic!
         return delegate.updatePetWithForm(petId, name, status);
     }
 
-    public ResponseEntity<ModelApiResponse> uploadFile(@ApiParam(value = "ID of pet to update",required=true) @PathVariable("petId") Long petId,
-        @ApiParam(value = "Additional data to pass to server") @RequestPart(value="additionalMetadata", required=false)  String additionalMetadata,
-        @ApiParam(value = "file detail") @Valid @RequestPart("file") MultipartFile file,
-        @RequestHeader(value = "Accept", required = false) String accept) throws Exception {
+    public ResponseEntity<ModelApiResponse> uploadFile(@ApiParam(value = "ID of pet to update",required=true) @PathVariable("petId") Long petId,@ApiParam(value = "Additional data to pass to server") @RequestPart(value="additionalMetadata", required=false)  String additionalMetadata,@ApiParam(value = "file detail") @Valid @RequestPart("file") MultipartFile file) {
         // do some magic!
         return delegate.uploadFile(petId, additionalMetadata, file);
     }

--- a/samples/server/petstore/springboot-delegate-j8/src/main/java/io/swagger/api/PetApiDelegate.java
+++ b/samples/server/petstore/springboot-delegate-j8/src/main/java/io/swagger/api/PetApiDelegate.java
@@ -3,28 +3,49 @@ package io.swagger.api;
 import io.swagger.model.ModelApiResponse;
 import io.swagger.model.Pet;
 import org.springframework.core.io.Resource;
-
+import com.fasterxml.jackson.databind.ObjectMapper;
 import io.swagger.annotations.*;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.multipart.MultipartFile;
+import java.io.IOException;
 
+import javax.servlet.http.HttpServletRequest;
 import java.util.List;
+import java.util.Optional;
 
 /**
  * A delegate to be called by the {@link PetApiController}}.
- * Should be implemented as a controller but without the {@link org.springframework.stereotype.Controller} annotation.
- * Instead, use spring to autowire this class into the {@link PetApiController}.
+ * Implement this interface with a {@link org.springframework.stereotype.Service} annotated class.
  */
 
 public interface PetApiDelegate {
+
+    Logger log = LoggerFactory.getLogger(PetApi.class);
+
+    default Optional<ObjectMapper> getObjectMapper() {
+        return Optional.empty();
+    }
+
+    default Optional<HttpServletRequest> getRequest() {
+        return Optional.empty();
+    }
+
+    default Optional<String> getAcceptHeader() {
+        return getRequest().map(r -> r.getHeader("Accept"));
+    }
 
     /**
      * @see PetApi#addPet
      */
     default ResponseEntity<Void> addPet(Pet body) {
-        // do some magic!
-        return new ResponseEntity<Void>(HttpStatus.NOT_IMPLEMENTED);
+        if(getObjectMapper().isPresent() && getAcceptHeader().isPresent()) {
+        } else {
+            log.warn("ObjectMapper or HttpServletRequest not configured in default PetApi interface so no example is generated");
+        }
+        return new ResponseEntity<>(HttpStatus.NOT_IMPLEMENTED);
     }
 
     /**
@@ -32,40 +53,103 @@ public interface PetApiDelegate {
      */
     default ResponseEntity<Void> deletePet(Long petId,
         String apiKey) {
-        // do some magic!
-        return new ResponseEntity<Void>(HttpStatus.NOT_IMPLEMENTED);
+        if(getObjectMapper().isPresent() && getAcceptHeader().isPresent()) {
+        } else {
+            log.warn("ObjectMapper or HttpServletRequest not configured in default PetApi interface so no example is generated");
+        }
+        return new ResponseEntity<>(HttpStatus.NOT_IMPLEMENTED);
     }
 
     /**
      * @see PetApi#findPetsByStatus
      */
     default ResponseEntity<List<Pet>> findPetsByStatus(List<String> status) {
-        // do some magic!
-        return new ResponseEntity<List<Pet>>(HttpStatus.NOT_IMPLEMENTED);
+        if(getObjectMapper().isPresent() && getAcceptHeader().isPresent()) {
+            if (getAcceptHeader().get().contains("application/xml")) {
+                try {
+                    return new ResponseEntity<>(getObjectMapper().get().readValue("<Pet>  <id>123456789</id>  <name>doggie</name>  <photoUrls>    <photoUrls>aeiou</photoUrls>  </photoUrls>  <tags>  </tags>  <status>aeiou</status></Pet>", List.class), HttpStatus.NOT_IMPLEMENTED);
+                } catch (IOException e) {
+                    log.error("Couldn't serialize response for content type application/xml", e);
+                    return new ResponseEntity<>(HttpStatus.INTERNAL_SERVER_ERROR);
+                }
+            }
+            if (getAcceptHeader().get().contains("application/json")) {
+                try {
+                    return new ResponseEntity<>(getObjectMapper().get().readValue("[ {  \"photoUrls\" : [ \"photoUrls\", \"photoUrls\" ],  \"name\" : \"doggie\",  \"id\" : 0,  \"category\" : {    \"name\" : \"name\",    \"id\" : 6  },  \"tags\" : [ {    \"name\" : \"name\",    \"id\" : 1  }, {    \"name\" : \"name\",    \"id\" : 1  } ],  \"status\" : \"available\"}, {  \"photoUrls\" : [ \"photoUrls\", \"photoUrls\" ],  \"name\" : \"doggie\",  \"id\" : 0,  \"category\" : {    \"name\" : \"name\",    \"id\" : 6  },  \"tags\" : [ {    \"name\" : \"name\",    \"id\" : 1  }, {    \"name\" : \"name\",    \"id\" : 1  } ],  \"status\" : \"available\"} ]", List.class), HttpStatus.NOT_IMPLEMENTED);
+                } catch (IOException e) {
+                    log.error("Couldn't serialize response for content type application/json", e);
+                    return new ResponseEntity<>(HttpStatus.INTERNAL_SERVER_ERROR);
+                }
+            }
+        } else {
+            log.warn("ObjectMapper or HttpServletRequest not configured in default PetApi interface so no example is generated");
+        }
+        return new ResponseEntity<>(HttpStatus.NOT_IMPLEMENTED);
     }
 
     /**
      * @see PetApi#findPetsByTags
      */
     default ResponseEntity<List<Pet>> findPetsByTags(List<String> tags) {
-        // do some magic!
-        return new ResponseEntity<List<Pet>>(HttpStatus.NOT_IMPLEMENTED);
+        if(getObjectMapper().isPresent() && getAcceptHeader().isPresent()) {
+            if (getAcceptHeader().get().contains("application/xml")) {
+                try {
+                    return new ResponseEntity<>(getObjectMapper().get().readValue("<Pet>  <id>123456789</id>  <name>doggie</name>  <photoUrls>    <photoUrls>aeiou</photoUrls>  </photoUrls>  <tags>  </tags>  <status>aeiou</status></Pet>", List.class), HttpStatus.NOT_IMPLEMENTED);
+                } catch (IOException e) {
+                    log.error("Couldn't serialize response for content type application/xml", e);
+                    return new ResponseEntity<>(HttpStatus.INTERNAL_SERVER_ERROR);
+                }
+            }
+            if (getAcceptHeader().get().contains("application/json")) {
+                try {
+                    return new ResponseEntity<>(getObjectMapper().get().readValue("[ {  \"photoUrls\" : [ \"photoUrls\", \"photoUrls\" ],  \"name\" : \"doggie\",  \"id\" : 0,  \"category\" : {    \"name\" : \"name\",    \"id\" : 6  },  \"tags\" : [ {    \"name\" : \"name\",    \"id\" : 1  }, {    \"name\" : \"name\",    \"id\" : 1  } ],  \"status\" : \"available\"}, {  \"photoUrls\" : [ \"photoUrls\", \"photoUrls\" ],  \"name\" : \"doggie\",  \"id\" : 0,  \"category\" : {    \"name\" : \"name\",    \"id\" : 6  },  \"tags\" : [ {    \"name\" : \"name\",    \"id\" : 1  }, {    \"name\" : \"name\",    \"id\" : 1  } ],  \"status\" : \"available\"} ]", List.class), HttpStatus.NOT_IMPLEMENTED);
+                } catch (IOException e) {
+                    log.error("Couldn't serialize response for content type application/json", e);
+                    return new ResponseEntity<>(HttpStatus.INTERNAL_SERVER_ERROR);
+                }
+            }
+        } else {
+            log.warn("ObjectMapper or HttpServletRequest not configured in default PetApi interface so no example is generated");
+        }
+        return new ResponseEntity<>(HttpStatus.NOT_IMPLEMENTED);
     }
 
     /**
      * @see PetApi#getPetById
      */
     default ResponseEntity<Pet> getPetById(Long petId) {
-        // do some magic!
-        return new ResponseEntity<Pet>(HttpStatus.NOT_IMPLEMENTED);
+        if(getObjectMapper().isPresent() && getAcceptHeader().isPresent()) {
+            if (getAcceptHeader().get().contains("application/xml")) {
+                try {
+                    return new ResponseEntity<>(getObjectMapper().get().readValue("<Pet>  <id>123456789</id>  <name>doggie</name>  <photoUrls>    <photoUrls>aeiou</photoUrls>  </photoUrls>  <tags>  </tags>  <status>aeiou</status></Pet>", Pet.class), HttpStatus.NOT_IMPLEMENTED);
+                } catch (IOException e) {
+                    log.error("Couldn't serialize response for content type application/xml", e);
+                    return new ResponseEntity<>(HttpStatus.INTERNAL_SERVER_ERROR);
+                }
+            }
+            if (getAcceptHeader().get().contains("application/json")) {
+                try {
+                    return new ResponseEntity<>(getObjectMapper().get().readValue("{  \"photoUrls\" : [ \"photoUrls\", \"photoUrls\" ],  \"name\" : \"doggie\",  \"id\" : 0,  \"category\" : {    \"name\" : \"name\",    \"id\" : 6  },  \"tags\" : [ {    \"name\" : \"name\",    \"id\" : 1  }, {    \"name\" : \"name\",    \"id\" : 1  } ],  \"status\" : \"available\"}", Pet.class), HttpStatus.NOT_IMPLEMENTED);
+                } catch (IOException e) {
+                    log.error("Couldn't serialize response for content type application/json", e);
+                    return new ResponseEntity<>(HttpStatus.INTERNAL_SERVER_ERROR);
+                }
+            }
+        } else {
+            log.warn("ObjectMapper or HttpServletRequest not configured in default PetApi interface so no example is generated");
+        }
+        return new ResponseEntity<>(HttpStatus.NOT_IMPLEMENTED);
     }
 
     /**
      * @see PetApi#updatePet
      */
     default ResponseEntity<Void> updatePet(Pet body) {
-        // do some magic!
-        return new ResponseEntity<Void>(HttpStatus.NOT_IMPLEMENTED);
+        if(getObjectMapper().isPresent() && getAcceptHeader().isPresent()) {
+        } else {
+            log.warn("ObjectMapper or HttpServletRequest not configured in default PetApi interface so no example is generated");
+        }
+        return new ResponseEntity<>(HttpStatus.NOT_IMPLEMENTED);
     }
 
     /**
@@ -74,8 +158,11 @@ public interface PetApiDelegate {
     default ResponseEntity<Void> updatePetWithForm(Long petId,
         String name,
         String status) {
-        // do some magic!
-        return new ResponseEntity<Void>(HttpStatus.NOT_IMPLEMENTED);
+        if(getObjectMapper().isPresent() && getAcceptHeader().isPresent()) {
+        } else {
+            log.warn("ObjectMapper or HttpServletRequest not configured in default PetApi interface so no example is generated");
+        }
+        return new ResponseEntity<>(HttpStatus.NOT_IMPLEMENTED);
     }
 
     /**
@@ -84,8 +171,19 @@ public interface PetApiDelegate {
     default ResponseEntity<ModelApiResponse> uploadFile(Long petId,
         String additionalMetadata,
         MultipartFile file) {
-        // do some magic!
-        return new ResponseEntity<ModelApiResponse>(HttpStatus.NOT_IMPLEMENTED);
+        if(getObjectMapper().isPresent() && getAcceptHeader().isPresent()) {
+            if (getAcceptHeader().get().contains("application/json")) {
+                try {
+                    return new ResponseEntity<>(getObjectMapper().get().readValue("{  \"code\" : 0,  \"type\" : \"type\",  \"message\" : \"message\"}", ModelApiResponse.class), HttpStatus.NOT_IMPLEMENTED);
+                } catch (IOException e) {
+                    log.error("Couldn't serialize response for content type application/json", e);
+                    return new ResponseEntity<>(HttpStatus.INTERNAL_SERVER_ERROR);
+                }
+            }
+        } else {
+            log.warn("ObjectMapper or HttpServletRequest not configured in default PetApi interface so no example is generated");
+        }
+        return new ResponseEntity<>(HttpStatus.NOT_IMPLEMENTED);
     }
 
 }

--- a/samples/server/petstore/springboot-delegate-j8/src/main/java/io/swagger/api/PetApiDelegate.java
+++ b/samples/server/petstore/springboot-delegate-j8/src/main/java/io/swagger/api/PetApiDelegate.java
@@ -24,7 +24,7 @@ public interface PetApiDelegate {
      */
     default ResponseEntity<Void> addPet(Pet body) {
     // do some magic!
-    return new ResponseEntity<Void>(HttpStatus.OK);
+    return new ResponseEntity<Void>(HttpStatus.NOT_IMPLEMENTED);
     }
 
     /**
@@ -33,7 +33,7 @@ public interface PetApiDelegate {
     default ResponseEntity<Void> deletePet(Long petId,
         String apiKey) {
     // do some magic!
-    return new ResponseEntity<Void>(HttpStatus.OK);
+    return new ResponseEntity<Void>(HttpStatus.NOT_IMPLEMENTED);
     }
 
     /**
@@ -41,7 +41,7 @@ public interface PetApiDelegate {
      */
     default ResponseEntity<List<Pet>> findPetsByStatus(List<String> status) {
     // do some magic!
-    return new ResponseEntity<List<Pet>>(HttpStatus.OK);
+    return new ResponseEntity<List<Pet>>(HttpStatus.NOT_IMPLEMENTED);
     }
 
     /**
@@ -49,7 +49,7 @@ public interface PetApiDelegate {
      */
     default ResponseEntity<List<Pet>> findPetsByTags(List<String> tags) {
     // do some magic!
-    return new ResponseEntity<List<Pet>>(HttpStatus.OK);
+    return new ResponseEntity<List<Pet>>(HttpStatus.NOT_IMPLEMENTED);
     }
 
     /**
@@ -57,7 +57,7 @@ public interface PetApiDelegate {
      */
     default ResponseEntity<Pet> getPetById(Long petId) {
     // do some magic!
-    return new ResponseEntity<Pet>(HttpStatus.OK);
+    return new ResponseEntity<Pet>(HttpStatus.NOT_IMPLEMENTED);
     }
 
     /**
@@ -65,7 +65,7 @@ public interface PetApiDelegate {
      */
     default ResponseEntity<Void> updatePet(Pet body) {
     // do some magic!
-    return new ResponseEntity<Void>(HttpStatus.OK);
+    return new ResponseEntity<Void>(HttpStatus.NOT_IMPLEMENTED);
     }
 
     /**
@@ -75,7 +75,7 @@ public interface PetApiDelegate {
         String name,
         String status) {
     // do some magic!
-    return new ResponseEntity<Void>(HttpStatus.OK);
+    return new ResponseEntity<Void>(HttpStatus.NOT_IMPLEMENTED);
     }
 
     /**
@@ -85,7 +85,7 @@ public interface PetApiDelegate {
         String additionalMetadata,
         MultipartFile file) {
     // do some magic!
-    return new ResponseEntity<ModelApiResponse>(HttpStatus.OK);
+    return new ResponseEntity<ModelApiResponse>(HttpStatus.NOT_IMPLEMENTED);
     }
 
 }

--- a/samples/server/petstore/springboot-delegate-j8/src/main/java/io/swagger/api/PetApiDelegate.java
+++ b/samples/server/petstore/springboot-delegate-j8/src/main/java/io/swagger/api/PetApiDelegate.java
@@ -23,8 +23,8 @@ public interface PetApiDelegate {
      * @see PetApi#addPet
      */
     default ResponseEntity<Void> addPet(Pet body) {
-    // do some magic!
-    return new ResponseEntity<Void>(HttpStatus.NOT_IMPLEMENTED);
+        // do some magic!
+        return new ResponseEntity<Void>(HttpStatus.NOT_IMPLEMENTED);
     }
 
     /**
@@ -32,40 +32,40 @@ public interface PetApiDelegate {
      */
     default ResponseEntity<Void> deletePet(Long petId,
         String apiKey) {
-    // do some magic!
-    return new ResponseEntity<Void>(HttpStatus.NOT_IMPLEMENTED);
+        // do some magic!
+        return new ResponseEntity<Void>(HttpStatus.NOT_IMPLEMENTED);
     }
 
     /**
      * @see PetApi#findPetsByStatus
      */
     default ResponseEntity<List<Pet>> findPetsByStatus(List<String> status) {
-    // do some magic!
-    return new ResponseEntity<List<Pet>>(HttpStatus.NOT_IMPLEMENTED);
+        // do some magic!
+        return new ResponseEntity<List<Pet>>(HttpStatus.NOT_IMPLEMENTED);
     }
 
     /**
      * @see PetApi#findPetsByTags
      */
     default ResponseEntity<List<Pet>> findPetsByTags(List<String> tags) {
-    // do some magic!
-    return new ResponseEntity<List<Pet>>(HttpStatus.NOT_IMPLEMENTED);
+        // do some magic!
+        return new ResponseEntity<List<Pet>>(HttpStatus.NOT_IMPLEMENTED);
     }
 
     /**
      * @see PetApi#getPetById
      */
     default ResponseEntity<Pet> getPetById(Long petId) {
-    // do some magic!
-    return new ResponseEntity<Pet>(HttpStatus.NOT_IMPLEMENTED);
+        // do some magic!
+        return new ResponseEntity<Pet>(HttpStatus.NOT_IMPLEMENTED);
     }
 
     /**
      * @see PetApi#updatePet
      */
     default ResponseEntity<Void> updatePet(Pet body) {
-    // do some magic!
-    return new ResponseEntity<Void>(HttpStatus.NOT_IMPLEMENTED);
+        // do some magic!
+        return new ResponseEntity<Void>(HttpStatus.NOT_IMPLEMENTED);
     }
 
     /**
@@ -74,8 +74,8 @@ public interface PetApiDelegate {
     default ResponseEntity<Void> updatePetWithForm(Long petId,
         String name,
         String status) {
-    // do some magic!
-    return new ResponseEntity<Void>(HttpStatus.NOT_IMPLEMENTED);
+        // do some magic!
+        return new ResponseEntity<Void>(HttpStatus.NOT_IMPLEMENTED);
     }
 
     /**
@@ -84,8 +84,8 @@ public interface PetApiDelegate {
     default ResponseEntity<ModelApiResponse> uploadFile(Long petId,
         String additionalMetadata,
         MultipartFile file) {
-    // do some magic!
-    return new ResponseEntity<ModelApiResponse>(HttpStatus.NOT_IMPLEMENTED);
+        // do some magic!
+        return new ResponseEntity<ModelApiResponse>(HttpStatus.NOT_IMPLEMENTED);
     }
 
 }

--- a/samples/server/petstore/springboot-delegate-j8/src/main/java/io/swagger/api/StoreApi.java
+++ b/samples/server/petstore/springboot-delegate-j8/src/main/java/io/swagger/api/StoreApi.java
@@ -7,10 +7,9 @@ package io.swagger.api;
 
 import java.util.Map;
 import io.swagger.model.Order;
-
 import io.swagger.annotations.*;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
@@ -19,15 +18,15 @@ import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.multipart.MultipartFile;
-import java.io.IOException;
 
-import java.util.List;
-import org.springframework.validation.annotation.Validated;
-import javax.validation.constraints.*;
 import javax.validation.Valid;
+import javax.validation.constraints.*;
+import java.util.List;
 
 @Api(value = "store", description = "the store API")
 public interface StoreApi {
+
+    StoreApiDelegate getDelegate();
 
     @ApiOperation(value = "Delete purchase order by ID", nickname = "deleteOrder", notes = "For valid response try integer IDs with value < 1000. Anything above 1000 or nonintegers will generate API errors", tags={ "store", })
     @ApiResponses(value = { 
@@ -37,8 +36,7 @@ public interface StoreApi {
         produces = { "application/xml", "application/json" }, 
         method = RequestMethod.DELETE)
     default ResponseEntity<Void> deleteOrder(@ApiParam(value = "ID of the order that needs to be deleted",required=true) @PathVariable("order_id") String orderId) {
-        // do some magic!
-        return new ResponseEntity<Void>(HttpStatus.NOT_IMPLEMENTED);
+        return getDelegate().deleteOrder(orderId);
     }
 
 
@@ -51,8 +49,7 @@ public interface StoreApi {
         produces = { "application/json" }, 
         method = RequestMethod.GET)
     default ResponseEntity<Map<String, Integer>> getInventory() {
-        // do some magic!
-        return new ResponseEntity<Map<String, Integer>>(HttpStatus.NOT_IMPLEMENTED);
+        return getDelegate().getInventory();
     }
 
 
@@ -65,8 +62,7 @@ public interface StoreApi {
         produces = { "application/xml", "application/json" }, 
         method = RequestMethod.GET)
     default ResponseEntity<Order> getOrderById(@Min(1) @Max(5) @ApiParam(value = "ID of pet that needs to be fetched",required=true) @PathVariable("order_id") Long orderId) {
-        // do some magic!
-        return new ResponseEntity<Order>(HttpStatus.NOT_IMPLEMENTED);
+        return getDelegate().getOrderById(orderId);
     }
 
 
@@ -78,8 +74,7 @@ public interface StoreApi {
         produces = { "application/xml", "application/json" }, 
         method = RequestMethod.POST)
     default ResponseEntity<Order> placeOrder(@ApiParam(value = "order placed for purchasing the pet" ,required=true )  @Valid @RequestBody Order body) {
-        // do some magic!
-        return new ResponseEntity<Order>(HttpStatus.NOT_IMPLEMENTED);
+        return getDelegate().placeOrder(body);
     }
 
 }

--- a/samples/server/petstore/springboot-delegate-j8/src/main/java/io/swagger/api/StoreApi.java
+++ b/samples/server/petstore/springboot-delegate-j8/src/main/java/io/swagger/api/StoreApi.java
@@ -36,9 +36,9 @@ public interface StoreApi {
     @RequestMapping(value = "/store/order/{order_id}",
         produces = { "application/xml", "application/json" }, 
         method = RequestMethod.DELETE)
-    default ResponseEntity<Void> deleteOrder(@ApiParam(value = "ID of the order that needs to be deleted",required=true) @PathVariable("order_id") String orderId, @RequestHeader(value = "Accept", required = false) String accept) throws Exception {
+    default ResponseEntity<Void> deleteOrder(@ApiParam(value = "ID of the order that needs to be deleted",required=true) @PathVariable("order_id") String orderId) {
         // do some magic!
-        return new ResponseEntity<Void>(HttpStatus.OK);
+        return new ResponseEntity<Void>(HttpStatus.NOT_IMPLEMENTED);
     }
 
 
@@ -50,9 +50,9 @@ public interface StoreApi {
     @RequestMapping(value = "/store/inventory",
         produces = { "application/json" }, 
         method = RequestMethod.GET)
-    default ResponseEntity<Map<String, Integer>> getInventory( @RequestHeader(value = "Accept", required = false) String accept) throws Exception {
+    default ResponseEntity<Map<String, Integer>> getInventory() {
         // do some magic!
-        return new ResponseEntity<Map<String, Integer>>(HttpStatus.OK);
+        return new ResponseEntity<Map<String, Integer>>(HttpStatus.NOT_IMPLEMENTED);
     }
 
 
@@ -64,9 +64,9 @@ public interface StoreApi {
     @RequestMapping(value = "/store/order/{order_id}",
         produces = { "application/xml", "application/json" }, 
         method = RequestMethod.GET)
-    default ResponseEntity<Order> getOrderById( @Min(1) @Max(5)@ApiParam(value = "ID of pet that needs to be fetched",required=true) @PathVariable("order_id") Long orderId, @RequestHeader(value = "Accept", required = false) String accept) throws Exception {
+    default ResponseEntity<Order> getOrderById(@Min(1) @Max(5) @ApiParam(value = "ID of pet that needs to be fetched",required=true) @PathVariable("order_id") Long orderId) {
         // do some magic!
-        return new ResponseEntity<Order>(HttpStatus.OK);
+        return new ResponseEntity<Order>(HttpStatus.NOT_IMPLEMENTED);
     }
 
 
@@ -77,9 +77,9 @@ public interface StoreApi {
     @RequestMapping(value = "/store/order",
         produces = { "application/xml", "application/json" }, 
         method = RequestMethod.POST)
-    default ResponseEntity<Order> placeOrder(@ApiParam(value = "order placed for purchasing the pet" ,required=true )  @Valid @RequestBody Order body, @RequestHeader(value = "Accept", required = false) String accept) throws Exception {
+    default ResponseEntity<Order> placeOrder(@ApiParam(value = "order placed for purchasing the pet" ,required=true )  @Valid @RequestBody Order body) {
         // do some magic!
-        return new ResponseEntity<Order>(HttpStatus.OK);
+        return new ResponseEntity<Order>(HttpStatus.NOT_IMPLEMENTED);
     }
 
 }

--- a/samples/server/petstore/springboot-delegate-j8/src/main/java/io/swagger/api/StoreApiController.java
+++ b/samples/server/petstore/springboot-delegate-j8/src/main/java/io/swagger/api/StoreApiController.java
@@ -22,19 +22,12 @@ import org.springframework.web.multipart.MultipartFile;
 import java.util.List;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.IOException;
+import javax.servlet.http.HttpServletRequest;
 import javax.validation.constraints.*;
 import javax.validation.Valid;
 
 @Controller
 public class StoreApiController implements StoreApi {
-
-    private final Logger log = LoggerFactory.getLogger(AnotherFakeApiController.class);
-
-    private final ObjectMapper objectMapper;
-
-    public StoreApiController(ObjectMapper objectMapper) {
-        this.objectMapper = objectMapper;
-    }
 
     private final StoreApiDelegate delegate;
 

--- a/samples/server/petstore/springboot-delegate-j8/src/main/java/io/swagger/api/StoreApiController.java
+++ b/samples/server/petstore/springboot-delegate-j8/src/main/java/io/swagger/api/StoreApiController.java
@@ -5,6 +5,8 @@ import io.swagger.model.Order;
 
 import io.swagger.annotations.*;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
@@ -13,6 +15,8 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RequestPart;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.util.List;
@@ -23,6 +27,9 @@ import javax.validation.Valid;
 
 @Controller
 public class StoreApiController implements StoreApi {
+
+    private final Logger log = LoggerFactory.getLogger(AnotherFakeApiController.class);
+
     private final ObjectMapper objectMapper;
 
     public StoreApiController(ObjectMapper objectMapper) {
@@ -36,25 +43,22 @@ public class StoreApiController implements StoreApi {
         this.delegate = delegate;
     }
 
-    public ResponseEntity<Void> deleteOrder(@ApiParam(value = "ID of the order that needs to be deleted",required=true) @PathVariable("order_id") String orderId,
-        @RequestHeader(value = "Accept", required = false) String accept) throws Exception {
+    public ResponseEntity<Void> deleteOrder(@ApiParam(value = "ID of the order that needs to be deleted",required=true) @PathVariable("order_id") String orderId) {
         // do some magic!
         return delegate.deleteOrder(orderId);
     }
 
-    public ResponseEntity<Map<String, Integer>> getInventory(@RequestHeader(value = "Accept", required = false) String accept) throws Exception {
+    public ResponseEntity<Map<String, Integer>> getInventory() {
         // do some magic!
         return delegate.getInventory();
     }
 
-    public ResponseEntity<Order> getOrderById( @Min(1) @Max(5)@ApiParam(value = "ID of pet that needs to be fetched",required=true) @PathVariable("order_id") Long orderId,
-        @RequestHeader(value = "Accept", required = false) String accept) throws Exception {
+    public ResponseEntity<Order> getOrderById(@Min(1) @Max(5) @ApiParam(value = "ID of pet that needs to be fetched",required=true) @PathVariable("order_id") Long orderId) {
         // do some magic!
         return delegate.getOrderById(orderId);
     }
 
-    public ResponseEntity<Order> placeOrder(@ApiParam(value = "order placed for purchasing the pet" ,required=true )  @Valid @RequestBody Order body,
-        @RequestHeader(value = "Accept", required = false) String accept) throws Exception {
+    public ResponseEntity<Order> placeOrder(@ApiParam(value = "order placed for purchasing the pet" ,required=true )  @Valid @RequestBody Order body) {
         // do some magic!
         return delegate.placeOrder(body);
     }

--- a/samples/server/petstore/springboot-delegate-j8/src/main/java/io/swagger/api/StoreApiController.java
+++ b/samples/server/petstore/springboot-delegate-j8/src/main/java/io/swagger/api/StoreApiController.java
@@ -1,30 +1,6 @@
 package io.swagger.api;
 
-import java.util.Map;
-import io.swagger.model.Order;
-
-import io.swagger.annotations.*;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import org.springframework.http.HttpStatus;
-import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestHeader;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RequestPart;
-import org.springframework.web.context.request.RequestContextHolder;
-import org.springframework.web.context.request.ServletRequestAttributes;
-import org.springframework.web.multipart.MultipartFile;
-
-import java.util.List;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import java.io.IOException;
-import javax.servlet.http.HttpServletRequest;
-import javax.validation.constraints.*;
-import javax.validation.Valid;
 
 @Controller
 public class StoreApiController implements StoreApi {
@@ -36,24 +12,8 @@ public class StoreApiController implements StoreApi {
         this.delegate = delegate;
     }
 
-    public ResponseEntity<Void> deleteOrder(@ApiParam(value = "ID of the order that needs to be deleted",required=true) @PathVariable("order_id") String orderId) {
-        // do some magic!
-        return delegate.deleteOrder(orderId);
+    @Override
+    public StoreApiDelegate getDelegate() {
+        return delegate;
     }
-
-    public ResponseEntity<Map<String, Integer>> getInventory() {
-        // do some magic!
-        return delegate.getInventory();
-    }
-
-    public ResponseEntity<Order> getOrderById(@Min(1) @Max(5) @ApiParam(value = "ID of pet that needs to be fetched",required=true) @PathVariable("order_id") Long orderId) {
-        // do some magic!
-        return delegate.getOrderById(orderId);
-    }
-
-    public ResponseEntity<Order> placeOrder(@ApiParam(value = "order placed for purchasing the pet" ,required=true )  @Valid @RequestBody Order body) {
-        // do some magic!
-        return delegate.placeOrder(body);
-    }
-
 }

--- a/samples/server/petstore/springboot-delegate-j8/src/main/java/io/swagger/api/StoreApiDelegate.java
+++ b/samples/server/petstore/springboot-delegate-j8/src/main/java/io/swagger/api/StoreApiDelegate.java
@@ -2,52 +2,122 @@ package io.swagger.api;
 
 import java.util.Map;
 import io.swagger.model.Order;
-
+import com.fasterxml.jackson.databind.ObjectMapper;
 import io.swagger.annotations.*;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.multipart.MultipartFile;
+import java.io.IOException;
 
+import javax.servlet.http.HttpServletRequest;
 import java.util.List;
+import java.util.Optional;
 
 /**
  * A delegate to be called by the {@link StoreApiController}}.
- * Should be implemented as a controller but without the {@link org.springframework.stereotype.Controller} annotation.
- * Instead, use spring to autowire this class into the {@link StoreApiController}.
+ * Implement this interface with a {@link org.springframework.stereotype.Service} annotated class.
  */
 
 public interface StoreApiDelegate {
+
+    Logger log = LoggerFactory.getLogger(StoreApi.class);
+
+    default Optional<ObjectMapper> getObjectMapper() {
+        return Optional.empty();
+    }
+
+    default Optional<HttpServletRequest> getRequest() {
+        return Optional.empty();
+    }
+
+    default Optional<String> getAcceptHeader() {
+        return getRequest().map(r -> r.getHeader("Accept"));
+    }
 
     /**
      * @see StoreApi#deleteOrder
      */
     default ResponseEntity<Void> deleteOrder(String orderId) {
-        // do some magic!
-        return new ResponseEntity<Void>(HttpStatus.NOT_IMPLEMENTED);
+        if(getObjectMapper().isPresent() && getAcceptHeader().isPresent()) {
+        } else {
+            log.warn("ObjectMapper or HttpServletRequest not configured in default StoreApi interface so no example is generated");
+        }
+        return new ResponseEntity<>(HttpStatus.NOT_IMPLEMENTED);
     }
 
     /**
      * @see StoreApi#getInventory
      */
     default ResponseEntity<Map<String, Integer>> getInventory() {
-        // do some magic!
-        return new ResponseEntity<Map<String, Integer>>(HttpStatus.NOT_IMPLEMENTED);
+        if(getObjectMapper().isPresent() && getAcceptHeader().isPresent()) {
+            if (getAcceptHeader().get().contains("application/json")) {
+                try {
+                    return new ResponseEntity<>(getObjectMapper().get().readValue("{  \"key\" : 0}", Map.class), HttpStatus.NOT_IMPLEMENTED);
+                } catch (IOException e) {
+                    log.error("Couldn't serialize response for content type application/json", e);
+                    return new ResponseEntity<>(HttpStatus.INTERNAL_SERVER_ERROR);
+                }
+            }
+        } else {
+            log.warn("ObjectMapper or HttpServletRequest not configured in default StoreApi interface so no example is generated");
+        }
+        return new ResponseEntity<>(HttpStatus.NOT_IMPLEMENTED);
     }
 
     /**
      * @see StoreApi#getOrderById
      */
     default ResponseEntity<Order> getOrderById(Long orderId) {
-        // do some magic!
-        return new ResponseEntity<Order>(HttpStatus.NOT_IMPLEMENTED);
+        if(getObjectMapper().isPresent() && getAcceptHeader().isPresent()) {
+            if (getAcceptHeader().get().contains("application/xml")) {
+                try {
+                    return new ResponseEntity<>(getObjectMapper().get().readValue("<Order>  <id>123456789</id>  <petId>123456789</petId>  <quantity>123</quantity>  <shipDate>2000-01-23T04:56:07.000Z</shipDate>  <status>aeiou</status>  <complete>true</complete></Order>", Order.class), HttpStatus.NOT_IMPLEMENTED);
+                } catch (IOException e) {
+                    log.error("Couldn't serialize response for content type application/xml", e);
+                    return new ResponseEntity<>(HttpStatus.INTERNAL_SERVER_ERROR);
+                }
+            }
+            if (getAcceptHeader().get().contains("application/json")) {
+                try {
+                    return new ResponseEntity<>(getObjectMapper().get().readValue("{  \"petId\" : 6,  \"quantity\" : 1,  \"id\" : 0,  \"shipDate\" : \"2000-01-23T04:56:07.000+00:00\",  \"complete\" : false,  \"status\" : \"placed\"}", Order.class), HttpStatus.NOT_IMPLEMENTED);
+                } catch (IOException e) {
+                    log.error("Couldn't serialize response for content type application/json", e);
+                    return new ResponseEntity<>(HttpStatus.INTERNAL_SERVER_ERROR);
+                }
+            }
+        } else {
+            log.warn("ObjectMapper or HttpServletRequest not configured in default StoreApi interface so no example is generated");
+        }
+        return new ResponseEntity<>(HttpStatus.NOT_IMPLEMENTED);
     }
 
     /**
      * @see StoreApi#placeOrder
      */
     default ResponseEntity<Order> placeOrder(Order body) {
-        // do some magic!
-        return new ResponseEntity<Order>(HttpStatus.NOT_IMPLEMENTED);
+        if(getObjectMapper().isPresent() && getAcceptHeader().isPresent()) {
+            if (getAcceptHeader().get().contains("application/xml")) {
+                try {
+                    return new ResponseEntity<>(getObjectMapper().get().readValue("<Order>  <id>123456789</id>  <petId>123456789</petId>  <quantity>123</quantity>  <shipDate>2000-01-23T04:56:07.000Z</shipDate>  <status>aeiou</status>  <complete>true</complete></Order>", Order.class), HttpStatus.NOT_IMPLEMENTED);
+                } catch (IOException e) {
+                    log.error("Couldn't serialize response for content type application/xml", e);
+                    return new ResponseEntity<>(HttpStatus.INTERNAL_SERVER_ERROR);
+                }
+            }
+            if (getAcceptHeader().get().contains("application/json")) {
+                try {
+                    return new ResponseEntity<>(getObjectMapper().get().readValue("{  \"petId\" : 6,  \"quantity\" : 1,  \"id\" : 0,  \"shipDate\" : \"2000-01-23T04:56:07.000+00:00\",  \"complete\" : false,  \"status\" : \"placed\"}", Order.class), HttpStatus.NOT_IMPLEMENTED);
+                } catch (IOException e) {
+                    log.error("Couldn't serialize response for content type application/json", e);
+                    return new ResponseEntity<>(HttpStatus.INTERNAL_SERVER_ERROR);
+                }
+            }
+        } else {
+            log.warn("ObjectMapper or HttpServletRequest not configured in default StoreApi interface so no example is generated");
+        }
+        return new ResponseEntity<>(HttpStatus.NOT_IMPLEMENTED);
     }
 
 }

--- a/samples/server/petstore/springboot-delegate-j8/src/main/java/io/swagger/api/StoreApiDelegate.java
+++ b/samples/server/petstore/springboot-delegate-j8/src/main/java/io/swagger/api/StoreApiDelegate.java
@@ -22,32 +22,32 @@ public interface StoreApiDelegate {
      * @see StoreApi#deleteOrder
      */
     default ResponseEntity<Void> deleteOrder(String orderId) {
-    // do some magic!
-    return new ResponseEntity<Void>(HttpStatus.NOT_IMPLEMENTED);
+        // do some magic!
+        return new ResponseEntity<Void>(HttpStatus.NOT_IMPLEMENTED);
     }
 
     /**
      * @see StoreApi#getInventory
      */
     default ResponseEntity<Map<String, Integer>> getInventory() {
-    // do some magic!
-    return new ResponseEntity<Map<String, Integer>>(HttpStatus.NOT_IMPLEMENTED);
+        // do some magic!
+        return new ResponseEntity<Map<String, Integer>>(HttpStatus.NOT_IMPLEMENTED);
     }
 
     /**
      * @see StoreApi#getOrderById
      */
     default ResponseEntity<Order> getOrderById(Long orderId) {
-    // do some magic!
-    return new ResponseEntity<Order>(HttpStatus.NOT_IMPLEMENTED);
+        // do some magic!
+        return new ResponseEntity<Order>(HttpStatus.NOT_IMPLEMENTED);
     }
 
     /**
      * @see StoreApi#placeOrder
      */
     default ResponseEntity<Order> placeOrder(Order body) {
-    // do some magic!
-    return new ResponseEntity<Order>(HttpStatus.NOT_IMPLEMENTED);
+        // do some magic!
+        return new ResponseEntity<Order>(HttpStatus.NOT_IMPLEMENTED);
     }
 
 }

--- a/samples/server/petstore/springboot-delegate-j8/src/main/java/io/swagger/api/StoreApiDelegate.java
+++ b/samples/server/petstore/springboot-delegate-j8/src/main/java/io/swagger/api/StoreApiDelegate.java
@@ -23,7 +23,7 @@ public interface StoreApiDelegate {
      */
     default ResponseEntity<Void> deleteOrder(String orderId) {
     // do some magic!
-    return new ResponseEntity<Void>(HttpStatus.OK);
+    return new ResponseEntity<Void>(HttpStatus.NOT_IMPLEMENTED);
     }
 
     /**
@@ -31,7 +31,7 @@ public interface StoreApiDelegate {
      */
     default ResponseEntity<Map<String, Integer>> getInventory() {
     // do some magic!
-    return new ResponseEntity<Map<String, Integer>>(HttpStatus.OK);
+    return new ResponseEntity<Map<String, Integer>>(HttpStatus.NOT_IMPLEMENTED);
     }
 
     /**
@@ -39,7 +39,7 @@ public interface StoreApiDelegate {
      */
     default ResponseEntity<Order> getOrderById(Long orderId) {
     // do some magic!
-    return new ResponseEntity<Order>(HttpStatus.OK);
+    return new ResponseEntity<Order>(HttpStatus.NOT_IMPLEMENTED);
     }
 
     /**
@@ -47,7 +47,7 @@ public interface StoreApiDelegate {
      */
     default ResponseEntity<Order> placeOrder(Order body) {
     // do some magic!
-    return new ResponseEntity<Order>(HttpStatus.OK);
+    return new ResponseEntity<Order>(HttpStatus.NOT_IMPLEMENTED);
     }
 
 }

--- a/samples/server/petstore/springboot-delegate-j8/src/main/java/io/swagger/api/UserApi.java
+++ b/samples/server/petstore/springboot-delegate-j8/src/main/java/io/swagger/api/UserApi.java
@@ -7,10 +7,9 @@ package io.swagger.api;
 
 import java.util.List;
 import io.swagger.model.User;
-
 import io.swagger.annotations.*;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
@@ -19,15 +18,15 @@ import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.multipart.MultipartFile;
-import java.io.IOException;
 
-import java.util.List;
-import org.springframework.validation.annotation.Validated;
-import javax.validation.constraints.*;
 import javax.validation.Valid;
+import javax.validation.constraints.*;
+import java.util.List;
 
 @Api(value = "user", description = "the user API")
 public interface UserApi {
+
+    UserApiDelegate getDelegate();
 
     @ApiOperation(value = "Create user", nickname = "createUser", notes = "This can only be done by the logged in user.", tags={ "user", })
     @ApiResponses(value = { 
@@ -36,8 +35,7 @@ public interface UserApi {
         produces = { "application/xml", "application/json" }, 
         method = RequestMethod.POST)
     default ResponseEntity<Void> createUser(@ApiParam(value = "Created user object" ,required=true )  @Valid @RequestBody User body) {
-        // do some magic!
-        return new ResponseEntity<Void>(HttpStatus.NOT_IMPLEMENTED);
+        return getDelegate().createUser(body);
     }
 
 
@@ -48,8 +46,7 @@ public interface UserApi {
         produces = { "application/xml", "application/json" }, 
         method = RequestMethod.POST)
     default ResponseEntity<Void> createUsersWithArrayInput(@ApiParam(value = "List of user object" ,required=true )  @Valid @RequestBody List<User> body) {
-        // do some magic!
-        return new ResponseEntity<Void>(HttpStatus.NOT_IMPLEMENTED);
+        return getDelegate().createUsersWithArrayInput(body);
     }
 
 
@@ -60,8 +57,7 @@ public interface UserApi {
         produces = { "application/xml", "application/json" }, 
         method = RequestMethod.POST)
     default ResponseEntity<Void> createUsersWithListInput(@ApiParam(value = "List of user object" ,required=true )  @Valid @RequestBody List<User> body) {
-        // do some magic!
-        return new ResponseEntity<Void>(HttpStatus.NOT_IMPLEMENTED);
+        return getDelegate().createUsersWithListInput(body);
     }
 
 
@@ -73,8 +69,7 @@ public interface UserApi {
         produces = { "application/xml", "application/json" }, 
         method = RequestMethod.DELETE)
     default ResponseEntity<Void> deleteUser(@ApiParam(value = "The name that needs to be deleted",required=true) @PathVariable("username") String username) {
-        // do some magic!
-        return new ResponseEntity<Void>(HttpStatus.NOT_IMPLEMENTED);
+        return getDelegate().deleteUser(username);
     }
 
 
@@ -87,8 +82,7 @@ public interface UserApi {
         produces = { "application/xml", "application/json" }, 
         method = RequestMethod.GET)
     default ResponseEntity<User> getUserByName(@ApiParam(value = "The name that needs to be fetched. Use user1 for testing. ",required=true) @PathVariable("username") String username) {
-        // do some magic!
-        return new ResponseEntity<User>(HttpStatus.NOT_IMPLEMENTED);
+        return getDelegate().getUserByName(username);
     }
 
 
@@ -100,8 +94,7 @@ public interface UserApi {
         produces = { "application/xml", "application/json" }, 
         method = RequestMethod.GET)
     default ResponseEntity<String> loginUser(@NotNull @ApiParam(value = "The user name for login", required = true) @Valid @RequestParam(value = "username", required = true) String username,@NotNull @ApiParam(value = "The password for login in clear text", required = true) @Valid @RequestParam(value = "password", required = true) String password) {
-        // do some magic!
-        return new ResponseEntity<String>(HttpStatus.NOT_IMPLEMENTED);
+        return getDelegate().loginUser(username, password);
     }
 
 
@@ -112,8 +105,7 @@ public interface UserApi {
         produces = { "application/xml", "application/json" }, 
         method = RequestMethod.GET)
     default ResponseEntity<Void> logoutUser() {
-        // do some magic!
-        return new ResponseEntity<Void>(HttpStatus.NOT_IMPLEMENTED);
+        return getDelegate().logoutUser();
     }
 
 
@@ -125,8 +117,7 @@ public interface UserApi {
         produces = { "application/xml", "application/json" }, 
         method = RequestMethod.PUT)
     default ResponseEntity<Void> updateUser(@ApiParam(value = "name that need to be deleted",required=true) @PathVariable("username") String username,@ApiParam(value = "Updated user object" ,required=true )  @Valid @RequestBody User body) {
-        // do some magic!
-        return new ResponseEntity<Void>(HttpStatus.NOT_IMPLEMENTED);
+        return getDelegate().updateUser(username, body);
     }
 
 }

--- a/samples/server/petstore/springboot-delegate-j8/src/main/java/io/swagger/api/UserApi.java
+++ b/samples/server/petstore/springboot-delegate-j8/src/main/java/io/swagger/api/UserApi.java
@@ -35,9 +35,9 @@ public interface UserApi {
     @RequestMapping(value = "/user",
         produces = { "application/xml", "application/json" }, 
         method = RequestMethod.POST)
-    default ResponseEntity<Void> createUser(@ApiParam(value = "Created user object" ,required=true )  @Valid @RequestBody User body, @RequestHeader(value = "Accept", required = false) String accept) throws Exception {
+    default ResponseEntity<Void> createUser(@ApiParam(value = "Created user object" ,required=true )  @Valid @RequestBody User body) {
         // do some magic!
-        return new ResponseEntity<Void>(HttpStatus.OK);
+        return new ResponseEntity<Void>(HttpStatus.NOT_IMPLEMENTED);
     }
 
 
@@ -47,9 +47,9 @@ public interface UserApi {
     @RequestMapping(value = "/user/createWithArray",
         produces = { "application/xml", "application/json" }, 
         method = RequestMethod.POST)
-    default ResponseEntity<Void> createUsersWithArrayInput(@ApiParam(value = "List of user object" ,required=true )  @Valid @RequestBody List<User> body, @RequestHeader(value = "Accept", required = false) String accept) throws Exception {
+    default ResponseEntity<Void> createUsersWithArrayInput(@ApiParam(value = "List of user object" ,required=true )  @Valid @RequestBody List<User> body) {
         // do some magic!
-        return new ResponseEntity<Void>(HttpStatus.OK);
+        return new ResponseEntity<Void>(HttpStatus.NOT_IMPLEMENTED);
     }
 
 
@@ -59,9 +59,9 @@ public interface UserApi {
     @RequestMapping(value = "/user/createWithList",
         produces = { "application/xml", "application/json" }, 
         method = RequestMethod.POST)
-    default ResponseEntity<Void> createUsersWithListInput(@ApiParam(value = "List of user object" ,required=true )  @Valid @RequestBody List<User> body, @RequestHeader(value = "Accept", required = false) String accept) throws Exception {
+    default ResponseEntity<Void> createUsersWithListInput(@ApiParam(value = "List of user object" ,required=true )  @Valid @RequestBody List<User> body) {
         // do some magic!
-        return new ResponseEntity<Void>(HttpStatus.OK);
+        return new ResponseEntity<Void>(HttpStatus.NOT_IMPLEMENTED);
     }
 
 
@@ -72,9 +72,9 @@ public interface UserApi {
     @RequestMapping(value = "/user/{username}",
         produces = { "application/xml", "application/json" }, 
         method = RequestMethod.DELETE)
-    default ResponseEntity<Void> deleteUser(@ApiParam(value = "The name that needs to be deleted",required=true) @PathVariable("username") String username, @RequestHeader(value = "Accept", required = false) String accept) throws Exception {
+    default ResponseEntity<Void> deleteUser(@ApiParam(value = "The name that needs to be deleted",required=true) @PathVariable("username") String username) {
         // do some magic!
-        return new ResponseEntity<Void>(HttpStatus.OK);
+        return new ResponseEntity<Void>(HttpStatus.NOT_IMPLEMENTED);
     }
 
 
@@ -86,9 +86,9 @@ public interface UserApi {
     @RequestMapping(value = "/user/{username}",
         produces = { "application/xml", "application/json" }, 
         method = RequestMethod.GET)
-    default ResponseEntity<User> getUserByName(@ApiParam(value = "The name that needs to be fetched. Use user1 for testing. ",required=true) @PathVariable("username") String username, @RequestHeader(value = "Accept", required = false) String accept) throws Exception {
+    default ResponseEntity<User> getUserByName(@ApiParam(value = "The name that needs to be fetched. Use user1 for testing. ",required=true) @PathVariable("username") String username) {
         // do some magic!
-        return new ResponseEntity<User>(HttpStatus.OK);
+        return new ResponseEntity<User>(HttpStatus.NOT_IMPLEMENTED);
     }
 
 
@@ -99,9 +99,9 @@ public interface UserApi {
     @RequestMapping(value = "/user/login",
         produces = { "application/xml", "application/json" }, 
         method = RequestMethod.GET)
-    default ResponseEntity<String> loginUser( @NotNull@ApiParam(value = "The user name for login", required = true) @Valid @RequestParam(value = "username", required = true) String username, @NotNull@ApiParam(value = "The password for login in clear text", required = true) @Valid @RequestParam(value = "password", required = true) String password, @RequestHeader(value = "Accept", required = false) String accept) throws Exception {
+    default ResponseEntity<String> loginUser(@NotNull @ApiParam(value = "The user name for login", required = true) @Valid @RequestParam(value = "username", required = true) String username,@NotNull @ApiParam(value = "The password for login in clear text", required = true) @Valid @RequestParam(value = "password", required = true) String password) {
         // do some magic!
-        return new ResponseEntity<String>(HttpStatus.OK);
+        return new ResponseEntity<String>(HttpStatus.NOT_IMPLEMENTED);
     }
 
 
@@ -111,9 +111,9 @@ public interface UserApi {
     @RequestMapping(value = "/user/logout",
         produces = { "application/xml", "application/json" }, 
         method = RequestMethod.GET)
-    default ResponseEntity<Void> logoutUser( @RequestHeader(value = "Accept", required = false) String accept) throws Exception {
+    default ResponseEntity<Void> logoutUser() {
         // do some magic!
-        return new ResponseEntity<Void>(HttpStatus.OK);
+        return new ResponseEntity<Void>(HttpStatus.NOT_IMPLEMENTED);
     }
 
 
@@ -124,9 +124,9 @@ public interface UserApi {
     @RequestMapping(value = "/user/{username}",
         produces = { "application/xml", "application/json" }, 
         method = RequestMethod.PUT)
-    default ResponseEntity<Void> updateUser(@ApiParam(value = "name that need to be deleted",required=true) @PathVariable("username") String username,@ApiParam(value = "Updated user object" ,required=true )  @Valid @RequestBody User body, @RequestHeader(value = "Accept", required = false) String accept) throws Exception {
+    default ResponseEntity<Void> updateUser(@ApiParam(value = "name that need to be deleted",required=true) @PathVariable("username") String username,@ApiParam(value = "Updated user object" ,required=true )  @Valid @RequestBody User body) {
         // do some magic!
-        return new ResponseEntity<Void>(HttpStatus.OK);
+        return new ResponseEntity<Void>(HttpStatus.NOT_IMPLEMENTED);
     }
 
 }

--- a/samples/server/petstore/springboot-delegate-j8/src/main/java/io/swagger/api/UserApiController.java
+++ b/samples/server/petstore/springboot-delegate-j8/src/main/java/io/swagger/api/UserApiController.java
@@ -22,19 +22,12 @@ import org.springframework.web.multipart.MultipartFile;
 import java.util.List;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.IOException;
+import javax.servlet.http.HttpServletRequest;
 import javax.validation.constraints.*;
 import javax.validation.Valid;
 
 @Controller
 public class UserApiController implements UserApi {
-
-    private final Logger log = LoggerFactory.getLogger(AnotherFakeApiController.class);
-
-    private final ObjectMapper objectMapper;
-
-    public UserApiController(ObjectMapper objectMapper) {
-        this.objectMapper = objectMapper;
-    }
 
     private final UserApiDelegate delegate;
 

--- a/samples/server/petstore/springboot-delegate-j8/src/main/java/io/swagger/api/UserApiController.java
+++ b/samples/server/petstore/springboot-delegate-j8/src/main/java/io/swagger/api/UserApiController.java
@@ -1,30 +1,6 @@
 package io.swagger.api;
 
-import java.util.List;
-import io.swagger.model.User;
-
-import io.swagger.annotations.*;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import org.springframework.http.HttpStatus;
-import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestHeader;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RequestPart;
-import org.springframework.web.context.request.RequestContextHolder;
-import org.springframework.web.context.request.ServletRequestAttributes;
-import org.springframework.web.multipart.MultipartFile;
-
-import java.util.List;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import java.io.IOException;
-import javax.servlet.http.HttpServletRequest;
-import javax.validation.constraints.*;
-import javax.validation.Valid;
 
 @Controller
 public class UserApiController implements UserApi {
@@ -36,44 +12,8 @@ public class UserApiController implements UserApi {
         this.delegate = delegate;
     }
 
-    public ResponseEntity<Void> createUser(@ApiParam(value = "Created user object" ,required=true )  @Valid @RequestBody User body) {
-        // do some magic!
-        return delegate.createUser(body);
+    @Override
+    public UserApiDelegate getDelegate() {
+        return delegate;
     }
-
-    public ResponseEntity<Void> createUsersWithArrayInput(@ApiParam(value = "List of user object" ,required=true )  @Valid @RequestBody List<User> body) {
-        // do some magic!
-        return delegate.createUsersWithArrayInput(body);
-    }
-
-    public ResponseEntity<Void> createUsersWithListInput(@ApiParam(value = "List of user object" ,required=true )  @Valid @RequestBody List<User> body) {
-        // do some magic!
-        return delegate.createUsersWithListInput(body);
-    }
-
-    public ResponseEntity<Void> deleteUser(@ApiParam(value = "The name that needs to be deleted",required=true) @PathVariable("username") String username) {
-        // do some magic!
-        return delegate.deleteUser(username);
-    }
-
-    public ResponseEntity<User> getUserByName(@ApiParam(value = "The name that needs to be fetched. Use user1 for testing. ",required=true) @PathVariable("username") String username) {
-        // do some magic!
-        return delegate.getUserByName(username);
-    }
-
-    public ResponseEntity<String> loginUser(@NotNull @ApiParam(value = "The user name for login", required = true) @Valid @RequestParam(value = "username", required = true) String username,@NotNull @ApiParam(value = "The password for login in clear text", required = true) @Valid @RequestParam(value = "password", required = true) String password) {
-        // do some magic!
-        return delegate.loginUser(username, password);
-    }
-
-    public ResponseEntity<Void> logoutUser() {
-        // do some magic!
-        return delegate.logoutUser();
-    }
-
-    public ResponseEntity<Void> updateUser(@ApiParam(value = "name that need to be deleted",required=true) @PathVariable("username") String username,@ApiParam(value = "Updated user object" ,required=true )  @Valid @RequestBody User body) {
-        // do some magic!
-        return delegate.updateUser(username, body);
-    }
-
 }

--- a/samples/server/petstore/springboot-delegate-j8/src/main/java/io/swagger/api/UserApiController.java
+++ b/samples/server/petstore/springboot-delegate-j8/src/main/java/io/swagger/api/UserApiController.java
@@ -5,6 +5,8 @@ import io.swagger.model.User;
 
 import io.swagger.annotations.*;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
@@ -13,6 +15,8 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RequestPart;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.util.List;
@@ -23,6 +27,9 @@ import javax.validation.Valid;
 
 @Controller
 public class UserApiController implements UserApi {
+
+    private final Logger log = LoggerFactory.getLogger(AnotherFakeApiController.class);
+
     private final ObjectMapper objectMapper;
 
     public UserApiController(ObjectMapper objectMapper) {
@@ -36,51 +43,42 @@ public class UserApiController implements UserApi {
         this.delegate = delegate;
     }
 
-    public ResponseEntity<Void> createUser(@ApiParam(value = "Created user object" ,required=true )  @Valid @RequestBody User body,
-        @RequestHeader(value = "Accept", required = false) String accept) throws Exception {
+    public ResponseEntity<Void> createUser(@ApiParam(value = "Created user object" ,required=true )  @Valid @RequestBody User body) {
         // do some magic!
         return delegate.createUser(body);
     }
 
-    public ResponseEntity<Void> createUsersWithArrayInput(@ApiParam(value = "List of user object" ,required=true )  @Valid @RequestBody List<User> body,
-        @RequestHeader(value = "Accept", required = false) String accept) throws Exception {
+    public ResponseEntity<Void> createUsersWithArrayInput(@ApiParam(value = "List of user object" ,required=true )  @Valid @RequestBody List<User> body) {
         // do some magic!
         return delegate.createUsersWithArrayInput(body);
     }
 
-    public ResponseEntity<Void> createUsersWithListInput(@ApiParam(value = "List of user object" ,required=true )  @Valid @RequestBody List<User> body,
-        @RequestHeader(value = "Accept", required = false) String accept) throws Exception {
+    public ResponseEntity<Void> createUsersWithListInput(@ApiParam(value = "List of user object" ,required=true )  @Valid @RequestBody List<User> body) {
         // do some magic!
         return delegate.createUsersWithListInput(body);
     }
 
-    public ResponseEntity<Void> deleteUser(@ApiParam(value = "The name that needs to be deleted",required=true) @PathVariable("username") String username,
-        @RequestHeader(value = "Accept", required = false) String accept) throws Exception {
+    public ResponseEntity<Void> deleteUser(@ApiParam(value = "The name that needs to be deleted",required=true) @PathVariable("username") String username) {
         // do some magic!
         return delegate.deleteUser(username);
     }
 
-    public ResponseEntity<User> getUserByName(@ApiParam(value = "The name that needs to be fetched. Use user1 for testing. ",required=true) @PathVariable("username") String username,
-        @RequestHeader(value = "Accept", required = false) String accept) throws Exception {
+    public ResponseEntity<User> getUserByName(@ApiParam(value = "The name that needs to be fetched. Use user1 for testing. ",required=true) @PathVariable("username") String username) {
         // do some magic!
         return delegate.getUserByName(username);
     }
 
-    public ResponseEntity<String> loginUser( @NotNull@ApiParam(value = "The user name for login", required = true) @Valid @RequestParam(value = "username", required = true) String username,
-         @NotNull@ApiParam(value = "The password for login in clear text", required = true) @Valid @RequestParam(value = "password", required = true) String password,
-        @RequestHeader(value = "Accept", required = false) String accept) throws Exception {
+    public ResponseEntity<String> loginUser(@NotNull @ApiParam(value = "The user name for login", required = true) @Valid @RequestParam(value = "username", required = true) String username,@NotNull @ApiParam(value = "The password for login in clear text", required = true) @Valid @RequestParam(value = "password", required = true) String password) {
         // do some magic!
         return delegate.loginUser(username, password);
     }
 
-    public ResponseEntity<Void> logoutUser(@RequestHeader(value = "Accept", required = false) String accept) throws Exception {
+    public ResponseEntity<Void> logoutUser() {
         // do some magic!
         return delegate.logoutUser();
     }
 
-    public ResponseEntity<Void> updateUser(@ApiParam(value = "name that need to be deleted",required=true) @PathVariable("username") String username,
-        @ApiParam(value = "Updated user object" ,required=true )  @Valid @RequestBody User body,
-        @RequestHeader(value = "Accept", required = false) String accept) throws Exception {
+    public ResponseEntity<Void> updateUser(@ApiParam(value = "name that need to be deleted",required=true) @PathVariable("username") String username,@ApiParam(value = "Updated user object" ,required=true )  @Valid @RequestBody User body) {
         // do some magic!
         return delegate.updateUser(username, body);
     }

--- a/samples/server/petstore/springboot-delegate-j8/src/main/java/io/swagger/api/UserApiDelegate.java
+++ b/samples/server/petstore/springboot-delegate-j8/src/main/java/io/swagger/api/UserApiDelegate.java
@@ -2,60 +2,109 @@ package io.swagger.api;
 
 import java.util.List;
 import io.swagger.model.User;
-
+import com.fasterxml.jackson.databind.ObjectMapper;
 import io.swagger.annotations.*;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.multipart.MultipartFile;
+import java.io.IOException;
 
+import javax.servlet.http.HttpServletRequest;
 import java.util.List;
+import java.util.Optional;
 
 /**
  * A delegate to be called by the {@link UserApiController}}.
- * Should be implemented as a controller but without the {@link org.springframework.stereotype.Controller} annotation.
- * Instead, use spring to autowire this class into the {@link UserApiController}.
+ * Implement this interface with a {@link org.springframework.stereotype.Service} annotated class.
  */
 
 public interface UserApiDelegate {
+
+    Logger log = LoggerFactory.getLogger(UserApi.class);
+
+    default Optional<ObjectMapper> getObjectMapper() {
+        return Optional.empty();
+    }
+
+    default Optional<HttpServletRequest> getRequest() {
+        return Optional.empty();
+    }
+
+    default Optional<String> getAcceptHeader() {
+        return getRequest().map(r -> r.getHeader("Accept"));
+    }
 
     /**
      * @see UserApi#createUser
      */
     default ResponseEntity<Void> createUser(User body) {
-        // do some magic!
-        return new ResponseEntity<Void>(HttpStatus.NOT_IMPLEMENTED);
+        if(getObjectMapper().isPresent() && getAcceptHeader().isPresent()) {
+        } else {
+            log.warn("ObjectMapper or HttpServletRequest not configured in default UserApi interface so no example is generated");
+        }
+        return new ResponseEntity<>(HttpStatus.NOT_IMPLEMENTED);
     }
 
     /**
      * @see UserApi#createUsersWithArrayInput
      */
     default ResponseEntity<Void> createUsersWithArrayInput(List<User> body) {
-        // do some magic!
-        return new ResponseEntity<Void>(HttpStatus.NOT_IMPLEMENTED);
+        if(getObjectMapper().isPresent() && getAcceptHeader().isPresent()) {
+        } else {
+            log.warn("ObjectMapper or HttpServletRequest not configured in default UserApi interface so no example is generated");
+        }
+        return new ResponseEntity<>(HttpStatus.NOT_IMPLEMENTED);
     }
 
     /**
      * @see UserApi#createUsersWithListInput
      */
     default ResponseEntity<Void> createUsersWithListInput(List<User> body) {
-        // do some magic!
-        return new ResponseEntity<Void>(HttpStatus.NOT_IMPLEMENTED);
+        if(getObjectMapper().isPresent() && getAcceptHeader().isPresent()) {
+        } else {
+            log.warn("ObjectMapper or HttpServletRequest not configured in default UserApi interface so no example is generated");
+        }
+        return new ResponseEntity<>(HttpStatus.NOT_IMPLEMENTED);
     }
 
     /**
      * @see UserApi#deleteUser
      */
     default ResponseEntity<Void> deleteUser(String username) {
-        // do some magic!
-        return new ResponseEntity<Void>(HttpStatus.NOT_IMPLEMENTED);
+        if(getObjectMapper().isPresent() && getAcceptHeader().isPresent()) {
+        } else {
+            log.warn("ObjectMapper or HttpServletRequest not configured in default UserApi interface so no example is generated");
+        }
+        return new ResponseEntity<>(HttpStatus.NOT_IMPLEMENTED);
     }
 
     /**
      * @see UserApi#getUserByName
      */
     default ResponseEntity<User> getUserByName(String username) {
-        // do some magic!
-        return new ResponseEntity<User>(HttpStatus.NOT_IMPLEMENTED);
+        if(getObjectMapper().isPresent() && getAcceptHeader().isPresent()) {
+            if (getAcceptHeader().get().contains("application/xml")) {
+                try {
+                    return new ResponseEntity<>(getObjectMapper().get().readValue("<User>  <id>123456789</id>  <username>aeiou</username>  <firstName>aeiou</firstName>  <lastName>aeiou</lastName>  <email>aeiou</email>  <password>aeiou</password>  <phone>aeiou</phone>  <userStatus>123</userStatus></User>", User.class), HttpStatus.NOT_IMPLEMENTED);
+                } catch (IOException e) {
+                    log.error("Couldn't serialize response for content type application/xml", e);
+                    return new ResponseEntity<>(HttpStatus.INTERNAL_SERVER_ERROR);
+                }
+            }
+            if (getAcceptHeader().get().contains("application/json")) {
+                try {
+                    return new ResponseEntity<>(getObjectMapper().get().readValue("{  \"firstName\" : \"firstName\",  \"lastName\" : \"lastName\",  \"password\" : \"password\",  \"userStatus\" : 6,  \"phone\" : \"phone\",  \"id\" : 0,  \"email\" : \"email\",  \"username\" : \"username\"}", User.class), HttpStatus.NOT_IMPLEMENTED);
+                } catch (IOException e) {
+                    log.error("Couldn't serialize response for content type application/json", e);
+                    return new ResponseEntity<>(HttpStatus.INTERNAL_SERVER_ERROR);
+                }
+            }
+        } else {
+            log.warn("ObjectMapper or HttpServletRequest not configured in default UserApi interface so no example is generated");
+        }
+        return new ResponseEntity<>(HttpStatus.NOT_IMPLEMENTED);
     }
 
     /**
@@ -63,16 +112,38 @@ public interface UserApiDelegate {
      */
     default ResponseEntity<String> loginUser(String username,
         String password) {
-        // do some magic!
-        return new ResponseEntity<String>(HttpStatus.NOT_IMPLEMENTED);
+        if(getObjectMapper().isPresent() && getAcceptHeader().isPresent()) {
+            if (getAcceptHeader().get().contains("application/xml")) {
+                try {
+                    return new ResponseEntity<>(getObjectMapper().get().readValue("aeiou", String.class), HttpStatus.NOT_IMPLEMENTED);
+                } catch (IOException e) {
+                    log.error("Couldn't serialize response for content type application/xml", e);
+                    return new ResponseEntity<>(HttpStatus.INTERNAL_SERVER_ERROR);
+                }
+            }
+            if (getAcceptHeader().get().contains("application/json")) {
+                try {
+                    return new ResponseEntity<>(getObjectMapper().get().readValue("\"\"", String.class), HttpStatus.NOT_IMPLEMENTED);
+                } catch (IOException e) {
+                    log.error("Couldn't serialize response for content type application/json", e);
+                    return new ResponseEntity<>(HttpStatus.INTERNAL_SERVER_ERROR);
+                }
+            }
+        } else {
+            log.warn("ObjectMapper or HttpServletRequest not configured in default UserApi interface so no example is generated");
+        }
+        return new ResponseEntity<>(HttpStatus.NOT_IMPLEMENTED);
     }
 
     /**
      * @see UserApi#logoutUser
      */
     default ResponseEntity<Void> logoutUser() {
-        // do some magic!
-        return new ResponseEntity<Void>(HttpStatus.NOT_IMPLEMENTED);
+        if(getObjectMapper().isPresent() && getAcceptHeader().isPresent()) {
+        } else {
+            log.warn("ObjectMapper or HttpServletRequest not configured in default UserApi interface so no example is generated");
+        }
+        return new ResponseEntity<>(HttpStatus.NOT_IMPLEMENTED);
     }
 
     /**
@@ -80,8 +151,11 @@ public interface UserApiDelegate {
      */
     default ResponseEntity<Void> updateUser(String username,
         User body) {
-        // do some magic!
-        return new ResponseEntity<Void>(HttpStatus.NOT_IMPLEMENTED);
+        if(getObjectMapper().isPresent() && getAcceptHeader().isPresent()) {
+        } else {
+            log.warn("ObjectMapper or HttpServletRequest not configured in default UserApi interface so no example is generated");
+        }
+        return new ResponseEntity<>(HttpStatus.NOT_IMPLEMENTED);
     }
 
 }

--- a/samples/server/petstore/springboot-delegate-j8/src/main/java/io/swagger/api/UserApiDelegate.java
+++ b/samples/server/petstore/springboot-delegate-j8/src/main/java/io/swagger/api/UserApiDelegate.java
@@ -23,7 +23,7 @@ public interface UserApiDelegate {
      */
     default ResponseEntity<Void> createUser(User body) {
     // do some magic!
-    return new ResponseEntity<Void>(HttpStatus.OK);
+    return new ResponseEntity<Void>(HttpStatus.NOT_IMPLEMENTED);
     }
 
     /**
@@ -31,7 +31,7 @@ public interface UserApiDelegate {
      */
     default ResponseEntity<Void> createUsersWithArrayInput(List<User> body) {
     // do some magic!
-    return new ResponseEntity<Void>(HttpStatus.OK);
+    return new ResponseEntity<Void>(HttpStatus.NOT_IMPLEMENTED);
     }
 
     /**
@@ -39,7 +39,7 @@ public interface UserApiDelegate {
      */
     default ResponseEntity<Void> createUsersWithListInput(List<User> body) {
     // do some magic!
-    return new ResponseEntity<Void>(HttpStatus.OK);
+    return new ResponseEntity<Void>(HttpStatus.NOT_IMPLEMENTED);
     }
 
     /**
@@ -47,7 +47,7 @@ public interface UserApiDelegate {
      */
     default ResponseEntity<Void> deleteUser(String username) {
     // do some magic!
-    return new ResponseEntity<Void>(HttpStatus.OK);
+    return new ResponseEntity<Void>(HttpStatus.NOT_IMPLEMENTED);
     }
 
     /**
@@ -55,7 +55,7 @@ public interface UserApiDelegate {
      */
     default ResponseEntity<User> getUserByName(String username) {
     // do some magic!
-    return new ResponseEntity<User>(HttpStatus.OK);
+    return new ResponseEntity<User>(HttpStatus.NOT_IMPLEMENTED);
     }
 
     /**
@@ -64,7 +64,7 @@ public interface UserApiDelegate {
     default ResponseEntity<String> loginUser(String username,
         String password) {
     // do some magic!
-    return new ResponseEntity<String>(HttpStatus.OK);
+    return new ResponseEntity<String>(HttpStatus.NOT_IMPLEMENTED);
     }
 
     /**
@@ -72,7 +72,7 @@ public interface UserApiDelegate {
      */
     default ResponseEntity<Void> logoutUser() {
     // do some magic!
-    return new ResponseEntity<Void>(HttpStatus.OK);
+    return new ResponseEntity<Void>(HttpStatus.NOT_IMPLEMENTED);
     }
 
     /**
@@ -81,7 +81,7 @@ public interface UserApiDelegate {
     default ResponseEntity<Void> updateUser(String username,
         User body) {
     // do some magic!
-    return new ResponseEntity<Void>(HttpStatus.OK);
+    return new ResponseEntity<Void>(HttpStatus.NOT_IMPLEMENTED);
     }
 
 }

--- a/samples/server/petstore/springboot-delegate-j8/src/main/java/io/swagger/api/UserApiDelegate.java
+++ b/samples/server/petstore/springboot-delegate-j8/src/main/java/io/swagger/api/UserApiDelegate.java
@@ -22,40 +22,40 @@ public interface UserApiDelegate {
      * @see UserApi#createUser
      */
     default ResponseEntity<Void> createUser(User body) {
-    // do some magic!
-    return new ResponseEntity<Void>(HttpStatus.NOT_IMPLEMENTED);
+        // do some magic!
+        return new ResponseEntity<Void>(HttpStatus.NOT_IMPLEMENTED);
     }
 
     /**
      * @see UserApi#createUsersWithArrayInput
      */
     default ResponseEntity<Void> createUsersWithArrayInput(List<User> body) {
-    // do some magic!
-    return new ResponseEntity<Void>(HttpStatus.NOT_IMPLEMENTED);
+        // do some magic!
+        return new ResponseEntity<Void>(HttpStatus.NOT_IMPLEMENTED);
     }
 
     /**
      * @see UserApi#createUsersWithListInput
      */
     default ResponseEntity<Void> createUsersWithListInput(List<User> body) {
-    // do some magic!
-    return new ResponseEntity<Void>(HttpStatus.NOT_IMPLEMENTED);
+        // do some magic!
+        return new ResponseEntity<Void>(HttpStatus.NOT_IMPLEMENTED);
     }
 
     /**
      * @see UserApi#deleteUser
      */
     default ResponseEntity<Void> deleteUser(String username) {
-    // do some magic!
-    return new ResponseEntity<Void>(HttpStatus.NOT_IMPLEMENTED);
+        // do some magic!
+        return new ResponseEntity<Void>(HttpStatus.NOT_IMPLEMENTED);
     }
 
     /**
      * @see UserApi#getUserByName
      */
     default ResponseEntity<User> getUserByName(String username) {
-    // do some magic!
-    return new ResponseEntity<User>(HttpStatus.NOT_IMPLEMENTED);
+        // do some magic!
+        return new ResponseEntity<User>(HttpStatus.NOT_IMPLEMENTED);
     }
 
     /**
@@ -63,16 +63,16 @@ public interface UserApiDelegate {
      */
     default ResponseEntity<String> loginUser(String username,
         String password) {
-    // do some magic!
-    return new ResponseEntity<String>(HttpStatus.NOT_IMPLEMENTED);
+        // do some magic!
+        return new ResponseEntity<String>(HttpStatus.NOT_IMPLEMENTED);
     }
 
     /**
      * @see UserApi#logoutUser
      */
     default ResponseEntity<Void> logoutUser() {
-    // do some magic!
-    return new ResponseEntity<Void>(HttpStatus.NOT_IMPLEMENTED);
+        // do some magic!
+        return new ResponseEntity<Void>(HttpStatus.NOT_IMPLEMENTED);
     }
 
     /**
@@ -80,8 +80,8 @@ public interface UserApiDelegate {
      */
     default ResponseEntity<Void> updateUser(String username,
         User body) {
-    // do some magic!
-    return new ResponseEntity<Void>(HttpStatus.NOT_IMPLEMENTED);
+        // do some magic!
+        return new ResponseEntity<Void>(HttpStatus.NOT_IMPLEMENTED);
     }
 
 }

--- a/samples/server/petstore/springboot-delegate-j8/src/main/java/io/swagger/model/FormatTest.java
+++ b/samples/server/petstore/springboot-delegate-j8/src/main/java/io/swagger/model/FormatTest.java
@@ -71,7 +71,7 @@ public class FormatTest   {
   **/
   @ApiModelProperty(value = "")
 
- @Min(10) @Max(100)
+@Min(10) @Max(100) 
   public Integer getInteger() {
     return integer;
   }
@@ -93,7 +93,7 @@ public class FormatTest   {
   **/
   @ApiModelProperty(value = "")
 
- @Min(20) @Max(200)
+@Min(20) @Max(200) 
   public Integer getInt32() {
     return int32;
   }
@@ -137,7 +137,7 @@ public class FormatTest   {
   @NotNull
 
   @Valid
- @DecimalMin("32.1") @DecimalMax("543.2")
+@DecimalMin("32.1") @DecimalMax("543.2") 
   public BigDecimal getNumber() {
     return number;
   }
@@ -159,7 +159,7 @@ public class FormatTest   {
   **/
   @ApiModelProperty(value = "")
 
- @DecimalMin("54.3") @DecimalMax("987.6")
+@DecimalMin("54.3") @DecimalMax("987.6") 
   public Float getFloat() {
     return _float;
   }
@@ -181,7 +181,7 @@ public class FormatTest   {
   **/
   @ApiModelProperty(value = "")
 
- @DecimalMin("67.8") @DecimalMax("123.4")
+@DecimalMin("67.8") @DecimalMax("123.4") 
   public Double getDouble() {
     return _double;
   }
@@ -201,7 +201,7 @@ public class FormatTest   {
   **/
   @ApiModelProperty(value = "")
 
- @Pattern(regexp="/[a-z]/i")
+@Pattern(regexp="/[a-z]/i") 
   public String getString() {
     return string;
   }
@@ -222,7 +222,7 @@ public class FormatTest   {
   @ApiModelProperty(required = true, value = "")
   @NotNull
 
- @Pattern(regexp="^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$")
+@Pattern(regexp="^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$") 
   public byte[] getByte() {
     return _byte;
   }
@@ -327,7 +327,7 @@ public class FormatTest   {
   @ApiModelProperty(required = true, value = "")
   @NotNull
 
- @Size(min=10,max=64)
+@Size(min=10,max=64) 
   public String getPassword() {
     return password;
   }

--- a/samples/server/petstore/springboot-delegate/src/main/java/io/swagger/api/AnotherFakeApi.java
+++ b/samples/server/petstore/springboot-delegate/src/main/java/io/swagger/api/AnotherFakeApi.java
@@ -34,6 +34,6 @@ public interface AnotherFakeApi {
         produces = { "application/json" }, 
         consumes = { "application/json" },
         method = RequestMethod.PATCH)
-    ResponseEntity<Client> testSpecialTags(@ApiParam(value = "client model" ,required=true )  @Valid @RequestBody Client body, @RequestHeader(value = "Accept", required = false) String accept) throws Exception;
+    ResponseEntity<Client> testSpecialTags(@ApiParam(value = "client model" ,required=true )  @Valid @RequestBody Client body);
 
 }

--- a/samples/server/petstore/springboot-delegate/src/main/java/io/swagger/api/AnotherFakeApi.java
+++ b/samples/server/petstore/springboot-delegate/src/main/java/io/swagger/api/AnotherFakeApi.java
@@ -6,9 +6,9 @@
 package io.swagger.api;
 
 import io.swagger.model.Client;
-
 import io.swagger.annotations.*;
 import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
@@ -17,12 +17,10 @@ import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.multipart.MultipartFile;
-import java.io.IOException;
 
-import java.util.List;
-import org.springframework.validation.annotation.Validated;
-import javax.validation.constraints.*;
 import javax.validation.Valid;
+import javax.validation.constraints.*;
+import java.util.List;
 
 @Api(value = "another-fake", description = "the another-fake API")
 public interface AnotherFakeApi {

--- a/samples/server/petstore/springboot-delegate/src/main/java/io/swagger/api/AnotherFakeApiController.java
+++ b/samples/server/petstore/springboot-delegate/src/main/java/io/swagger/api/AnotherFakeApiController.java
@@ -4,6 +4,8 @@ import io.swagger.model.Client;
 
 import io.swagger.annotations.*;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
@@ -12,6 +14,8 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RequestPart;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.util.List;
@@ -22,6 +26,9 @@ import javax.validation.Valid;
 
 @Controller
 public class AnotherFakeApiController implements AnotherFakeApi {
+
+    private final Logger log = LoggerFactory.getLogger(AnotherFakeApiController.class);
+
     private final ObjectMapper objectMapper;
 
     public AnotherFakeApiController(ObjectMapper objectMapper) {
@@ -35,8 +42,7 @@ public class AnotherFakeApiController implements AnotherFakeApi {
         this.delegate = delegate;
     }
 
-    public ResponseEntity<Client> testSpecialTags(@ApiParam(value = "client model" ,required=true )  @Valid @RequestBody Client body,
-        @RequestHeader(value = "Accept", required = false) String accept) throws Exception {
+    public ResponseEntity<Client> testSpecialTags(@ApiParam(value = "client model" ,required=true )  @Valid @RequestBody Client body) {
         // do some magic!
         return delegate.testSpecialTags(body);
     }

--- a/samples/server/petstore/springboot-delegate/src/main/java/io/swagger/api/AnotherFakeApiController.java
+++ b/samples/server/petstore/springboot-delegate/src/main/java/io/swagger/api/AnotherFakeApiController.java
@@ -21,19 +21,12 @@ import org.springframework.web.multipart.MultipartFile;
 import java.util.List;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.IOException;
+import javax.servlet.http.HttpServletRequest;
 import javax.validation.constraints.*;
 import javax.validation.Valid;
 
 @Controller
 public class AnotherFakeApiController implements AnotherFakeApi {
-
-    private final Logger log = LoggerFactory.getLogger(AnotherFakeApiController.class);
-
-    private final ObjectMapper objectMapper;
-
-    public AnotherFakeApiController(ObjectMapper objectMapper) {
-        this.objectMapper = objectMapper;
-    }
 
     private final AnotherFakeApiDelegate delegate;
 

--- a/samples/server/petstore/springboot-delegate/src/main/java/io/swagger/api/AnotherFakeApiController.java
+++ b/samples/server/petstore/springboot-delegate/src/main/java/io/swagger/api/AnotherFakeApiController.java
@@ -1,9 +1,7 @@
 package io.swagger.api;
 
 import io.swagger.model.Client;
-
 import io.swagger.annotations.*;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpStatus;
@@ -14,16 +12,11 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RequestPart;
-import org.springframework.web.context.request.RequestContextHolder;
-import org.springframework.web.context.request.ServletRequestAttributes;
 import org.springframework.web.multipart.MultipartFile;
 
-import java.util.List;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import java.io.IOException;
-import javax.servlet.http.HttpServletRequest;
 import javax.validation.constraints.*;
 import javax.validation.Valid;
+import java.util.List;
 
 @Controller
 public class AnotherFakeApiController implements AnotherFakeApi {
@@ -34,9 +27,7 @@ public class AnotherFakeApiController implements AnotherFakeApi {
     public AnotherFakeApiController(AnotherFakeApiDelegate delegate) {
         this.delegate = delegate;
     }
-
     public ResponseEntity<Client> testSpecialTags(@ApiParam(value = "client model" ,required=true )  @Valid @RequestBody Client body) {
-        // do some magic!
         return delegate.testSpecialTags(body);
     }
 

--- a/samples/server/petstore/springboot-delegate/src/main/java/io/swagger/api/AnotherFakeApiDelegate.java
+++ b/samples/server/petstore/springboot-delegate/src/main/java/io/swagger/api/AnotherFakeApiDelegate.java
@@ -1,7 +1,6 @@
 package io.swagger.api;
 
 import io.swagger.model.Client;
-
 import io.swagger.annotations.*;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.multipart.MultipartFile;
@@ -10,8 +9,7 @@ import java.util.List;
 
 /**
  * A delegate to be called by the {@link AnotherFakeApiController}}.
- * Should be implemented as a controller but without the {@link org.springframework.stereotype.Controller} annotation.
- * Instead, use spring to autowire this class into the {@link AnotherFakeApiController}.
+ * Implement this interface with a {@link org.springframework.stereotype.Service} annotated class.
  */
 
 public interface AnotherFakeApiDelegate {

--- a/samples/server/petstore/springboot-delegate/src/main/java/io/swagger/api/FakeApi.java
+++ b/samples/server/petstore/springboot-delegate/src/main/java/io/swagger/api/FakeApi.java
@@ -10,9 +10,9 @@ import io.swagger.model.Client;
 import org.threeten.bp.LocalDate;
 import org.threeten.bp.OffsetDateTime;
 import io.swagger.model.OuterComposite;
-
 import io.swagger.annotations.*;
 import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
@@ -21,12 +21,10 @@ import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.multipart.MultipartFile;
-import java.io.IOException;
 
-import java.util.List;
-import org.springframework.validation.annotation.Validated;
-import javax.validation.constraints.*;
 import javax.validation.Valid;
+import javax.validation.constraints.*;
+import java.util.List;
 
 @Api(value = "fake", description = "the fake API")
 public interface FakeApi {

--- a/samples/server/petstore/springboot-delegate/src/main/java/io/swagger/api/FakeApi.java
+++ b/samples/server/petstore/springboot-delegate/src/main/java/io/swagger/api/FakeApi.java
@@ -36,7 +36,7 @@ public interface FakeApi {
         @ApiResponse(code = 200, message = "Output boolean", response = Boolean.class) })
     @RequestMapping(value = "/fake/outer/boolean",
         method = RequestMethod.POST)
-    ResponseEntity<Boolean> fakeOuterBooleanSerialize(@ApiParam(value = "Input boolean as post body"  )  @Valid @RequestBody Boolean body, @RequestHeader(value = "Accept", required = false) String accept) throws Exception;
+    ResponseEntity<Boolean> fakeOuterBooleanSerialize(@ApiParam(value = "Input boolean as post body"  )  @Valid @RequestBody Boolean body);
 
 
     @ApiOperation(value = "", nickname = "fakeOuterCompositeSerialize", notes = "Test serialization of object with outer number type", response = OuterComposite.class, tags={ "fake", })
@@ -44,7 +44,7 @@ public interface FakeApi {
         @ApiResponse(code = 200, message = "Output composite", response = OuterComposite.class) })
     @RequestMapping(value = "/fake/outer/composite",
         method = RequestMethod.POST)
-    ResponseEntity<OuterComposite> fakeOuterCompositeSerialize(@ApiParam(value = "Input composite as post body"  )  @Valid @RequestBody OuterComposite body, @RequestHeader(value = "Accept", required = false) String accept) throws Exception;
+    ResponseEntity<OuterComposite> fakeOuterCompositeSerialize(@ApiParam(value = "Input composite as post body"  )  @Valid @RequestBody OuterComposite body);
 
 
     @ApiOperation(value = "", nickname = "fakeOuterNumberSerialize", notes = "Test serialization of outer number types", response = BigDecimal.class, tags={ "fake", })
@@ -52,7 +52,7 @@ public interface FakeApi {
         @ApiResponse(code = 200, message = "Output number", response = BigDecimal.class) })
     @RequestMapping(value = "/fake/outer/number",
         method = RequestMethod.POST)
-    ResponseEntity<BigDecimal> fakeOuterNumberSerialize(@ApiParam(value = "Input number as post body"  )  @Valid @RequestBody BigDecimal body, @RequestHeader(value = "Accept", required = false) String accept) throws Exception;
+    ResponseEntity<BigDecimal> fakeOuterNumberSerialize(@ApiParam(value = "Input number as post body"  )  @Valid @RequestBody BigDecimal body);
 
 
     @ApiOperation(value = "", nickname = "fakeOuterStringSerialize", notes = "Test serialization of outer string types", response = String.class, tags={ "fake", })
@@ -60,7 +60,7 @@ public interface FakeApi {
         @ApiResponse(code = 200, message = "Output string", response = String.class) })
     @RequestMapping(value = "/fake/outer/string",
         method = RequestMethod.POST)
-    ResponseEntity<String> fakeOuterStringSerialize(@ApiParam(value = "Input string as post body"  )  @Valid @RequestBody String body, @RequestHeader(value = "Accept", required = false) String accept) throws Exception;
+    ResponseEntity<String> fakeOuterStringSerialize(@ApiParam(value = "Input string as post body"  )  @Valid @RequestBody String body);
 
 
     @ApiOperation(value = "To test \"client\" model", nickname = "testClientModel", notes = "To test \"client\" model", response = Client.class, tags={ "fake", })
@@ -70,7 +70,7 @@ public interface FakeApi {
         produces = { "application/json" }, 
         consumes = { "application/json" },
         method = RequestMethod.PATCH)
-    ResponseEntity<Client> testClientModel(@ApiParam(value = "client model" ,required=true )  @Valid @RequestBody Client body, @RequestHeader(value = "Accept", required = false) String accept) throws Exception;
+    ResponseEntity<Client> testClientModel(@ApiParam(value = "client model" ,required=true )  @Valid @RequestBody Client body);
 
 
     @ApiOperation(value = "Fake endpoint for testing various parameters 假端點 偽のエンドポイント 가짜 엔드 포인트 ", nickname = "testEndpointParameters", notes = "Fake endpoint for testing various parameters 假端點 偽のエンドポイント 가짜 엔드 포인트 ", authorizations = {
@@ -83,7 +83,7 @@ public interface FakeApi {
         produces = { "application/xml; charset=utf-8", "application/json; charset=utf-8" }, 
         consumes = { "application/xml; charset=utf-8", "application/json; charset=utf-8" },
         method = RequestMethod.POST)
-    ResponseEntity<Void> testEndpointParameters(@ApiParam(value = "None", required=true) @RequestPart(value="number", required=true)  BigDecimal number,@ApiParam(value = "None", required=true) @RequestPart(value="double", required=true)  Double _double,@ApiParam(value = "None", required=true) @RequestPart(value="pattern_without_delimiter", required=true)  String patternWithoutDelimiter,@ApiParam(value = "None", required=true) @RequestPart(value="byte", required=true)  byte[] _byte,@ApiParam(value = "None") @RequestPart(value="integer", required=false)  Integer integer,@ApiParam(value = "None") @RequestPart(value="int32", required=false)  Integer int32,@ApiParam(value = "None") @RequestPart(value="int64", required=false)  Long int64,@ApiParam(value = "None") @RequestPart(value="float", required=false)  Float _float,@ApiParam(value = "None") @RequestPart(value="string", required=false)  String string,@ApiParam(value = "None") @RequestPart(value="binary", required=false)  byte[] binary,@ApiParam(value = "None") @RequestPart(value="date", required=false)  LocalDate date,@ApiParam(value = "None") @RequestPart(value="dateTime", required=false)  OffsetDateTime dateTime,@ApiParam(value = "None") @RequestPart(value="password", required=false)  String password,@ApiParam(value = "None") @RequestPart(value="callback", required=false)  String paramCallback, @RequestHeader(value = "Accept", required = false) String accept) throws Exception;
+    ResponseEntity<Void> testEndpointParameters(@ApiParam(value = "None", required=true) @RequestPart(value="number", required=true)  BigDecimal number,@ApiParam(value = "None", required=true) @RequestPart(value="double", required=true)  Double _double,@ApiParam(value = "None", required=true) @RequestPart(value="pattern_without_delimiter", required=true)  String patternWithoutDelimiter,@ApiParam(value = "None", required=true) @RequestPart(value="byte", required=true)  byte[] _byte,@ApiParam(value = "None") @RequestPart(value="integer", required=false)  Integer integer,@ApiParam(value = "None") @RequestPart(value="int32", required=false)  Integer int32,@ApiParam(value = "None") @RequestPart(value="int64", required=false)  Long int64,@ApiParam(value = "None") @RequestPart(value="float", required=false)  Float _float,@ApiParam(value = "None") @RequestPart(value="string", required=false)  String string,@ApiParam(value = "None") @RequestPart(value="binary", required=false)  byte[] binary,@ApiParam(value = "None") @RequestPart(value="date", required=false)  LocalDate date,@ApiParam(value = "None") @RequestPart(value="dateTime", required=false)  OffsetDateTime dateTime,@ApiParam(value = "None") @RequestPart(value="password", required=false)  String password,@ApiParam(value = "None") @RequestPart(value="callback", required=false)  String paramCallback);
 
 
     @ApiOperation(value = "To test enum parameters", nickname = "testEnumParameters", notes = "To test enum parameters", tags={ "fake", })
@@ -94,7 +94,7 @@ public interface FakeApi {
         produces = { "*/*" }, 
         consumes = { "*/*" },
         method = RequestMethod.GET)
-    ResponseEntity<Void> testEnumParameters(@ApiParam(value = "Form parameter enum test (string array)", allowableValues=">, $") @RequestPart(value="enum_form_string_array", required=false)  List<String> enumFormStringArray,@ApiParam(value = "Form parameter enum test (string)", allowableValues="_abc, -efg, (xyz)", defaultValue="-efg") @RequestPart(value="enum_form_string", required=false)  String enumFormString,@ApiParam(value = "Header parameter enum test (string array)" , allowableValues=">, $") @RequestHeader(value="enum_header_string_array", required=false) List<String> enumHeaderStringArray,@ApiParam(value = "Header parameter enum test (string)" , allowableValues="_abc, -efg, (xyz)", defaultValue="-efg") @RequestHeader(value="enum_header_string", required=false) String enumHeaderString,@ApiParam(value = "Query parameter enum test (string array)", allowableValues = ">, $") @Valid @RequestParam(value = "enum_query_string_array", required = false) List<String> enumQueryStringArray,@ApiParam(value = "Query parameter enum test (string)", allowableValues = "_abc, -efg, (xyz)", defaultValue = "-efg") @Valid @RequestParam(value = "enum_query_string", required = false, defaultValue="-efg") String enumQueryString,@ApiParam(value = "Query parameter enum test (double)", allowableValues = "1, -2") @Valid @RequestParam(value = "enum_query_integer", required = false) Integer enumQueryInteger,@ApiParam(value = "Query parameter enum test (double)", allowableValues="1.1, -1.2") @RequestPart(value="enum_query_double", required=false)  Double enumQueryDouble, @RequestHeader(value = "Accept", required = false) String accept) throws Exception;
+    ResponseEntity<Void> testEnumParameters(@ApiParam(value = "Form parameter enum test (string array)", allowableValues=">, $") @RequestPart(value="enum_form_string_array", required=false)  List<String> enumFormStringArray,@ApiParam(value = "Form parameter enum test (string)", allowableValues="_abc, -efg, (xyz)", defaultValue="-efg") @RequestPart(value="enum_form_string", required=false)  String enumFormString,@ApiParam(value = "Header parameter enum test (string array)" , allowableValues=">, $") @RequestHeader(value="enum_header_string_array", required=false) List<String> enumHeaderStringArray,@ApiParam(value = "Header parameter enum test (string)" , allowableValues="_abc, -efg, (xyz)", defaultValue="-efg") @RequestHeader(value="enum_header_string", required=false) String enumHeaderString,@ApiParam(value = "Query parameter enum test (string array)", allowableValues = ">, $") @Valid @RequestParam(value = "enum_query_string_array", required = false) List<String> enumQueryStringArray,@ApiParam(value = "Query parameter enum test (string)", allowableValues = "_abc, -efg, (xyz)", defaultValue = "-efg") @Valid @RequestParam(value = "enum_query_string", required = false, defaultValue="-efg") String enumQueryString,@ApiParam(value = "Query parameter enum test (double)", allowableValues = "1, -2") @Valid @RequestParam(value = "enum_query_integer", required = false) Integer enumQueryInteger,@ApiParam(value = "Query parameter enum test (double)", allowableValues="1.1, -1.2") @RequestPart(value="enum_query_double", required=false)  Double enumQueryDouble);
 
 
     @ApiOperation(value = "test inline additionalProperties", nickname = "testInlineAdditionalProperties", notes = "", tags={ "fake", })
@@ -103,7 +103,7 @@ public interface FakeApi {
     @RequestMapping(value = "/fake/inline-additionalProperties",
         consumes = { "application/json" },
         method = RequestMethod.POST)
-    ResponseEntity<Void> testInlineAdditionalProperties(@ApiParam(value = "request body" ,required=true )  @Valid @RequestBody Object param, @RequestHeader(value = "Accept", required = false) String accept) throws Exception;
+    ResponseEntity<Void> testInlineAdditionalProperties(@ApiParam(value = "request body" ,required=true )  @Valid @RequestBody Object param);
 
 
     @ApiOperation(value = "test json serialization of form data", nickname = "testJsonFormData", notes = "", tags={ "fake", })
@@ -112,6 +112,6 @@ public interface FakeApi {
     @RequestMapping(value = "/fake/jsonFormData",
         consumes = { "application/json" },
         method = RequestMethod.GET)
-    ResponseEntity<Void> testJsonFormData(@ApiParam(value = "field1", required=true) @RequestPart(value="param", required=true)  String param,@ApiParam(value = "field2", required=true) @RequestPart(value="param2", required=true)  String param2, @RequestHeader(value = "Accept", required = false) String accept) throws Exception;
+    ResponseEntity<Void> testJsonFormData(@ApiParam(value = "field1", required=true) @RequestPart(value="param", required=true)  String param,@ApiParam(value = "field2", required=true) @RequestPart(value="param2", required=true)  String param2);
 
 }

--- a/samples/server/petstore/springboot-delegate/src/main/java/io/swagger/api/FakeApiController.java
+++ b/samples/server/petstore/springboot-delegate/src/main/java/io/swagger/api/FakeApiController.java
@@ -25,19 +25,12 @@ import org.springframework.web.multipart.MultipartFile;
 import java.util.List;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.IOException;
+import javax.servlet.http.HttpServletRequest;
 import javax.validation.constraints.*;
 import javax.validation.Valid;
 
 @Controller
 public class FakeApiController implements FakeApi {
-
-    private final Logger log = LoggerFactory.getLogger(AnotherFakeApiController.class);
-
-    private final ObjectMapper objectMapper;
-
-    public FakeApiController(ObjectMapper objectMapper) {
-        this.objectMapper = objectMapper;
-    }
 
     private final FakeApiDelegate delegate;
 

--- a/samples/server/petstore/springboot-delegate/src/main/java/io/swagger/api/FakeApiController.java
+++ b/samples/server/petstore/springboot-delegate/src/main/java/io/swagger/api/FakeApiController.java
@@ -8,6 +8,8 @@ import io.swagger.model.OuterComposite;
 
 import io.swagger.annotations.*;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
@@ -16,6 +18,8 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RequestPart;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.util.List;
@@ -26,6 +30,9 @@ import javax.validation.Valid;
 
 @Controller
 public class FakeApiController implements FakeApi {
+
+    private final Logger log = LoggerFactory.getLogger(AnotherFakeApiController.class);
+
     private final ObjectMapper objectMapper;
 
     public FakeApiController(ObjectMapper objectMapper) {
@@ -39,77 +46,47 @@ public class FakeApiController implements FakeApi {
         this.delegate = delegate;
     }
 
-    public ResponseEntity<Boolean> fakeOuterBooleanSerialize(@ApiParam(value = "Input boolean as post body"  )  @Valid @RequestBody Boolean body,
-        @RequestHeader(value = "Accept", required = false) String accept) throws Exception {
+    public ResponseEntity<Boolean> fakeOuterBooleanSerialize(@ApiParam(value = "Input boolean as post body"  )  @Valid @RequestBody Boolean body) {
         // do some magic!
         return delegate.fakeOuterBooleanSerialize(body);
     }
 
-    public ResponseEntity<OuterComposite> fakeOuterCompositeSerialize(@ApiParam(value = "Input composite as post body"  )  @Valid @RequestBody OuterComposite body,
-        @RequestHeader(value = "Accept", required = false) String accept) throws Exception {
+    public ResponseEntity<OuterComposite> fakeOuterCompositeSerialize(@ApiParam(value = "Input composite as post body"  )  @Valid @RequestBody OuterComposite body) {
         // do some magic!
         return delegate.fakeOuterCompositeSerialize(body);
     }
 
-    public ResponseEntity<BigDecimal> fakeOuterNumberSerialize(@ApiParam(value = "Input number as post body"  )  @Valid @RequestBody BigDecimal body,
-        @RequestHeader(value = "Accept", required = false) String accept) throws Exception {
+    public ResponseEntity<BigDecimal> fakeOuterNumberSerialize(@ApiParam(value = "Input number as post body"  )  @Valid @RequestBody BigDecimal body) {
         // do some magic!
         return delegate.fakeOuterNumberSerialize(body);
     }
 
-    public ResponseEntity<String> fakeOuterStringSerialize(@ApiParam(value = "Input string as post body"  )  @Valid @RequestBody String body,
-        @RequestHeader(value = "Accept", required = false) String accept) throws Exception {
+    public ResponseEntity<String> fakeOuterStringSerialize(@ApiParam(value = "Input string as post body"  )  @Valid @RequestBody String body) {
         // do some magic!
         return delegate.fakeOuterStringSerialize(body);
     }
 
-    public ResponseEntity<Client> testClientModel(@ApiParam(value = "client model" ,required=true )  @Valid @RequestBody Client body,
-        @RequestHeader(value = "Accept", required = false) String accept) throws Exception {
+    public ResponseEntity<Client> testClientModel(@ApiParam(value = "client model" ,required=true )  @Valid @RequestBody Client body) {
         // do some magic!
         return delegate.testClientModel(body);
     }
 
-    public ResponseEntity<Void> testEndpointParameters(@ApiParam(value = "None", required=true) @RequestPart(value="number", required=true)  BigDecimal number,
-        @ApiParam(value = "None", required=true) @RequestPart(value="double", required=true)  Double _double,
-        @ApiParam(value = "None", required=true) @RequestPart(value="pattern_without_delimiter", required=true)  String patternWithoutDelimiter,
-        @ApiParam(value = "None", required=true) @RequestPart(value="byte", required=true)  byte[] _byte,
-        @ApiParam(value = "None") @RequestPart(value="integer", required=false)  Integer integer,
-        @ApiParam(value = "None") @RequestPart(value="int32", required=false)  Integer int32,
-        @ApiParam(value = "None") @RequestPart(value="int64", required=false)  Long int64,
-        @ApiParam(value = "None") @RequestPart(value="float", required=false)  Float _float,
-        @ApiParam(value = "None") @RequestPart(value="string", required=false)  String string,
-        @ApiParam(value = "None") @RequestPart(value="binary", required=false)  byte[] binary,
-        @ApiParam(value = "None") @RequestPart(value="date", required=false)  LocalDate date,
-        @ApiParam(value = "None") @RequestPart(value="dateTime", required=false)  OffsetDateTime dateTime,
-        @ApiParam(value = "None") @RequestPart(value="password", required=false)  String password,
-        @ApiParam(value = "None") @RequestPart(value="callback", required=false)  String paramCallback,
-        @RequestHeader(value = "Accept", required = false) String accept) throws Exception {
+    public ResponseEntity<Void> testEndpointParameters(@ApiParam(value = "None", required=true) @RequestPart(value="number", required=true)  BigDecimal number,@ApiParam(value = "None", required=true) @RequestPart(value="double", required=true)  Double _double,@ApiParam(value = "None", required=true) @RequestPart(value="pattern_without_delimiter", required=true)  String patternWithoutDelimiter,@ApiParam(value = "None", required=true) @RequestPart(value="byte", required=true)  byte[] _byte,@ApiParam(value = "None") @RequestPart(value="integer", required=false)  Integer integer,@ApiParam(value = "None") @RequestPart(value="int32", required=false)  Integer int32,@ApiParam(value = "None") @RequestPart(value="int64", required=false)  Long int64,@ApiParam(value = "None") @RequestPart(value="float", required=false)  Float _float,@ApiParam(value = "None") @RequestPart(value="string", required=false)  String string,@ApiParam(value = "None") @RequestPart(value="binary", required=false)  byte[] binary,@ApiParam(value = "None") @RequestPart(value="date", required=false)  LocalDate date,@ApiParam(value = "None") @RequestPart(value="dateTime", required=false)  OffsetDateTime dateTime,@ApiParam(value = "None") @RequestPart(value="password", required=false)  String password,@ApiParam(value = "None") @RequestPart(value="callback", required=false)  String paramCallback) {
         // do some magic!
         return delegate.testEndpointParameters(number, _double, patternWithoutDelimiter, _byte, integer, int32, int64, _float, string, binary, date, dateTime, password, paramCallback);
     }
 
-    public ResponseEntity<Void> testEnumParameters(@ApiParam(value = "Form parameter enum test (string array)", allowableValues=">, $") @RequestPart(value="enum_form_string_array", required=false)  List<String> enumFormStringArray,
-        @ApiParam(value = "Form parameter enum test (string)", allowableValues="_abc, -efg, (xyz)", defaultValue="-efg") @RequestPart(value="enum_form_string", required=false)  String enumFormString,
-        @ApiParam(value = "Header parameter enum test (string array)" , allowableValues=">, $") @RequestHeader(value="enum_header_string_array", required=false) List<String> enumHeaderStringArray,
-        @ApiParam(value = "Header parameter enum test (string)" , allowableValues="_abc, -efg, (xyz)", defaultValue="-efg") @RequestHeader(value="enum_header_string", required=false) String enumHeaderString,
-        @ApiParam(value = "Query parameter enum test (string array)", allowableValues = ">, $") @Valid @RequestParam(value = "enum_query_string_array", required = false) List<String> enumQueryStringArray,
-        @ApiParam(value = "Query parameter enum test (string)", allowableValues = "_abc, -efg, (xyz)", defaultValue = "-efg") @Valid @RequestParam(value = "enum_query_string", required = false, defaultValue="-efg") String enumQueryString,
-        @ApiParam(value = "Query parameter enum test (double)", allowableValues = "1, -2") @Valid @RequestParam(value = "enum_query_integer", required = false) Integer enumQueryInteger,
-        @ApiParam(value = "Query parameter enum test (double)", allowableValues="1.1, -1.2") @RequestPart(value="enum_query_double", required=false)  Double enumQueryDouble,
-        @RequestHeader(value = "Accept", required = false) String accept) throws Exception {
+    public ResponseEntity<Void> testEnumParameters(@ApiParam(value = "Form parameter enum test (string array)", allowableValues=">, $") @RequestPart(value="enum_form_string_array", required=false)  List<String> enumFormStringArray,@ApiParam(value = "Form parameter enum test (string)", allowableValues="_abc, -efg, (xyz)", defaultValue="-efg") @RequestPart(value="enum_form_string", required=false)  String enumFormString,@ApiParam(value = "Header parameter enum test (string array)" , allowableValues=">, $") @RequestHeader(value="enum_header_string_array", required=false) List<String> enumHeaderStringArray,@ApiParam(value = "Header parameter enum test (string)" , allowableValues="_abc, -efg, (xyz)", defaultValue="-efg") @RequestHeader(value="enum_header_string", required=false) String enumHeaderString,@ApiParam(value = "Query parameter enum test (string array)", allowableValues = ">, $") @Valid @RequestParam(value = "enum_query_string_array", required = false) List<String> enumQueryStringArray,@ApiParam(value = "Query parameter enum test (string)", allowableValues = "_abc, -efg, (xyz)", defaultValue = "-efg") @Valid @RequestParam(value = "enum_query_string", required = false, defaultValue="-efg") String enumQueryString,@ApiParam(value = "Query parameter enum test (double)", allowableValues = "1, -2") @Valid @RequestParam(value = "enum_query_integer", required = false) Integer enumQueryInteger,@ApiParam(value = "Query parameter enum test (double)", allowableValues="1.1, -1.2") @RequestPart(value="enum_query_double", required=false)  Double enumQueryDouble) {
         // do some magic!
         return delegate.testEnumParameters(enumFormStringArray, enumFormString, enumHeaderStringArray, enumHeaderString, enumQueryStringArray, enumQueryString, enumQueryInteger, enumQueryDouble);
     }
 
-    public ResponseEntity<Void> testInlineAdditionalProperties(@ApiParam(value = "request body" ,required=true )  @Valid @RequestBody Object param,
-        @RequestHeader(value = "Accept", required = false) String accept) throws Exception {
+    public ResponseEntity<Void> testInlineAdditionalProperties(@ApiParam(value = "request body" ,required=true )  @Valid @RequestBody Object param) {
         // do some magic!
         return delegate.testInlineAdditionalProperties(param);
     }
 
-    public ResponseEntity<Void> testJsonFormData(@ApiParam(value = "field1", required=true) @RequestPart(value="param", required=true)  String param,
-        @ApiParam(value = "field2", required=true) @RequestPart(value="param2", required=true)  String param2,
-        @RequestHeader(value = "Accept", required = false) String accept) throws Exception {
+    public ResponseEntity<Void> testJsonFormData(@ApiParam(value = "field1", required=true) @RequestPart(value="param", required=true)  String param,@ApiParam(value = "field2", required=true) @RequestPart(value="param2", required=true)  String param2) {
         // do some magic!
         return delegate.testJsonFormData(param, param2);
     }

--- a/samples/server/petstore/springboot-delegate/src/main/java/io/swagger/api/FakeApiController.java
+++ b/samples/server/petstore/springboot-delegate/src/main/java/io/swagger/api/FakeApiController.java
@@ -5,9 +5,7 @@ import io.swagger.model.Client;
 import org.threeten.bp.LocalDate;
 import org.threeten.bp.OffsetDateTime;
 import io.swagger.model.OuterComposite;
-
 import io.swagger.annotations.*;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpStatus;
@@ -18,16 +16,11 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RequestPart;
-import org.springframework.web.context.request.RequestContextHolder;
-import org.springframework.web.context.request.ServletRequestAttributes;
 import org.springframework.web.multipart.MultipartFile;
 
-import java.util.List;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import java.io.IOException;
-import javax.servlet.http.HttpServletRequest;
 import javax.validation.constraints.*;
 import javax.validation.Valid;
+import java.util.List;
 
 @Controller
 public class FakeApiController implements FakeApi {
@@ -38,49 +31,39 @@ public class FakeApiController implements FakeApi {
     public FakeApiController(FakeApiDelegate delegate) {
         this.delegate = delegate;
     }
-
     public ResponseEntity<Boolean> fakeOuterBooleanSerialize(@ApiParam(value = "Input boolean as post body"  )  @Valid @RequestBody Boolean body) {
-        // do some magic!
         return delegate.fakeOuterBooleanSerialize(body);
     }
 
     public ResponseEntity<OuterComposite> fakeOuterCompositeSerialize(@ApiParam(value = "Input composite as post body"  )  @Valid @RequestBody OuterComposite body) {
-        // do some magic!
         return delegate.fakeOuterCompositeSerialize(body);
     }
 
     public ResponseEntity<BigDecimal> fakeOuterNumberSerialize(@ApiParam(value = "Input number as post body"  )  @Valid @RequestBody BigDecimal body) {
-        // do some magic!
         return delegate.fakeOuterNumberSerialize(body);
     }
 
     public ResponseEntity<String> fakeOuterStringSerialize(@ApiParam(value = "Input string as post body"  )  @Valid @RequestBody String body) {
-        // do some magic!
         return delegate.fakeOuterStringSerialize(body);
     }
 
     public ResponseEntity<Client> testClientModel(@ApiParam(value = "client model" ,required=true )  @Valid @RequestBody Client body) {
-        // do some magic!
         return delegate.testClientModel(body);
     }
 
     public ResponseEntity<Void> testEndpointParameters(@ApiParam(value = "None", required=true) @RequestPart(value="number", required=true)  BigDecimal number,@ApiParam(value = "None", required=true) @RequestPart(value="double", required=true)  Double _double,@ApiParam(value = "None", required=true) @RequestPart(value="pattern_without_delimiter", required=true)  String patternWithoutDelimiter,@ApiParam(value = "None", required=true) @RequestPart(value="byte", required=true)  byte[] _byte,@ApiParam(value = "None") @RequestPart(value="integer", required=false)  Integer integer,@ApiParam(value = "None") @RequestPart(value="int32", required=false)  Integer int32,@ApiParam(value = "None") @RequestPart(value="int64", required=false)  Long int64,@ApiParam(value = "None") @RequestPart(value="float", required=false)  Float _float,@ApiParam(value = "None") @RequestPart(value="string", required=false)  String string,@ApiParam(value = "None") @RequestPart(value="binary", required=false)  byte[] binary,@ApiParam(value = "None") @RequestPart(value="date", required=false)  LocalDate date,@ApiParam(value = "None") @RequestPart(value="dateTime", required=false)  OffsetDateTime dateTime,@ApiParam(value = "None") @RequestPart(value="password", required=false)  String password,@ApiParam(value = "None") @RequestPart(value="callback", required=false)  String paramCallback) {
-        // do some magic!
         return delegate.testEndpointParameters(number, _double, patternWithoutDelimiter, _byte, integer, int32, int64, _float, string, binary, date, dateTime, password, paramCallback);
     }
 
     public ResponseEntity<Void> testEnumParameters(@ApiParam(value = "Form parameter enum test (string array)", allowableValues=">, $") @RequestPart(value="enum_form_string_array", required=false)  List<String> enumFormStringArray,@ApiParam(value = "Form parameter enum test (string)", allowableValues="_abc, -efg, (xyz)", defaultValue="-efg") @RequestPart(value="enum_form_string", required=false)  String enumFormString,@ApiParam(value = "Header parameter enum test (string array)" , allowableValues=">, $") @RequestHeader(value="enum_header_string_array", required=false) List<String> enumHeaderStringArray,@ApiParam(value = "Header parameter enum test (string)" , allowableValues="_abc, -efg, (xyz)", defaultValue="-efg") @RequestHeader(value="enum_header_string", required=false) String enumHeaderString,@ApiParam(value = "Query parameter enum test (string array)", allowableValues = ">, $") @Valid @RequestParam(value = "enum_query_string_array", required = false) List<String> enumQueryStringArray,@ApiParam(value = "Query parameter enum test (string)", allowableValues = "_abc, -efg, (xyz)", defaultValue = "-efg") @Valid @RequestParam(value = "enum_query_string", required = false, defaultValue="-efg") String enumQueryString,@ApiParam(value = "Query parameter enum test (double)", allowableValues = "1, -2") @Valid @RequestParam(value = "enum_query_integer", required = false) Integer enumQueryInteger,@ApiParam(value = "Query parameter enum test (double)", allowableValues="1.1, -1.2") @RequestPart(value="enum_query_double", required=false)  Double enumQueryDouble) {
-        // do some magic!
         return delegate.testEnumParameters(enumFormStringArray, enumFormString, enumHeaderStringArray, enumHeaderString, enumQueryStringArray, enumQueryString, enumQueryInteger, enumQueryDouble);
     }
 
     public ResponseEntity<Void> testInlineAdditionalProperties(@ApiParam(value = "request body" ,required=true )  @Valid @RequestBody Object param) {
-        // do some magic!
         return delegate.testInlineAdditionalProperties(param);
     }
 
     public ResponseEntity<Void> testJsonFormData(@ApiParam(value = "field1", required=true) @RequestPart(value="param", required=true)  String param,@ApiParam(value = "field2", required=true) @RequestPart(value="param2", required=true)  String param2) {
-        // do some magic!
         return delegate.testJsonFormData(param, param2);
     }
 

--- a/samples/server/petstore/springboot-delegate/src/main/java/io/swagger/api/FakeApiDelegate.java
+++ b/samples/server/petstore/springboot-delegate/src/main/java/io/swagger/api/FakeApiDelegate.java
@@ -5,7 +5,6 @@ import io.swagger.model.Client;
 import org.threeten.bp.LocalDate;
 import org.threeten.bp.OffsetDateTime;
 import io.swagger.model.OuterComposite;
-
 import io.swagger.annotations.*;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.multipart.MultipartFile;
@@ -14,8 +13,7 @@ import java.util.List;
 
 /**
  * A delegate to be called by the {@link FakeApiController}}.
- * Should be implemented as a controller but without the {@link org.springframework.stereotype.Controller} annotation.
- * Instead, use spring to autowire this class into the {@link FakeApiController}.
+ * Implement this interface with a {@link org.springframework.stereotype.Service} annotated class.
  */
 
 public interface FakeApiDelegate {

--- a/samples/server/petstore/springboot-delegate/src/main/java/io/swagger/api/FakeClassnameTestApi.java
+++ b/samples/server/petstore/springboot-delegate/src/main/java/io/swagger/api/FakeClassnameTestApi.java
@@ -6,9 +6,9 @@
 package io.swagger.api;
 
 import io.swagger.model.Client;
-
 import io.swagger.annotations.*;
 import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
@@ -17,12 +17,10 @@ import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.multipart.MultipartFile;
-import java.io.IOException;
 
-import java.util.List;
-import org.springframework.validation.annotation.Validated;
-import javax.validation.constraints.*;
 import javax.validation.Valid;
+import javax.validation.constraints.*;
+import java.util.List;
 
 @Api(value = "fake_classname_test", description = "the fake_classname_test API")
 public interface FakeClassnameTestApi {

--- a/samples/server/petstore/springboot-delegate/src/main/java/io/swagger/api/FakeClassnameTestApi.java
+++ b/samples/server/petstore/springboot-delegate/src/main/java/io/swagger/api/FakeClassnameTestApi.java
@@ -36,6 +36,6 @@ public interface FakeClassnameTestApi {
         produces = { "application/json" }, 
         consumes = { "application/json" },
         method = RequestMethod.PATCH)
-    ResponseEntity<Client> testClassname(@ApiParam(value = "client model" ,required=true )  @Valid @RequestBody Client body, @RequestHeader(value = "Accept", required = false) String accept) throws Exception;
+    ResponseEntity<Client> testClassname(@ApiParam(value = "client model" ,required=true )  @Valid @RequestBody Client body);
 
 }

--- a/samples/server/petstore/springboot-delegate/src/main/java/io/swagger/api/FakeClassnameTestApiController.java
+++ b/samples/server/petstore/springboot-delegate/src/main/java/io/swagger/api/FakeClassnameTestApiController.java
@@ -21,19 +21,12 @@ import org.springframework.web.multipart.MultipartFile;
 import java.util.List;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.IOException;
+import javax.servlet.http.HttpServletRequest;
 import javax.validation.constraints.*;
 import javax.validation.Valid;
 
 @Controller
 public class FakeClassnameTestApiController implements FakeClassnameTestApi {
-
-    private final Logger log = LoggerFactory.getLogger(AnotherFakeApiController.class);
-
-    private final ObjectMapper objectMapper;
-
-    public FakeClassnameTestApiController(ObjectMapper objectMapper) {
-        this.objectMapper = objectMapper;
-    }
 
     private final FakeClassnameTestApiDelegate delegate;
 

--- a/samples/server/petstore/springboot-delegate/src/main/java/io/swagger/api/FakeClassnameTestApiController.java
+++ b/samples/server/petstore/springboot-delegate/src/main/java/io/swagger/api/FakeClassnameTestApiController.java
@@ -4,6 +4,8 @@ import io.swagger.model.Client;
 
 import io.swagger.annotations.*;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
@@ -12,6 +14,8 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RequestPart;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.util.List;
@@ -22,6 +26,9 @@ import javax.validation.Valid;
 
 @Controller
 public class FakeClassnameTestApiController implements FakeClassnameTestApi {
+
+    private final Logger log = LoggerFactory.getLogger(AnotherFakeApiController.class);
+
     private final ObjectMapper objectMapper;
 
     public FakeClassnameTestApiController(ObjectMapper objectMapper) {
@@ -35,8 +42,7 @@ public class FakeClassnameTestApiController implements FakeClassnameTestApi {
         this.delegate = delegate;
     }
 
-    public ResponseEntity<Client> testClassname(@ApiParam(value = "client model" ,required=true )  @Valid @RequestBody Client body,
-        @RequestHeader(value = "Accept", required = false) String accept) throws Exception {
+    public ResponseEntity<Client> testClassname(@ApiParam(value = "client model" ,required=true )  @Valid @RequestBody Client body) {
         // do some magic!
         return delegate.testClassname(body);
     }

--- a/samples/server/petstore/springboot-delegate/src/main/java/io/swagger/api/FakeClassnameTestApiController.java
+++ b/samples/server/petstore/springboot-delegate/src/main/java/io/swagger/api/FakeClassnameTestApiController.java
@@ -1,9 +1,7 @@
 package io.swagger.api;
 
 import io.swagger.model.Client;
-
 import io.swagger.annotations.*;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpStatus;
@@ -14,16 +12,11 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RequestPart;
-import org.springframework.web.context.request.RequestContextHolder;
-import org.springframework.web.context.request.ServletRequestAttributes;
 import org.springframework.web.multipart.MultipartFile;
 
-import java.util.List;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import java.io.IOException;
-import javax.servlet.http.HttpServletRequest;
 import javax.validation.constraints.*;
 import javax.validation.Valid;
+import java.util.List;
 
 @Controller
 public class FakeClassnameTestApiController implements FakeClassnameTestApi {
@@ -34,9 +27,7 @@ public class FakeClassnameTestApiController implements FakeClassnameTestApi {
     public FakeClassnameTestApiController(FakeClassnameTestApiDelegate delegate) {
         this.delegate = delegate;
     }
-
     public ResponseEntity<Client> testClassname(@ApiParam(value = "client model" ,required=true )  @Valid @RequestBody Client body) {
-        // do some magic!
         return delegate.testClassname(body);
     }
 

--- a/samples/server/petstore/springboot-delegate/src/main/java/io/swagger/api/FakeClassnameTestApiDelegate.java
+++ b/samples/server/petstore/springboot-delegate/src/main/java/io/swagger/api/FakeClassnameTestApiDelegate.java
@@ -1,7 +1,6 @@
 package io.swagger.api;
 
 import io.swagger.model.Client;
-
 import io.swagger.annotations.*;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.multipart.MultipartFile;
@@ -10,8 +9,7 @@ import java.util.List;
 
 /**
  * A delegate to be called by the {@link FakeClassnameTestApiController}}.
- * Should be implemented as a controller but without the {@link org.springframework.stereotype.Controller} annotation.
- * Instead, use spring to autowire this class into the {@link FakeClassnameTestApiController}.
+ * Implement this interface with a {@link org.springframework.stereotype.Service} annotated class.
  */
 
 public interface FakeClassnameTestApiDelegate {

--- a/samples/server/petstore/springboot-delegate/src/main/java/io/swagger/api/PetApi.java
+++ b/samples/server/petstore/springboot-delegate/src/main/java/io/swagger/api/PetApi.java
@@ -8,9 +8,9 @@ package io.swagger.api;
 import io.swagger.model.ModelApiResponse;
 import io.swagger.model.Pet;
 import org.springframework.core.io.Resource;
-
 import io.swagger.annotations.*;
 import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
@@ -19,12 +19,10 @@ import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.multipart.MultipartFile;
-import java.io.IOException;
 
-import java.util.List;
-import org.springframework.validation.annotation.Validated;
-import javax.validation.constraints.*;
 import javax.validation.Valid;
+import javax.validation.constraints.*;
+import java.util.List;
 
 @Api(value = "pet", description = "the pet API")
 public interface PetApi {

--- a/samples/server/petstore/springboot-delegate/src/main/java/io/swagger/api/PetApi.java
+++ b/samples/server/petstore/springboot-delegate/src/main/java/io/swagger/api/PetApi.java
@@ -41,7 +41,7 @@ public interface PetApi {
         produces = { "application/xml", "application/json" }, 
         consumes = { "application/json", "application/xml" },
         method = RequestMethod.POST)
-    ResponseEntity<Void> addPet(@ApiParam(value = "Pet object that needs to be added to the store" ,required=true )  @Valid @RequestBody Pet body, @RequestHeader(value = "Accept", required = false) String accept) throws Exception;
+    ResponseEntity<Void> addPet(@ApiParam(value = "Pet object that needs to be added to the store" ,required=true )  @Valid @RequestBody Pet body);
 
 
     @ApiOperation(value = "Deletes a pet", nickname = "deletePet", notes = "", authorizations = {
@@ -55,7 +55,7 @@ public interface PetApi {
     @RequestMapping(value = "/pet/{petId}",
         produces = { "application/xml", "application/json" }, 
         method = RequestMethod.DELETE)
-    ResponseEntity<Void> deletePet(@ApiParam(value = "Pet id to delete",required=true) @PathVariable("petId") Long petId,@ApiParam(value = "" ) @RequestHeader(value="api_key", required=false) String apiKey, @RequestHeader(value = "Accept", required = false) String accept) throws Exception;
+    ResponseEntity<Void> deletePet(@ApiParam(value = "Pet id to delete",required=true) @PathVariable("petId") Long petId,@ApiParam(value = "" ) @RequestHeader(value="api_key", required=false) String apiKey);
 
 
     @ApiOperation(value = "Finds Pets by status", nickname = "findPetsByStatus", notes = "Multiple status values can be provided with comma separated strings", response = Pet.class, responseContainer = "List", authorizations = {
@@ -70,7 +70,7 @@ public interface PetApi {
     @RequestMapping(value = "/pet/findByStatus",
         produces = { "application/xml", "application/json" }, 
         method = RequestMethod.GET)
-    ResponseEntity<List<Pet>> findPetsByStatus( @NotNull@ApiParam(value = "Status values that need to be considered for filter", required = true, allowableValues = "available, pending, sold") @Valid @RequestParam(value = "status", required = true) List<String> status, @RequestHeader(value = "Accept", required = false) String accept) throws Exception;
+    ResponseEntity<List<Pet>> findPetsByStatus(@NotNull @ApiParam(value = "Status values that need to be considered for filter", required = true, allowableValues = "available, pending, sold") @Valid @RequestParam(value = "status", required = true) List<String> status);
 
 
     @ApiOperation(value = "Finds Pets by tags", nickname = "findPetsByTags", notes = "Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.", response = Pet.class, responseContainer = "List", authorizations = {
@@ -85,7 +85,7 @@ public interface PetApi {
     @RequestMapping(value = "/pet/findByTags",
         produces = { "application/xml", "application/json" }, 
         method = RequestMethod.GET)
-    ResponseEntity<List<Pet>> findPetsByTags( @NotNull@ApiParam(value = "Tags to filter by", required = true) @Valid @RequestParam(value = "tags", required = true) List<String> tags, @RequestHeader(value = "Accept", required = false) String accept) throws Exception;
+    ResponseEntity<List<Pet>> findPetsByTags(@NotNull @ApiParam(value = "Tags to filter by", required = true) @Valid @RequestParam(value = "tags", required = true) List<String> tags);
 
 
     @ApiOperation(value = "Find pet by ID", nickname = "getPetById", notes = "Returns a single pet", response = Pet.class, authorizations = {
@@ -98,7 +98,7 @@ public interface PetApi {
     @RequestMapping(value = "/pet/{petId}",
         produces = { "application/xml", "application/json" }, 
         method = RequestMethod.GET)
-    ResponseEntity<Pet> getPetById(@ApiParam(value = "ID of pet to return",required=true) @PathVariable("petId") Long petId, @RequestHeader(value = "Accept", required = false) String accept) throws Exception;
+    ResponseEntity<Pet> getPetById(@ApiParam(value = "ID of pet to return",required=true) @PathVariable("petId") Long petId);
 
 
     @ApiOperation(value = "Update an existing pet", nickname = "updatePet", notes = "", authorizations = {
@@ -115,7 +115,7 @@ public interface PetApi {
         produces = { "application/xml", "application/json" }, 
         consumes = { "application/json", "application/xml" },
         method = RequestMethod.PUT)
-    ResponseEntity<Void> updatePet(@ApiParam(value = "Pet object that needs to be added to the store" ,required=true )  @Valid @RequestBody Pet body, @RequestHeader(value = "Accept", required = false) String accept) throws Exception;
+    ResponseEntity<Void> updatePet(@ApiParam(value = "Pet object that needs to be added to the store" ,required=true )  @Valid @RequestBody Pet body);
 
 
     @ApiOperation(value = "Updates a pet in the store with form data", nickname = "updatePetWithForm", notes = "", authorizations = {
@@ -130,7 +130,7 @@ public interface PetApi {
         produces = { "application/xml", "application/json" }, 
         consumes = { "application/x-www-form-urlencoded" },
         method = RequestMethod.POST)
-    ResponseEntity<Void> updatePetWithForm(@ApiParam(value = "ID of pet that needs to be updated",required=true) @PathVariable("petId") Long petId,@ApiParam(value = "Updated name of the pet") @RequestPart(value="name", required=false)  String name,@ApiParam(value = "Updated status of the pet") @RequestPart(value="status", required=false)  String status, @RequestHeader(value = "Accept", required = false) String accept) throws Exception;
+    ResponseEntity<Void> updatePetWithForm(@ApiParam(value = "ID of pet that needs to be updated",required=true) @PathVariable("petId") Long petId,@ApiParam(value = "Updated name of the pet") @RequestPart(value="name", required=false)  String name,@ApiParam(value = "Updated status of the pet") @RequestPart(value="status", required=false)  String status);
 
 
     @ApiOperation(value = "uploads an image", nickname = "uploadFile", notes = "", response = ModelApiResponse.class, authorizations = {
@@ -145,6 +145,6 @@ public interface PetApi {
         produces = { "application/json" }, 
         consumes = { "multipart/form-data" },
         method = RequestMethod.POST)
-    ResponseEntity<ModelApiResponse> uploadFile(@ApiParam(value = "ID of pet to update",required=true) @PathVariable("petId") Long petId,@ApiParam(value = "Additional data to pass to server") @RequestPart(value="additionalMetadata", required=false)  String additionalMetadata,@ApiParam(value = "file detail") @Valid @RequestPart("file") MultipartFile file, @RequestHeader(value = "Accept", required = false) String accept) throws Exception;
+    ResponseEntity<ModelApiResponse> uploadFile(@ApiParam(value = "ID of pet to update",required=true) @PathVariable("petId") Long petId,@ApiParam(value = "Additional data to pass to server") @RequestPart(value="additionalMetadata", required=false)  String additionalMetadata,@ApiParam(value = "file detail") @Valid @RequestPart("file") MultipartFile file);
 
 }

--- a/samples/server/petstore/springboot-delegate/src/main/java/io/swagger/api/PetApiController.java
+++ b/samples/server/petstore/springboot-delegate/src/main/java/io/swagger/api/PetApiController.java
@@ -23,19 +23,12 @@ import org.springframework.web.multipart.MultipartFile;
 import java.util.List;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.IOException;
+import javax.servlet.http.HttpServletRequest;
 import javax.validation.constraints.*;
 import javax.validation.Valid;
 
 @Controller
 public class PetApiController implements PetApi {
-
-    private final Logger log = LoggerFactory.getLogger(AnotherFakeApiController.class);
-
-    private final ObjectMapper objectMapper;
-
-    public PetApiController(ObjectMapper objectMapper) {
-        this.objectMapper = objectMapper;
-    }
 
     private final PetApiDelegate delegate;
 

--- a/samples/server/petstore/springboot-delegate/src/main/java/io/swagger/api/PetApiController.java
+++ b/samples/server/petstore/springboot-delegate/src/main/java/io/swagger/api/PetApiController.java
@@ -3,9 +3,7 @@ package io.swagger.api;
 import io.swagger.model.ModelApiResponse;
 import io.swagger.model.Pet;
 import org.springframework.core.io.Resource;
-
 import io.swagger.annotations.*;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpStatus;
@@ -16,16 +14,11 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RequestPart;
-import org.springframework.web.context.request.RequestContextHolder;
-import org.springframework.web.context.request.ServletRequestAttributes;
 import org.springframework.web.multipart.MultipartFile;
 
-import java.util.List;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import java.io.IOException;
-import javax.servlet.http.HttpServletRequest;
 import javax.validation.constraints.*;
 import javax.validation.Valid;
+import java.util.List;
 
 @Controller
 public class PetApiController implements PetApi {
@@ -36,44 +29,35 @@ public class PetApiController implements PetApi {
     public PetApiController(PetApiDelegate delegate) {
         this.delegate = delegate;
     }
-
     public ResponseEntity<Void> addPet(@ApiParam(value = "Pet object that needs to be added to the store" ,required=true )  @Valid @RequestBody Pet body) {
-        // do some magic!
         return delegate.addPet(body);
     }
 
     public ResponseEntity<Void> deletePet(@ApiParam(value = "Pet id to delete",required=true) @PathVariable("petId") Long petId,@ApiParam(value = "" ) @RequestHeader(value="api_key", required=false) String apiKey) {
-        // do some magic!
         return delegate.deletePet(petId, apiKey);
     }
 
     public ResponseEntity<List<Pet>> findPetsByStatus(@NotNull @ApiParam(value = "Status values that need to be considered for filter", required = true, allowableValues = "available, pending, sold") @Valid @RequestParam(value = "status", required = true) List<String> status) {
-        // do some magic!
         return delegate.findPetsByStatus(status);
     }
 
     public ResponseEntity<List<Pet>> findPetsByTags(@NotNull @ApiParam(value = "Tags to filter by", required = true) @Valid @RequestParam(value = "tags", required = true) List<String> tags) {
-        // do some magic!
         return delegate.findPetsByTags(tags);
     }
 
     public ResponseEntity<Pet> getPetById(@ApiParam(value = "ID of pet to return",required=true) @PathVariable("petId") Long petId) {
-        // do some magic!
         return delegate.getPetById(petId);
     }
 
     public ResponseEntity<Void> updatePet(@ApiParam(value = "Pet object that needs to be added to the store" ,required=true )  @Valid @RequestBody Pet body) {
-        // do some magic!
         return delegate.updatePet(body);
     }
 
     public ResponseEntity<Void> updatePetWithForm(@ApiParam(value = "ID of pet that needs to be updated",required=true) @PathVariable("petId") Long petId,@ApiParam(value = "Updated name of the pet") @RequestPart(value="name", required=false)  String name,@ApiParam(value = "Updated status of the pet") @RequestPart(value="status", required=false)  String status) {
-        // do some magic!
         return delegate.updatePetWithForm(petId, name, status);
     }
 
     public ResponseEntity<ModelApiResponse> uploadFile(@ApiParam(value = "ID of pet to update",required=true) @PathVariable("petId") Long petId,@ApiParam(value = "Additional data to pass to server") @RequestPart(value="additionalMetadata", required=false)  String additionalMetadata,@ApiParam(value = "file detail") @Valid @RequestPart("file") MultipartFile file) {
-        // do some magic!
         return delegate.uploadFile(petId, additionalMetadata, file);
     }
 

--- a/samples/server/petstore/springboot-delegate/src/main/java/io/swagger/api/PetApiController.java
+++ b/samples/server/petstore/springboot-delegate/src/main/java/io/swagger/api/PetApiController.java
@@ -6,6 +6,8 @@ import org.springframework.core.io.Resource;
 
 import io.swagger.annotations.*;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
@@ -14,6 +16,8 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RequestPart;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.util.List;
@@ -24,6 +28,9 @@ import javax.validation.Valid;
 
 @Controller
 public class PetApiController implements PetApi {
+
+    private final Logger log = LoggerFactory.getLogger(AnotherFakeApiController.class);
+
     private final ObjectMapper objectMapper;
 
     public PetApiController(ObjectMapper objectMapper) {
@@ -37,55 +44,42 @@ public class PetApiController implements PetApi {
         this.delegate = delegate;
     }
 
-    public ResponseEntity<Void> addPet(@ApiParam(value = "Pet object that needs to be added to the store" ,required=true )  @Valid @RequestBody Pet body,
-        @RequestHeader(value = "Accept", required = false) String accept) throws Exception {
+    public ResponseEntity<Void> addPet(@ApiParam(value = "Pet object that needs to be added to the store" ,required=true )  @Valid @RequestBody Pet body) {
         // do some magic!
         return delegate.addPet(body);
     }
 
-    public ResponseEntity<Void> deletePet(@ApiParam(value = "Pet id to delete",required=true) @PathVariable("petId") Long petId,
-        @ApiParam(value = "" ) @RequestHeader(value="api_key", required=false) String apiKey,
-        @RequestHeader(value = "Accept", required = false) String accept) throws Exception {
+    public ResponseEntity<Void> deletePet(@ApiParam(value = "Pet id to delete",required=true) @PathVariable("petId") Long petId,@ApiParam(value = "" ) @RequestHeader(value="api_key", required=false) String apiKey) {
         // do some magic!
         return delegate.deletePet(petId, apiKey);
     }
 
-    public ResponseEntity<List<Pet>> findPetsByStatus( @NotNull@ApiParam(value = "Status values that need to be considered for filter", required = true, allowableValues = "available, pending, sold") @Valid @RequestParam(value = "status", required = true) List<String> status,
-        @RequestHeader(value = "Accept", required = false) String accept) throws Exception {
+    public ResponseEntity<List<Pet>> findPetsByStatus(@NotNull @ApiParam(value = "Status values that need to be considered for filter", required = true, allowableValues = "available, pending, sold") @Valid @RequestParam(value = "status", required = true) List<String> status) {
         // do some magic!
         return delegate.findPetsByStatus(status);
     }
 
-    public ResponseEntity<List<Pet>> findPetsByTags( @NotNull@ApiParam(value = "Tags to filter by", required = true) @Valid @RequestParam(value = "tags", required = true) List<String> tags,
-        @RequestHeader(value = "Accept", required = false) String accept) throws Exception {
+    public ResponseEntity<List<Pet>> findPetsByTags(@NotNull @ApiParam(value = "Tags to filter by", required = true) @Valid @RequestParam(value = "tags", required = true) List<String> tags) {
         // do some magic!
         return delegate.findPetsByTags(tags);
     }
 
-    public ResponseEntity<Pet> getPetById(@ApiParam(value = "ID of pet to return",required=true) @PathVariable("petId") Long petId,
-        @RequestHeader(value = "Accept", required = false) String accept) throws Exception {
+    public ResponseEntity<Pet> getPetById(@ApiParam(value = "ID of pet to return",required=true) @PathVariable("petId") Long petId) {
         // do some magic!
         return delegate.getPetById(petId);
     }
 
-    public ResponseEntity<Void> updatePet(@ApiParam(value = "Pet object that needs to be added to the store" ,required=true )  @Valid @RequestBody Pet body,
-        @RequestHeader(value = "Accept", required = false) String accept) throws Exception {
+    public ResponseEntity<Void> updatePet(@ApiParam(value = "Pet object that needs to be added to the store" ,required=true )  @Valid @RequestBody Pet body) {
         // do some magic!
         return delegate.updatePet(body);
     }
 
-    public ResponseEntity<Void> updatePetWithForm(@ApiParam(value = "ID of pet that needs to be updated",required=true) @PathVariable("petId") Long petId,
-        @ApiParam(value = "Updated name of the pet") @RequestPart(value="name", required=false)  String name,
-        @ApiParam(value = "Updated status of the pet") @RequestPart(value="status", required=false)  String status,
-        @RequestHeader(value = "Accept", required = false) String accept) throws Exception {
+    public ResponseEntity<Void> updatePetWithForm(@ApiParam(value = "ID of pet that needs to be updated",required=true) @PathVariable("petId") Long petId,@ApiParam(value = "Updated name of the pet") @RequestPart(value="name", required=false)  String name,@ApiParam(value = "Updated status of the pet") @RequestPart(value="status", required=false)  String status) {
         // do some magic!
         return delegate.updatePetWithForm(petId, name, status);
     }
 
-    public ResponseEntity<ModelApiResponse> uploadFile(@ApiParam(value = "ID of pet to update",required=true) @PathVariable("petId") Long petId,
-        @ApiParam(value = "Additional data to pass to server") @RequestPart(value="additionalMetadata", required=false)  String additionalMetadata,
-        @ApiParam(value = "file detail") @Valid @RequestPart("file") MultipartFile file,
-        @RequestHeader(value = "Accept", required = false) String accept) throws Exception {
+    public ResponseEntity<ModelApiResponse> uploadFile(@ApiParam(value = "ID of pet to update",required=true) @PathVariable("petId") Long petId,@ApiParam(value = "Additional data to pass to server") @RequestPart(value="additionalMetadata", required=false)  String additionalMetadata,@ApiParam(value = "file detail") @Valid @RequestPart("file") MultipartFile file) {
         // do some magic!
         return delegate.uploadFile(petId, additionalMetadata, file);
     }

--- a/samples/server/petstore/springboot-delegate/src/main/java/io/swagger/api/PetApiDelegate.java
+++ b/samples/server/petstore/springboot-delegate/src/main/java/io/swagger/api/PetApiDelegate.java
@@ -3,7 +3,6 @@ package io.swagger.api;
 import io.swagger.model.ModelApiResponse;
 import io.swagger.model.Pet;
 import org.springframework.core.io.Resource;
-
 import io.swagger.annotations.*;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.multipart.MultipartFile;
@@ -12,8 +11,7 @@ import java.util.List;
 
 /**
  * A delegate to be called by the {@link PetApiController}}.
- * Should be implemented as a controller but without the {@link org.springframework.stereotype.Controller} annotation.
- * Instead, use spring to autowire this class into the {@link PetApiController}.
+ * Implement this interface with a {@link org.springframework.stereotype.Service} annotated class.
  */
 
 public interface PetApiDelegate {

--- a/samples/server/petstore/springboot-delegate/src/main/java/io/swagger/api/StoreApi.java
+++ b/samples/server/petstore/springboot-delegate/src/main/java/io/swagger/api/StoreApi.java
@@ -7,9 +7,9 @@ package io.swagger.api;
 
 import java.util.Map;
 import io.swagger.model.Order;
-
 import io.swagger.annotations.*;
 import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
@@ -18,12 +18,10 @@ import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.multipart.MultipartFile;
-import java.io.IOException;
 
-import java.util.List;
-import org.springframework.validation.annotation.Validated;
-import javax.validation.constraints.*;
 import javax.validation.Valid;
+import javax.validation.constraints.*;
+import java.util.List;
 
 @Api(value = "store", description = "the store API")
 public interface StoreApi {

--- a/samples/server/petstore/springboot-delegate/src/main/java/io/swagger/api/StoreApi.java
+++ b/samples/server/petstore/springboot-delegate/src/main/java/io/swagger/api/StoreApi.java
@@ -35,7 +35,7 @@ public interface StoreApi {
     @RequestMapping(value = "/store/order/{order_id}",
         produces = { "application/xml", "application/json" }, 
         method = RequestMethod.DELETE)
-    ResponseEntity<Void> deleteOrder(@ApiParam(value = "ID of the order that needs to be deleted",required=true) @PathVariable("order_id") String orderId, @RequestHeader(value = "Accept", required = false) String accept) throws Exception;
+    ResponseEntity<Void> deleteOrder(@ApiParam(value = "ID of the order that needs to be deleted",required=true) @PathVariable("order_id") String orderId);
 
 
     @ApiOperation(value = "Returns pet inventories by status", nickname = "getInventory", notes = "Returns a map of status codes to quantities", response = Integer.class, responseContainer = "Map", authorizations = {
@@ -46,7 +46,7 @@ public interface StoreApi {
     @RequestMapping(value = "/store/inventory",
         produces = { "application/json" }, 
         method = RequestMethod.GET)
-    ResponseEntity<Map<String, Integer>> getInventory( @RequestHeader(value = "Accept", required = false) String accept) throws Exception;
+    ResponseEntity<Map<String, Integer>> getInventory();
 
 
     @ApiOperation(value = "Find purchase order by ID", nickname = "getOrderById", notes = "For valid response try integer IDs with value <= 5 or > 10. Other values will generated exceptions", response = Order.class, tags={ "store", })
@@ -57,7 +57,7 @@ public interface StoreApi {
     @RequestMapping(value = "/store/order/{order_id}",
         produces = { "application/xml", "application/json" }, 
         method = RequestMethod.GET)
-    ResponseEntity<Order> getOrderById( @Min(1) @Max(5)@ApiParam(value = "ID of pet that needs to be fetched",required=true) @PathVariable("order_id") Long orderId, @RequestHeader(value = "Accept", required = false) String accept) throws Exception;
+    ResponseEntity<Order> getOrderById(@Min(1) @Max(5) @ApiParam(value = "ID of pet that needs to be fetched",required=true) @PathVariable("order_id") Long orderId);
 
 
     @ApiOperation(value = "Place an order for a pet", nickname = "placeOrder", notes = "", response = Order.class, tags={ "store", })
@@ -67,6 +67,6 @@ public interface StoreApi {
     @RequestMapping(value = "/store/order",
         produces = { "application/xml", "application/json" }, 
         method = RequestMethod.POST)
-    ResponseEntity<Order> placeOrder(@ApiParam(value = "order placed for purchasing the pet" ,required=true )  @Valid @RequestBody Order body, @RequestHeader(value = "Accept", required = false) String accept) throws Exception;
+    ResponseEntity<Order> placeOrder(@ApiParam(value = "order placed for purchasing the pet" ,required=true )  @Valid @RequestBody Order body);
 
 }

--- a/samples/server/petstore/springboot-delegate/src/main/java/io/swagger/api/StoreApiController.java
+++ b/samples/server/petstore/springboot-delegate/src/main/java/io/swagger/api/StoreApiController.java
@@ -22,19 +22,12 @@ import org.springframework.web.multipart.MultipartFile;
 import java.util.List;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.IOException;
+import javax.servlet.http.HttpServletRequest;
 import javax.validation.constraints.*;
 import javax.validation.Valid;
 
 @Controller
 public class StoreApiController implements StoreApi {
-
-    private final Logger log = LoggerFactory.getLogger(AnotherFakeApiController.class);
-
-    private final ObjectMapper objectMapper;
-
-    public StoreApiController(ObjectMapper objectMapper) {
-        this.objectMapper = objectMapper;
-    }
 
     private final StoreApiDelegate delegate;
 

--- a/samples/server/petstore/springboot-delegate/src/main/java/io/swagger/api/StoreApiController.java
+++ b/samples/server/petstore/springboot-delegate/src/main/java/io/swagger/api/StoreApiController.java
@@ -5,6 +5,8 @@ import io.swagger.model.Order;
 
 import io.swagger.annotations.*;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
@@ -13,6 +15,8 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RequestPart;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.util.List;
@@ -23,6 +27,9 @@ import javax.validation.Valid;
 
 @Controller
 public class StoreApiController implements StoreApi {
+
+    private final Logger log = LoggerFactory.getLogger(AnotherFakeApiController.class);
+
     private final ObjectMapper objectMapper;
 
     public StoreApiController(ObjectMapper objectMapper) {
@@ -36,25 +43,22 @@ public class StoreApiController implements StoreApi {
         this.delegate = delegate;
     }
 
-    public ResponseEntity<Void> deleteOrder(@ApiParam(value = "ID of the order that needs to be deleted",required=true) @PathVariable("order_id") String orderId,
-        @RequestHeader(value = "Accept", required = false) String accept) throws Exception {
+    public ResponseEntity<Void> deleteOrder(@ApiParam(value = "ID of the order that needs to be deleted",required=true) @PathVariable("order_id") String orderId) {
         // do some magic!
         return delegate.deleteOrder(orderId);
     }
 
-    public ResponseEntity<Map<String, Integer>> getInventory(@RequestHeader(value = "Accept", required = false) String accept) throws Exception {
+    public ResponseEntity<Map<String, Integer>> getInventory() {
         // do some magic!
         return delegate.getInventory();
     }
 
-    public ResponseEntity<Order> getOrderById( @Min(1) @Max(5)@ApiParam(value = "ID of pet that needs to be fetched",required=true) @PathVariable("order_id") Long orderId,
-        @RequestHeader(value = "Accept", required = false) String accept) throws Exception {
+    public ResponseEntity<Order> getOrderById(@Min(1) @Max(5) @ApiParam(value = "ID of pet that needs to be fetched",required=true) @PathVariable("order_id") Long orderId) {
         // do some magic!
         return delegate.getOrderById(orderId);
     }
 
-    public ResponseEntity<Order> placeOrder(@ApiParam(value = "order placed for purchasing the pet" ,required=true )  @Valid @RequestBody Order body,
-        @RequestHeader(value = "Accept", required = false) String accept) throws Exception {
+    public ResponseEntity<Order> placeOrder(@ApiParam(value = "order placed for purchasing the pet" ,required=true )  @Valid @RequestBody Order body) {
         // do some magic!
         return delegate.placeOrder(body);
     }

--- a/samples/server/petstore/springboot-delegate/src/main/java/io/swagger/api/StoreApiController.java
+++ b/samples/server/petstore/springboot-delegate/src/main/java/io/swagger/api/StoreApiController.java
@@ -2,9 +2,7 @@ package io.swagger.api;
 
 import java.util.Map;
 import io.swagger.model.Order;
-
 import io.swagger.annotations.*;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpStatus;
@@ -15,16 +13,11 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RequestPart;
-import org.springframework.web.context.request.RequestContextHolder;
-import org.springframework.web.context.request.ServletRequestAttributes;
 import org.springframework.web.multipart.MultipartFile;
 
-import java.util.List;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import java.io.IOException;
-import javax.servlet.http.HttpServletRequest;
 import javax.validation.constraints.*;
 import javax.validation.Valid;
+import java.util.List;
 
 @Controller
 public class StoreApiController implements StoreApi {
@@ -35,24 +28,19 @@ public class StoreApiController implements StoreApi {
     public StoreApiController(StoreApiDelegate delegate) {
         this.delegate = delegate;
     }
-
     public ResponseEntity<Void> deleteOrder(@ApiParam(value = "ID of the order that needs to be deleted",required=true) @PathVariable("order_id") String orderId) {
-        // do some magic!
         return delegate.deleteOrder(orderId);
     }
 
     public ResponseEntity<Map<String, Integer>> getInventory() {
-        // do some magic!
         return delegate.getInventory();
     }
 
     public ResponseEntity<Order> getOrderById(@Min(1) @Max(5) @ApiParam(value = "ID of pet that needs to be fetched",required=true) @PathVariable("order_id") Long orderId) {
-        // do some magic!
         return delegate.getOrderById(orderId);
     }
 
     public ResponseEntity<Order> placeOrder(@ApiParam(value = "order placed for purchasing the pet" ,required=true )  @Valid @RequestBody Order body) {
-        // do some magic!
         return delegate.placeOrder(body);
     }
 

--- a/samples/server/petstore/springboot-delegate/src/main/java/io/swagger/api/StoreApiDelegate.java
+++ b/samples/server/petstore/springboot-delegate/src/main/java/io/swagger/api/StoreApiDelegate.java
@@ -2,7 +2,6 @@ package io.swagger.api;
 
 import java.util.Map;
 import io.swagger.model.Order;
-
 import io.swagger.annotations.*;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.multipart.MultipartFile;
@@ -11,8 +10,7 @@ import java.util.List;
 
 /**
  * A delegate to be called by the {@link StoreApiController}}.
- * Should be implemented as a controller but without the {@link org.springframework.stereotype.Controller} annotation.
- * Instead, use spring to autowire this class into the {@link StoreApiController}.
+ * Implement this interface with a {@link org.springframework.stereotype.Service} annotated class.
  */
 
 public interface StoreApiDelegate {

--- a/samples/server/petstore/springboot-delegate/src/main/java/io/swagger/api/UserApi.java
+++ b/samples/server/petstore/springboot-delegate/src/main/java/io/swagger/api/UserApi.java
@@ -7,9 +7,9 @@ package io.swagger.api;
 
 import java.util.List;
 import io.swagger.model.User;
-
 import io.swagger.annotations.*;
 import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
@@ -18,12 +18,10 @@ import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.multipart.MultipartFile;
-import java.io.IOException;
 
-import java.util.List;
-import org.springframework.validation.annotation.Validated;
-import javax.validation.constraints.*;
 import javax.validation.Valid;
+import javax.validation.constraints.*;
+import java.util.List;
 
 @Api(value = "user", description = "the user API")
 public interface UserApi {

--- a/samples/server/petstore/springboot-delegate/src/main/java/io/swagger/api/UserApi.java
+++ b/samples/server/petstore/springboot-delegate/src/main/java/io/swagger/api/UserApi.java
@@ -34,7 +34,7 @@ public interface UserApi {
     @RequestMapping(value = "/user",
         produces = { "application/xml", "application/json" }, 
         method = RequestMethod.POST)
-    ResponseEntity<Void> createUser(@ApiParam(value = "Created user object" ,required=true )  @Valid @RequestBody User body, @RequestHeader(value = "Accept", required = false) String accept) throws Exception;
+    ResponseEntity<Void> createUser(@ApiParam(value = "Created user object" ,required=true )  @Valid @RequestBody User body);
 
 
     @ApiOperation(value = "Creates list of users with given input array", nickname = "createUsersWithArrayInput", notes = "", tags={ "user", })
@@ -43,7 +43,7 @@ public interface UserApi {
     @RequestMapping(value = "/user/createWithArray",
         produces = { "application/xml", "application/json" }, 
         method = RequestMethod.POST)
-    ResponseEntity<Void> createUsersWithArrayInput(@ApiParam(value = "List of user object" ,required=true )  @Valid @RequestBody List<User> body, @RequestHeader(value = "Accept", required = false) String accept) throws Exception;
+    ResponseEntity<Void> createUsersWithArrayInput(@ApiParam(value = "List of user object" ,required=true )  @Valid @RequestBody List<User> body);
 
 
     @ApiOperation(value = "Creates list of users with given input array", nickname = "createUsersWithListInput", notes = "", tags={ "user", })
@@ -52,7 +52,7 @@ public interface UserApi {
     @RequestMapping(value = "/user/createWithList",
         produces = { "application/xml", "application/json" }, 
         method = RequestMethod.POST)
-    ResponseEntity<Void> createUsersWithListInput(@ApiParam(value = "List of user object" ,required=true )  @Valid @RequestBody List<User> body, @RequestHeader(value = "Accept", required = false) String accept) throws Exception;
+    ResponseEntity<Void> createUsersWithListInput(@ApiParam(value = "List of user object" ,required=true )  @Valid @RequestBody List<User> body);
 
 
     @ApiOperation(value = "Delete user", nickname = "deleteUser", notes = "This can only be done by the logged in user.", tags={ "user", })
@@ -62,7 +62,7 @@ public interface UserApi {
     @RequestMapping(value = "/user/{username}",
         produces = { "application/xml", "application/json" }, 
         method = RequestMethod.DELETE)
-    ResponseEntity<Void> deleteUser(@ApiParam(value = "The name that needs to be deleted",required=true) @PathVariable("username") String username, @RequestHeader(value = "Accept", required = false) String accept) throws Exception;
+    ResponseEntity<Void> deleteUser(@ApiParam(value = "The name that needs to be deleted",required=true) @PathVariable("username") String username);
 
 
     @ApiOperation(value = "Get user by user name", nickname = "getUserByName", notes = "", response = User.class, tags={ "user", })
@@ -73,7 +73,7 @@ public interface UserApi {
     @RequestMapping(value = "/user/{username}",
         produces = { "application/xml", "application/json" }, 
         method = RequestMethod.GET)
-    ResponseEntity<User> getUserByName(@ApiParam(value = "The name that needs to be fetched. Use user1 for testing. ",required=true) @PathVariable("username") String username, @RequestHeader(value = "Accept", required = false) String accept) throws Exception;
+    ResponseEntity<User> getUserByName(@ApiParam(value = "The name that needs to be fetched. Use user1 for testing. ",required=true) @PathVariable("username") String username);
 
 
     @ApiOperation(value = "Logs user into the system", nickname = "loginUser", notes = "", response = String.class, tags={ "user", })
@@ -83,7 +83,7 @@ public interface UserApi {
     @RequestMapping(value = "/user/login",
         produces = { "application/xml", "application/json" }, 
         method = RequestMethod.GET)
-    ResponseEntity<String> loginUser( @NotNull@ApiParam(value = "The user name for login", required = true) @Valid @RequestParam(value = "username", required = true) String username, @NotNull@ApiParam(value = "The password for login in clear text", required = true) @Valid @RequestParam(value = "password", required = true) String password, @RequestHeader(value = "Accept", required = false) String accept) throws Exception;
+    ResponseEntity<String> loginUser(@NotNull @ApiParam(value = "The user name for login", required = true) @Valid @RequestParam(value = "username", required = true) String username,@NotNull @ApiParam(value = "The password for login in clear text", required = true) @Valid @RequestParam(value = "password", required = true) String password);
 
 
     @ApiOperation(value = "Logs out current logged in user session", nickname = "logoutUser", notes = "", tags={ "user", })
@@ -92,7 +92,7 @@ public interface UserApi {
     @RequestMapping(value = "/user/logout",
         produces = { "application/xml", "application/json" }, 
         method = RequestMethod.GET)
-    ResponseEntity<Void> logoutUser( @RequestHeader(value = "Accept", required = false) String accept) throws Exception;
+    ResponseEntity<Void> logoutUser();
 
 
     @ApiOperation(value = "Updated user", nickname = "updateUser", notes = "This can only be done by the logged in user.", tags={ "user", })
@@ -102,6 +102,6 @@ public interface UserApi {
     @RequestMapping(value = "/user/{username}",
         produces = { "application/xml", "application/json" }, 
         method = RequestMethod.PUT)
-    ResponseEntity<Void> updateUser(@ApiParam(value = "name that need to be deleted",required=true) @PathVariable("username") String username,@ApiParam(value = "Updated user object" ,required=true )  @Valid @RequestBody User body, @RequestHeader(value = "Accept", required = false) String accept) throws Exception;
+    ResponseEntity<Void> updateUser(@ApiParam(value = "name that need to be deleted",required=true) @PathVariable("username") String username,@ApiParam(value = "Updated user object" ,required=true )  @Valid @RequestBody User body);
 
 }

--- a/samples/server/petstore/springboot-delegate/src/main/java/io/swagger/api/UserApiController.java
+++ b/samples/server/petstore/springboot-delegate/src/main/java/io/swagger/api/UserApiController.java
@@ -22,19 +22,12 @@ import org.springframework.web.multipart.MultipartFile;
 import java.util.List;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.IOException;
+import javax.servlet.http.HttpServletRequest;
 import javax.validation.constraints.*;
 import javax.validation.Valid;
 
 @Controller
 public class UserApiController implements UserApi {
-
-    private final Logger log = LoggerFactory.getLogger(AnotherFakeApiController.class);
-
-    private final ObjectMapper objectMapper;
-
-    public UserApiController(ObjectMapper objectMapper) {
-        this.objectMapper = objectMapper;
-    }
 
     private final UserApiDelegate delegate;
 

--- a/samples/server/petstore/springboot-delegate/src/main/java/io/swagger/api/UserApiController.java
+++ b/samples/server/petstore/springboot-delegate/src/main/java/io/swagger/api/UserApiController.java
@@ -5,6 +5,8 @@ import io.swagger.model.User;
 
 import io.swagger.annotations.*;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
@@ -13,6 +15,8 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RequestPart;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.util.List;
@@ -23,6 +27,9 @@ import javax.validation.Valid;
 
 @Controller
 public class UserApiController implements UserApi {
+
+    private final Logger log = LoggerFactory.getLogger(AnotherFakeApiController.class);
+
     private final ObjectMapper objectMapper;
 
     public UserApiController(ObjectMapper objectMapper) {
@@ -36,51 +43,42 @@ public class UserApiController implements UserApi {
         this.delegate = delegate;
     }
 
-    public ResponseEntity<Void> createUser(@ApiParam(value = "Created user object" ,required=true )  @Valid @RequestBody User body,
-        @RequestHeader(value = "Accept", required = false) String accept) throws Exception {
+    public ResponseEntity<Void> createUser(@ApiParam(value = "Created user object" ,required=true )  @Valid @RequestBody User body) {
         // do some magic!
         return delegate.createUser(body);
     }
 
-    public ResponseEntity<Void> createUsersWithArrayInput(@ApiParam(value = "List of user object" ,required=true )  @Valid @RequestBody List<User> body,
-        @RequestHeader(value = "Accept", required = false) String accept) throws Exception {
+    public ResponseEntity<Void> createUsersWithArrayInput(@ApiParam(value = "List of user object" ,required=true )  @Valid @RequestBody List<User> body) {
         // do some magic!
         return delegate.createUsersWithArrayInput(body);
     }
 
-    public ResponseEntity<Void> createUsersWithListInput(@ApiParam(value = "List of user object" ,required=true )  @Valid @RequestBody List<User> body,
-        @RequestHeader(value = "Accept", required = false) String accept) throws Exception {
+    public ResponseEntity<Void> createUsersWithListInput(@ApiParam(value = "List of user object" ,required=true )  @Valid @RequestBody List<User> body) {
         // do some magic!
         return delegate.createUsersWithListInput(body);
     }
 
-    public ResponseEntity<Void> deleteUser(@ApiParam(value = "The name that needs to be deleted",required=true) @PathVariable("username") String username,
-        @RequestHeader(value = "Accept", required = false) String accept) throws Exception {
+    public ResponseEntity<Void> deleteUser(@ApiParam(value = "The name that needs to be deleted",required=true) @PathVariable("username") String username) {
         // do some magic!
         return delegate.deleteUser(username);
     }
 
-    public ResponseEntity<User> getUserByName(@ApiParam(value = "The name that needs to be fetched. Use user1 for testing. ",required=true) @PathVariable("username") String username,
-        @RequestHeader(value = "Accept", required = false) String accept) throws Exception {
+    public ResponseEntity<User> getUserByName(@ApiParam(value = "The name that needs to be fetched. Use user1 for testing. ",required=true) @PathVariable("username") String username) {
         // do some magic!
         return delegate.getUserByName(username);
     }
 
-    public ResponseEntity<String> loginUser( @NotNull@ApiParam(value = "The user name for login", required = true) @Valid @RequestParam(value = "username", required = true) String username,
-         @NotNull@ApiParam(value = "The password for login in clear text", required = true) @Valid @RequestParam(value = "password", required = true) String password,
-        @RequestHeader(value = "Accept", required = false) String accept) throws Exception {
+    public ResponseEntity<String> loginUser(@NotNull @ApiParam(value = "The user name for login", required = true) @Valid @RequestParam(value = "username", required = true) String username,@NotNull @ApiParam(value = "The password for login in clear text", required = true) @Valid @RequestParam(value = "password", required = true) String password) {
         // do some magic!
         return delegate.loginUser(username, password);
     }
 
-    public ResponseEntity<Void> logoutUser(@RequestHeader(value = "Accept", required = false) String accept) throws Exception {
+    public ResponseEntity<Void> logoutUser() {
         // do some magic!
         return delegate.logoutUser();
     }
 
-    public ResponseEntity<Void> updateUser(@ApiParam(value = "name that need to be deleted",required=true) @PathVariable("username") String username,
-        @ApiParam(value = "Updated user object" ,required=true )  @Valid @RequestBody User body,
-        @RequestHeader(value = "Accept", required = false) String accept) throws Exception {
+    public ResponseEntity<Void> updateUser(@ApiParam(value = "name that need to be deleted",required=true) @PathVariable("username") String username,@ApiParam(value = "Updated user object" ,required=true )  @Valid @RequestBody User body) {
         // do some magic!
         return delegate.updateUser(username, body);
     }

--- a/samples/server/petstore/springboot-delegate/src/main/java/io/swagger/api/UserApiController.java
+++ b/samples/server/petstore/springboot-delegate/src/main/java/io/swagger/api/UserApiController.java
@@ -2,9 +2,7 @@ package io.swagger.api;
 
 import java.util.List;
 import io.swagger.model.User;
-
 import io.swagger.annotations.*;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpStatus;
@@ -15,16 +13,11 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RequestPart;
-import org.springframework.web.context.request.RequestContextHolder;
-import org.springframework.web.context.request.ServletRequestAttributes;
 import org.springframework.web.multipart.MultipartFile;
 
-import java.util.List;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import java.io.IOException;
-import javax.servlet.http.HttpServletRequest;
 import javax.validation.constraints.*;
 import javax.validation.Valid;
+import java.util.List;
 
 @Controller
 public class UserApiController implements UserApi {
@@ -35,44 +28,35 @@ public class UserApiController implements UserApi {
     public UserApiController(UserApiDelegate delegate) {
         this.delegate = delegate;
     }
-
     public ResponseEntity<Void> createUser(@ApiParam(value = "Created user object" ,required=true )  @Valid @RequestBody User body) {
-        // do some magic!
         return delegate.createUser(body);
     }
 
     public ResponseEntity<Void> createUsersWithArrayInput(@ApiParam(value = "List of user object" ,required=true )  @Valid @RequestBody List<User> body) {
-        // do some magic!
         return delegate.createUsersWithArrayInput(body);
     }
 
     public ResponseEntity<Void> createUsersWithListInput(@ApiParam(value = "List of user object" ,required=true )  @Valid @RequestBody List<User> body) {
-        // do some magic!
         return delegate.createUsersWithListInput(body);
     }
 
     public ResponseEntity<Void> deleteUser(@ApiParam(value = "The name that needs to be deleted",required=true) @PathVariable("username") String username) {
-        // do some magic!
         return delegate.deleteUser(username);
     }
 
     public ResponseEntity<User> getUserByName(@ApiParam(value = "The name that needs to be fetched. Use user1 for testing. ",required=true) @PathVariable("username") String username) {
-        // do some magic!
         return delegate.getUserByName(username);
     }
 
     public ResponseEntity<String> loginUser(@NotNull @ApiParam(value = "The user name for login", required = true) @Valid @RequestParam(value = "username", required = true) String username,@NotNull @ApiParam(value = "The password for login in clear text", required = true) @Valid @RequestParam(value = "password", required = true) String password) {
-        // do some magic!
         return delegate.loginUser(username, password);
     }
 
     public ResponseEntity<Void> logoutUser() {
-        // do some magic!
         return delegate.logoutUser();
     }
 
     public ResponseEntity<Void> updateUser(@ApiParam(value = "name that need to be deleted",required=true) @PathVariable("username") String username,@ApiParam(value = "Updated user object" ,required=true )  @Valid @RequestBody User body) {
-        // do some magic!
         return delegate.updateUser(username, body);
     }
 

--- a/samples/server/petstore/springboot-delegate/src/main/java/io/swagger/api/UserApiDelegate.java
+++ b/samples/server/petstore/springboot-delegate/src/main/java/io/swagger/api/UserApiDelegate.java
@@ -2,7 +2,6 @@ package io.swagger.api;
 
 import java.util.List;
 import io.swagger.model.User;
-
 import io.swagger.annotations.*;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.multipart.MultipartFile;
@@ -11,8 +10,7 @@ import java.util.List;
 
 /**
  * A delegate to be called by the {@link UserApiController}}.
- * Should be implemented as a controller but without the {@link org.springframework.stereotype.Controller} annotation.
- * Instead, use spring to autowire this class into the {@link UserApiController}.
+ * Implement this interface with a {@link org.springframework.stereotype.Service} annotated class.
  */
 
 public interface UserApiDelegate {

--- a/samples/server/petstore/springboot-delegate/src/main/java/io/swagger/model/FormatTest.java
+++ b/samples/server/petstore/springboot-delegate/src/main/java/io/swagger/model/FormatTest.java
@@ -71,7 +71,7 @@ public class FormatTest   {
   **/
   @ApiModelProperty(value = "")
 
- @Min(10) @Max(100)
+@Min(10) @Max(100) 
   public Integer getInteger() {
     return integer;
   }
@@ -93,7 +93,7 @@ public class FormatTest   {
   **/
   @ApiModelProperty(value = "")
 
- @Min(20) @Max(200)
+@Min(20) @Max(200) 
   public Integer getInt32() {
     return int32;
   }
@@ -137,7 +137,7 @@ public class FormatTest   {
   @NotNull
 
   @Valid
- @DecimalMin("32.1") @DecimalMax("543.2")
+@DecimalMin("32.1") @DecimalMax("543.2") 
   public BigDecimal getNumber() {
     return number;
   }
@@ -159,7 +159,7 @@ public class FormatTest   {
   **/
   @ApiModelProperty(value = "")
 
- @DecimalMin("54.3") @DecimalMax("987.6")
+@DecimalMin("54.3") @DecimalMax("987.6") 
   public Float getFloat() {
     return _float;
   }
@@ -181,7 +181,7 @@ public class FormatTest   {
   **/
   @ApiModelProperty(value = "")
 
- @DecimalMin("67.8") @DecimalMax("123.4")
+@DecimalMin("67.8") @DecimalMax("123.4") 
   public Double getDouble() {
     return _double;
   }
@@ -201,7 +201,7 @@ public class FormatTest   {
   **/
   @ApiModelProperty(value = "")
 
- @Pattern(regexp="/[a-z]/i")
+@Pattern(regexp="/[a-z]/i") 
   public String getString() {
     return string;
   }
@@ -222,7 +222,7 @@ public class FormatTest   {
   @ApiModelProperty(required = true, value = "")
   @NotNull
 
- @Pattern(regexp="^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$")
+@Pattern(regexp="^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$") 
   public byte[] getByte() {
     return _byte;
   }
@@ -327,7 +327,7 @@ public class FormatTest   {
   @ApiModelProperty(required = true, value = "")
   @NotNull
 
- @Size(min=10,max=64)
+@Size(min=10,max=64) 
   public String getPassword() {
     return password;
   }

--- a/samples/server/petstore/springboot-implicitHeaders/src/main/java/io/swagger/api/AnotherFakeApi.java
+++ b/samples/server/petstore/springboot-implicitHeaders/src/main/java/io/swagger/api/AnotherFakeApi.java
@@ -6,9 +6,9 @@
 package io.swagger.api;
 
 import io.swagger.model.Client;
-
 import io.swagger.annotations.*;
 import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
@@ -17,12 +17,10 @@ import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.multipart.MultipartFile;
-import java.io.IOException;
 
-import java.util.List;
-import org.springframework.validation.annotation.Validated;
-import javax.validation.constraints.*;
 import javax.validation.Valid;
+import javax.validation.constraints.*;
+import java.util.List;
 
 @Api(value = "another-fake", description = "the another-fake API")
 public interface AnotherFakeApi {

--- a/samples/server/petstore/springboot-implicitHeaders/src/main/java/io/swagger/api/AnotherFakeApi.java
+++ b/samples/server/petstore/springboot-implicitHeaders/src/main/java/io/swagger/api/AnotherFakeApi.java
@@ -36,6 +36,6 @@ public interface AnotherFakeApi {
         produces = { "application/json" }, 
         consumes = { "application/json" },
         method = RequestMethod.PATCH)
-    ResponseEntity<Client> testSpecialTags(@ApiParam(value = "client model" ,required=true )  @Valid @RequestBody Client body, @RequestHeader(value = "Accept", required = false) String accept) throws Exception;
+    ResponseEntity<Client> testSpecialTags(@ApiParam(value = "client model" ,required=true )  @Valid @RequestBody Client body);
 
 }

--- a/samples/server/petstore/springboot-implicitHeaders/src/main/java/io/swagger/api/AnotherFakeApiController.java
+++ b/samples/server/petstore/springboot-implicitHeaders/src/main/java/io/swagger/api/AnotherFakeApiController.java
@@ -4,6 +4,8 @@ import io.swagger.model.Client;
 
 import io.swagger.annotations.*;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
@@ -12,6 +14,8 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RequestPart;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.util.List;
@@ -22,18 +26,25 @@ import javax.validation.Valid;
 
 @Controller
 public class AnotherFakeApiController implements AnotherFakeApi {
+
+    private final Logger log = LoggerFactory.getLogger(AnotherFakeApiController.class);
+
     private final ObjectMapper objectMapper;
 
     public AnotherFakeApiController(ObjectMapper objectMapper) {
         this.objectMapper = objectMapper;
     }
 
-    public ResponseEntity<Client> testSpecialTags(@ApiParam(value = "client model" ,required=true )  @Valid @RequestBody Client body,
-        @RequestHeader(value = "Accept", required = false) String accept) throws Exception {
+    public ResponseEntity<Client> testSpecialTags(@ApiParam(value = "client model" ,required=true )  @Valid @RequestBody Client body) {
         // do some magic!
-
+        String accept = ((ServletRequestAttributes)RequestContextHolder.getRequestAttributes()).getRequest().getHeader("Accept");
         if (accept != null && accept.contains("application/json")) {
-            return new ResponseEntity<Client>(objectMapper.readValue("{  \"client\" : \"client\"}", Client.class), HttpStatus.OK);
+            try {
+                return new ResponseEntity<Client>(objectMapper.readValue("{  \"client\" : \"client\"}", Client.class), HttpStatus.NOT_IMPLEMENTED);
+            } catch (IOException e) {
+                log.error("Couldn't serialize response for content type application/json", e);
+                return new ResponseEntity<Client>(HttpStatus.INTERNAL_SERVER_ERROR);
+            }
         }
 
         return new ResponseEntity<Client>(HttpStatus.OK);

--- a/samples/server/petstore/springboot-implicitHeaders/src/main/java/io/swagger/api/AnotherFakeApiController.java
+++ b/samples/server/petstore/springboot-implicitHeaders/src/main/java/io/swagger/api/AnotherFakeApiController.java
@@ -32,12 +32,12 @@ public class AnotherFakeApiController implements AnotherFakeApi {
 
     private final ObjectMapper objectMapper;
 
-    @org.springframework.beans.factory.annotation.Autowired
-    private HttpServletRequest request;
+    private final HttpServletRequest request;
 
     @org.springframework.beans.factory.annotation.Autowired
-    public AnotherFakeApiController(ObjectMapper objectMapper) {
+    public AnotherFakeApiController(ObjectMapper objectMapper, HttpServletRequest request) {
         this.objectMapper = objectMapper;
+        this.request = request;
     }
 
     public ResponseEntity<Client> testSpecialTags(@ApiParam(value = "client model" ,required=true )  @Valid @RequestBody Client body) {

--- a/samples/server/petstore/springboot-implicitHeaders/src/main/java/io/swagger/api/AnotherFakeApiController.java
+++ b/samples/server/petstore/springboot-implicitHeaders/src/main/java/io/swagger/api/AnotherFakeApiController.java
@@ -21,23 +21,28 @@ import org.springframework.web.multipart.MultipartFile;
 import java.util.List;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.IOException;
+import javax.servlet.http.HttpServletRequest;
 import javax.validation.constraints.*;
 import javax.validation.Valid;
 
 @Controller
 public class AnotherFakeApiController implements AnotherFakeApi {
 
-    private final Logger log = LoggerFactory.getLogger(AnotherFakeApiController.class);
+    private static final Logger log = LoggerFactory.getLogger(AnotherFakeApiController.class);
 
     private final ObjectMapper objectMapper;
 
+    @org.springframework.beans.factory.annotation.Autowired
+    private HttpServletRequest request;
+
+    @org.springframework.beans.factory.annotation.Autowired
     public AnotherFakeApiController(ObjectMapper objectMapper) {
         this.objectMapper = objectMapper;
     }
 
     public ResponseEntity<Client> testSpecialTags(@ApiParam(value = "client model" ,required=true )  @Valid @RequestBody Client body) {
         // do some magic!
-        String accept = ((ServletRequestAttributes)RequestContextHolder.getRequestAttributes()).getRequest().getHeader("Accept");
+        String accept = request.getHeader("Accept");
         if (accept != null && accept.contains("application/json")) {
             try {
                 return new ResponseEntity<Client>(objectMapper.readValue("{  \"client\" : \"client\"}", Client.class), HttpStatus.NOT_IMPLEMENTED);

--- a/samples/server/petstore/springboot-implicitHeaders/src/main/java/io/swagger/api/AnotherFakeApiController.java
+++ b/samples/server/petstore/springboot-implicitHeaders/src/main/java/io/swagger/api/AnotherFakeApiController.java
@@ -1,9 +1,8 @@
 package io.swagger.api;
 
 import io.swagger.model.Client;
-
+import com.fasterxml.jackson.databind.ObjectMapper;
 import io.swagger.annotations.*;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpStatus;
@@ -14,16 +13,13 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RequestPart;
-import org.springframework.web.context.request.RequestContextHolder;
-import org.springframework.web.context.request.ServletRequestAttributes;
 import org.springframework.web.multipart.MultipartFile;
 
-import java.util.List;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import java.io.IOException;
-import javax.servlet.http.HttpServletRequest;
 import javax.validation.constraints.*;
 import javax.validation.Valid;
+import javax.servlet.http.HttpServletRequest;
+import java.io.IOException;
+import java.util.List;
 
 @Controller
 public class AnotherFakeApiController implements AnotherFakeApi {
@@ -41,7 +37,6 @@ public class AnotherFakeApiController implements AnotherFakeApi {
     }
 
     public ResponseEntity<Client> testSpecialTags(@ApiParam(value = "client model" ,required=true )  @Valid @RequestBody Client body) {
-        // do some magic!
         String accept = request.getHeader("Accept");
         if (accept != null && accept.contains("application/json")) {
             try {
@@ -52,7 +47,7 @@ public class AnotherFakeApiController implements AnotherFakeApi {
             }
         }
 
-        return new ResponseEntity<Client>(HttpStatus.OK);
+        return new ResponseEntity<Client>(HttpStatus.NOT_IMPLEMENTED);
     }
 
 }

--- a/samples/server/petstore/springboot-implicitHeaders/src/main/java/io/swagger/api/FakeApi.java
+++ b/samples/server/petstore/springboot-implicitHeaders/src/main/java/io/swagger/api/FakeApi.java
@@ -38,7 +38,7 @@ public interface FakeApi {
     })
     @RequestMapping(value = "/fake/outer/boolean",
         method = RequestMethod.POST)
-    ResponseEntity<Boolean> fakeOuterBooleanSerialize(@ApiParam(value = "Input boolean as post body"  )  @Valid @RequestBody Boolean body, @RequestHeader(value = "Accept", required = false) String accept) throws Exception;
+    ResponseEntity<Boolean> fakeOuterBooleanSerialize(@ApiParam(value = "Input boolean as post body"  )  @Valid @RequestBody Boolean body);
 
 
     @ApiOperation(value = "", nickname = "fakeOuterCompositeSerialize", notes = "Test serialization of object with outer number type", response = OuterComposite.class, tags={ "fake", })
@@ -48,7 +48,7 @@ public interface FakeApi {
     })
     @RequestMapping(value = "/fake/outer/composite",
         method = RequestMethod.POST)
-    ResponseEntity<OuterComposite> fakeOuterCompositeSerialize(@ApiParam(value = "Input composite as post body"  )  @Valid @RequestBody OuterComposite body, @RequestHeader(value = "Accept", required = false) String accept) throws Exception;
+    ResponseEntity<OuterComposite> fakeOuterCompositeSerialize(@ApiParam(value = "Input composite as post body"  )  @Valid @RequestBody OuterComposite body);
 
 
     @ApiOperation(value = "", nickname = "fakeOuterNumberSerialize", notes = "Test serialization of outer number types", response = BigDecimal.class, tags={ "fake", })
@@ -58,7 +58,7 @@ public interface FakeApi {
     })
     @RequestMapping(value = "/fake/outer/number",
         method = RequestMethod.POST)
-    ResponseEntity<BigDecimal> fakeOuterNumberSerialize(@ApiParam(value = "Input number as post body"  )  @Valid @RequestBody BigDecimal body, @RequestHeader(value = "Accept", required = false) String accept) throws Exception;
+    ResponseEntity<BigDecimal> fakeOuterNumberSerialize(@ApiParam(value = "Input number as post body"  )  @Valid @RequestBody BigDecimal body);
 
 
     @ApiOperation(value = "", nickname = "fakeOuterStringSerialize", notes = "Test serialization of outer string types", response = String.class, tags={ "fake", })
@@ -68,7 +68,7 @@ public interface FakeApi {
     })
     @RequestMapping(value = "/fake/outer/string",
         method = RequestMethod.POST)
-    ResponseEntity<String> fakeOuterStringSerialize(@ApiParam(value = "Input string as post body"  )  @Valid @RequestBody String body, @RequestHeader(value = "Accept", required = false) String accept) throws Exception;
+    ResponseEntity<String> fakeOuterStringSerialize(@ApiParam(value = "Input string as post body"  )  @Valid @RequestBody String body);
 
 
     @ApiOperation(value = "To test \"client\" model", nickname = "testClientModel", notes = "To test \"client\" model", response = Client.class, tags={ "fake", })
@@ -80,7 +80,7 @@ public interface FakeApi {
         produces = { "application/json" }, 
         consumes = { "application/json" },
         method = RequestMethod.PATCH)
-    ResponseEntity<Client> testClientModel(@ApiParam(value = "client model" ,required=true )  @Valid @RequestBody Client body, @RequestHeader(value = "Accept", required = false) String accept) throws Exception;
+    ResponseEntity<Client> testClientModel(@ApiParam(value = "client model" ,required=true )  @Valid @RequestBody Client body);
 
 
     @ApiOperation(value = "Fake endpoint for testing various parameters 假端點 偽のエンドポイント 가짜 엔드 포인트 ", nickname = "testEndpointParameters", notes = "Fake endpoint for testing various parameters 假端點 偽のエンドポイント 가짜 엔드 포인트 ", authorizations = {
@@ -95,7 +95,7 @@ public interface FakeApi {
         produces = { "application/xml; charset=utf-8", "application/json; charset=utf-8" }, 
         consumes = { "application/xml; charset=utf-8", "application/json; charset=utf-8" },
         method = RequestMethod.POST)
-    ResponseEntity<Void> testEndpointParameters(@ApiParam(value = "None", required=true) @RequestPart(value="number", required=true)  BigDecimal number,@ApiParam(value = "None", required=true) @RequestPart(value="double", required=true)  Double _double,@ApiParam(value = "None", required=true) @RequestPart(value="pattern_without_delimiter", required=true)  String patternWithoutDelimiter,@ApiParam(value = "None", required=true) @RequestPart(value="byte", required=true)  byte[] _byte,@ApiParam(value = "None") @RequestPart(value="integer", required=false)  Integer integer,@ApiParam(value = "None") @RequestPart(value="int32", required=false)  Integer int32,@ApiParam(value = "None") @RequestPart(value="int64", required=false)  Long int64,@ApiParam(value = "None") @RequestPart(value="float", required=false)  Float _float,@ApiParam(value = "None") @RequestPart(value="string", required=false)  String string,@ApiParam(value = "None") @RequestPart(value="binary", required=false)  byte[] binary,@ApiParam(value = "None") @RequestPart(value="date", required=false)  LocalDate date,@ApiParam(value = "None") @RequestPart(value="dateTime", required=false)  OffsetDateTime dateTime,@ApiParam(value = "None") @RequestPart(value="password", required=false)  String password,@ApiParam(value = "None") @RequestPart(value="callback", required=false)  String paramCallback, @RequestHeader(value = "Accept", required = false) String accept) throws Exception;
+    ResponseEntity<Void> testEndpointParameters(@ApiParam(value = "None", required=true) @RequestPart(value="number", required=true)  BigDecimal number,@ApiParam(value = "None", required=true) @RequestPart(value="double", required=true)  Double _double,@ApiParam(value = "None", required=true) @RequestPart(value="pattern_without_delimiter", required=true)  String patternWithoutDelimiter,@ApiParam(value = "None", required=true) @RequestPart(value="byte", required=true)  byte[] _byte,@ApiParam(value = "None") @RequestPart(value="integer", required=false)  Integer integer,@ApiParam(value = "None") @RequestPart(value="int32", required=false)  Integer int32,@ApiParam(value = "None") @RequestPart(value="int64", required=false)  Long int64,@ApiParam(value = "None") @RequestPart(value="float", required=false)  Float _float,@ApiParam(value = "None") @RequestPart(value="string", required=false)  String string,@ApiParam(value = "None") @RequestPart(value="binary", required=false)  byte[] binary,@ApiParam(value = "None") @RequestPart(value="date", required=false)  LocalDate date,@ApiParam(value = "None") @RequestPart(value="dateTime", required=false)  OffsetDateTime dateTime,@ApiParam(value = "None") @RequestPart(value="password", required=false)  String password,@ApiParam(value = "None") @RequestPart(value="callback", required=false)  String paramCallback);
 
 
     @ApiOperation(value = "To test enum parameters", nickname = "testEnumParameters", notes = "To test enum parameters", tags={ "fake", })
@@ -110,7 +110,7 @@ public interface FakeApi {
         produces = { "*/*" }, 
         consumes = { "*/*" },
         method = RequestMethod.GET)
-    ResponseEntity<Void> testEnumParameters(@ApiParam(value = "Form parameter enum test (string array)", allowableValues=">, $") @RequestPart(value="enum_form_string_array", required=false)  List<String> enumFormStringArray,@ApiParam(value = "Form parameter enum test (string)", allowableValues="_abc, -efg, (xyz)", defaultValue="-efg") @RequestPart(value="enum_form_string", required=false)  String enumFormString,@ApiParam(value = "Query parameter enum test (string array)", allowableValues = ">, $") @Valid @RequestParam(value = "enum_query_string_array", required = false) List<String> enumQueryStringArray,@ApiParam(value = "Query parameter enum test (string)", allowableValues = "_abc, -efg, (xyz)", defaultValue = "-efg") @Valid @RequestParam(value = "enum_query_string", required = false, defaultValue="-efg") String enumQueryString,@ApiParam(value = "Query parameter enum test (double)", allowableValues = "1, -2") @Valid @RequestParam(value = "enum_query_integer", required = false) Integer enumQueryInteger,@ApiParam(value = "Query parameter enum test (double)", allowableValues="1.1, -1.2") @RequestPart(value="enum_query_double", required=false)  Double enumQueryDouble, @RequestHeader(value = "Accept", required = false) String accept) throws Exception;
+    ResponseEntity<Void> testEnumParameters(@ApiParam(value = "Form parameter enum test (string array)", allowableValues=">, $") @RequestPart(value="enum_form_string_array", required=false)  List<String> enumFormStringArray,@ApiParam(value = "Form parameter enum test (string)", allowableValues="_abc, -efg, (xyz)", defaultValue="-efg") @RequestPart(value="enum_form_string", required=false)  String enumFormString,@ApiParam(value = "Query parameter enum test (string array)", allowableValues = ">, $") @Valid @RequestParam(value = "enum_query_string_array", required = false) List<String> enumQueryStringArray,@ApiParam(value = "Query parameter enum test (string)", allowableValues = "_abc, -efg, (xyz)", defaultValue = "-efg") @Valid @RequestParam(value = "enum_query_string", required = false, defaultValue="-efg") String enumQueryString,@ApiParam(value = "Query parameter enum test (double)", allowableValues = "1, -2") @Valid @RequestParam(value = "enum_query_integer", required = false) Integer enumQueryInteger,@ApiParam(value = "Query parameter enum test (double)", allowableValues="1.1, -1.2") @RequestPart(value="enum_query_double", required=false)  Double enumQueryDouble);
 
 
     @ApiOperation(value = "test inline additionalProperties", nickname = "testInlineAdditionalProperties", notes = "", tags={ "fake", })
@@ -121,7 +121,7 @@ public interface FakeApi {
     @RequestMapping(value = "/fake/inline-additionalProperties",
         consumes = { "application/json" },
         method = RequestMethod.POST)
-    ResponseEntity<Void> testInlineAdditionalProperties(@ApiParam(value = "request body" ,required=true )  @Valid @RequestBody Object param, @RequestHeader(value = "Accept", required = false) String accept) throws Exception;
+    ResponseEntity<Void> testInlineAdditionalProperties(@ApiParam(value = "request body" ,required=true )  @Valid @RequestBody Object param);
 
 
     @ApiOperation(value = "test json serialization of form data", nickname = "testJsonFormData", notes = "", tags={ "fake", })
@@ -132,6 +132,6 @@ public interface FakeApi {
     @RequestMapping(value = "/fake/jsonFormData",
         consumes = { "application/json" },
         method = RequestMethod.GET)
-    ResponseEntity<Void> testJsonFormData(@ApiParam(value = "field1", required=true) @RequestPart(value="param", required=true)  String param,@ApiParam(value = "field2", required=true) @RequestPart(value="param2", required=true)  String param2, @RequestHeader(value = "Accept", required = false) String accept) throws Exception;
+    ResponseEntity<Void> testJsonFormData(@ApiParam(value = "field1", required=true) @RequestPart(value="param", required=true)  String param,@ApiParam(value = "field2", required=true) @RequestPart(value="param2", required=true)  String param2);
 
 }

--- a/samples/server/petstore/springboot-implicitHeaders/src/main/java/io/swagger/api/FakeApi.java
+++ b/samples/server/petstore/springboot-implicitHeaders/src/main/java/io/swagger/api/FakeApi.java
@@ -10,9 +10,9 @@ import io.swagger.model.Client;
 import org.threeten.bp.LocalDate;
 import org.threeten.bp.OffsetDateTime;
 import io.swagger.model.OuterComposite;
-
 import io.swagger.annotations.*;
 import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
@@ -21,12 +21,10 @@ import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.multipart.MultipartFile;
-import java.io.IOException;
 
-import java.util.List;
-import org.springframework.validation.annotation.Validated;
-import javax.validation.constraints.*;
 import javax.validation.Valid;
+import javax.validation.constraints.*;
+import java.util.List;
 
 @Api(value = "fake", description = "the fake API")
 public interface FakeApi {

--- a/samples/server/petstore/springboot-implicitHeaders/src/main/java/io/swagger/api/FakeApiController.java
+++ b/samples/server/petstore/springboot-implicitHeaders/src/main/java/io/swagger/api/FakeApiController.java
@@ -36,12 +36,12 @@ public class FakeApiController implements FakeApi {
 
     private final ObjectMapper objectMapper;
 
-    @org.springframework.beans.factory.annotation.Autowired
-    private HttpServletRequest request;
+    private final HttpServletRequest request;
 
     @org.springframework.beans.factory.annotation.Autowired
-    public FakeApiController(ObjectMapper objectMapper) {
+    public FakeApiController(ObjectMapper objectMapper, HttpServletRequest request) {
         this.objectMapper = objectMapper;
+        this.request = request;
     }
 
     public ResponseEntity<Boolean> fakeOuterBooleanSerialize(@ApiParam(value = "Input boolean as post body"  )  @Valid @RequestBody Boolean body) {

--- a/samples/server/petstore/springboot-implicitHeaders/src/main/java/io/swagger/api/FakeApiController.java
+++ b/samples/server/petstore/springboot-implicitHeaders/src/main/java/io/swagger/api/FakeApiController.java
@@ -25,23 +25,28 @@ import org.springframework.web.multipart.MultipartFile;
 import java.util.List;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.IOException;
+import javax.servlet.http.HttpServletRequest;
 import javax.validation.constraints.*;
 import javax.validation.Valid;
 
 @Controller
 public class FakeApiController implements FakeApi {
 
-    private final Logger log = LoggerFactory.getLogger(AnotherFakeApiController.class);
+    private static final Logger log = LoggerFactory.getLogger(FakeApiController.class);
 
     private final ObjectMapper objectMapper;
 
+    @org.springframework.beans.factory.annotation.Autowired
+    private HttpServletRequest request;
+
+    @org.springframework.beans.factory.annotation.Autowired
     public FakeApiController(ObjectMapper objectMapper) {
         this.objectMapper = objectMapper;
     }
 
     public ResponseEntity<Boolean> fakeOuterBooleanSerialize(@ApiParam(value = "Input boolean as post body"  )  @Valid @RequestBody Boolean body) {
         // do some magic!
-        String accept = ((ServletRequestAttributes)RequestContextHolder.getRequestAttributes()).getRequest().getHeader("Accept");
+        String accept = request.getHeader("Accept");
         if (accept != null && accept.contains("application/json")) {
             try {
                 return new ResponseEntity<Boolean>(objectMapper.readValue("{ }", Boolean.class), HttpStatus.NOT_IMPLEMENTED);
@@ -56,7 +61,7 @@ public class FakeApiController implements FakeApi {
 
     public ResponseEntity<OuterComposite> fakeOuterCompositeSerialize(@ApiParam(value = "Input composite as post body"  )  @Valid @RequestBody OuterComposite body) {
         // do some magic!
-        String accept = ((ServletRequestAttributes)RequestContextHolder.getRequestAttributes()).getRequest().getHeader("Accept");
+        String accept = request.getHeader("Accept");
         if (accept != null && accept.contains("application/json")) {
             try {
                 return new ResponseEntity<OuterComposite>(objectMapper.readValue("{  \"my_string\" : { },  \"my_number\" : { },  \"my_boolean\" : { }}", OuterComposite.class), HttpStatus.NOT_IMPLEMENTED);
@@ -71,7 +76,7 @@ public class FakeApiController implements FakeApi {
 
     public ResponseEntity<BigDecimal> fakeOuterNumberSerialize(@ApiParam(value = "Input number as post body"  )  @Valid @RequestBody BigDecimal body) {
         // do some magic!
-        String accept = ((ServletRequestAttributes)RequestContextHolder.getRequestAttributes()).getRequest().getHeader("Accept");
+        String accept = request.getHeader("Accept");
         if (accept != null && accept.contains("application/json")) {
             try {
                 return new ResponseEntity<BigDecimal>(objectMapper.readValue("{ }", BigDecimal.class), HttpStatus.NOT_IMPLEMENTED);
@@ -86,7 +91,7 @@ public class FakeApiController implements FakeApi {
 
     public ResponseEntity<String> fakeOuterStringSerialize(@ApiParam(value = "Input string as post body"  )  @Valid @RequestBody String body) {
         // do some magic!
-        String accept = ((ServletRequestAttributes)RequestContextHolder.getRequestAttributes()).getRequest().getHeader("Accept");
+        String accept = request.getHeader("Accept");
         if (accept != null && accept.contains("application/json")) {
             try {
                 return new ResponseEntity<String>(objectMapper.readValue("{ }", String.class), HttpStatus.NOT_IMPLEMENTED);
@@ -101,7 +106,7 @@ public class FakeApiController implements FakeApi {
 
     public ResponseEntity<Client> testClientModel(@ApiParam(value = "client model" ,required=true )  @Valid @RequestBody Client body) {
         // do some magic!
-        String accept = ((ServletRequestAttributes)RequestContextHolder.getRequestAttributes()).getRequest().getHeader("Accept");
+        String accept = request.getHeader("Accept");
         if (accept != null && accept.contains("application/json")) {
             try {
                 return new ResponseEntity<Client>(objectMapper.readValue("{  \"client\" : \"client\"}", Client.class), HttpStatus.NOT_IMPLEMENTED);
@@ -116,25 +121,25 @@ public class FakeApiController implements FakeApi {
 
     public ResponseEntity<Void> testEndpointParameters(@ApiParam(value = "None", required=true) @RequestPart(value="number", required=true)  BigDecimal number,@ApiParam(value = "None", required=true) @RequestPart(value="double", required=true)  Double _double,@ApiParam(value = "None", required=true) @RequestPart(value="pattern_without_delimiter", required=true)  String patternWithoutDelimiter,@ApiParam(value = "None", required=true) @RequestPart(value="byte", required=true)  byte[] _byte,@ApiParam(value = "None") @RequestPart(value="integer", required=false)  Integer integer,@ApiParam(value = "None") @RequestPart(value="int32", required=false)  Integer int32,@ApiParam(value = "None") @RequestPart(value="int64", required=false)  Long int64,@ApiParam(value = "None") @RequestPart(value="float", required=false)  Float _float,@ApiParam(value = "None") @RequestPart(value="string", required=false)  String string,@ApiParam(value = "None") @RequestPart(value="binary", required=false)  byte[] binary,@ApiParam(value = "None") @RequestPart(value="date", required=false)  LocalDate date,@ApiParam(value = "None") @RequestPart(value="dateTime", required=false)  OffsetDateTime dateTime,@ApiParam(value = "None") @RequestPart(value="password", required=false)  String password,@ApiParam(value = "None") @RequestPart(value="callback", required=false)  String paramCallback) {
         // do some magic!
-        String accept = ((ServletRequestAttributes)RequestContextHolder.getRequestAttributes()).getRequest().getHeader("Accept");
+        String accept = request.getHeader("Accept");
         return new ResponseEntity<Void>(HttpStatus.OK);
     }
 
     public ResponseEntity<Void> testEnumParameters(@ApiParam(value = "Form parameter enum test (string array)", allowableValues=">, $") @RequestPart(value="enum_form_string_array", required=false)  List<String> enumFormStringArray,@ApiParam(value = "Form parameter enum test (string)", allowableValues="_abc, -efg, (xyz)", defaultValue="-efg") @RequestPart(value="enum_form_string", required=false)  String enumFormString,@ApiParam(value = "Query parameter enum test (string array)", allowableValues = ">, $") @Valid @RequestParam(value = "enum_query_string_array", required = false) List<String> enumQueryStringArray,@ApiParam(value = "Query parameter enum test (string)", allowableValues = "_abc, -efg, (xyz)", defaultValue = "-efg") @Valid @RequestParam(value = "enum_query_string", required = false, defaultValue="-efg") String enumQueryString,@ApiParam(value = "Query parameter enum test (double)", allowableValues = "1, -2") @Valid @RequestParam(value = "enum_query_integer", required = false) Integer enumQueryInteger,@ApiParam(value = "Query parameter enum test (double)", allowableValues="1.1, -1.2") @RequestPart(value="enum_query_double", required=false)  Double enumQueryDouble) {
         // do some magic!
-        String accept = ((ServletRequestAttributes)RequestContextHolder.getRequestAttributes()).getRequest().getHeader("Accept");
+        String accept = request.getHeader("Accept");
         return new ResponseEntity<Void>(HttpStatus.OK);
     }
 
     public ResponseEntity<Void> testInlineAdditionalProperties(@ApiParam(value = "request body" ,required=true )  @Valid @RequestBody Object param) {
         // do some magic!
-        String accept = ((ServletRequestAttributes)RequestContextHolder.getRequestAttributes()).getRequest().getHeader("Accept");
+        String accept = request.getHeader("Accept");
         return new ResponseEntity<Void>(HttpStatus.OK);
     }
 
     public ResponseEntity<Void> testJsonFormData(@ApiParam(value = "field1", required=true) @RequestPart(value="param", required=true)  String param,@ApiParam(value = "field2", required=true) @RequestPart(value="param2", required=true)  String param2) {
         // do some magic!
-        String accept = ((ServletRequestAttributes)RequestContextHolder.getRequestAttributes()).getRequest().getHeader("Accept");
+        String accept = request.getHeader("Accept");
         return new ResponseEntity<Void>(HttpStatus.OK);
     }
 

--- a/samples/server/petstore/springboot-implicitHeaders/src/main/java/io/swagger/api/FakeApiController.java
+++ b/samples/server/petstore/springboot-implicitHeaders/src/main/java/io/swagger/api/FakeApiController.java
@@ -5,9 +5,8 @@ import io.swagger.model.Client;
 import org.threeten.bp.LocalDate;
 import org.threeten.bp.OffsetDateTime;
 import io.swagger.model.OuterComposite;
-
+import com.fasterxml.jackson.databind.ObjectMapper;
 import io.swagger.annotations.*;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpStatus;
@@ -18,16 +17,13 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RequestPart;
-import org.springframework.web.context.request.RequestContextHolder;
-import org.springframework.web.context.request.ServletRequestAttributes;
 import org.springframework.web.multipart.MultipartFile;
 
-import java.util.List;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import java.io.IOException;
-import javax.servlet.http.HttpServletRequest;
 import javax.validation.constraints.*;
 import javax.validation.Valid;
+import javax.servlet.http.HttpServletRequest;
+import java.io.IOException;
+import java.util.List;
 
 @Controller
 public class FakeApiController implements FakeApi {
@@ -45,7 +41,6 @@ public class FakeApiController implements FakeApi {
     }
 
     public ResponseEntity<Boolean> fakeOuterBooleanSerialize(@ApiParam(value = "Input boolean as post body"  )  @Valid @RequestBody Boolean body) {
-        // do some magic!
         String accept = request.getHeader("Accept");
         if (accept != null && accept.contains("application/json")) {
             try {
@@ -56,11 +51,10 @@ public class FakeApiController implements FakeApi {
             }
         }
 
-        return new ResponseEntity<Boolean>(HttpStatus.OK);
+        return new ResponseEntity<Boolean>(HttpStatus.NOT_IMPLEMENTED);
     }
 
     public ResponseEntity<OuterComposite> fakeOuterCompositeSerialize(@ApiParam(value = "Input composite as post body"  )  @Valid @RequestBody OuterComposite body) {
-        // do some magic!
         String accept = request.getHeader("Accept");
         if (accept != null && accept.contains("application/json")) {
             try {
@@ -71,11 +65,10 @@ public class FakeApiController implements FakeApi {
             }
         }
 
-        return new ResponseEntity<OuterComposite>(HttpStatus.OK);
+        return new ResponseEntity<OuterComposite>(HttpStatus.NOT_IMPLEMENTED);
     }
 
     public ResponseEntity<BigDecimal> fakeOuterNumberSerialize(@ApiParam(value = "Input number as post body"  )  @Valid @RequestBody BigDecimal body) {
-        // do some magic!
         String accept = request.getHeader("Accept");
         if (accept != null && accept.contains("application/json")) {
             try {
@@ -86,11 +79,10 @@ public class FakeApiController implements FakeApi {
             }
         }
 
-        return new ResponseEntity<BigDecimal>(HttpStatus.OK);
+        return new ResponseEntity<BigDecimal>(HttpStatus.NOT_IMPLEMENTED);
     }
 
     public ResponseEntity<String> fakeOuterStringSerialize(@ApiParam(value = "Input string as post body"  )  @Valid @RequestBody String body) {
-        // do some magic!
         String accept = request.getHeader("Accept");
         if (accept != null && accept.contains("application/json")) {
             try {
@@ -101,11 +93,10 @@ public class FakeApiController implements FakeApi {
             }
         }
 
-        return new ResponseEntity<String>(HttpStatus.OK);
+        return new ResponseEntity<String>(HttpStatus.NOT_IMPLEMENTED);
     }
 
     public ResponseEntity<Client> testClientModel(@ApiParam(value = "client model" ,required=true )  @Valid @RequestBody Client body) {
-        // do some magic!
         String accept = request.getHeader("Accept");
         if (accept != null && accept.contains("application/json")) {
             try {
@@ -116,31 +107,27 @@ public class FakeApiController implements FakeApi {
             }
         }
 
-        return new ResponseEntity<Client>(HttpStatus.OK);
+        return new ResponseEntity<Client>(HttpStatus.NOT_IMPLEMENTED);
     }
 
     public ResponseEntity<Void> testEndpointParameters(@ApiParam(value = "None", required=true) @RequestPart(value="number", required=true)  BigDecimal number,@ApiParam(value = "None", required=true) @RequestPart(value="double", required=true)  Double _double,@ApiParam(value = "None", required=true) @RequestPart(value="pattern_without_delimiter", required=true)  String patternWithoutDelimiter,@ApiParam(value = "None", required=true) @RequestPart(value="byte", required=true)  byte[] _byte,@ApiParam(value = "None") @RequestPart(value="integer", required=false)  Integer integer,@ApiParam(value = "None") @RequestPart(value="int32", required=false)  Integer int32,@ApiParam(value = "None") @RequestPart(value="int64", required=false)  Long int64,@ApiParam(value = "None") @RequestPart(value="float", required=false)  Float _float,@ApiParam(value = "None") @RequestPart(value="string", required=false)  String string,@ApiParam(value = "None") @RequestPart(value="binary", required=false)  byte[] binary,@ApiParam(value = "None") @RequestPart(value="date", required=false)  LocalDate date,@ApiParam(value = "None") @RequestPart(value="dateTime", required=false)  OffsetDateTime dateTime,@ApiParam(value = "None") @RequestPart(value="password", required=false)  String password,@ApiParam(value = "None") @RequestPart(value="callback", required=false)  String paramCallback) {
-        // do some magic!
         String accept = request.getHeader("Accept");
-        return new ResponseEntity<Void>(HttpStatus.OK);
+        return new ResponseEntity<Void>(HttpStatus.NOT_IMPLEMENTED);
     }
 
     public ResponseEntity<Void> testEnumParameters(@ApiParam(value = "Form parameter enum test (string array)", allowableValues=">, $") @RequestPart(value="enum_form_string_array", required=false)  List<String> enumFormStringArray,@ApiParam(value = "Form parameter enum test (string)", allowableValues="_abc, -efg, (xyz)", defaultValue="-efg") @RequestPart(value="enum_form_string", required=false)  String enumFormString,@ApiParam(value = "Query parameter enum test (string array)", allowableValues = ">, $") @Valid @RequestParam(value = "enum_query_string_array", required = false) List<String> enumQueryStringArray,@ApiParam(value = "Query parameter enum test (string)", allowableValues = "_abc, -efg, (xyz)", defaultValue = "-efg") @Valid @RequestParam(value = "enum_query_string", required = false, defaultValue="-efg") String enumQueryString,@ApiParam(value = "Query parameter enum test (double)", allowableValues = "1, -2") @Valid @RequestParam(value = "enum_query_integer", required = false) Integer enumQueryInteger,@ApiParam(value = "Query parameter enum test (double)", allowableValues="1.1, -1.2") @RequestPart(value="enum_query_double", required=false)  Double enumQueryDouble) {
-        // do some magic!
         String accept = request.getHeader("Accept");
-        return new ResponseEntity<Void>(HttpStatus.OK);
+        return new ResponseEntity<Void>(HttpStatus.NOT_IMPLEMENTED);
     }
 
     public ResponseEntity<Void> testInlineAdditionalProperties(@ApiParam(value = "request body" ,required=true )  @Valid @RequestBody Object param) {
-        // do some magic!
         String accept = request.getHeader("Accept");
-        return new ResponseEntity<Void>(HttpStatus.OK);
+        return new ResponseEntity<Void>(HttpStatus.NOT_IMPLEMENTED);
     }
 
     public ResponseEntity<Void> testJsonFormData(@ApiParam(value = "field1", required=true) @RequestPart(value="param", required=true)  String param,@ApiParam(value = "field2", required=true) @RequestPart(value="param2", required=true)  String param2) {
-        // do some magic!
         String accept = request.getHeader("Accept");
-        return new ResponseEntity<Void>(HttpStatus.OK);
+        return new ResponseEntity<Void>(HttpStatus.NOT_IMPLEMENTED);
     }
 
 }

--- a/samples/server/petstore/springboot-implicitHeaders/src/main/java/io/swagger/api/FakeApiController.java
+++ b/samples/server/petstore/springboot-implicitHeaders/src/main/java/io/swagger/api/FakeApiController.java
@@ -8,6 +8,8 @@ import io.swagger.model.OuterComposite;
 
 import io.swagger.annotations.*;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
@@ -16,6 +18,8 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RequestPart;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.util.List;
@@ -26,107 +30,111 @@ import javax.validation.Valid;
 
 @Controller
 public class FakeApiController implements FakeApi {
+
+    private final Logger log = LoggerFactory.getLogger(AnotherFakeApiController.class);
+
     private final ObjectMapper objectMapper;
 
     public FakeApiController(ObjectMapper objectMapper) {
         this.objectMapper = objectMapper;
     }
 
-    public ResponseEntity<Boolean> fakeOuterBooleanSerialize(@ApiParam(value = "Input boolean as post body"  )  @Valid @RequestBody Boolean body,
-        @RequestHeader(value = "Accept", required = false) String accept) throws Exception {
+    public ResponseEntity<Boolean> fakeOuterBooleanSerialize(@ApiParam(value = "Input boolean as post body"  )  @Valid @RequestBody Boolean body) {
         // do some magic!
-
+        String accept = ((ServletRequestAttributes)RequestContextHolder.getRequestAttributes()).getRequest().getHeader("Accept");
         if (accept != null && accept.contains("application/json")) {
-            return new ResponseEntity<Boolean>(objectMapper.readValue("{ }", Boolean.class), HttpStatus.OK);
+            try {
+                return new ResponseEntity<Boolean>(objectMapper.readValue("{ }", Boolean.class), HttpStatus.NOT_IMPLEMENTED);
+            } catch (IOException e) {
+                log.error("Couldn't serialize response for content type application/json", e);
+                return new ResponseEntity<Boolean>(HttpStatus.INTERNAL_SERVER_ERROR);
+            }
         }
 
         return new ResponseEntity<Boolean>(HttpStatus.OK);
     }
 
-    public ResponseEntity<OuterComposite> fakeOuterCompositeSerialize(@ApiParam(value = "Input composite as post body"  )  @Valid @RequestBody OuterComposite body,
-        @RequestHeader(value = "Accept", required = false) String accept) throws Exception {
+    public ResponseEntity<OuterComposite> fakeOuterCompositeSerialize(@ApiParam(value = "Input composite as post body"  )  @Valid @RequestBody OuterComposite body) {
         // do some magic!
-
+        String accept = ((ServletRequestAttributes)RequestContextHolder.getRequestAttributes()).getRequest().getHeader("Accept");
         if (accept != null && accept.contains("application/json")) {
-            return new ResponseEntity<OuterComposite>(objectMapper.readValue("{  \"my_string\" : { },  \"my_number\" : { },  \"my_boolean\" : { }}", OuterComposite.class), HttpStatus.OK);
+            try {
+                return new ResponseEntity<OuterComposite>(objectMapper.readValue("{  \"my_string\" : { },  \"my_number\" : { },  \"my_boolean\" : { }}", OuterComposite.class), HttpStatus.NOT_IMPLEMENTED);
+            } catch (IOException e) {
+                log.error("Couldn't serialize response for content type application/json", e);
+                return new ResponseEntity<OuterComposite>(HttpStatus.INTERNAL_SERVER_ERROR);
+            }
         }
 
         return new ResponseEntity<OuterComposite>(HttpStatus.OK);
     }
 
-    public ResponseEntity<BigDecimal> fakeOuterNumberSerialize(@ApiParam(value = "Input number as post body"  )  @Valid @RequestBody BigDecimal body,
-        @RequestHeader(value = "Accept", required = false) String accept) throws Exception {
+    public ResponseEntity<BigDecimal> fakeOuterNumberSerialize(@ApiParam(value = "Input number as post body"  )  @Valid @RequestBody BigDecimal body) {
         // do some magic!
-
+        String accept = ((ServletRequestAttributes)RequestContextHolder.getRequestAttributes()).getRequest().getHeader("Accept");
         if (accept != null && accept.contains("application/json")) {
-            return new ResponseEntity<BigDecimal>(objectMapper.readValue("{ }", BigDecimal.class), HttpStatus.OK);
+            try {
+                return new ResponseEntity<BigDecimal>(objectMapper.readValue("{ }", BigDecimal.class), HttpStatus.NOT_IMPLEMENTED);
+            } catch (IOException e) {
+                log.error("Couldn't serialize response for content type application/json", e);
+                return new ResponseEntity<BigDecimal>(HttpStatus.INTERNAL_SERVER_ERROR);
+            }
         }
 
         return new ResponseEntity<BigDecimal>(HttpStatus.OK);
     }
 
-    public ResponseEntity<String> fakeOuterStringSerialize(@ApiParam(value = "Input string as post body"  )  @Valid @RequestBody String body,
-        @RequestHeader(value = "Accept", required = false) String accept) throws Exception {
+    public ResponseEntity<String> fakeOuterStringSerialize(@ApiParam(value = "Input string as post body"  )  @Valid @RequestBody String body) {
         // do some magic!
-
+        String accept = ((ServletRequestAttributes)RequestContextHolder.getRequestAttributes()).getRequest().getHeader("Accept");
         if (accept != null && accept.contains("application/json")) {
-            return new ResponseEntity<String>(objectMapper.readValue("{ }", String.class), HttpStatus.OK);
+            try {
+                return new ResponseEntity<String>(objectMapper.readValue("{ }", String.class), HttpStatus.NOT_IMPLEMENTED);
+            } catch (IOException e) {
+                log.error("Couldn't serialize response for content type application/json", e);
+                return new ResponseEntity<String>(HttpStatus.INTERNAL_SERVER_ERROR);
+            }
         }
 
         return new ResponseEntity<String>(HttpStatus.OK);
     }
 
-    public ResponseEntity<Client> testClientModel(@ApiParam(value = "client model" ,required=true )  @Valid @RequestBody Client body,
-        @RequestHeader(value = "Accept", required = false) String accept) throws Exception {
+    public ResponseEntity<Client> testClientModel(@ApiParam(value = "client model" ,required=true )  @Valid @RequestBody Client body) {
         // do some magic!
-
+        String accept = ((ServletRequestAttributes)RequestContextHolder.getRequestAttributes()).getRequest().getHeader("Accept");
         if (accept != null && accept.contains("application/json")) {
-            return new ResponseEntity<Client>(objectMapper.readValue("{  \"client\" : \"client\"}", Client.class), HttpStatus.OK);
+            try {
+                return new ResponseEntity<Client>(objectMapper.readValue("{  \"client\" : \"client\"}", Client.class), HttpStatus.NOT_IMPLEMENTED);
+            } catch (IOException e) {
+                log.error("Couldn't serialize response for content type application/json", e);
+                return new ResponseEntity<Client>(HttpStatus.INTERNAL_SERVER_ERROR);
+            }
         }
 
         return new ResponseEntity<Client>(HttpStatus.OK);
     }
 
-    public ResponseEntity<Void> testEndpointParameters(@ApiParam(value = "None", required=true) @RequestPart(value="number", required=true)  BigDecimal number,
-        @ApiParam(value = "None", required=true) @RequestPart(value="double", required=true)  Double _double,
-        @ApiParam(value = "None", required=true) @RequestPart(value="pattern_without_delimiter", required=true)  String patternWithoutDelimiter,
-        @ApiParam(value = "None", required=true) @RequestPart(value="byte", required=true)  byte[] _byte,
-        @ApiParam(value = "None") @RequestPart(value="integer", required=false)  Integer integer,
-        @ApiParam(value = "None") @RequestPart(value="int32", required=false)  Integer int32,
-        @ApiParam(value = "None") @RequestPart(value="int64", required=false)  Long int64,
-        @ApiParam(value = "None") @RequestPart(value="float", required=false)  Float _float,
-        @ApiParam(value = "None") @RequestPart(value="string", required=false)  String string,
-        @ApiParam(value = "None") @RequestPart(value="binary", required=false)  byte[] binary,
-        @ApiParam(value = "None") @RequestPart(value="date", required=false)  LocalDate date,
-        @ApiParam(value = "None") @RequestPart(value="dateTime", required=false)  OffsetDateTime dateTime,
-        @ApiParam(value = "None") @RequestPart(value="password", required=false)  String password,
-        @ApiParam(value = "None") @RequestPart(value="callback", required=false)  String paramCallback,
-        @RequestHeader(value = "Accept", required = false) String accept) throws Exception {
+    public ResponseEntity<Void> testEndpointParameters(@ApiParam(value = "None", required=true) @RequestPart(value="number", required=true)  BigDecimal number,@ApiParam(value = "None", required=true) @RequestPart(value="double", required=true)  Double _double,@ApiParam(value = "None", required=true) @RequestPart(value="pattern_without_delimiter", required=true)  String patternWithoutDelimiter,@ApiParam(value = "None", required=true) @RequestPart(value="byte", required=true)  byte[] _byte,@ApiParam(value = "None") @RequestPart(value="integer", required=false)  Integer integer,@ApiParam(value = "None") @RequestPart(value="int32", required=false)  Integer int32,@ApiParam(value = "None") @RequestPart(value="int64", required=false)  Long int64,@ApiParam(value = "None") @RequestPart(value="float", required=false)  Float _float,@ApiParam(value = "None") @RequestPart(value="string", required=false)  String string,@ApiParam(value = "None") @RequestPart(value="binary", required=false)  byte[] binary,@ApiParam(value = "None") @RequestPart(value="date", required=false)  LocalDate date,@ApiParam(value = "None") @RequestPart(value="dateTime", required=false)  OffsetDateTime dateTime,@ApiParam(value = "None") @RequestPart(value="password", required=false)  String password,@ApiParam(value = "None") @RequestPart(value="callback", required=false)  String paramCallback) {
         // do some magic!
+        String accept = ((ServletRequestAttributes)RequestContextHolder.getRequestAttributes()).getRequest().getHeader("Accept");
         return new ResponseEntity<Void>(HttpStatus.OK);
     }
 
-    public ResponseEntity<Void> testEnumParameters(@ApiParam(value = "Form parameter enum test (string array)", allowableValues=">, $") @RequestPart(value="enum_form_string_array", required=false)  List<String> enumFormStringArray,
-        @ApiParam(value = "Form parameter enum test (string)", allowableValues="_abc, -efg, (xyz)", defaultValue="-efg") @RequestPart(value="enum_form_string", required=false)  String enumFormString,
-        @ApiParam(value = "Query parameter enum test (string array)", allowableValues = ">, $") @Valid @RequestParam(value = "enum_query_string_array", required = false) List<String> enumQueryStringArray,
-        @ApiParam(value = "Query parameter enum test (string)", allowableValues = "_abc, -efg, (xyz)", defaultValue = "-efg") @Valid @RequestParam(value = "enum_query_string", required = false, defaultValue="-efg") String enumQueryString,
-        @ApiParam(value = "Query parameter enum test (double)", allowableValues = "1, -2") @Valid @RequestParam(value = "enum_query_integer", required = false) Integer enumQueryInteger,
-        @ApiParam(value = "Query parameter enum test (double)", allowableValues="1.1, -1.2") @RequestPart(value="enum_query_double", required=false)  Double enumQueryDouble,
-        @RequestHeader(value = "Accept", required = false) String accept) throws Exception {
+    public ResponseEntity<Void> testEnumParameters(@ApiParam(value = "Form parameter enum test (string array)", allowableValues=">, $") @RequestPart(value="enum_form_string_array", required=false)  List<String> enumFormStringArray,@ApiParam(value = "Form parameter enum test (string)", allowableValues="_abc, -efg, (xyz)", defaultValue="-efg") @RequestPart(value="enum_form_string", required=false)  String enumFormString,@ApiParam(value = "Query parameter enum test (string array)", allowableValues = ">, $") @Valid @RequestParam(value = "enum_query_string_array", required = false) List<String> enumQueryStringArray,@ApiParam(value = "Query parameter enum test (string)", allowableValues = "_abc, -efg, (xyz)", defaultValue = "-efg") @Valid @RequestParam(value = "enum_query_string", required = false, defaultValue="-efg") String enumQueryString,@ApiParam(value = "Query parameter enum test (double)", allowableValues = "1, -2") @Valid @RequestParam(value = "enum_query_integer", required = false) Integer enumQueryInteger,@ApiParam(value = "Query parameter enum test (double)", allowableValues="1.1, -1.2") @RequestPart(value="enum_query_double", required=false)  Double enumQueryDouble) {
         // do some magic!
+        String accept = ((ServletRequestAttributes)RequestContextHolder.getRequestAttributes()).getRequest().getHeader("Accept");
         return new ResponseEntity<Void>(HttpStatus.OK);
     }
 
-    public ResponseEntity<Void> testInlineAdditionalProperties(@ApiParam(value = "request body" ,required=true )  @Valid @RequestBody Object param,
-        @RequestHeader(value = "Accept", required = false) String accept) throws Exception {
+    public ResponseEntity<Void> testInlineAdditionalProperties(@ApiParam(value = "request body" ,required=true )  @Valid @RequestBody Object param) {
         // do some magic!
+        String accept = ((ServletRequestAttributes)RequestContextHolder.getRequestAttributes()).getRequest().getHeader("Accept");
         return new ResponseEntity<Void>(HttpStatus.OK);
     }
 
-    public ResponseEntity<Void> testJsonFormData(@ApiParam(value = "field1", required=true) @RequestPart(value="param", required=true)  String param,
-        @ApiParam(value = "field2", required=true) @RequestPart(value="param2", required=true)  String param2,
-        @RequestHeader(value = "Accept", required = false) String accept) throws Exception {
+    public ResponseEntity<Void> testJsonFormData(@ApiParam(value = "field1", required=true) @RequestPart(value="param", required=true)  String param,@ApiParam(value = "field2", required=true) @RequestPart(value="param2", required=true)  String param2) {
         // do some magic!
+        String accept = ((ServletRequestAttributes)RequestContextHolder.getRequestAttributes()).getRequest().getHeader("Accept");
         return new ResponseEntity<Void>(HttpStatus.OK);
     }
 

--- a/samples/server/petstore/springboot-implicitHeaders/src/main/java/io/swagger/api/FakeClassnameTestApi.java
+++ b/samples/server/petstore/springboot-implicitHeaders/src/main/java/io/swagger/api/FakeClassnameTestApi.java
@@ -6,9 +6,9 @@
 package io.swagger.api;
 
 import io.swagger.model.Client;
-
 import io.swagger.annotations.*;
 import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
@@ -17,12 +17,10 @@ import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.multipart.MultipartFile;
-import java.io.IOException;
 
-import java.util.List;
-import org.springframework.validation.annotation.Validated;
-import javax.validation.constraints.*;
 import javax.validation.Valid;
+import javax.validation.constraints.*;
+import java.util.List;
 
 @Api(value = "fake_classname_test", description = "the fake_classname_test API")
 public interface FakeClassnameTestApi {

--- a/samples/server/petstore/springboot-implicitHeaders/src/main/java/io/swagger/api/FakeClassnameTestApi.java
+++ b/samples/server/petstore/springboot-implicitHeaders/src/main/java/io/swagger/api/FakeClassnameTestApi.java
@@ -38,6 +38,6 @@ public interface FakeClassnameTestApi {
         produces = { "application/json" }, 
         consumes = { "application/json" },
         method = RequestMethod.PATCH)
-    ResponseEntity<Client> testClassname(@ApiParam(value = "client model" ,required=true )  @Valid @RequestBody Client body, @RequestHeader(value = "Accept", required = false) String accept) throws Exception;
+    ResponseEntity<Client> testClassname(@ApiParam(value = "client model" ,required=true )  @Valid @RequestBody Client body);
 
 }

--- a/samples/server/petstore/springboot-implicitHeaders/src/main/java/io/swagger/api/FakeClassnameTestApiController.java
+++ b/samples/server/petstore/springboot-implicitHeaders/src/main/java/io/swagger/api/FakeClassnameTestApiController.java
@@ -4,6 +4,8 @@ import io.swagger.model.Client;
 
 import io.swagger.annotations.*;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
@@ -12,6 +14,8 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RequestPart;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.util.List;
@@ -22,18 +26,25 @@ import javax.validation.Valid;
 
 @Controller
 public class FakeClassnameTestApiController implements FakeClassnameTestApi {
+
+    private final Logger log = LoggerFactory.getLogger(AnotherFakeApiController.class);
+
     private final ObjectMapper objectMapper;
 
     public FakeClassnameTestApiController(ObjectMapper objectMapper) {
         this.objectMapper = objectMapper;
     }
 
-    public ResponseEntity<Client> testClassname(@ApiParam(value = "client model" ,required=true )  @Valid @RequestBody Client body,
-        @RequestHeader(value = "Accept", required = false) String accept) throws Exception {
+    public ResponseEntity<Client> testClassname(@ApiParam(value = "client model" ,required=true )  @Valid @RequestBody Client body) {
         // do some magic!
-
+        String accept = ((ServletRequestAttributes)RequestContextHolder.getRequestAttributes()).getRequest().getHeader("Accept");
         if (accept != null && accept.contains("application/json")) {
-            return new ResponseEntity<Client>(objectMapper.readValue("{  \"client\" : \"client\"}", Client.class), HttpStatus.OK);
+            try {
+                return new ResponseEntity<Client>(objectMapper.readValue("{  \"client\" : \"client\"}", Client.class), HttpStatus.NOT_IMPLEMENTED);
+            } catch (IOException e) {
+                log.error("Couldn't serialize response for content type application/json", e);
+                return new ResponseEntity<Client>(HttpStatus.INTERNAL_SERVER_ERROR);
+            }
         }
 
         return new ResponseEntity<Client>(HttpStatus.OK);

--- a/samples/server/petstore/springboot-implicitHeaders/src/main/java/io/swagger/api/FakeClassnameTestApiController.java
+++ b/samples/server/petstore/springboot-implicitHeaders/src/main/java/io/swagger/api/FakeClassnameTestApiController.java
@@ -21,23 +21,28 @@ import org.springframework.web.multipart.MultipartFile;
 import java.util.List;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.IOException;
+import javax.servlet.http.HttpServletRequest;
 import javax.validation.constraints.*;
 import javax.validation.Valid;
 
 @Controller
 public class FakeClassnameTestApiController implements FakeClassnameTestApi {
 
-    private final Logger log = LoggerFactory.getLogger(AnotherFakeApiController.class);
+    private static final Logger log = LoggerFactory.getLogger(FakeClassnameTestApiController.class);
 
     private final ObjectMapper objectMapper;
 
+    @org.springframework.beans.factory.annotation.Autowired
+    private HttpServletRequest request;
+
+    @org.springframework.beans.factory.annotation.Autowired
     public FakeClassnameTestApiController(ObjectMapper objectMapper) {
         this.objectMapper = objectMapper;
     }
 
     public ResponseEntity<Client> testClassname(@ApiParam(value = "client model" ,required=true )  @Valid @RequestBody Client body) {
         // do some magic!
-        String accept = ((ServletRequestAttributes)RequestContextHolder.getRequestAttributes()).getRequest().getHeader("Accept");
+        String accept = request.getHeader("Accept");
         if (accept != null && accept.contains("application/json")) {
             try {
                 return new ResponseEntity<Client>(objectMapper.readValue("{  \"client\" : \"client\"}", Client.class), HttpStatus.NOT_IMPLEMENTED);

--- a/samples/server/petstore/springboot-implicitHeaders/src/main/java/io/swagger/api/FakeClassnameTestApiController.java
+++ b/samples/server/petstore/springboot-implicitHeaders/src/main/java/io/swagger/api/FakeClassnameTestApiController.java
@@ -32,12 +32,12 @@ public class FakeClassnameTestApiController implements FakeClassnameTestApi {
 
     private final ObjectMapper objectMapper;
 
-    @org.springframework.beans.factory.annotation.Autowired
-    private HttpServletRequest request;
+    private final HttpServletRequest request;
 
     @org.springframework.beans.factory.annotation.Autowired
-    public FakeClassnameTestApiController(ObjectMapper objectMapper) {
+    public FakeClassnameTestApiController(ObjectMapper objectMapper, HttpServletRequest request) {
         this.objectMapper = objectMapper;
+        this.request = request;
     }
 
     public ResponseEntity<Client> testClassname(@ApiParam(value = "client model" ,required=true )  @Valid @RequestBody Client body) {

--- a/samples/server/petstore/springboot-implicitHeaders/src/main/java/io/swagger/api/FakeClassnameTestApiController.java
+++ b/samples/server/petstore/springboot-implicitHeaders/src/main/java/io/swagger/api/FakeClassnameTestApiController.java
@@ -1,9 +1,8 @@
 package io.swagger.api;
 
 import io.swagger.model.Client;
-
+import com.fasterxml.jackson.databind.ObjectMapper;
 import io.swagger.annotations.*;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpStatus;
@@ -14,16 +13,13 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RequestPart;
-import org.springframework.web.context.request.RequestContextHolder;
-import org.springframework.web.context.request.ServletRequestAttributes;
 import org.springframework.web.multipart.MultipartFile;
 
-import java.util.List;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import java.io.IOException;
-import javax.servlet.http.HttpServletRequest;
 import javax.validation.constraints.*;
 import javax.validation.Valid;
+import javax.servlet.http.HttpServletRequest;
+import java.io.IOException;
+import java.util.List;
 
 @Controller
 public class FakeClassnameTestApiController implements FakeClassnameTestApi {
@@ -41,7 +37,6 @@ public class FakeClassnameTestApiController implements FakeClassnameTestApi {
     }
 
     public ResponseEntity<Client> testClassname(@ApiParam(value = "client model" ,required=true )  @Valid @RequestBody Client body) {
-        // do some magic!
         String accept = request.getHeader("Accept");
         if (accept != null && accept.contains("application/json")) {
             try {
@@ -52,7 +47,7 @@ public class FakeClassnameTestApiController implements FakeClassnameTestApi {
             }
         }
 
-        return new ResponseEntity<Client>(HttpStatus.OK);
+        return new ResponseEntity<Client>(HttpStatus.NOT_IMPLEMENTED);
     }
 
 }

--- a/samples/server/petstore/springboot-implicitHeaders/src/main/java/io/swagger/api/PetApi.java
+++ b/samples/server/petstore/springboot-implicitHeaders/src/main/java/io/swagger/api/PetApi.java
@@ -8,9 +8,9 @@ package io.swagger.api;
 import io.swagger.model.ModelApiResponse;
 import io.swagger.model.Pet;
 import org.springframework.core.io.Resource;
-
 import io.swagger.annotations.*;
 import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
@@ -19,12 +19,10 @@ import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.multipart.MultipartFile;
-import java.io.IOException;
 
-import java.util.List;
-import org.springframework.validation.annotation.Validated;
-import javax.validation.constraints.*;
 import javax.validation.Valid;
+import javax.validation.constraints.*;
+import java.util.List;
 
 @Api(value = "pet", description = "the pet API")
 public interface PetApi {

--- a/samples/server/petstore/springboot-implicitHeaders/src/main/java/io/swagger/api/PetApi.java
+++ b/samples/server/petstore/springboot-implicitHeaders/src/main/java/io/swagger/api/PetApi.java
@@ -43,7 +43,7 @@ public interface PetApi {
         produces = { "application/xml", "application/json" }, 
         consumes = { "application/json", "application/xml" },
         method = RequestMethod.POST)
-    ResponseEntity<Void> addPet(@ApiParam(value = "Pet object that needs to be added to the store" ,required=true )  @Valid @RequestBody Pet body, @RequestHeader(value = "Accept", required = false) String accept) throws Exception;
+    ResponseEntity<Void> addPet(@ApiParam(value = "Pet object that needs to be added to the store" ,required=true )  @Valid @RequestBody Pet body);
 
 
     @ApiOperation(value = "Deletes a pet", nickname = "deletePet", notes = "", authorizations = {
@@ -60,7 +60,7 @@ public interface PetApi {
     @RequestMapping(value = "/pet/{petId}",
         produces = { "application/xml", "application/json" }, 
         method = RequestMethod.DELETE)
-    ResponseEntity<Void> deletePet(@ApiParam(value = "Pet id to delete",required=true) @PathVariable("petId") Long petId, @RequestHeader(value = "Accept", required = false) String accept) throws Exception;
+    ResponseEntity<Void> deletePet(@ApiParam(value = "Pet id to delete",required=true) @PathVariable("petId") Long petId);
 
 
     @ApiOperation(value = "Finds Pets by status", nickname = "findPetsByStatus", notes = "Multiple status values can be provided with comma separated strings", response = Pet.class, responseContainer = "List", authorizations = {
@@ -77,7 +77,7 @@ public interface PetApi {
     @RequestMapping(value = "/pet/findByStatus",
         produces = { "application/xml", "application/json" }, 
         method = RequestMethod.GET)
-    ResponseEntity<List<Pet>> findPetsByStatus( @NotNull@ApiParam(value = "Status values that need to be considered for filter", required = true, allowableValues = "available, pending, sold") @Valid @RequestParam(value = "status", required = true) List<String> status, @RequestHeader(value = "Accept", required = false) String accept) throws Exception;
+    ResponseEntity<List<Pet>> findPetsByStatus(@NotNull @ApiParam(value = "Status values that need to be considered for filter", required = true, allowableValues = "available, pending, sold") @Valid @RequestParam(value = "status", required = true) List<String> status);
 
 
     @ApiOperation(value = "Finds Pets by tags", nickname = "findPetsByTags", notes = "Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.", response = Pet.class, responseContainer = "List", authorizations = {
@@ -94,7 +94,7 @@ public interface PetApi {
     @RequestMapping(value = "/pet/findByTags",
         produces = { "application/xml", "application/json" }, 
         method = RequestMethod.GET)
-    ResponseEntity<List<Pet>> findPetsByTags( @NotNull@ApiParam(value = "Tags to filter by", required = true) @Valid @RequestParam(value = "tags", required = true) List<String> tags, @RequestHeader(value = "Accept", required = false) String accept) throws Exception;
+    ResponseEntity<List<Pet>> findPetsByTags(@NotNull @ApiParam(value = "Tags to filter by", required = true) @Valid @RequestParam(value = "tags", required = true) List<String> tags);
 
 
     @ApiOperation(value = "Find pet by ID", nickname = "getPetById", notes = "Returns a single pet", response = Pet.class, authorizations = {
@@ -109,7 +109,7 @@ public interface PetApi {
     @RequestMapping(value = "/pet/{petId}",
         produces = { "application/xml", "application/json" }, 
         method = RequestMethod.GET)
-    ResponseEntity<Pet> getPetById(@ApiParam(value = "ID of pet to return",required=true) @PathVariable("petId") Long petId, @RequestHeader(value = "Accept", required = false) String accept) throws Exception;
+    ResponseEntity<Pet> getPetById(@ApiParam(value = "ID of pet to return",required=true) @PathVariable("petId") Long petId);
 
 
     @ApiOperation(value = "Update an existing pet", nickname = "updatePet", notes = "", authorizations = {
@@ -128,7 +128,7 @@ public interface PetApi {
         produces = { "application/xml", "application/json" }, 
         consumes = { "application/json", "application/xml" },
         method = RequestMethod.PUT)
-    ResponseEntity<Void> updatePet(@ApiParam(value = "Pet object that needs to be added to the store" ,required=true )  @Valid @RequestBody Pet body, @RequestHeader(value = "Accept", required = false) String accept) throws Exception;
+    ResponseEntity<Void> updatePet(@ApiParam(value = "Pet object that needs to be added to the store" ,required=true )  @Valid @RequestBody Pet body);
 
 
     @ApiOperation(value = "Updates a pet in the store with form data", nickname = "updatePetWithForm", notes = "", authorizations = {
@@ -145,7 +145,7 @@ public interface PetApi {
         produces = { "application/xml", "application/json" }, 
         consumes = { "application/x-www-form-urlencoded" },
         method = RequestMethod.POST)
-    ResponseEntity<Void> updatePetWithForm(@ApiParam(value = "ID of pet that needs to be updated",required=true) @PathVariable("petId") Long petId,@ApiParam(value = "Updated name of the pet") @RequestPart(value="name", required=false)  String name,@ApiParam(value = "Updated status of the pet") @RequestPart(value="status", required=false)  String status, @RequestHeader(value = "Accept", required = false) String accept) throws Exception;
+    ResponseEntity<Void> updatePetWithForm(@ApiParam(value = "ID of pet that needs to be updated",required=true) @PathVariable("petId") Long petId,@ApiParam(value = "Updated name of the pet") @RequestPart(value="name", required=false)  String name,@ApiParam(value = "Updated status of the pet") @RequestPart(value="status", required=false)  String status);
 
 
     @ApiOperation(value = "uploads an image", nickname = "uploadFile", notes = "", response = ModelApiResponse.class, authorizations = {
@@ -162,6 +162,6 @@ public interface PetApi {
         produces = { "application/json" }, 
         consumes = { "multipart/form-data" },
         method = RequestMethod.POST)
-    ResponseEntity<ModelApiResponse> uploadFile(@ApiParam(value = "ID of pet to update",required=true) @PathVariable("petId") Long petId,@ApiParam(value = "Additional data to pass to server") @RequestPart(value="additionalMetadata", required=false)  String additionalMetadata,@ApiParam(value = "file detail") @Valid @RequestPart("file") MultipartFile file, @RequestHeader(value = "Accept", required = false) String accept) throws Exception;
+    ResponseEntity<ModelApiResponse> uploadFile(@ApiParam(value = "ID of pet to update",required=true) @PathVariable("petId") Long petId,@ApiParam(value = "Additional data to pass to server") @RequestPart(value="additionalMetadata", required=false)  String additionalMetadata,@ApiParam(value = "file detail") @Valid @RequestPart("file") MultipartFile file);
 
 }

--- a/samples/server/petstore/springboot-implicitHeaders/src/main/java/io/swagger/api/PetApiController.java
+++ b/samples/server/petstore/springboot-implicitHeaders/src/main/java/io/swagger/api/PetApiController.java
@@ -34,12 +34,12 @@ public class PetApiController implements PetApi {
 
     private final ObjectMapper objectMapper;
 
-    @org.springframework.beans.factory.annotation.Autowired
-    private HttpServletRequest request;
+    private final HttpServletRequest request;
 
     @org.springframework.beans.factory.annotation.Autowired
-    public PetApiController(ObjectMapper objectMapper) {
+    public PetApiController(ObjectMapper objectMapper, HttpServletRequest request) {
         this.objectMapper = objectMapper;
+        this.request = request;
     }
 
     public ResponseEntity<Void> addPet(@ApiParam(value = "Pet object that needs to be added to the store" ,required=true )  @Valid @RequestBody Pet body) {

--- a/samples/server/petstore/springboot-implicitHeaders/src/main/java/io/swagger/api/PetApiController.java
+++ b/samples/server/petstore/springboot-implicitHeaders/src/main/java/io/swagger/api/PetApiController.java
@@ -3,9 +3,8 @@ package io.swagger.api;
 import io.swagger.model.ModelApiResponse;
 import io.swagger.model.Pet;
 import org.springframework.core.io.Resource;
-
+import com.fasterxml.jackson.databind.ObjectMapper;
 import io.swagger.annotations.*;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpStatus;
@@ -16,16 +15,13 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RequestPart;
-import org.springframework.web.context.request.RequestContextHolder;
-import org.springframework.web.context.request.ServletRequestAttributes;
 import org.springframework.web.multipart.MultipartFile;
 
-import java.util.List;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import java.io.IOException;
-import javax.servlet.http.HttpServletRequest;
 import javax.validation.constraints.*;
 import javax.validation.Valid;
+import javax.servlet.http.HttpServletRequest;
+import java.io.IOException;
+import java.util.List;
 
 @Controller
 public class PetApiController implements PetApi {
@@ -43,19 +39,16 @@ public class PetApiController implements PetApi {
     }
 
     public ResponseEntity<Void> addPet(@ApiParam(value = "Pet object that needs to be added to the store" ,required=true )  @Valid @RequestBody Pet body) {
-        // do some magic!
         String accept = request.getHeader("Accept");
-        return new ResponseEntity<Void>(HttpStatus.OK);
+        return new ResponseEntity<Void>(HttpStatus.NOT_IMPLEMENTED);
     }
 
     public ResponseEntity<Void> deletePet(@ApiParam(value = "Pet id to delete",required=true) @PathVariable("petId") Long petId) {
-        // do some magic!
         String accept = request.getHeader("Accept");
-        return new ResponseEntity<Void>(HttpStatus.OK);
+        return new ResponseEntity<Void>(HttpStatus.NOT_IMPLEMENTED);
     }
 
     public ResponseEntity<List<Pet>> findPetsByStatus(@NotNull @ApiParam(value = "Status values that need to be considered for filter", required = true, allowableValues = "available, pending, sold") @Valid @RequestParam(value = "status", required = true) List<String> status) {
-        // do some magic!
         String accept = request.getHeader("Accept");
         if (accept != null && accept.contains("application/xml")) {
             try {
@@ -75,11 +68,10 @@ public class PetApiController implements PetApi {
             }
         }
 
-        return new ResponseEntity<List<Pet>>(HttpStatus.OK);
+        return new ResponseEntity<List<Pet>>(HttpStatus.NOT_IMPLEMENTED);
     }
 
     public ResponseEntity<List<Pet>> findPetsByTags(@NotNull @ApiParam(value = "Tags to filter by", required = true) @Valid @RequestParam(value = "tags", required = true) List<String> tags) {
-        // do some magic!
         String accept = request.getHeader("Accept");
         if (accept != null && accept.contains("application/xml")) {
             try {
@@ -99,11 +91,10 @@ public class PetApiController implements PetApi {
             }
         }
 
-        return new ResponseEntity<List<Pet>>(HttpStatus.OK);
+        return new ResponseEntity<List<Pet>>(HttpStatus.NOT_IMPLEMENTED);
     }
 
     public ResponseEntity<Pet> getPetById(@ApiParam(value = "ID of pet to return",required=true) @PathVariable("petId") Long petId) {
-        // do some magic!
         String accept = request.getHeader("Accept");
         if (accept != null && accept.contains("application/xml")) {
             try {
@@ -123,23 +114,20 @@ public class PetApiController implements PetApi {
             }
         }
 
-        return new ResponseEntity<Pet>(HttpStatus.OK);
+        return new ResponseEntity<Pet>(HttpStatus.NOT_IMPLEMENTED);
     }
 
     public ResponseEntity<Void> updatePet(@ApiParam(value = "Pet object that needs to be added to the store" ,required=true )  @Valid @RequestBody Pet body) {
-        // do some magic!
         String accept = request.getHeader("Accept");
-        return new ResponseEntity<Void>(HttpStatus.OK);
+        return new ResponseEntity<Void>(HttpStatus.NOT_IMPLEMENTED);
     }
 
     public ResponseEntity<Void> updatePetWithForm(@ApiParam(value = "ID of pet that needs to be updated",required=true) @PathVariable("petId") Long petId,@ApiParam(value = "Updated name of the pet") @RequestPart(value="name", required=false)  String name,@ApiParam(value = "Updated status of the pet") @RequestPart(value="status", required=false)  String status) {
-        // do some magic!
         String accept = request.getHeader("Accept");
-        return new ResponseEntity<Void>(HttpStatus.OK);
+        return new ResponseEntity<Void>(HttpStatus.NOT_IMPLEMENTED);
     }
 
     public ResponseEntity<ModelApiResponse> uploadFile(@ApiParam(value = "ID of pet to update",required=true) @PathVariable("petId") Long petId,@ApiParam(value = "Additional data to pass to server") @RequestPart(value="additionalMetadata", required=false)  String additionalMetadata,@ApiParam(value = "file detail") @Valid @RequestPart("file") MultipartFile file) {
-        // do some magic!
         String accept = request.getHeader("Accept");
         if (accept != null && accept.contains("application/json")) {
             try {
@@ -150,7 +138,7 @@ public class PetApiController implements PetApi {
             }
         }
 
-        return new ResponseEntity<ModelApiResponse>(HttpStatus.OK);
+        return new ResponseEntity<ModelApiResponse>(HttpStatus.NOT_IMPLEMENTED);
     }
 
 }

--- a/samples/server/petstore/springboot-implicitHeaders/src/main/java/io/swagger/api/PetApiController.java
+++ b/samples/server/petstore/springboot-implicitHeaders/src/main/java/io/swagger/api/PetApiController.java
@@ -6,6 +6,8 @@ import org.springframework.core.io.Resource;
 
 import io.swagger.annotations.*;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
@@ -14,6 +16,8 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RequestPart;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.util.List;
@@ -24,94 +28,121 @@ import javax.validation.Valid;
 
 @Controller
 public class PetApiController implements PetApi {
+
+    private final Logger log = LoggerFactory.getLogger(AnotherFakeApiController.class);
+
     private final ObjectMapper objectMapper;
 
     public PetApiController(ObjectMapper objectMapper) {
         this.objectMapper = objectMapper;
     }
 
-    public ResponseEntity<Void> addPet(@ApiParam(value = "Pet object that needs to be added to the store" ,required=true )  @Valid @RequestBody Pet body,
-        @RequestHeader(value = "Accept", required = false) String accept) throws Exception {
+    public ResponseEntity<Void> addPet(@ApiParam(value = "Pet object that needs to be added to the store" ,required=true )  @Valid @RequestBody Pet body) {
         // do some magic!
+        String accept = ((ServletRequestAttributes)RequestContextHolder.getRequestAttributes()).getRequest().getHeader("Accept");
         return new ResponseEntity<Void>(HttpStatus.OK);
     }
 
-    public ResponseEntity<Void> deletePet(@ApiParam(value = "Pet id to delete",required=true) @PathVariable("petId") Long petId,
-        @RequestHeader(value = "Accept", required = false) String accept) throws Exception {
+    public ResponseEntity<Void> deletePet(@ApiParam(value = "Pet id to delete",required=true) @PathVariable("petId") Long petId) {
         // do some magic!
+        String accept = ((ServletRequestAttributes)RequestContextHolder.getRequestAttributes()).getRequest().getHeader("Accept");
         return new ResponseEntity<Void>(HttpStatus.OK);
     }
 
-    public ResponseEntity<List<Pet>> findPetsByStatus( @NotNull@ApiParam(value = "Status values that need to be considered for filter", required = true, allowableValues = "available, pending, sold") @Valid @RequestParam(value = "status", required = true) List<String> status,
-        @RequestHeader(value = "Accept", required = false) String accept) throws Exception {
+    public ResponseEntity<List<Pet>> findPetsByStatus(@NotNull @ApiParam(value = "Status values that need to be considered for filter", required = true, allowableValues = "available, pending, sold") @Valid @RequestParam(value = "status", required = true) List<String> status) {
         // do some magic!
-
+        String accept = ((ServletRequestAttributes)RequestContextHolder.getRequestAttributes()).getRequest().getHeader("Accept");
         if (accept != null && accept.contains("application/xml")) {
-            return new ResponseEntity<List<Pet>>(objectMapper.readValue("<Pet>  <id>123456789</id>  <name>doggie</name>  <photoUrls>    <photoUrls>aeiou</photoUrls>  </photoUrls>  <tags>  </tags>  <status>aeiou</status></Pet>", List.class), HttpStatus.OK);
+            try {
+                return new ResponseEntity<List<Pet>>(objectMapper.readValue("<Pet>  <id>123456789</id>  <name>doggie</name>  <photoUrls>    <photoUrls>aeiou</photoUrls>  </photoUrls>  <tags>  </tags>  <status>aeiou</status></Pet>", List.class), HttpStatus.NOT_IMPLEMENTED);
+            } catch (IOException e) {
+                log.error("Couldn't serialize response for content type application/xml", e);
+                return new ResponseEntity<List<Pet>>(HttpStatus.INTERNAL_SERVER_ERROR);
+            }
         }
 
-
         if (accept != null && accept.contains("application/json")) {
-            return new ResponseEntity<List<Pet>>(objectMapper.readValue("[ {  \"photoUrls\" : [ \"photoUrls\", \"photoUrls\" ],  \"name\" : \"doggie\",  \"id\" : 0,  \"category\" : {    \"name\" : \"name\",    \"id\" : 6  },  \"tags\" : [ {    \"name\" : \"name\",    \"id\" : 1  }, {    \"name\" : \"name\",    \"id\" : 1  } ],  \"status\" : \"available\"}, {  \"photoUrls\" : [ \"photoUrls\", \"photoUrls\" ],  \"name\" : \"doggie\",  \"id\" : 0,  \"category\" : {    \"name\" : \"name\",    \"id\" : 6  },  \"tags\" : [ {    \"name\" : \"name\",    \"id\" : 1  }, {    \"name\" : \"name\",    \"id\" : 1  } ],  \"status\" : \"available\"} ]", List.class), HttpStatus.OK);
+            try {
+                return new ResponseEntity<List<Pet>>(objectMapper.readValue("[ {  \"photoUrls\" : [ \"photoUrls\", \"photoUrls\" ],  \"name\" : \"doggie\",  \"id\" : 0,  \"category\" : {    \"name\" : \"name\",    \"id\" : 6  },  \"tags\" : [ {    \"name\" : \"name\",    \"id\" : 1  }, {    \"name\" : \"name\",    \"id\" : 1  } ],  \"status\" : \"available\"}, {  \"photoUrls\" : [ \"photoUrls\", \"photoUrls\" ],  \"name\" : \"doggie\",  \"id\" : 0,  \"category\" : {    \"name\" : \"name\",    \"id\" : 6  },  \"tags\" : [ {    \"name\" : \"name\",    \"id\" : 1  }, {    \"name\" : \"name\",    \"id\" : 1  } ],  \"status\" : \"available\"} ]", List.class), HttpStatus.NOT_IMPLEMENTED);
+            } catch (IOException e) {
+                log.error("Couldn't serialize response for content type application/json", e);
+                return new ResponseEntity<List<Pet>>(HttpStatus.INTERNAL_SERVER_ERROR);
+            }
         }
 
         return new ResponseEntity<List<Pet>>(HttpStatus.OK);
     }
 
-    public ResponseEntity<List<Pet>> findPetsByTags( @NotNull@ApiParam(value = "Tags to filter by", required = true) @Valid @RequestParam(value = "tags", required = true) List<String> tags,
-        @RequestHeader(value = "Accept", required = false) String accept) throws Exception {
+    public ResponseEntity<List<Pet>> findPetsByTags(@NotNull @ApiParam(value = "Tags to filter by", required = true) @Valid @RequestParam(value = "tags", required = true) List<String> tags) {
         // do some magic!
-
+        String accept = ((ServletRequestAttributes)RequestContextHolder.getRequestAttributes()).getRequest().getHeader("Accept");
         if (accept != null && accept.contains("application/xml")) {
-            return new ResponseEntity<List<Pet>>(objectMapper.readValue("<Pet>  <id>123456789</id>  <name>doggie</name>  <photoUrls>    <photoUrls>aeiou</photoUrls>  </photoUrls>  <tags>  </tags>  <status>aeiou</status></Pet>", List.class), HttpStatus.OK);
+            try {
+                return new ResponseEntity<List<Pet>>(objectMapper.readValue("<Pet>  <id>123456789</id>  <name>doggie</name>  <photoUrls>    <photoUrls>aeiou</photoUrls>  </photoUrls>  <tags>  </tags>  <status>aeiou</status></Pet>", List.class), HttpStatus.NOT_IMPLEMENTED);
+            } catch (IOException e) {
+                log.error("Couldn't serialize response for content type application/xml", e);
+                return new ResponseEntity<List<Pet>>(HttpStatus.INTERNAL_SERVER_ERROR);
+            }
         }
 
-
         if (accept != null && accept.contains("application/json")) {
-            return new ResponseEntity<List<Pet>>(objectMapper.readValue("[ {  \"photoUrls\" : [ \"photoUrls\", \"photoUrls\" ],  \"name\" : \"doggie\",  \"id\" : 0,  \"category\" : {    \"name\" : \"name\",    \"id\" : 6  },  \"tags\" : [ {    \"name\" : \"name\",    \"id\" : 1  }, {    \"name\" : \"name\",    \"id\" : 1  } ],  \"status\" : \"available\"}, {  \"photoUrls\" : [ \"photoUrls\", \"photoUrls\" ],  \"name\" : \"doggie\",  \"id\" : 0,  \"category\" : {    \"name\" : \"name\",    \"id\" : 6  },  \"tags\" : [ {    \"name\" : \"name\",    \"id\" : 1  }, {    \"name\" : \"name\",    \"id\" : 1  } ],  \"status\" : \"available\"} ]", List.class), HttpStatus.OK);
+            try {
+                return new ResponseEntity<List<Pet>>(objectMapper.readValue("[ {  \"photoUrls\" : [ \"photoUrls\", \"photoUrls\" ],  \"name\" : \"doggie\",  \"id\" : 0,  \"category\" : {    \"name\" : \"name\",    \"id\" : 6  },  \"tags\" : [ {    \"name\" : \"name\",    \"id\" : 1  }, {    \"name\" : \"name\",    \"id\" : 1  } ],  \"status\" : \"available\"}, {  \"photoUrls\" : [ \"photoUrls\", \"photoUrls\" ],  \"name\" : \"doggie\",  \"id\" : 0,  \"category\" : {    \"name\" : \"name\",    \"id\" : 6  },  \"tags\" : [ {    \"name\" : \"name\",    \"id\" : 1  }, {    \"name\" : \"name\",    \"id\" : 1  } ],  \"status\" : \"available\"} ]", List.class), HttpStatus.NOT_IMPLEMENTED);
+            } catch (IOException e) {
+                log.error("Couldn't serialize response for content type application/json", e);
+                return new ResponseEntity<List<Pet>>(HttpStatus.INTERNAL_SERVER_ERROR);
+            }
         }
 
         return new ResponseEntity<List<Pet>>(HttpStatus.OK);
     }
 
-    public ResponseEntity<Pet> getPetById(@ApiParam(value = "ID of pet to return",required=true) @PathVariable("petId") Long petId,
-        @RequestHeader(value = "Accept", required = false) String accept) throws Exception {
+    public ResponseEntity<Pet> getPetById(@ApiParam(value = "ID of pet to return",required=true) @PathVariable("petId") Long petId) {
         // do some magic!
-
+        String accept = ((ServletRequestAttributes)RequestContextHolder.getRequestAttributes()).getRequest().getHeader("Accept");
         if (accept != null && accept.contains("application/xml")) {
-            return new ResponseEntity<Pet>(objectMapper.readValue("<Pet>  <id>123456789</id>  <name>doggie</name>  <photoUrls>    <photoUrls>aeiou</photoUrls>  </photoUrls>  <tags>  </tags>  <status>aeiou</status></Pet>", Pet.class), HttpStatus.OK);
+            try {
+                return new ResponseEntity<Pet>(objectMapper.readValue("<Pet>  <id>123456789</id>  <name>doggie</name>  <photoUrls>    <photoUrls>aeiou</photoUrls>  </photoUrls>  <tags>  </tags>  <status>aeiou</status></Pet>", Pet.class), HttpStatus.NOT_IMPLEMENTED);
+            } catch (IOException e) {
+                log.error("Couldn't serialize response for content type application/xml", e);
+                return new ResponseEntity<Pet>(HttpStatus.INTERNAL_SERVER_ERROR);
+            }
         }
 
-
         if (accept != null && accept.contains("application/json")) {
-            return new ResponseEntity<Pet>(objectMapper.readValue("{  \"photoUrls\" : [ \"photoUrls\", \"photoUrls\" ],  \"name\" : \"doggie\",  \"id\" : 0,  \"category\" : {    \"name\" : \"name\",    \"id\" : 6  },  \"tags\" : [ {    \"name\" : \"name\",    \"id\" : 1  }, {    \"name\" : \"name\",    \"id\" : 1  } ],  \"status\" : \"available\"}", Pet.class), HttpStatus.OK);
+            try {
+                return new ResponseEntity<Pet>(objectMapper.readValue("{  \"photoUrls\" : [ \"photoUrls\", \"photoUrls\" ],  \"name\" : \"doggie\",  \"id\" : 0,  \"category\" : {    \"name\" : \"name\",    \"id\" : 6  },  \"tags\" : [ {    \"name\" : \"name\",    \"id\" : 1  }, {    \"name\" : \"name\",    \"id\" : 1  } ],  \"status\" : \"available\"}", Pet.class), HttpStatus.NOT_IMPLEMENTED);
+            } catch (IOException e) {
+                log.error("Couldn't serialize response for content type application/json", e);
+                return new ResponseEntity<Pet>(HttpStatus.INTERNAL_SERVER_ERROR);
+            }
         }
 
         return new ResponseEntity<Pet>(HttpStatus.OK);
     }
 
-    public ResponseEntity<Void> updatePet(@ApiParam(value = "Pet object that needs to be added to the store" ,required=true )  @Valid @RequestBody Pet body,
-        @RequestHeader(value = "Accept", required = false) String accept) throws Exception {
+    public ResponseEntity<Void> updatePet(@ApiParam(value = "Pet object that needs to be added to the store" ,required=true )  @Valid @RequestBody Pet body) {
         // do some magic!
+        String accept = ((ServletRequestAttributes)RequestContextHolder.getRequestAttributes()).getRequest().getHeader("Accept");
         return new ResponseEntity<Void>(HttpStatus.OK);
     }
 
-    public ResponseEntity<Void> updatePetWithForm(@ApiParam(value = "ID of pet that needs to be updated",required=true) @PathVariable("petId") Long petId,
-        @ApiParam(value = "Updated name of the pet") @RequestPart(value="name", required=false)  String name,
-        @ApiParam(value = "Updated status of the pet") @RequestPart(value="status", required=false)  String status,
-        @RequestHeader(value = "Accept", required = false) String accept) throws Exception {
+    public ResponseEntity<Void> updatePetWithForm(@ApiParam(value = "ID of pet that needs to be updated",required=true) @PathVariable("petId") Long petId,@ApiParam(value = "Updated name of the pet") @RequestPart(value="name", required=false)  String name,@ApiParam(value = "Updated status of the pet") @RequestPart(value="status", required=false)  String status) {
         // do some magic!
+        String accept = ((ServletRequestAttributes)RequestContextHolder.getRequestAttributes()).getRequest().getHeader("Accept");
         return new ResponseEntity<Void>(HttpStatus.OK);
     }
 
-    public ResponseEntity<ModelApiResponse> uploadFile(@ApiParam(value = "ID of pet to update",required=true) @PathVariable("petId") Long petId,
-        @ApiParam(value = "Additional data to pass to server") @RequestPart(value="additionalMetadata", required=false)  String additionalMetadata,
-        @ApiParam(value = "file detail") @Valid @RequestPart("file") MultipartFile file,
-        @RequestHeader(value = "Accept", required = false) String accept) throws Exception {
+    public ResponseEntity<ModelApiResponse> uploadFile(@ApiParam(value = "ID of pet to update",required=true) @PathVariable("petId") Long petId,@ApiParam(value = "Additional data to pass to server") @RequestPart(value="additionalMetadata", required=false)  String additionalMetadata,@ApiParam(value = "file detail") @Valid @RequestPart("file") MultipartFile file) {
         // do some magic!
-
+        String accept = ((ServletRequestAttributes)RequestContextHolder.getRequestAttributes()).getRequest().getHeader("Accept");
         if (accept != null && accept.contains("application/json")) {
-            return new ResponseEntity<ModelApiResponse>(objectMapper.readValue("{  \"code\" : 0,  \"type\" : \"type\",  \"message\" : \"message\"}", ModelApiResponse.class), HttpStatus.OK);
+            try {
+                return new ResponseEntity<ModelApiResponse>(objectMapper.readValue("{  \"code\" : 0,  \"type\" : \"type\",  \"message\" : \"message\"}", ModelApiResponse.class), HttpStatus.NOT_IMPLEMENTED);
+            } catch (IOException e) {
+                log.error("Couldn't serialize response for content type application/json", e);
+                return new ResponseEntity<ModelApiResponse>(HttpStatus.INTERNAL_SERVER_ERROR);
+            }
         }
 
         return new ResponseEntity<ModelApiResponse>(HttpStatus.OK);

--- a/samples/server/petstore/springboot-implicitHeaders/src/main/java/io/swagger/api/PetApiController.java
+++ b/samples/server/petstore/springboot-implicitHeaders/src/main/java/io/swagger/api/PetApiController.java
@@ -23,35 +23,40 @@ import org.springframework.web.multipart.MultipartFile;
 import java.util.List;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.IOException;
+import javax.servlet.http.HttpServletRequest;
 import javax.validation.constraints.*;
 import javax.validation.Valid;
 
 @Controller
 public class PetApiController implements PetApi {
 
-    private final Logger log = LoggerFactory.getLogger(AnotherFakeApiController.class);
+    private static final Logger log = LoggerFactory.getLogger(PetApiController.class);
 
     private final ObjectMapper objectMapper;
 
+    @org.springframework.beans.factory.annotation.Autowired
+    private HttpServletRequest request;
+
+    @org.springframework.beans.factory.annotation.Autowired
     public PetApiController(ObjectMapper objectMapper) {
         this.objectMapper = objectMapper;
     }
 
     public ResponseEntity<Void> addPet(@ApiParam(value = "Pet object that needs to be added to the store" ,required=true )  @Valid @RequestBody Pet body) {
         // do some magic!
-        String accept = ((ServletRequestAttributes)RequestContextHolder.getRequestAttributes()).getRequest().getHeader("Accept");
+        String accept = request.getHeader("Accept");
         return new ResponseEntity<Void>(HttpStatus.OK);
     }
 
     public ResponseEntity<Void> deletePet(@ApiParam(value = "Pet id to delete",required=true) @PathVariable("petId") Long petId) {
         // do some magic!
-        String accept = ((ServletRequestAttributes)RequestContextHolder.getRequestAttributes()).getRequest().getHeader("Accept");
+        String accept = request.getHeader("Accept");
         return new ResponseEntity<Void>(HttpStatus.OK);
     }
 
     public ResponseEntity<List<Pet>> findPetsByStatus(@NotNull @ApiParam(value = "Status values that need to be considered for filter", required = true, allowableValues = "available, pending, sold") @Valid @RequestParam(value = "status", required = true) List<String> status) {
         // do some magic!
-        String accept = ((ServletRequestAttributes)RequestContextHolder.getRequestAttributes()).getRequest().getHeader("Accept");
+        String accept = request.getHeader("Accept");
         if (accept != null && accept.contains("application/xml")) {
             try {
                 return new ResponseEntity<List<Pet>>(objectMapper.readValue("<Pet>  <id>123456789</id>  <name>doggie</name>  <photoUrls>    <photoUrls>aeiou</photoUrls>  </photoUrls>  <tags>  </tags>  <status>aeiou</status></Pet>", List.class), HttpStatus.NOT_IMPLEMENTED);
@@ -75,7 +80,7 @@ public class PetApiController implements PetApi {
 
     public ResponseEntity<List<Pet>> findPetsByTags(@NotNull @ApiParam(value = "Tags to filter by", required = true) @Valid @RequestParam(value = "tags", required = true) List<String> tags) {
         // do some magic!
-        String accept = ((ServletRequestAttributes)RequestContextHolder.getRequestAttributes()).getRequest().getHeader("Accept");
+        String accept = request.getHeader("Accept");
         if (accept != null && accept.contains("application/xml")) {
             try {
                 return new ResponseEntity<List<Pet>>(objectMapper.readValue("<Pet>  <id>123456789</id>  <name>doggie</name>  <photoUrls>    <photoUrls>aeiou</photoUrls>  </photoUrls>  <tags>  </tags>  <status>aeiou</status></Pet>", List.class), HttpStatus.NOT_IMPLEMENTED);
@@ -99,7 +104,7 @@ public class PetApiController implements PetApi {
 
     public ResponseEntity<Pet> getPetById(@ApiParam(value = "ID of pet to return",required=true) @PathVariable("petId") Long petId) {
         // do some magic!
-        String accept = ((ServletRequestAttributes)RequestContextHolder.getRequestAttributes()).getRequest().getHeader("Accept");
+        String accept = request.getHeader("Accept");
         if (accept != null && accept.contains("application/xml")) {
             try {
                 return new ResponseEntity<Pet>(objectMapper.readValue("<Pet>  <id>123456789</id>  <name>doggie</name>  <photoUrls>    <photoUrls>aeiou</photoUrls>  </photoUrls>  <tags>  </tags>  <status>aeiou</status></Pet>", Pet.class), HttpStatus.NOT_IMPLEMENTED);
@@ -123,19 +128,19 @@ public class PetApiController implements PetApi {
 
     public ResponseEntity<Void> updatePet(@ApiParam(value = "Pet object that needs to be added to the store" ,required=true )  @Valid @RequestBody Pet body) {
         // do some magic!
-        String accept = ((ServletRequestAttributes)RequestContextHolder.getRequestAttributes()).getRequest().getHeader("Accept");
+        String accept = request.getHeader("Accept");
         return new ResponseEntity<Void>(HttpStatus.OK);
     }
 
     public ResponseEntity<Void> updatePetWithForm(@ApiParam(value = "ID of pet that needs to be updated",required=true) @PathVariable("petId") Long petId,@ApiParam(value = "Updated name of the pet") @RequestPart(value="name", required=false)  String name,@ApiParam(value = "Updated status of the pet") @RequestPart(value="status", required=false)  String status) {
         // do some magic!
-        String accept = ((ServletRequestAttributes)RequestContextHolder.getRequestAttributes()).getRequest().getHeader("Accept");
+        String accept = request.getHeader("Accept");
         return new ResponseEntity<Void>(HttpStatus.OK);
     }
 
     public ResponseEntity<ModelApiResponse> uploadFile(@ApiParam(value = "ID of pet to update",required=true) @PathVariable("petId") Long petId,@ApiParam(value = "Additional data to pass to server") @RequestPart(value="additionalMetadata", required=false)  String additionalMetadata,@ApiParam(value = "file detail") @Valid @RequestPart("file") MultipartFile file) {
         // do some magic!
-        String accept = ((ServletRequestAttributes)RequestContextHolder.getRequestAttributes()).getRequest().getHeader("Accept");
+        String accept = request.getHeader("Accept");
         if (accept != null && accept.contains("application/json")) {
             try {
                 return new ResponseEntity<ModelApiResponse>(objectMapper.readValue("{  \"code\" : 0,  \"type\" : \"type\",  \"message\" : \"message\"}", ModelApiResponse.class), HttpStatus.NOT_IMPLEMENTED);

--- a/samples/server/petstore/springboot-implicitHeaders/src/main/java/io/swagger/api/StoreApi.java
+++ b/samples/server/petstore/springboot-implicitHeaders/src/main/java/io/swagger/api/StoreApi.java
@@ -7,9 +7,9 @@ package io.swagger.api;
 
 import java.util.Map;
 import io.swagger.model.Order;
-
 import io.swagger.annotations.*;
 import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
@@ -18,12 +18,10 @@ import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.multipart.MultipartFile;
-import java.io.IOException;
 
-import java.util.List;
-import org.springframework.validation.annotation.Validated;
-import javax.validation.constraints.*;
 import javax.validation.Valid;
+import javax.validation.constraints.*;
+import java.util.List;
 
 @Api(value = "store", description = "the store API")
 public interface StoreApi {

--- a/samples/server/petstore/springboot-implicitHeaders/src/main/java/io/swagger/api/StoreApi.java
+++ b/samples/server/petstore/springboot-implicitHeaders/src/main/java/io/swagger/api/StoreApi.java
@@ -37,7 +37,7 @@ public interface StoreApi {
     @RequestMapping(value = "/store/order/{order_id}",
         produces = { "application/xml", "application/json" }, 
         method = RequestMethod.DELETE)
-    ResponseEntity<Void> deleteOrder(@ApiParam(value = "ID of the order that needs to be deleted",required=true) @PathVariable("order_id") String orderId, @RequestHeader(value = "Accept", required = false) String accept) throws Exception;
+    ResponseEntity<Void> deleteOrder(@ApiParam(value = "ID of the order that needs to be deleted",required=true) @PathVariable("order_id") String orderId);
 
 
     @ApiOperation(value = "Returns pet inventories by status", nickname = "getInventory", notes = "Returns a map of status codes to quantities", response = Integer.class, responseContainer = "Map", authorizations = {
@@ -50,7 +50,7 @@ public interface StoreApi {
     @RequestMapping(value = "/store/inventory",
         produces = { "application/json" }, 
         method = RequestMethod.GET)
-    ResponseEntity<Map<String, Integer>> getInventory( @RequestHeader(value = "Accept", required = false) String accept) throws Exception;
+    ResponseEntity<Map<String, Integer>> getInventory();
 
 
     @ApiOperation(value = "Find purchase order by ID", nickname = "getOrderById", notes = "For valid response try integer IDs with value <= 5 or > 10. Other values will generated exceptions", response = Order.class, tags={ "store", })
@@ -63,7 +63,7 @@ public interface StoreApi {
     @RequestMapping(value = "/store/order/{order_id}",
         produces = { "application/xml", "application/json" }, 
         method = RequestMethod.GET)
-    ResponseEntity<Order> getOrderById( @Min(1) @Max(5)@ApiParam(value = "ID of pet that needs to be fetched",required=true) @PathVariable("order_id") Long orderId, @RequestHeader(value = "Accept", required = false) String accept) throws Exception;
+    ResponseEntity<Order> getOrderById(@Min(1) @Max(5) @ApiParam(value = "ID of pet that needs to be fetched",required=true) @PathVariable("order_id") Long orderId);
 
 
     @ApiOperation(value = "Place an order for a pet", nickname = "placeOrder", notes = "", response = Order.class, tags={ "store", })
@@ -75,6 +75,6 @@ public interface StoreApi {
     @RequestMapping(value = "/store/order",
         produces = { "application/xml", "application/json" }, 
         method = RequestMethod.POST)
-    ResponseEntity<Order> placeOrder(@ApiParam(value = "order placed for purchasing the pet" ,required=true )  @Valid @RequestBody Order body, @RequestHeader(value = "Accept", required = false) String accept) throws Exception;
+    ResponseEntity<Order> placeOrder(@ApiParam(value = "order placed for purchasing the pet" ,required=true )  @Valid @RequestBody Order body);
 
 }

--- a/samples/server/petstore/springboot-implicitHeaders/src/main/java/io/swagger/api/StoreApiController.java
+++ b/samples/server/petstore/springboot-implicitHeaders/src/main/java/io/swagger/api/StoreApiController.java
@@ -2,9 +2,8 @@ package io.swagger.api;
 
 import java.util.Map;
 import io.swagger.model.Order;
-
+import com.fasterxml.jackson.databind.ObjectMapper;
 import io.swagger.annotations.*;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpStatus;
@@ -15,16 +14,13 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RequestPart;
-import org.springframework.web.context.request.RequestContextHolder;
-import org.springframework.web.context.request.ServletRequestAttributes;
 import org.springframework.web.multipart.MultipartFile;
 
-import java.util.List;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import java.io.IOException;
-import javax.servlet.http.HttpServletRequest;
 import javax.validation.constraints.*;
 import javax.validation.Valid;
+import javax.servlet.http.HttpServletRequest;
+import java.io.IOException;
+import java.util.List;
 
 @Controller
 public class StoreApiController implements StoreApi {
@@ -42,13 +38,11 @@ public class StoreApiController implements StoreApi {
     }
 
     public ResponseEntity<Void> deleteOrder(@ApiParam(value = "ID of the order that needs to be deleted",required=true) @PathVariable("order_id") String orderId) {
-        // do some magic!
         String accept = request.getHeader("Accept");
-        return new ResponseEntity<Void>(HttpStatus.OK);
+        return new ResponseEntity<Void>(HttpStatus.NOT_IMPLEMENTED);
     }
 
     public ResponseEntity<Map<String, Integer>> getInventory() {
-        // do some magic!
         String accept = request.getHeader("Accept");
         if (accept != null && accept.contains("application/json")) {
             try {
@@ -59,11 +53,10 @@ public class StoreApiController implements StoreApi {
             }
         }
 
-        return new ResponseEntity<Map<String, Integer>>(HttpStatus.OK);
+        return new ResponseEntity<Map<String, Integer>>(HttpStatus.NOT_IMPLEMENTED);
     }
 
     public ResponseEntity<Order> getOrderById(@Min(1) @Max(5) @ApiParam(value = "ID of pet that needs to be fetched",required=true) @PathVariable("order_id") Long orderId) {
-        // do some magic!
         String accept = request.getHeader("Accept");
         if (accept != null && accept.contains("application/xml")) {
             try {
@@ -83,11 +76,10 @@ public class StoreApiController implements StoreApi {
             }
         }
 
-        return new ResponseEntity<Order>(HttpStatus.OK);
+        return new ResponseEntity<Order>(HttpStatus.NOT_IMPLEMENTED);
     }
 
     public ResponseEntity<Order> placeOrder(@ApiParam(value = "order placed for purchasing the pet" ,required=true )  @Valid @RequestBody Order body) {
-        // do some magic!
         String accept = request.getHeader("Accept");
         if (accept != null && accept.contains("application/xml")) {
             try {
@@ -107,7 +99,7 @@ public class StoreApiController implements StoreApi {
             }
         }
 
-        return new ResponseEntity<Order>(HttpStatus.OK);
+        return new ResponseEntity<Order>(HttpStatus.NOT_IMPLEMENTED);
     }
 
 }

--- a/samples/server/petstore/springboot-implicitHeaders/src/main/java/io/swagger/api/StoreApiController.java
+++ b/samples/server/petstore/springboot-implicitHeaders/src/main/java/io/swagger/api/StoreApiController.java
@@ -33,12 +33,12 @@ public class StoreApiController implements StoreApi {
 
     private final ObjectMapper objectMapper;
 
-    @org.springframework.beans.factory.annotation.Autowired
-    private HttpServletRequest request;
+    private final HttpServletRequest request;
 
     @org.springframework.beans.factory.annotation.Autowired
-    public StoreApiController(ObjectMapper objectMapper) {
+    public StoreApiController(ObjectMapper objectMapper, HttpServletRequest request) {
         this.objectMapper = objectMapper;
+        this.request = request;
     }
 
     public ResponseEntity<Void> deleteOrder(@ApiParam(value = "ID of the order that needs to be deleted",required=true) @PathVariable("order_id") String orderId) {

--- a/samples/server/petstore/springboot-implicitHeaders/src/main/java/io/swagger/api/StoreApiController.java
+++ b/samples/server/petstore/springboot-implicitHeaders/src/main/java/io/swagger/api/StoreApiController.java
@@ -5,6 +5,8 @@ import io.swagger.model.Order;
 
 import io.swagger.annotations.*;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
@@ -13,6 +15,8 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RequestPart;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.util.List;
@@ -23,55 +27,79 @@ import javax.validation.Valid;
 
 @Controller
 public class StoreApiController implements StoreApi {
+
+    private final Logger log = LoggerFactory.getLogger(AnotherFakeApiController.class);
+
     private final ObjectMapper objectMapper;
 
     public StoreApiController(ObjectMapper objectMapper) {
         this.objectMapper = objectMapper;
     }
 
-    public ResponseEntity<Void> deleteOrder(@ApiParam(value = "ID of the order that needs to be deleted",required=true) @PathVariable("order_id") String orderId,
-        @RequestHeader(value = "Accept", required = false) String accept) throws Exception {
+    public ResponseEntity<Void> deleteOrder(@ApiParam(value = "ID of the order that needs to be deleted",required=true) @PathVariable("order_id") String orderId) {
         // do some magic!
+        String accept = ((ServletRequestAttributes)RequestContextHolder.getRequestAttributes()).getRequest().getHeader("Accept");
         return new ResponseEntity<Void>(HttpStatus.OK);
     }
 
-    public ResponseEntity<Map<String, Integer>> getInventory(@RequestHeader(value = "Accept", required = false) String accept) throws Exception {
+    public ResponseEntity<Map<String, Integer>> getInventory() {
         // do some magic!
-
+        String accept = ((ServletRequestAttributes)RequestContextHolder.getRequestAttributes()).getRequest().getHeader("Accept");
         if (accept != null && accept.contains("application/json")) {
-            return new ResponseEntity<Map<String, Integer>>(objectMapper.readValue("{  \"key\" : 0}", Map.class), HttpStatus.OK);
+            try {
+                return new ResponseEntity<Map<String, Integer>>(objectMapper.readValue("{  \"key\" : 0}", Map.class), HttpStatus.NOT_IMPLEMENTED);
+            } catch (IOException e) {
+                log.error("Couldn't serialize response for content type application/json", e);
+                return new ResponseEntity<Map<String, Integer>>(HttpStatus.INTERNAL_SERVER_ERROR);
+            }
         }
 
         return new ResponseEntity<Map<String, Integer>>(HttpStatus.OK);
     }
 
-    public ResponseEntity<Order> getOrderById( @Min(1) @Max(5)@ApiParam(value = "ID of pet that needs to be fetched",required=true) @PathVariable("order_id") Long orderId,
-        @RequestHeader(value = "Accept", required = false) String accept) throws Exception {
+    public ResponseEntity<Order> getOrderById(@Min(1) @Max(5) @ApiParam(value = "ID of pet that needs to be fetched",required=true) @PathVariable("order_id") Long orderId) {
         // do some magic!
-
+        String accept = ((ServletRequestAttributes)RequestContextHolder.getRequestAttributes()).getRequest().getHeader("Accept");
         if (accept != null && accept.contains("application/xml")) {
-            return new ResponseEntity<Order>(objectMapper.readValue("<Order>  <id>123456789</id>  <petId>123456789</petId>  <quantity>123</quantity>  <shipDate>2000-01-23T04:56:07.000Z</shipDate>  <status>aeiou</status>  <complete>true</complete></Order>", Order.class), HttpStatus.OK);
+            try {
+                return new ResponseEntity<Order>(objectMapper.readValue("<Order>  <id>123456789</id>  <petId>123456789</petId>  <quantity>123</quantity>  <shipDate>2000-01-23T04:56:07.000Z</shipDate>  <status>aeiou</status>  <complete>true</complete></Order>", Order.class), HttpStatus.NOT_IMPLEMENTED);
+            } catch (IOException e) {
+                log.error("Couldn't serialize response for content type application/xml", e);
+                return new ResponseEntity<Order>(HttpStatus.INTERNAL_SERVER_ERROR);
+            }
         }
 
-
         if (accept != null && accept.contains("application/json")) {
-            return new ResponseEntity<Order>(objectMapper.readValue("{  \"petId\" : 6,  \"quantity\" : 1,  \"id\" : 0,  \"shipDate\" : \"2000-01-23T04:56:07.000+00:00\",  \"complete\" : false,  \"status\" : \"placed\"}", Order.class), HttpStatus.OK);
+            try {
+                return new ResponseEntity<Order>(objectMapper.readValue("{  \"petId\" : 6,  \"quantity\" : 1,  \"id\" : 0,  \"shipDate\" : \"2000-01-23T04:56:07.000+00:00\",  \"complete\" : false,  \"status\" : \"placed\"}", Order.class), HttpStatus.NOT_IMPLEMENTED);
+            } catch (IOException e) {
+                log.error("Couldn't serialize response for content type application/json", e);
+                return new ResponseEntity<Order>(HttpStatus.INTERNAL_SERVER_ERROR);
+            }
         }
 
         return new ResponseEntity<Order>(HttpStatus.OK);
     }
 
-    public ResponseEntity<Order> placeOrder(@ApiParam(value = "order placed for purchasing the pet" ,required=true )  @Valid @RequestBody Order body,
-        @RequestHeader(value = "Accept", required = false) String accept) throws Exception {
+    public ResponseEntity<Order> placeOrder(@ApiParam(value = "order placed for purchasing the pet" ,required=true )  @Valid @RequestBody Order body) {
         // do some magic!
-
+        String accept = ((ServletRequestAttributes)RequestContextHolder.getRequestAttributes()).getRequest().getHeader("Accept");
         if (accept != null && accept.contains("application/xml")) {
-            return new ResponseEntity<Order>(objectMapper.readValue("<Order>  <id>123456789</id>  <petId>123456789</petId>  <quantity>123</quantity>  <shipDate>2000-01-23T04:56:07.000Z</shipDate>  <status>aeiou</status>  <complete>true</complete></Order>", Order.class), HttpStatus.OK);
+            try {
+                return new ResponseEntity<Order>(objectMapper.readValue("<Order>  <id>123456789</id>  <petId>123456789</petId>  <quantity>123</quantity>  <shipDate>2000-01-23T04:56:07.000Z</shipDate>  <status>aeiou</status>  <complete>true</complete></Order>", Order.class), HttpStatus.NOT_IMPLEMENTED);
+            } catch (IOException e) {
+                log.error("Couldn't serialize response for content type application/xml", e);
+                return new ResponseEntity<Order>(HttpStatus.INTERNAL_SERVER_ERROR);
+            }
         }
 
-
         if (accept != null && accept.contains("application/json")) {
-            return new ResponseEntity<Order>(objectMapper.readValue("{  \"petId\" : 6,  \"quantity\" : 1,  \"id\" : 0,  \"shipDate\" : \"2000-01-23T04:56:07.000+00:00\",  \"complete\" : false,  \"status\" : \"placed\"}", Order.class), HttpStatus.OK);
+            try {
+                return new ResponseEntity<Order>(objectMapper.readValue("{  \"petId\" : 6,  \"quantity\" : 1,  \"id\" : 0,  \"shipDate\" : \"2000-01-23T04:56:07.000+00:00\",  \"complete\" : false,  \"status\" : \"placed\"}", Order.class), HttpStatus.NOT_IMPLEMENTED);
+            } catch (IOException e) {
+                log.error("Couldn't serialize response for content type application/json", e);
+                return new ResponseEntity<Order>(HttpStatus.INTERNAL_SERVER_ERROR);
+            }
         }
 
         return new ResponseEntity<Order>(HttpStatus.OK);

--- a/samples/server/petstore/springboot-implicitHeaders/src/main/java/io/swagger/api/StoreApiController.java
+++ b/samples/server/petstore/springboot-implicitHeaders/src/main/java/io/swagger/api/StoreApiController.java
@@ -22,29 +22,34 @@ import org.springframework.web.multipart.MultipartFile;
 import java.util.List;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.IOException;
+import javax.servlet.http.HttpServletRequest;
 import javax.validation.constraints.*;
 import javax.validation.Valid;
 
 @Controller
 public class StoreApiController implements StoreApi {
 
-    private final Logger log = LoggerFactory.getLogger(AnotherFakeApiController.class);
+    private static final Logger log = LoggerFactory.getLogger(StoreApiController.class);
 
     private final ObjectMapper objectMapper;
 
+    @org.springframework.beans.factory.annotation.Autowired
+    private HttpServletRequest request;
+
+    @org.springframework.beans.factory.annotation.Autowired
     public StoreApiController(ObjectMapper objectMapper) {
         this.objectMapper = objectMapper;
     }
 
     public ResponseEntity<Void> deleteOrder(@ApiParam(value = "ID of the order that needs to be deleted",required=true) @PathVariable("order_id") String orderId) {
         // do some magic!
-        String accept = ((ServletRequestAttributes)RequestContextHolder.getRequestAttributes()).getRequest().getHeader("Accept");
+        String accept = request.getHeader("Accept");
         return new ResponseEntity<Void>(HttpStatus.OK);
     }
 
     public ResponseEntity<Map<String, Integer>> getInventory() {
         // do some magic!
-        String accept = ((ServletRequestAttributes)RequestContextHolder.getRequestAttributes()).getRequest().getHeader("Accept");
+        String accept = request.getHeader("Accept");
         if (accept != null && accept.contains("application/json")) {
             try {
                 return new ResponseEntity<Map<String, Integer>>(objectMapper.readValue("{  \"key\" : 0}", Map.class), HttpStatus.NOT_IMPLEMENTED);
@@ -59,7 +64,7 @@ public class StoreApiController implements StoreApi {
 
     public ResponseEntity<Order> getOrderById(@Min(1) @Max(5) @ApiParam(value = "ID of pet that needs to be fetched",required=true) @PathVariable("order_id") Long orderId) {
         // do some magic!
-        String accept = ((ServletRequestAttributes)RequestContextHolder.getRequestAttributes()).getRequest().getHeader("Accept");
+        String accept = request.getHeader("Accept");
         if (accept != null && accept.contains("application/xml")) {
             try {
                 return new ResponseEntity<Order>(objectMapper.readValue("<Order>  <id>123456789</id>  <petId>123456789</petId>  <quantity>123</quantity>  <shipDate>2000-01-23T04:56:07.000Z</shipDate>  <status>aeiou</status>  <complete>true</complete></Order>", Order.class), HttpStatus.NOT_IMPLEMENTED);
@@ -83,7 +88,7 @@ public class StoreApiController implements StoreApi {
 
     public ResponseEntity<Order> placeOrder(@ApiParam(value = "order placed for purchasing the pet" ,required=true )  @Valid @RequestBody Order body) {
         // do some magic!
-        String accept = ((ServletRequestAttributes)RequestContextHolder.getRequestAttributes()).getRequest().getHeader("Accept");
+        String accept = request.getHeader("Accept");
         if (accept != null && accept.contains("application/xml")) {
             try {
                 return new ResponseEntity<Order>(objectMapper.readValue("<Order>  <id>123456789</id>  <petId>123456789</petId>  <quantity>123</quantity>  <shipDate>2000-01-23T04:56:07.000Z</shipDate>  <status>aeiou</status>  <complete>true</complete></Order>", Order.class), HttpStatus.NOT_IMPLEMENTED);

--- a/samples/server/petstore/springboot-implicitHeaders/src/main/java/io/swagger/api/UserApi.java
+++ b/samples/server/petstore/springboot-implicitHeaders/src/main/java/io/swagger/api/UserApi.java
@@ -7,9 +7,9 @@ package io.swagger.api;
 
 import java.util.List;
 import io.swagger.model.User;
-
 import io.swagger.annotations.*;
 import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
@@ -18,12 +18,10 @@ import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.multipart.MultipartFile;
-import java.io.IOException;
 
-import java.util.List;
-import org.springframework.validation.annotation.Validated;
-import javax.validation.constraints.*;
 import javax.validation.Valid;
+import javax.validation.constraints.*;
+import java.util.List;
 
 @Api(value = "user", description = "the user API")
 public interface UserApi {

--- a/samples/server/petstore/springboot-implicitHeaders/src/main/java/io/swagger/api/UserApi.java
+++ b/samples/server/petstore/springboot-implicitHeaders/src/main/java/io/swagger/api/UserApi.java
@@ -36,7 +36,7 @@ public interface UserApi {
     @RequestMapping(value = "/user",
         produces = { "application/xml", "application/json" }, 
         method = RequestMethod.POST)
-    ResponseEntity<Void> createUser(@ApiParam(value = "Created user object" ,required=true )  @Valid @RequestBody User body, @RequestHeader(value = "Accept", required = false) String accept) throws Exception;
+    ResponseEntity<Void> createUser(@ApiParam(value = "Created user object" ,required=true )  @Valid @RequestBody User body);
 
 
     @ApiOperation(value = "Creates list of users with given input array", nickname = "createUsersWithArrayInput", notes = "", tags={ "user", })
@@ -47,7 +47,7 @@ public interface UserApi {
     @RequestMapping(value = "/user/createWithArray",
         produces = { "application/xml", "application/json" }, 
         method = RequestMethod.POST)
-    ResponseEntity<Void> createUsersWithArrayInput(@ApiParam(value = "List of user object" ,required=true )  @Valid @RequestBody List<User> body, @RequestHeader(value = "Accept", required = false) String accept) throws Exception;
+    ResponseEntity<Void> createUsersWithArrayInput(@ApiParam(value = "List of user object" ,required=true )  @Valid @RequestBody List<User> body);
 
 
     @ApiOperation(value = "Creates list of users with given input array", nickname = "createUsersWithListInput", notes = "", tags={ "user", })
@@ -58,7 +58,7 @@ public interface UserApi {
     @RequestMapping(value = "/user/createWithList",
         produces = { "application/xml", "application/json" }, 
         method = RequestMethod.POST)
-    ResponseEntity<Void> createUsersWithListInput(@ApiParam(value = "List of user object" ,required=true )  @Valid @RequestBody List<User> body, @RequestHeader(value = "Accept", required = false) String accept) throws Exception;
+    ResponseEntity<Void> createUsersWithListInput(@ApiParam(value = "List of user object" ,required=true )  @Valid @RequestBody List<User> body);
 
 
     @ApiOperation(value = "Delete user", nickname = "deleteUser", notes = "This can only be done by the logged in user.", tags={ "user", })
@@ -70,7 +70,7 @@ public interface UserApi {
     @RequestMapping(value = "/user/{username}",
         produces = { "application/xml", "application/json" }, 
         method = RequestMethod.DELETE)
-    ResponseEntity<Void> deleteUser(@ApiParam(value = "The name that needs to be deleted",required=true) @PathVariable("username") String username, @RequestHeader(value = "Accept", required = false) String accept) throws Exception;
+    ResponseEntity<Void> deleteUser(@ApiParam(value = "The name that needs to be deleted",required=true) @PathVariable("username") String username);
 
 
     @ApiOperation(value = "Get user by user name", nickname = "getUserByName", notes = "", response = User.class, tags={ "user", })
@@ -83,7 +83,7 @@ public interface UserApi {
     @RequestMapping(value = "/user/{username}",
         produces = { "application/xml", "application/json" }, 
         method = RequestMethod.GET)
-    ResponseEntity<User> getUserByName(@ApiParam(value = "The name that needs to be fetched. Use user1 for testing. ",required=true) @PathVariable("username") String username, @RequestHeader(value = "Accept", required = false) String accept) throws Exception;
+    ResponseEntity<User> getUserByName(@ApiParam(value = "The name that needs to be fetched. Use user1 for testing. ",required=true) @PathVariable("username") String username);
 
 
     @ApiOperation(value = "Logs user into the system", nickname = "loginUser", notes = "", response = String.class, tags={ "user", })
@@ -95,7 +95,7 @@ public interface UserApi {
     @RequestMapping(value = "/user/login",
         produces = { "application/xml", "application/json" }, 
         method = RequestMethod.GET)
-    ResponseEntity<String> loginUser( @NotNull@ApiParam(value = "The user name for login", required = true) @Valid @RequestParam(value = "username", required = true) String username, @NotNull@ApiParam(value = "The password for login in clear text", required = true) @Valid @RequestParam(value = "password", required = true) String password, @RequestHeader(value = "Accept", required = false) String accept) throws Exception;
+    ResponseEntity<String> loginUser(@NotNull @ApiParam(value = "The user name for login", required = true) @Valid @RequestParam(value = "username", required = true) String username,@NotNull @ApiParam(value = "The password for login in clear text", required = true) @Valid @RequestParam(value = "password", required = true) String password);
 
 
     @ApiOperation(value = "Logs out current logged in user session", nickname = "logoutUser", notes = "", tags={ "user", })
@@ -106,7 +106,7 @@ public interface UserApi {
     @RequestMapping(value = "/user/logout",
         produces = { "application/xml", "application/json" }, 
         method = RequestMethod.GET)
-    ResponseEntity<Void> logoutUser( @RequestHeader(value = "Accept", required = false) String accept) throws Exception;
+    ResponseEntity<Void> logoutUser();
 
 
     @ApiOperation(value = "Updated user", nickname = "updateUser", notes = "This can only be done by the logged in user.", tags={ "user", })
@@ -118,6 +118,6 @@ public interface UserApi {
     @RequestMapping(value = "/user/{username}",
         produces = { "application/xml", "application/json" }, 
         method = RequestMethod.PUT)
-    ResponseEntity<Void> updateUser(@ApiParam(value = "name that need to be deleted",required=true) @PathVariable("username") String username,@ApiParam(value = "Updated user object" ,required=true )  @Valid @RequestBody User body, @RequestHeader(value = "Accept", required = false) String accept) throws Exception;
+    ResponseEntity<Void> updateUser(@ApiParam(value = "name that need to be deleted",required=true) @PathVariable("username") String username,@ApiParam(value = "Updated user object" ,required=true )  @Valid @RequestBody User body);
 
 }

--- a/samples/server/petstore/springboot-implicitHeaders/src/main/java/io/swagger/api/UserApiController.java
+++ b/samples/server/petstore/springboot-implicitHeaders/src/main/java/io/swagger/api/UserApiController.java
@@ -33,12 +33,12 @@ public class UserApiController implements UserApi {
 
     private final ObjectMapper objectMapper;
 
-    @org.springframework.beans.factory.annotation.Autowired
-    private HttpServletRequest request;
+    private final HttpServletRequest request;
 
     @org.springframework.beans.factory.annotation.Autowired
-    public UserApiController(ObjectMapper objectMapper) {
+    public UserApiController(ObjectMapper objectMapper, HttpServletRequest request) {
         this.objectMapper = objectMapper;
+        this.request = request;
     }
 
     public ResponseEntity<Void> createUser(@ApiParam(value = "Created user object" ,required=true )  @Valid @RequestBody User body) {

--- a/samples/server/petstore/springboot-implicitHeaders/src/main/java/io/swagger/api/UserApiController.java
+++ b/samples/server/petstore/springboot-implicitHeaders/src/main/java/io/swagger/api/UserApiController.java
@@ -2,9 +2,8 @@ package io.swagger.api;
 
 import java.util.List;
 import io.swagger.model.User;
-
+import com.fasterxml.jackson.databind.ObjectMapper;
 import io.swagger.annotations.*;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpStatus;
@@ -15,16 +14,13 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RequestPart;
-import org.springframework.web.context.request.RequestContextHolder;
-import org.springframework.web.context.request.ServletRequestAttributes;
 import org.springframework.web.multipart.MultipartFile;
 
-import java.util.List;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import java.io.IOException;
-import javax.servlet.http.HttpServletRequest;
 import javax.validation.constraints.*;
 import javax.validation.Valid;
+import javax.servlet.http.HttpServletRequest;
+import java.io.IOException;
+import java.util.List;
 
 @Controller
 public class UserApiController implements UserApi {
@@ -42,31 +38,26 @@ public class UserApiController implements UserApi {
     }
 
     public ResponseEntity<Void> createUser(@ApiParam(value = "Created user object" ,required=true )  @Valid @RequestBody User body) {
-        // do some magic!
         String accept = request.getHeader("Accept");
-        return new ResponseEntity<Void>(HttpStatus.OK);
+        return new ResponseEntity<Void>(HttpStatus.NOT_IMPLEMENTED);
     }
 
     public ResponseEntity<Void> createUsersWithArrayInput(@ApiParam(value = "List of user object" ,required=true )  @Valid @RequestBody List<User> body) {
-        // do some magic!
         String accept = request.getHeader("Accept");
-        return new ResponseEntity<Void>(HttpStatus.OK);
+        return new ResponseEntity<Void>(HttpStatus.NOT_IMPLEMENTED);
     }
 
     public ResponseEntity<Void> createUsersWithListInput(@ApiParam(value = "List of user object" ,required=true )  @Valid @RequestBody List<User> body) {
-        // do some magic!
         String accept = request.getHeader("Accept");
-        return new ResponseEntity<Void>(HttpStatus.OK);
+        return new ResponseEntity<Void>(HttpStatus.NOT_IMPLEMENTED);
     }
 
     public ResponseEntity<Void> deleteUser(@ApiParam(value = "The name that needs to be deleted",required=true) @PathVariable("username") String username) {
-        // do some magic!
         String accept = request.getHeader("Accept");
-        return new ResponseEntity<Void>(HttpStatus.OK);
+        return new ResponseEntity<Void>(HttpStatus.NOT_IMPLEMENTED);
     }
 
     public ResponseEntity<User> getUserByName(@ApiParam(value = "The name that needs to be fetched. Use user1 for testing. ",required=true) @PathVariable("username") String username) {
-        // do some magic!
         String accept = request.getHeader("Accept");
         if (accept != null && accept.contains("application/xml")) {
             try {
@@ -86,11 +77,10 @@ public class UserApiController implements UserApi {
             }
         }
 
-        return new ResponseEntity<User>(HttpStatus.OK);
+        return new ResponseEntity<User>(HttpStatus.NOT_IMPLEMENTED);
     }
 
     public ResponseEntity<String> loginUser(@NotNull @ApiParam(value = "The user name for login", required = true) @Valid @RequestParam(value = "username", required = true) String username,@NotNull @ApiParam(value = "The password for login in clear text", required = true) @Valid @RequestParam(value = "password", required = true) String password) {
-        // do some magic!
         String accept = request.getHeader("Accept");
         if (accept != null && accept.contains("application/xml")) {
             try {
@@ -110,19 +100,17 @@ public class UserApiController implements UserApi {
             }
         }
 
-        return new ResponseEntity<String>(HttpStatus.OK);
+        return new ResponseEntity<String>(HttpStatus.NOT_IMPLEMENTED);
     }
 
     public ResponseEntity<Void> logoutUser() {
-        // do some magic!
         String accept = request.getHeader("Accept");
-        return new ResponseEntity<Void>(HttpStatus.OK);
+        return new ResponseEntity<Void>(HttpStatus.NOT_IMPLEMENTED);
     }
 
     public ResponseEntity<Void> updateUser(@ApiParam(value = "name that need to be deleted",required=true) @PathVariable("username") String username,@ApiParam(value = "Updated user object" ,required=true )  @Valid @RequestBody User body) {
-        // do some magic!
         String accept = request.getHeader("Accept");
-        return new ResponseEntity<Void>(HttpStatus.OK);
+        return new ResponseEntity<Void>(HttpStatus.NOT_IMPLEMENTED);
     }
 
 }

--- a/samples/server/petstore/springboot-implicitHeaders/src/main/java/io/swagger/api/UserApiController.java
+++ b/samples/server/petstore/springboot-implicitHeaders/src/main/java/io/swagger/api/UserApiController.java
@@ -5,6 +5,8 @@ import io.swagger.model.User;
 
 import io.swagger.annotations.*;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
@@ -13,6 +15,8 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RequestPart;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.util.List;
@@ -23,78 +27,96 @@ import javax.validation.Valid;
 
 @Controller
 public class UserApiController implements UserApi {
+
+    private final Logger log = LoggerFactory.getLogger(AnotherFakeApiController.class);
+
     private final ObjectMapper objectMapper;
 
     public UserApiController(ObjectMapper objectMapper) {
         this.objectMapper = objectMapper;
     }
 
-    public ResponseEntity<Void> createUser(@ApiParam(value = "Created user object" ,required=true )  @Valid @RequestBody User body,
-        @RequestHeader(value = "Accept", required = false) String accept) throws Exception {
+    public ResponseEntity<Void> createUser(@ApiParam(value = "Created user object" ,required=true )  @Valid @RequestBody User body) {
         // do some magic!
+        String accept = ((ServletRequestAttributes)RequestContextHolder.getRequestAttributes()).getRequest().getHeader("Accept");
         return new ResponseEntity<Void>(HttpStatus.OK);
     }
 
-    public ResponseEntity<Void> createUsersWithArrayInput(@ApiParam(value = "List of user object" ,required=true )  @Valid @RequestBody List<User> body,
-        @RequestHeader(value = "Accept", required = false) String accept) throws Exception {
+    public ResponseEntity<Void> createUsersWithArrayInput(@ApiParam(value = "List of user object" ,required=true )  @Valid @RequestBody List<User> body) {
         // do some magic!
+        String accept = ((ServletRequestAttributes)RequestContextHolder.getRequestAttributes()).getRequest().getHeader("Accept");
         return new ResponseEntity<Void>(HttpStatus.OK);
     }
 
-    public ResponseEntity<Void> createUsersWithListInput(@ApiParam(value = "List of user object" ,required=true )  @Valid @RequestBody List<User> body,
-        @RequestHeader(value = "Accept", required = false) String accept) throws Exception {
+    public ResponseEntity<Void> createUsersWithListInput(@ApiParam(value = "List of user object" ,required=true )  @Valid @RequestBody List<User> body) {
         // do some magic!
+        String accept = ((ServletRequestAttributes)RequestContextHolder.getRequestAttributes()).getRequest().getHeader("Accept");
         return new ResponseEntity<Void>(HttpStatus.OK);
     }
 
-    public ResponseEntity<Void> deleteUser(@ApiParam(value = "The name that needs to be deleted",required=true) @PathVariable("username") String username,
-        @RequestHeader(value = "Accept", required = false) String accept) throws Exception {
+    public ResponseEntity<Void> deleteUser(@ApiParam(value = "The name that needs to be deleted",required=true) @PathVariable("username") String username) {
         // do some magic!
+        String accept = ((ServletRequestAttributes)RequestContextHolder.getRequestAttributes()).getRequest().getHeader("Accept");
         return new ResponseEntity<Void>(HttpStatus.OK);
     }
 
-    public ResponseEntity<User> getUserByName(@ApiParam(value = "The name that needs to be fetched. Use user1 for testing. ",required=true) @PathVariable("username") String username,
-        @RequestHeader(value = "Accept", required = false) String accept) throws Exception {
+    public ResponseEntity<User> getUserByName(@ApiParam(value = "The name that needs to be fetched. Use user1 for testing. ",required=true) @PathVariable("username") String username) {
         // do some magic!
-
+        String accept = ((ServletRequestAttributes)RequestContextHolder.getRequestAttributes()).getRequest().getHeader("Accept");
         if (accept != null && accept.contains("application/xml")) {
-            return new ResponseEntity<User>(objectMapper.readValue("<User>  <id>123456789</id>  <username>aeiou</username>  <firstName>aeiou</firstName>  <lastName>aeiou</lastName>  <email>aeiou</email>  <password>aeiou</password>  <phone>aeiou</phone>  <userStatus>123</userStatus></User>", User.class), HttpStatus.OK);
+            try {
+                return new ResponseEntity<User>(objectMapper.readValue("<User>  <id>123456789</id>  <username>aeiou</username>  <firstName>aeiou</firstName>  <lastName>aeiou</lastName>  <email>aeiou</email>  <password>aeiou</password>  <phone>aeiou</phone>  <userStatus>123</userStatus></User>", User.class), HttpStatus.NOT_IMPLEMENTED);
+            } catch (IOException e) {
+                log.error("Couldn't serialize response for content type application/xml", e);
+                return new ResponseEntity<User>(HttpStatus.INTERNAL_SERVER_ERROR);
+            }
         }
 
-
         if (accept != null && accept.contains("application/json")) {
-            return new ResponseEntity<User>(objectMapper.readValue("{  \"firstName\" : \"firstName\",  \"lastName\" : \"lastName\",  \"password\" : \"password\",  \"userStatus\" : 6,  \"phone\" : \"phone\",  \"id\" : 0,  \"email\" : \"email\",  \"username\" : \"username\"}", User.class), HttpStatus.OK);
+            try {
+                return new ResponseEntity<User>(objectMapper.readValue("{  \"firstName\" : \"firstName\",  \"lastName\" : \"lastName\",  \"password\" : \"password\",  \"userStatus\" : 6,  \"phone\" : \"phone\",  \"id\" : 0,  \"email\" : \"email\",  \"username\" : \"username\"}", User.class), HttpStatus.NOT_IMPLEMENTED);
+            } catch (IOException e) {
+                log.error("Couldn't serialize response for content type application/json", e);
+                return new ResponseEntity<User>(HttpStatus.INTERNAL_SERVER_ERROR);
+            }
         }
 
         return new ResponseEntity<User>(HttpStatus.OK);
     }
 
-    public ResponseEntity<String> loginUser( @NotNull@ApiParam(value = "The user name for login", required = true) @Valid @RequestParam(value = "username", required = true) String username,
-         @NotNull@ApiParam(value = "The password for login in clear text", required = true) @Valid @RequestParam(value = "password", required = true) String password,
-        @RequestHeader(value = "Accept", required = false) String accept) throws Exception {
+    public ResponseEntity<String> loginUser(@NotNull @ApiParam(value = "The user name for login", required = true) @Valid @RequestParam(value = "username", required = true) String username,@NotNull @ApiParam(value = "The password for login in clear text", required = true) @Valid @RequestParam(value = "password", required = true) String password) {
         // do some magic!
-
+        String accept = ((ServletRequestAttributes)RequestContextHolder.getRequestAttributes()).getRequest().getHeader("Accept");
         if (accept != null && accept.contains("application/xml")) {
-            return new ResponseEntity<String>(objectMapper.readValue("aeiou", String.class), HttpStatus.OK);
+            try {
+                return new ResponseEntity<String>(objectMapper.readValue("aeiou", String.class), HttpStatus.NOT_IMPLEMENTED);
+            } catch (IOException e) {
+                log.error("Couldn't serialize response for content type application/xml", e);
+                return new ResponseEntity<String>(HttpStatus.INTERNAL_SERVER_ERROR);
+            }
         }
 
-
         if (accept != null && accept.contains("application/json")) {
-            return new ResponseEntity<String>(objectMapper.readValue("\"\"", String.class), HttpStatus.OK);
+            try {
+                return new ResponseEntity<String>(objectMapper.readValue("\"\"", String.class), HttpStatus.NOT_IMPLEMENTED);
+            } catch (IOException e) {
+                log.error("Couldn't serialize response for content type application/json", e);
+                return new ResponseEntity<String>(HttpStatus.INTERNAL_SERVER_ERROR);
+            }
         }
 
         return new ResponseEntity<String>(HttpStatus.OK);
     }
 
-    public ResponseEntity<Void> logoutUser(@RequestHeader(value = "Accept", required = false) String accept) throws Exception {
+    public ResponseEntity<Void> logoutUser() {
         // do some magic!
+        String accept = ((ServletRequestAttributes)RequestContextHolder.getRequestAttributes()).getRequest().getHeader("Accept");
         return new ResponseEntity<Void>(HttpStatus.OK);
     }
 
-    public ResponseEntity<Void> updateUser(@ApiParam(value = "name that need to be deleted",required=true) @PathVariable("username") String username,
-        @ApiParam(value = "Updated user object" ,required=true )  @Valid @RequestBody User body,
-        @RequestHeader(value = "Accept", required = false) String accept) throws Exception {
+    public ResponseEntity<Void> updateUser(@ApiParam(value = "name that need to be deleted",required=true) @PathVariable("username") String username,@ApiParam(value = "Updated user object" ,required=true )  @Valid @RequestBody User body) {
         // do some magic!
+        String accept = ((ServletRequestAttributes)RequestContextHolder.getRequestAttributes()).getRequest().getHeader("Accept");
         return new ResponseEntity<Void>(HttpStatus.OK);
     }
 

--- a/samples/server/petstore/springboot-implicitHeaders/src/main/java/io/swagger/api/UserApiController.java
+++ b/samples/server/petstore/springboot-implicitHeaders/src/main/java/io/swagger/api/UserApiController.java
@@ -22,47 +22,52 @@ import org.springframework.web.multipart.MultipartFile;
 import java.util.List;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.IOException;
+import javax.servlet.http.HttpServletRequest;
 import javax.validation.constraints.*;
 import javax.validation.Valid;
 
 @Controller
 public class UserApiController implements UserApi {
 
-    private final Logger log = LoggerFactory.getLogger(AnotherFakeApiController.class);
+    private static final Logger log = LoggerFactory.getLogger(UserApiController.class);
 
     private final ObjectMapper objectMapper;
 
+    @org.springframework.beans.factory.annotation.Autowired
+    private HttpServletRequest request;
+
+    @org.springframework.beans.factory.annotation.Autowired
     public UserApiController(ObjectMapper objectMapper) {
         this.objectMapper = objectMapper;
     }
 
     public ResponseEntity<Void> createUser(@ApiParam(value = "Created user object" ,required=true )  @Valid @RequestBody User body) {
         // do some magic!
-        String accept = ((ServletRequestAttributes)RequestContextHolder.getRequestAttributes()).getRequest().getHeader("Accept");
+        String accept = request.getHeader("Accept");
         return new ResponseEntity<Void>(HttpStatus.OK);
     }
 
     public ResponseEntity<Void> createUsersWithArrayInput(@ApiParam(value = "List of user object" ,required=true )  @Valid @RequestBody List<User> body) {
         // do some magic!
-        String accept = ((ServletRequestAttributes)RequestContextHolder.getRequestAttributes()).getRequest().getHeader("Accept");
+        String accept = request.getHeader("Accept");
         return new ResponseEntity<Void>(HttpStatus.OK);
     }
 
     public ResponseEntity<Void> createUsersWithListInput(@ApiParam(value = "List of user object" ,required=true )  @Valid @RequestBody List<User> body) {
         // do some magic!
-        String accept = ((ServletRequestAttributes)RequestContextHolder.getRequestAttributes()).getRequest().getHeader("Accept");
+        String accept = request.getHeader("Accept");
         return new ResponseEntity<Void>(HttpStatus.OK);
     }
 
     public ResponseEntity<Void> deleteUser(@ApiParam(value = "The name that needs to be deleted",required=true) @PathVariable("username") String username) {
         // do some magic!
-        String accept = ((ServletRequestAttributes)RequestContextHolder.getRequestAttributes()).getRequest().getHeader("Accept");
+        String accept = request.getHeader("Accept");
         return new ResponseEntity<Void>(HttpStatus.OK);
     }
 
     public ResponseEntity<User> getUserByName(@ApiParam(value = "The name that needs to be fetched. Use user1 for testing. ",required=true) @PathVariable("username") String username) {
         // do some magic!
-        String accept = ((ServletRequestAttributes)RequestContextHolder.getRequestAttributes()).getRequest().getHeader("Accept");
+        String accept = request.getHeader("Accept");
         if (accept != null && accept.contains("application/xml")) {
             try {
                 return new ResponseEntity<User>(objectMapper.readValue("<User>  <id>123456789</id>  <username>aeiou</username>  <firstName>aeiou</firstName>  <lastName>aeiou</lastName>  <email>aeiou</email>  <password>aeiou</password>  <phone>aeiou</phone>  <userStatus>123</userStatus></User>", User.class), HttpStatus.NOT_IMPLEMENTED);
@@ -86,7 +91,7 @@ public class UserApiController implements UserApi {
 
     public ResponseEntity<String> loginUser(@NotNull @ApiParam(value = "The user name for login", required = true) @Valid @RequestParam(value = "username", required = true) String username,@NotNull @ApiParam(value = "The password for login in clear text", required = true) @Valid @RequestParam(value = "password", required = true) String password) {
         // do some magic!
-        String accept = ((ServletRequestAttributes)RequestContextHolder.getRequestAttributes()).getRequest().getHeader("Accept");
+        String accept = request.getHeader("Accept");
         if (accept != null && accept.contains("application/xml")) {
             try {
                 return new ResponseEntity<String>(objectMapper.readValue("aeiou", String.class), HttpStatus.NOT_IMPLEMENTED);
@@ -110,13 +115,13 @@ public class UserApiController implements UserApi {
 
     public ResponseEntity<Void> logoutUser() {
         // do some magic!
-        String accept = ((ServletRequestAttributes)RequestContextHolder.getRequestAttributes()).getRequest().getHeader("Accept");
+        String accept = request.getHeader("Accept");
         return new ResponseEntity<Void>(HttpStatus.OK);
     }
 
     public ResponseEntity<Void> updateUser(@ApiParam(value = "name that need to be deleted",required=true) @PathVariable("username") String username,@ApiParam(value = "Updated user object" ,required=true )  @Valid @RequestBody User body) {
         // do some magic!
-        String accept = ((ServletRequestAttributes)RequestContextHolder.getRequestAttributes()).getRequest().getHeader("Accept");
+        String accept = request.getHeader("Accept");
         return new ResponseEntity<Void>(HttpStatus.OK);
     }
 

--- a/samples/server/petstore/springboot-implicitHeaders/src/main/java/io/swagger/model/FormatTest.java
+++ b/samples/server/petstore/springboot-implicitHeaders/src/main/java/io/swagger/model/FormatTest.java
@@ -71,7 +71,7 @@ public class FormatTest   {
   **/
   @ApiModelProperty(value = "")
 
- @Min(10) @Max(100)
+@Min(10) @Max(100) 
   public Integer getInteger() {
     return integer;
   }
@@ -93,7 +93,7 @@ public class FormatTest   {
   **/
   @ApiModelProperty(value = "")
 
- @Min(20) @Max(200)
+@Min(20) @Max(200) 
   public Integer getInt32() {
     return int32;
   }
@@ -137,7 +137,7 @@ public class FormatTest   {
   @NotNull
 
   @Valid
- @DecimalMin("32.1") @DecimalMax("543.2")
+@DecimalMin("32.1") @DecimalMax("543.2") 
   public BigDecimal getNumber() {
     return number;
   }
@@ -159,7 +159,7 @@ public class FormatTest   {
   **/
   @ApiModelProperty(value = "")
 
- @DecimalMin("54.3") @DecimalMax("987.6")
+@DecimalMin("54.3") @DecimalMax("987.6") 
   public Float getFloat() {
     return _float;
   }
@@ -181,7 +181,7 @@ public class FormatTest   {
   **/
   @ApiModelProperty(value = "")
 
- @DecimalMin("67.8") @DecimalMax("123.4")
+@DecimalMin("67.8") @DecimalMax("123.4") 
   public Double getDouble() {
     return _double;
   }
@@ -201,7 +201,7 @@ public class FormatTest   {
   **/
   @ApiModelProperty(value = "")
 
- @Pattern(regexp="/[a-z]/i")
+@Pattern(regexp="/[a-z]/i") 
   public String getString() {
     return string;
   }
@@ -222,7 +222,7 @@ public class FormatTest   {
   @ApiModelProperty(required = true, value = "")
   @NotNull
 
- @Pattern(regexp="^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$")
+@Pattern(regexp="^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$") 
   public byte[] getByte() {
     return _byte;
   }
@@ -327,7 +327,7 @@ public class FormatTest   {
   @ApiModelProperty(required = true, value = "")
   @NotNull
 
- @Size(min=10,max=64)
+@Size(min=10,max=64) 
   public String getPassword() {
     return password;
   }

--- a/samples/server/petstore/springboot-useoptional/src/main/java/io/swagger/api/AnotherFakeApi.java
+++ b/samples/server/petstore/springboot-useoptional/src/main/java/io/swagger/api/AnotherFakeApi.java
@@ -35,6 +35,6 @@ public interface AnotherFakeApi {
         produces = { "application/json" }, 
         consumes = { "application/json" },
         method = RequestMethod.PATCH)
-    ResponseEntity<Client> testSpecialTags(@ApiParam(value = "client model" ,required=true )  @Valid @RequestBody Client body, @RequestHeader(value = "Accept", required = false) String accept) throws Exception;
+    ResponseEntity<Client> testSpecialTags(@ApiParam(value = "client model" ,required=true )  @Valid @RequestBody Client body);
 
 }

--- a/samples/server/petstore/springboot-useoptional/src/main/java/io/swagger/api/AnotherFakeApi.java
+++ b/samples/server/petstore/springboot-useoptional/src/main/java/io/swagger/api/AnotherFakeApi.java
@@ -6,9 +6,9 @@
 package io.swagger.api;
 
 import io.swagger.model.Client;
-
 import io.swagger.annotations.*;
 import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
@@ -17,13 +17,11 @@ import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.multipart.MultipartFile;
-import java.io.IOException;
 
+import javax.validation.Valid;
+import javax.validation.constraints.*;
 import java.util.List;
 import java.util.Optional;
-import org.springframework.validation.annotation.Validated;
-import javax.validation.constraints.*;
-import javax.validation.Valid;
 
 @Api(value = "another-fake", description = "the another-fake API")
 public interface AnotherFakeApi {

--- a/samples/server/petstore/springboot-useoptional/src/main/java/io/swagger/api/AnotherFakeApiController.java
+++ b/samples/server/petstore/springboot-useoptional/src/main/java/io/swagger/api/AnotherFakeApiController.java
@@ -22,23 +22,28 @@ import java.util.List;
 import java.util.Optional;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.IOException;
+import javax.servlet.http.HttpServletRequest;
 import javax.validation.constraints.*;
 import javax.validation.Valid;
 
 @Controller
 public class AnotherFakeApiController implements AnotherFakeApi {
 
-    private final Logger log = LoggerFactory.getLogger(AnotherFakeApiController.class);
+    private static final Logger log = LoggerFactory.getLogger(AnotherFakeApiController.class);
 
     private final ObjectMapper objectMapper;
 
+    @org.springframework.beans.factory.annotation.Autowired
+    private HttpServletRequest request;
+
+    @org.springframework.beans.factory.annotation.Autowired
     public AnotherFakeApiController(ObjectMapper objectMapper) {
         this.objectMapper = objectMapper;
     }
 
     public ResponseEntity<Client> testSpecialTags(@ApiParam(value = "client model" ,required=true )  @Valid @RequestBody Client body) {
         // do some magic!
-        String accept = ((ServletRequestAttributes)RequestContextHolder.getRequestAttributes()).getRequest().getHeader("Accept");
+        String accept = request.getHeader("Accept");
         if (accept != null && accept.contains("application/json")) {
             try {
                 return new ResponseEntity<Client>(objectMapper.readValue("{  \"client\" : \"client\"}", Client.class), HttpStatus.NOT_IMPLEMENTED);

--- a/samples/server/petstore/springboot-useoptional/src/main/java/io/swagger/api/AnotherFakeApiController.java
+++ b/samples/server/petstore/springboot-useoptional/src/main/java/io/swagger/api/AnotherFakeApiController.java
@@ -4,6 +4,8 @@ import io.swagger.model.Client;
 
 import io.swagger.annotations.*;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
@@ -12,6 +14,8 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RequestPart;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.util.List;
@@ -23,18 +27,25 @@ import javax.validation.Valid;
 
 @Controller
 public class AnotherFakeApiController implements AnotherFakeApi {
+
+    private final Logger log = LoggerFactory.getLogger(AnotherFakeApiController.class);
+
     private final ObjectMapper objectMapper;
 
     public AnotherFakeApiController(ObjectMapper objectMapper) {
         this.objectMapper = objectMapper;
     }
 
-    public ResponseEntity<Client> testSpecialTags(@ApiParam(value = "client model" ,required=true )  @Valid @RequestBody Client body,
-        @RequestHeader(value = "Accept", required = false) String accept) throws Exception {
+    public ResponseEntity<Client> testSpecialTags(@ApiParam(value = "client model" ,required=true )  @Valid @RequestBody Client body) {
         // do some magic!
-
+        String accept = ((ServletRequestAttributes)RequestContextHolder.getRequestAttributes()).getRequest().getHeader("Accept");
         if (accept != null && accept.contains("application/json")) {
-            return new ResponseEntity<Client>(objectMapper.readValue("{  \"client\" : \"client\"}", Client.class), HttpStatus.OK);
+            try {
+                return new ResponseEntity<Client>(objectMapper.readValue("{  \"client\" : \"client\"}", Client.class), HttpStatus.NOT_IMPLEMENTED);
+            } catch (IOException e) {
+                log.error("Couldn't serialize response for content type application/json", e);
+                return new ResponseEntity<Client>(HttpStatus.INTERNAL_SERVER_ERROR);
+            }
         }
 
         return new ResponseEntity<Client>(HttpStatus.OK);

--- a/samples/server/petstore/springboot-useoptional/src/main/java/io/swagger/api/AnotherFakeApiController.java
+++ b/samples/server/petstore/springboot-useoptional/src/main/java/io/swagger/api/AnotherFakeApiController.java
@@ -33,12 +33,12 @@ public class AnotherFakeApiController implements AnotherFakeApi {
 
     private final ObjectMapper objectMapper;
 
-    @org.springframework.beans.factory.annotation.Autowired
-    private HttpServletRequest request;
+    private final HttpServletRequest request;
 
     @org.springframework.beans.factory.annotation.Autowired
-    public AnotherFakeApiController(ObjectMapper objectMapper) {
+    public AnotherFakeApiController(ObjectMapper objectMapper, HttpServletRequest request) {
         this.objectMapper = objectMapper;
+        this.request = request;
     }
 
     public ResponseEntity<Client> testSpecialTags(@ApiParam(value = "client model" ,required=true )  @Valid @RequestBody Client body) {

--- a/samples/server/petstore/springboot-useoptional/src/main/java/io/swagger/api/AnotherFakeApiController.java
+++ b/samples/server/petstore/springboot-useoptional/src/main/java/io/swagger/api/AnotherFakeApiController.java
@@ -1,9 +1,8 @@
 package io.swagger.api;
 
 import io.swagger.model.Client;
-
+import com.fasterxml.jackson.databind.ObjectMapper;
 import io.swagger.annotations.*;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpStatus;
@@ -14,17 +13,14 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RequestPart;
-import org.springframework.web.context.request.RequestContextHolder;
-import org.springframework.web.context.request.ServletRequestAttributes;
 import org.springframework.web.multipart.MultipartFile;
 
-import java.util.List;
-import java.util.Optional;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import java.io.IOException;
-import javax.servlet.http.HttpServletRequest;
 import javax.validation.constraints.*;
 import javax.validation.Valid;
+import javax.servlet.http.HttpServletRequest;
+import java.util.Optional;
+import java.io.IOException;
+import java.util.List;
 
 @Controller
 public class AnotherFakeApiController implements AnotherFakeApi {
@@ -42,7 +38,6 @@ public class AnotherFakeApiController implements AnotherFakeApi {
     }
 
     public ResponseEntity<Client> testSpecialTags(@ApiParam(value = "client model" ,required=true )  @Valid @RequestBody Client body) {
-        // do some magic!
         String accept = request.getHeader("Accept");
         if (accept != null && accept.contains("application/json")) {
             try {
@@ -53,7 +48,7 @@ public class AnotherFakeApiController implements AnotherFakeApi {
             }
         }
 
-        return new ResponseEntity<Client>(HttpStatus.OK);
+        return new ResponseEntity<Client>(HttpStatus.NOT_IMPLEMENTED);
     }
 
 }

--- a/samples/server/petstore/springboot-useoptional/src/main/java/io/swagger/api/FakeApi.java
+++ b/samples/server/petstore/springboot-useoptional/src/main/java/io/swagger/api/FakeApi.java
@@ -10,9 +10,9 @@ import io.swagger.model.Client;
 import org.threeten.bp.LocalDate;
 import org.threeten.bp.OffsetDateTime;
 import io.swagger.model.OuterComposite;
-
 import io.swagger.annotations.*;
 import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
@@ -21,13 +21,11 @@ import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.multipart.MultipartFile;
-import java.io.IOException;
 
+import javax.validation.Valid;
+import javax.validation.constraints.*;
 import java.util.List;
 import java.util.Optional;
-import org.springframework.validation.annotation.Validated;
-import javax.validation.constraints.*;
-import javax.validation.Valid;
 
 @Api(value = "fake", description = "the fake API")
 public interface FakeApi {

--- a/samples/server/petstore/springboot-useoptional/src/main/java/io/swagger/api/FakeApi.java
+++ b/samples/server/petstore/springboot-useoptional/src/main/java/io/swagger/api/FakeApi.java
@@ -37,7 +37,7 @@ public interface FakeApi {
         @ApiResponse(code = 200, message = "Output boolean", response = Boolean.class) })
     @RequestMapping(value = "/fake/outer/boolean",
         method = RequestMethod.POST)
-    ResponseEntity<Boolean> fakeOuterBooleanSerialize(@ApiParam(value = "Input boolean as post body"  )  @Valid @RequestBody Boolean body, @RequestHeader(value = "Accept", required = false) String accept) throws Exception;
+    ResponseEntity<Boolean> fakeOuterBooleanSerialize(@ApiParam(value = "Input boolean as post body"  )  @Valid @RequestBody Boolean body);
 
 
     @ApiOperation(value = "", nickname = "fakeOuterCompositeSerialize", notes = "Test serialization of object with outer number type", response = OuterComposite.class, tags={ "fake", })
@@ -45,7 +45,7 @@ public interface FakeApi {
         @ApiResponse(code = 200, message = "Output composite", response = OuterComposite.class) })
     @RequestMapping(value = "/fake/outer/composite",
         method = RequestMethod.POST)
-    ResponseEntity<OuterComposite> fakeOuterCompositeSerialize(@ApiParam(value = "Input composite as post body"  )  @Valid @RequestBody OuterComposite body, @RequestHeader(value = "Accept", required = false) String accept) throws Exception;
+    ResponseEntity<OuterComposite> fakeOuterCompositeSerialize(@ApiParam(value = "Input composite as post body"  )  @Valid @RequestBody OuterComposite body);
 
 
     @ApiOperation(value = "", nickname = "fakeOuterNumberSerialize", notes = "Test serialization of outer number types", response = BigDecimal.class, tags={ "fake", })
@@ -53,7 +53,7 @@ public interface FakeApi {
         @ApiResponse(code = 200, message = "Output number", response = BigDecimal.class) })
     @RequestMapping(value = "/fake/outer/number",
         method = RequestMethod.POST)
-    ResponseEntity<BigDecimal> fakeOuterNumberSerialize(@ApiParam(value = "Input number as post body"  )  @Valid @RequestBody BigDecimal body, @RequestHeader(value = "Accept", required = false) String accept) throws Exception;
+    ResponseEntity<BigDecimal> fakeOuterNumberSerialize(@ApiParam(value = "Input number as post body"  )  @Valid @RequestBody BigDecimal body);
 
 
     @ApiOperation(value = "", nickname = "fakeOuterStringSerialize", notes = "Test serialization of outer string types", response = String.class, tags={ "fake", })
@@ -61,7 +61,7 @@ public interface FakeApi {
         @ApiResponse(code = 200, message = "Output string", response = String.class) })
     @RequestMapping(value = "/fake/outer/string",
         method = RequestMethod.POST)
-    ResponseEntity<String> fakeOuterStringSerialize(@ApiParam(value = "Input string as post body"  )  @Valid @RequestBody String body, @RequestHeader(value = "Accept", required = false) String accept) throws Exception;
+    ResponseEntity<String> fakeOuterStringSerialize(@ApiParam(value = "Input string as post body"  )  @Valid @RequestBody String body);
 
 
     @ApiOperation(value = "To test \"client\" model", nickname = "testClientModel", notes = "To test \"client\" model", response = Client.class, tags={ "fake", })
@@ -71,7 +71,7 @@ public interface FakeApi {
         produces = { "application/json" }, 
         consumes = { "application/json" },
         method = RequestMethod.PATCH)
-    ResponseEntity<Client> testClientModel(@ApiParam(value = "client model" ,required=true )  @Valid @RequestBody Client body, @RequestHeader(value = "Accept", required = false) String accept) throws Exception;
+    ResponseEntity<Client> testClientModel(@ApiParam(value = "client model" ,required=true )  @Valid @RequestBody Client body);
 
 
     @ApiOperation(value = "Fake endpoint for testing various parameters 假端點 偽のエンドポイント 가짜 엔드 포인트 ", nickname = "testEndpointParameters", notes = "Fake endpoint for testing various parameters 假端點 偽のエンドポイント 가짜 엔드 포인트 ", authorizations = {
@@ -84,7 +84,7 @@ public interface FakeApi {
         produces = { "application/xml; charset=utf-8", "application/json; charset=utf-8" }, 
         consumes = { "application/xml; charset=utf-8", "application/json; charset=utf-8" },
         method = RequestMethod.POST)
-    ResponseEntity<Void> testEndpointParameters(@ApiParam(value = "None", required=true) @RequestPart(value="number", required=true)  BigDecimal number,@ApiParam(value = "None", required=true) @RequestPart(value="double", required=true)  Double _double,@ApiParam(value = "None", required=true) @RequestPart(value="pattern_without_delimiter", required=true)  String patternWithoutDelimiter,@ApiParam(value = "None", required=true) @RequestPart(value="byte", required=true)  byte[] _byte,@ApiParam(value = "None") @RequestPart(value="integer", required=false)  Integer integer,@ApiParam(value = "None") @RequestPart(value="int32", required=false)  Integer int32,@ApiParam(value = "None") @RequestPart(value="int64", required=false)  Long int64,@ApiParam(value = "None") @RequestPart(value="float", required=false)  Float _float,@ApiParam(value = "None") @RequestPart(value="string", required=false)  String string,@ApiParam(value = "None") @RequestPart(value="binary", required=false)  byte[] binary,@ApiParam(value = "None") @RequestPart(value="date", required=false)  LocalDate date,@ApiParam(value = "None") @RequestPart(value="dateTime", required=false)  OffsetDateTime dateTime,@ApiParam(value = "None") @RequestPart(value="password", required=false)  String password,@ApiParam(value = "None") @RequestPart(value="callback", required=false)  String paramCallback, @RequestHeader(value = "Accept", required = false) String accept) throws Exception;
+    ResponseEntity<Void> testEndpointParameters(@ApiParam(value = "None", required=true) @RequestPart(value="number", required=true)  BigDecimal number,@ApiParam(value = "None", required=true) @RequestPart(value="double", required=true)  Double _double,@ApiParam(value = "None", required=true) @RequestPart(value="pattern_without_delimiter", required=true)  String patternWithoutDelimiter,@ApiParam(value = "None", required=true) @RequestPart(value="byte", required=true)  byte[] _byte,@ApiParam(value = "None") @RequestPart(value="integer", required=false)  Integer integer,@ApiParam(value = "None") @RequestPart(value="int32", required=false)  Integer int32,@ApiParam(value = "None") @RequestPart(value="int64", required=false)  Long int64,@ApiParam(value = "None") @RequestPart(value="float", required=false)  Float _float,@ApiParam(value = "None") @RequestPart(value="string", required=false)  String string,@ApiParam(value = "None") @RequestPart(value="binary", required=false)  byte[] binary,@ApiParam(value = "None") @RequestPart(value="date", required=false)  LocalDate date,@ApiParam(value = "None") @RequestPart(value="dateTime", required=false)  OffsetDateTime dateTime,@ApiParam(value = "None") @RequestPart(value="password", required=false)  String password,@ApiParam(value = "None") @RequestPart(value="callback", required=false)  String paramCallback);
 
 
     @ApiOperation(value = "To test enum parameters", nickname = "testEnumParameters", notes = "To test enum parameters", tags={ "fake", })
@@ -95,7 +95,7 @@ public interface FakeApi {
         produces = { "*/*" }, 
         consumes = { "*/*" },
         method = RequestMethod.GET)
-    ResponseEntity<Void> testEnumParameters(@ApiParam(value = "Form parameter enum test (string array)", allowableValues=">, $") @RequestPart(value="enum_form_string_array", required=false)  List<String> enumFormStringArray,@ApiParam(value = "Form parameter enum test (string)", allowableValues="_abc, -efg, (xyz)", defaultValue="-efg") @RequestPart(value="enum_form_string", required=false)  String enumFormString,@ApiParam(value = "Header parameter enum test (string array)" , allowableValues=">, $") @RequestHeader(value="enum_header_string_array", required=false) Optional<List<String>> enumHeaderStringArray,@ApiParam(value = "Header parameter enum test (string)" , allowableValues="_abc, -efg, (xyz)", defaultValue="-efg") @RequestHeader(value="enum_header_string", required=false) Optional<String> enumHeaderString,@ApiParam(value = "Query parameter enum test (string array)", allowableValues = ">, $") @Valid @RequestParam(value = "enum_query_string_array", required = false) Optional<List<String>> enumQueryStringArray,@ApiParam(value = "Query parameter enum test (string)", allowableValues = "_abc, -efg, (xyz)", defaultValue = "-efg") @Valid @RequestParam(value = "enum_query_string", required = false, defaultValue="-efg") Optional<String> enumQueryString,@ApiParam(value = "Query parameter enum test (double)", allowableValues = "1, -2") @Valid @RequestParam(value = "enum_query_integer", required = false) Optional<Integer> enumQueryInteger,@ApiParam(value = "Query parameter enum test (double)", allowableValues="1.1, -1.2") @RequestPart(value="enum_query_double", required=false)  Double enumQueryDouble, @RequestHeader(value = "Accept", required = false) String accept) throws Exception;
+    ResponseEntity<Void> testEnumParameters(@ApiParam(value = "Form parameter enum test (string array)", allowableValues=">, $") @RequestPart(value="enum_form_string_array", required=false)  List<String> enumFormStringArray,@ApiParam(value = "Form parameter enum test (string)", allowableValues="_abc, -efg, (xyz)", defaultValue="-efg") @RequestPart(value="enum_form_string", required=false)  String enumFormString,@ApiParam(value = "Header parameter enum test (string array)" , allowableValues=">, $") @RequestHeader(value="enum_header_string_array", required=false) Optional<List<String>> enumHeaderStringArray,@ApiParam(value = "Header parameter enum test (string)" , allowableValues="_abc, -efg, (xyz)", defaultValue="-efg") @RequestHeader(value="enum_header_string", required=false) Optional<String> enumHeaderString,@ApiParam(value = "Query parameter enum test (string array)", allowableValues = ">, $") @Valid @RequestParam(value = "enum_query_string_array", required = false) Optional<List<String>> enumQueryStringArray,@ApiParam(value = "Query parameter enum test (string)", allowableValues = "_abc, -efg, (xyz)", defaultValue = "-efg") @Valid @RequestParam(value = "enum_query_string", required = false, defaultValue="-efg") Optional<String> enumQueryString,@ApiParam(value = "Query parameter enum test (double)", allowableValues = "1, -2") @Valid @RequestParam(value = "enum_query_integer", required = false) Optional<Integer> enumQueryInteger,@ApiParam(value = "Query parameter enum test (double)", allowableValues="1.1, -1.2") @RequestPart(value="enum_query_double", required=false)  Double enumQueryDouble);
 
 
     @ApiOperation(value = "test inline additionalProperties", nickname = "testInlineAdditionalProperties", notes = "", tags={ "fake", })
@@ -104,7 +104,7 @@ public interface FakeApi {
     @RequestMapping(value = "/fake/inline-additionalProperties",
         consumes = { "application/json" },
         method = RequestMethod.POST)
-    ResponseEntity<Void> testInlineAdditionalProperties(@ApiParam(value = "request body" ,required=true )  @Valid @RequestBody Object param, @RequestHeader(value = "Accept", required = false) String accept) throws Exception;
+    ResponseEntity<Void> testInlineAdditionalProperties(@ApiParam(value = "request body" ,required=true )  @Valid @RequestBody Object param);
 
 
     @ApiOperation(value = "test json serialization of form data", nickname = "testJsonFormData", notes = "", tags={ "fake", })
@@ -113,6 +113,6 @@ public interface FakeApi {
     @RequestMapping(value = "/fake/jsonFormData",
         consumes = { "application/json" },
         method = RequestMethod.GET)
-    ResponseEntity<Void> testJsonFormData(@ApiParam(value = "field1", required=true) @RequestPart(value="param", required=true)  String param,@ApiParam(value = "field2", required=true) @RequestPart(value="param2", required=true)  String param2, @RequestHeader(value = "Accept", required = false) String accept) throws Exception;
+    ResponseEntity<Void> testJsonFormData(@ApiParam(value = "field1", required=true) @RequestPart(value="param", required=true)  String param,@ApiParam(value = "field2", required=true) @RequestPart(value="param2", required=true)  String param2);
 
 }

--- a/samples/server/petstore/springboot-useoptional/src/main/java/io/swagger/api/FakeApiController.java
+++ b/samples/server/petstore/springboot-useoptional/src/main/java/io/swagger/api/FakeApiController.java
@@ -37,12 +37,12 @@ public class FakeApiController implements FakeApi {
 
     private final ObjectMapper objectMapper;
 
-    @org.springframework.beans.factory.annotation.Autowired
-    private HttpServletRequest request;
+    private final HttpServletRequest request;
 
     @org.springframework.beans.factory.annotation.Autowired
-    public FakeApiController(ObjectMapper objectMapper) {
+    public FakeApiController(ObjectMapper objectMapper, HttpServletRequest request) {
         this.objectMapper = objectMapper;
+        this.request = request;
     }
 
     public ResponseEntity<Boolean> fakeOuterBooleanSerialize(@ApiParam(value = "Input boolean as post body"  )  @Valid @RequestBody Boolean body) {

--- a/samples/server/petstore/springboot-useoptional/src/main/java/io/swagger/api/FakeApiController.java
+++ b/samples/server/petstore/springboot-useoptional/src/main/java/io/swagger/api/FakeApiController.java
@@ -5,9 +5,8 @@ import io.swagger.model.Client;
 import org.threeten.bp.LocalDate;
 import org.threeten.bp.OffsetDateTime;
 import io.swagger.model.OuterComposite;
-
+import com.fasterxml.jackson.databind.ObjectMapper;
 import io.swagger.annotations.*;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpStatus;
@@ -18,17 +17,14 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RequestPart;
-import org.springframework.web.context.request.RequestContextHolder;
-import org.springframework.web.context.request.ServletRequestAttributes;
 import org.springframework.web.multipart.MultipartFile;
 
-import java.util.List;
-import java.util.Optional;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import java.io.IOException;
-import javax.servlet.http.HttpServletRequest;
 import javax.validation.constraints.*;
 import javax.validation.Valid;
+import javax.servlet.http.HttpServletRequest;
+import java.util.Optional;
+import java.io.IOException;
+import java.util.List;
 
 @Controller
 public class FakeApiController implements FakeApi {
@@ -46,7 +42,6 @@ public class FakeApiController implements FakeApi {
     }
 
     public ResponseEntity<Boolean> fakeOuterBooleanSerialize(@ApiParam(value = "Input boolean as post body"  )  @Valid @RequestBody Boolean body) {
-        // do some magic!
         String accept = request.getHeader("Accept");
         if (accept != null && accept.contains("application/json")) {
             try {
@@ -57,11 +52,10 @@ public class FakeApiController implements FakeApi {
             }
         }
 
-        return new ResponseEntity<Boolean>(HttpStatus.OK);
+        return new ResponseEntity<Boolean>(HttpStatus.NOT_IMPLEMENTED);
     }
 
     public ResponseEntity<OuterComposite> fakeOuterCompositeSerialize(@ApiParam(value = "Input composite as post body"  )  @Valid @RequestBody OuterComposite body) {
-        // do some magic!
         String accept = request.getHeader("Accept");
         if (accept != null && accept.contains("application/json")) {
             try {
@@ -72,11 +66,10 @@ public class FakeApiController implements FakeApi {
             }
         }
 
-        return new ResponseEntity<OuterComposite>(HttpStatus.OK);
+        return new ResponseEntity<OuterComposite>(HttpStatus.NOT_IMPLEMENTED);
     }
 
     public ResponseEntity<BigDecimal> fakeOuterNumberSerialize(@ApiParam(value = "Input number as post body"  )  @Valid @RequestBody BigDecimal body) {
-        // do some magic!
         String accept = request.getHeader("Accept");
         if (accept != null && accept.contains("application/json")) {
             try {
@@ -87,11 +80,10 @@ public class FakeApiController implements FakeApi {
             }
         }
 
-        return new ResponseEntity<BigDecimal>(HttpStatus.OK);
+        return new ResponseEntity<BigDecimal>(HttpStatus.NOT_IMPLEMENTED);
     }
 
     public ResponseEntity<String> fakeOuterStringSerialize(@ApiParam(value = "Input string as post body"  )  @Valid @RequestBody String body) {
-        // do some magic!
         String accept = request.getHeader("Accept");
         if (accept != null && accept.contains("application/json")) {
             try {
@@ -102,11 +94,10 @@ public class FakeApiController implements FakeApi {
             }
         }
 
-        return new ResponseEntity<String>(HttpStatus.OK);
+        return new ResponseEntity<String>(HttpStatus.NOT_IMPLEMENTED);
     }
 
     public ResponseEntity<Client> testClientModel(@ApiParam(value = "client model" ,required=true )  @Valid @RequestBody Client body) {
-        // do some magic!
         String accept = request.getHeader("Accept");
         if (accept != null && accept.contains("application/json")) {
             try {
@@ -117,31 +108,27 @@ public class FakeApiController implements FakeApi {
             }
         }
 
-        return new ResponseEntity<Client>(HttpStatus.OK);
+        return new ResponseEntity<Client>(HttpStatus.NOT_IMPLEMENTED);
     }
 
     public ResponseEntity<Void> testEndpointParameters(@ApiParam(value = "None", required=true) @RequestPart(value="number", required=true)  BigDecimal number,@ApiParam(value = "None", required=true) @RequestPart(value="double", required=true)  Double _double,@ApiParam(value = "None", required=true) @RequestPart(value="pattern_without_delimiter", required=true)  String patternWithoutDelimiter,@ApiParam(value = "None", required=true) @RequestPart(value="byte", required=true)  byte[] _byte,@ApiParam(value = "None") @RequestPart(value="integer", required=false)  Integer integer,@ApiParam(value = "None") @RequestPart(value="int32", required=false)  Integer int32,@ApiParam(value = "None") @RequestPart(value="int64", required=false)  Long int64,@ApiParam(value = "None") @RequestPart(value="float", required=false)  Float _float,@ApiParam(value = "None") @RequestPart(value="string", required=false)  String string,@ApiParam(value = "None") @RequestPart(value="binary", required=false)  byte[] binary,@ApiParam(value = "None") @RequestPart(value="date", required=false)  LocalDate date,@ApiParam(value = "None") @RequestPart(value="dateTime", required=false)  OffsetDateTime dateTime,@ApiParam(value = "None") @RequestPart(value="password", required=false)  String password,@ApiParam(value = "None") @RequestPart(value="callback", required=false)  String paramCallback) {
-        // do some magic!
         String accept = request.getHeader("Accept");
-        return new ResponseEntity<Void>(HttpStatus.OK);
+        return new ResponseEntity<Void>(HttpStatus.NOT_IMPLEMENTED);
     }
 
     public ResponseEntity<Void> testEnumParameters(@ApiParam(value = "Form parameter enum test (string array)", allowableValues=">, $") @RequestPart(value="enum_form_string_array", required=false)  List<String> enumFormStringArray,@ApiParam(value = "Form parameter enum test (string)", allowableValues="_abc, -efg, (xyz)", defaultValue="-efg") @RequestPart(value="enum_form_string", required=false)  String enumFormString,@ApiParam(value = "Header parameter enum test (string array)" , allowableValues=">, $") @RequestHeader(value="enum_header_string_array", required=false) Optional<List<String>> enumHeaderStringArray,@ApiParam(value = "Header parameter enum test (string)" , allowableValues="_abc, -efg, (xyz)", defaultValue="-efg") @RequestHeader(value="enum_header_string", required=false) Optional<String> enumHeaderString,@ApiParam(value = "Query parameter enum test (string array)", allowableValues = ">, $") @Valid @RequestParam(value = "enum_query_string_array", required = false) Optional<List<String>> enumQueryStringArray,@ApiParam(value = "Query parameter enum test (string)", allowableValues = "_abc, -efg, (xyz)", defaultValue = "-efg") @Valid @RequestParam(value = "enum_query_string", required = false, defaultValue="-efg") Optional<String> enumQueryString,@ApiParam(value = "Query parameter enum test (double)", allowableValues = "1, -2") @Valid @RequestParam(value = "enum_query_integer", required = false) Optional<Integer> enumQueryInteger,@ApiParam(value = "Query parameter enum test (double)", allowableValues="1.1, -1.2") @RequestPart(value="enum_query_double", required=false)  Double enumQueryDouble) {
-        // do some magic!
         String accept = request.getHeader("Accept");
-        return new ResponseEntity<Void>(HttpStatus.OK);
+        return new ResponseEntity<Void>(HttpStatus.NOT_IMPLEMENTED);
     }
 
     public ResponseEntity<Void> testInlineAdditionalProperties(@ApiParam(value = "request body" ,required=true )  @Valid @RequestBody Object param) {
-        // do some magic!
         String accept = request.getHeader("Accept");
-        return new ResponseEntity<Void>(HttpStatus.OK);
+        return new ResponseEntity<Void>(HttpStatus.NOT_IMPLEMENTED);
     }
 
     public ResponseEntity<Void> testJsonFormData(@ApiParam(value = "field1", required=true) @RequestPart(value="param", required=true)  String param,@ApiParam(value = "field2", required=true) @RequestPart(value="param2", required=true)  String param2) {
-        // do some magic!
         String accept = request.getHeader("Accept");
-        return new ResponseEntity<Void>(HttpStatus.OK);
+        return new ResponseEntity<Void>(HttpStatus.NOT_IMPLEMENTED);
     }
 
 }

--- a/samples/server/petstore/springboot-useoptional/src/main/java/io/swagger/api/FakeApiController.java
+++ b/samples/server/petstore/springboot-useoptional/src/main/java/io/swagger/api/FakeApiController.java
@@ -26,23 +26,28 @@ import java.util.List;
 import java.util.Optional;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.IOException;
+import javax.servlet.http.HttpServletRequest;
 import javax.validation.constraints.*;
 import javax.validation.Valid;
 
 @Controller
 public class FakeApiController implements FakeApi {
 
-    private final Logger log = LoggerFactory.getLogger(AnotherFakeApiController.class);
+    private static final Logger log = LoggerFactory.getLogger(FakeApiController.class);
 
     private final ObjectMapper objectMapper;
 
+    @org.springframework.beans.factory.annotation.Autowired
+    private HttpServletRequest request;
+
+    @org.springframework.beans.factory.annotation.Autowired
     public FakeApiController(ObjectMapper objectMapper) {
         this.objectMapper = objectMapper;
     }
 
     public ResponseEntity<Boolean> fakeOuterBooleanSerialize(@ApiParam(value = "Input boolean as post body"  )  @Valid @RequestBody Boolean body) {
         // do some magic!
-        String accept = ((ServletRequestAttributes)RequestContextHolder.getRequestAttributes()).getRequest().getHeader("Accept");
+        String accept = request.getHeader("Accept");
         if (accept != null && accept.contains("application/json")) {
             try {
                 return new ResponseEntity<Boolean>(objectMapper.readValue("{ }", Boolean.class), HttpStatus.NOT_IMPLEMENTED);
@@ -57,7 +62,7 @@ public class FakeApiController implements FakeApi {
 
     public ResponseEntity<OuterComposite> fakeOuterCompositeSerialize(@ApiParam(value = "Input composite as post body"  )  @Valid @RequestBody OuterComposite body) {
         // do some magic!
-        String accept = ((ServletRequestAttributes)RequestContextHolder.getRequestAttributes()).getRequest().getHeader("Accept");
+        String accept = request.getHeader("Accept");
         if (accept != null && accept.contains("application/json")) {
             try {
                 return new ResponseEntity<OuterComposite>(objectMapper.readValue("{  \"my_string\" : { },  \"my_number\" : { },  \"my_boolean\" : { }}", OuterComposite.class), HttpStatus.NOT_IMPLEMENTED);
@@ -72,7 +77,7 @@ public class FakeApiController implements FakeApi {
 
     public ResponseEntity<BigDecimal> fakeOuterNumberSerialize(@ApiParam(value = "Input number as post body"  )  @Valid @RequestBody BigDecimal body) {
         // do some magic!
-        String accept = ((ServletRequestAttributes)RequestContextHolder.getRequestAttributes()).getRequest().getHeader("Accept");
+        String accept = request.getHeader("Accept");
         if (accept != null && accept.contains("application/json")) {
             try {
                 return new ResponseEntity<BigDecimal>(objectMapper.readValue("{ }", BigDecimal.class), HttpStatus.NOT_IMPLEMENTED);
@@ -87,7 +92,7 @@ public class FakeApiController implements FakeApi {
 
     public ResponseEntity<String> fakeOuterStringSerialize(@ApiParam(value = "Input string as post body"  )  @Valid @RequestBody String body) {
         // do some magic!
-        String accept = ((ServletRequestAttributes)RequestContextHolder.getRequestAttributes()).getRequest().getHeader("Accept");
+        String accept = request.getHeader("Accept");
         if (accept != null && accept.contains("application/json")) {
             try {
                 return new ResponseEntity<String>(objectMapper.readValue("{ }", String.class), HttpStatus.NOT_IMPLEMENTED);
@@ -102,7 +107,7 @@ public class FakeApiController implements FakeApi {
 
     public ResponseEntity<Client> testClientModel(@ApiParam(value = "client model" ,required=true )  @Valid @RequestBody Client body) {
         // do some magic!
-        String accept = ((ServletRequestAttributes)RequestContextHolder.getRequestAttributes()).getRequest().getHeader("Accept");
+        String accept = request.getHeader("Accept");
         if (accept != null && accept.contains("application/json")) {
             try {
                 return new ResponseEntity<Client>(objectMapper.readValue("{  \"client\" : \"client\"}", Client.class), HttpStatus.NOT_IMPLEMENTED);
@@ -117,25 +122,25 @@ public class FakeApiController implements FakeApi {
 
     public ResponseEntity<Void> testEndpointParameters(@ApiParam(value = "None", required=true) @RequestPart(value="number", required=true)  BigDecimal number,@ApiParam(value = "None", required=true) @RequestPart(value="double", required=true)  Double _double,@ApiParam(value = "None", required=true) @RequestPart(value="pattern_without_delimiter", required=true)  String patternWithoutDelimiter,@ApiParam(value = "None", required=true) @RequestPart(value="byte", required=true)  byte[] _byte,@ApiParam(value = "None") @RequestPart(value="integer", required=false)  Integer integer,@ApiParam(value = "None") @RequestPart(value="int32", required=false)  Integer int32,@ApiParam(value = "None") @RequestPart(value="int64", required=false)  Long int64,@ApiParam(value = "None") @RequestPart(value="float", required=false)  Float _float,@ApiParam(value = "None") @RequestPart(value="string", required=false)  String string,@ApiParam(value = "None") @RequestPart(value="binary", required=false)  byte[] binary,@ApiParam(value = "None") @RequestPart(value="date", required=false)  LocalDate date,@ApiParam(value = "None") @RequestPart(value="dateTime", required=false)  OffsetDateTime dateTime,@ApiParam(value = "None") @RequestPart(value="password", required=false)  String password,@ApiParam(value = "None") @RequestPart(value="callback", required=false)  String paramCallback) {
         // do some magic!
-        String accept = ((ServletRequestAttributes)RequestContextHolder.getRequestAttributes()).getRequest().getHeader("Accept");
+        String accept = request.getHeader("Accept");
         return new ResponseEntity<Void>(HttpStatus.OK);
     }
 
     public ResponseEntity<Void> testEnumParameters(@ApiParam(value = "Form parameter enum test (string array)", allowableValues=">, $") @RequestPart(value="enum_form_string_array", required=false)  List<String> enumFormStringArray,@ApiParam(value = "Form parameter enum test (string)", allowableValues="_abc, -efg, (xyz)", defaultValue="-efg") @RequestPart(value="enum_form_string", required=false)  String enumFormString,@ApiParam(value = "Header parameter enum test (string array)" , allowableValues=">, $") @RequestHeader(value="enum_header_string_array", required=false) Optional<List<String>> enumHeaderStringArray,@ApiParam(value = "Header parameter enum test (string)" , allowableValues="_abc, -efg, (xyz)", defaultValue="-efg") @RequestHeader(value="enum_header_string", required=false) Optional<String> enumHeaderString,@ApiParam(value = "Query parameter enum test (string array)", allowableValues = ">, $") @Valid @RequestParam(value = "enum_query_string_array", required = false) Optional<List<String>> enumQueryStringArray,@ApiParam(value = "Query parameter enum test (string)", allowableValues = "_abc, -efg, (xyz)", defaultValue = "-efg") @Valid @RequestParam(value = "enum_query_string", required = false, defaultValue="-efg") Optional<String> enumQueryString,@ApiParam(value = "Query parameter enum test (double)", allowableValues = "1, -2") @Valid @RequestParam(value = "enum_query_integer", required = false) Optional<Integer> enumQueryInteger,@ApiParam(value = "Query parameter enum test (double)", allowableValues="1.1, -1.2") @RequestPart(value="enum_query_double", required=false)  Double enumQueryDouble) {
         // do some magic!
-        String accept = ((ServletRequestAttributes)RequestContextHolder.getRequestAttributes()).getRequest().getHeader("Accept");
+        String accept = request.getHeader("Accept");
         return new ResponseEntity<Void>(HttpStatus.OK);
     }
 
     public ResponseEntity<Void> testInlineAdditionalProperties(@ApiParam(value = "request body" ,required=true )  @Valid @RequestBody Object param) {
         // do some magic!
-        String accept = ((ServletRequestAttributes)RequestContextHolder.getRequestAttributes()).getRequest().getHeader("Accept");
+        String accept = request.getHeader("Accept");
         return new ResponseEntity<Void>(HttpStatus.OK);
     }
 
     public ResponseEntity<Void> testJsonFormData(@ApiParam(value = "field1", required=true) @RequestPart(value="param", required=true)  String param,@ApiParam(value = "field2", required=true) @RequestPart(value="param2", required=true)  String param2) {
         // do some magic!
-        String accept = ((ServletRequestAttributes)RequestContextHolder.getRequestAttributes()).getRequest().getHeader("Accept");
+        String accept = request.getHeader("Accept");
         return new ResponseEntity<Void>(HttpStatus.OK);
     }
 

--- a/samples/server/petstore/springboot-useoptional/src/main/java/io/swagger/api/FakeApiController.java
+++ b/samples/server/petstore/springboot-useoptional/src/main/java/io/swagger/api/FakeApiController.java
@@ -8,6 +8,8 @@ import io.swagger.model.OuterComposite;
 
 import io.swagger.annotations.*;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
@@ -16,6 +18,8 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RequestPart;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.util.List;
@@ -27,109 +31,111 @@ import javax.validation.Valid;
 
 @Controller
 public class FakeApiController implements FakeApi {
+
+    private final Logger log = LoggerFactory.getLogger(AnotherFakeApiController.class);
+
     private final ObjectMapper objectMapper;
 
     public FakeApiController(ObjectMapper objectMapper) {
         this.objectMapper = objectMapper;
     }
 
-    public ResponseEntity<Boolean> fakeOuterBooleanSerialize(@ApiParam(value = "Input boolean as post body"  )  @Valid @RequestBody Boolean body,
-        @RequestHeader(value = "Accept", required = false) String accept) throws Exception {
+    public ResponseEntity<Boolean> fakeOuterBooleanSerialize(@ApiParam(value = "Input boolean as post body"  )  @Valid @RequestBody Boolean body) {
         // do some magic!
-
+        String accept = ((ServletRequestAttributes)RequestContextHolder.getRequestAttributes()).getRequest().getHeader("Accept");
         if (accept != null && accept.contains("application/json")) {
-            return new ResponseEntity<Boolean>(objectMapper.readValue("{ }", Boolean.class), HttpStatus.OK);
+            try {
+                return new ResponseEntity<Boolean>(objectMapper.readValue("{ }", Boolean.class), HttpStatus.NOT_IMPLEMENTED);
+            } catch (IOException e) {
+                log.error("Couldn't serialize response for content type application/json", e);
+                return new ResponseEntity<Boolean>(HttpStatus.INTERNAL_SERVER_ERROR);
+            }
         }
 
         return new ResponseEntity<Boolean>(HttpStatus.OK);
     }
 
-    public ResponseEntity<OuterComposite> fakeOuterCompositeSerialize(@ApiParam(value = "Input composite as post body"  )  @Valid @RequestBody OuterComposite body,
-        @RequestHeader(value = "Accept", required = false) String accept) throws Exception {
+    public ResponseEntity<OuterComposite> fakeOuterCompositeSerialize(@ApiParam(value = "Input composite as post body"  )  @Valid @RequestBody OuterComposite body) {
         // do some magic!
-
+        String accept = ((ServletRequestAttributes)RequestContextHolder.getRequestAttributes()).getRequest().getHeader("Accept");
         if (accept != null && accept.contains("application/json")) {
-            return new ResponseEntity<OuterComposite>(objectMapper.readValue("{  \"my_string\" : { },  \"my_number\" : { },  \"my_boolean\" : { }}", OuterComposite.class), HttpStatus.OK);
+            try {
+                return new ResponseEntity<OuterComposite>(objectMapper.readValue("{  \"my_string\" : { },  \"my_number\" : { },  \"my_boolean\" : { }}", OuterComposite.class), HttpStatus.NOT_IMPLEMENTED);
+            } catch (IOException e) {
+                log.error("Couldn't serialize response for content type application/json", e);
+                return new ResponseEntity<OuterComposite>(HttpStatus.INTERNAL_SERVER_ERROR);
+            }
         }
 
         return new ResponseEntity<OuterComposite>(HttpStatus.OK);
     }
 
-    public ResponseEntity<BigDecimal> fakeOuterNumberSerialize(@ApiParam(value = "Input number as post body"  )  @Valid @RequestBody BigDecimal body,
-        @RequestHeader(value = "Accept", required = false) String accept) throws Exception {
+    public ResponseEntity<BigDecimal> fakeOuterNumberSerialize(@ApiParam(value = "Input number as post body"  )  @Valid @RequestBody BigDecimal body) {
         // do some magic!
-
+        String accept = ((ServletRequestAttributes)RequestContextHolder.getRequestAttributes()).getRequest().getHeader("Accept");
         if (accept != null && accept.contains("application/json")) {
-            return new ResponseEntity<BigDecimal>(objectMapper.readValue("{ }", BigDecimal.class), HttpStatus.OK);
+            try {
+                return new ResponseEntity<BigDecimal>(objectMapper.readValue("{ }", BigDecimal.class), HttpStatus.NOT_IMPLEMENTED);
+            } catch (IOException e) {
+                log.error("Couldn't serialize response for content type application/json", e);
+                return new ResponseEntity<BigDecimal>(HttpStatus.INTERNAL_SERVER_ERROR);
+            }
         }
 
         return new ResponseEntity<BigDecimal>(HttpStatus.OK);
     }
 
-    public ResponseEntity<String> fakeOuterStringSerialize(@ApiParam(value = "Input string as post body"  )  @Valid @RequestBody String body,
-        @RequestHeader(value = "Accept", required = false) String accept) throws Exception {
+    public ResponseEntity<String> fakeOuterStringSerialize(@ApiParam(value = "Input string as post body"  )  @Valid @RequestBody String body) {
         // do some magic!
-
+        String accept = ((ServletRequestAttributes)RequestContextHolder.getRequestAttributes()).getRequest().getHeader("Accept");
         if (accept != null && accept.contains("application/json")) {
-            return new ResponseEntity<String>(objectMapper.readValue("{ }", String.class), HttpStatus.OK);
+            try {
+                return new ResponseEntity<String>(objectMapper.readValue("{ }", String.class), HttpStatus.NOT_IMPLEMENTED);
+            } catch (IOException e) {
+                log.error("Couldn't serialize response for content type application/json", e);
+                return new ResponseEntity<String>(HttpStatus.INTERNAL_SERVER_ERROR);
+            }
         }
 
         return new ResponseEntity<String>(HttpStatus.OK);
     }
 
-    public ResponseEntity<Client> testClientModel(@ApiParam(value = "client model" ,required=true )  @Valid @RequestBody Client body,
-        @RequestHeader(value = "Accept", required = false) String accept) throws Exception {
+    public ResponseEntity<Client> testClientModel(@ApiParam(value = "client model" ,required=true )  @Valid @RequestBody Client body) {
         // do some magic!
-
+        String accept = ((ServletRequestAttributes)RequestContextHolder.getRequestAttributes()).getRequest().getHeader("Accept");
         if (accept != null && accept.contains("application/json")) {
-            return new ResponseEntity<Client>(objectMapper.readValue("{  \"client\" : \"client\"}", Client.class), HttpStatus.OK);
+            try {
+                return new ResponseEntity<Client>(objectMapper.readValue("{  \"client\" : \"client\"}", Client.class), HttpStatus.NOT_IMPLEMENTED);
+            } catch (IOException e) {
+                log.error("Couldn't serialize response for content type application/json", e);
+                return new ResponseEntity<Client>(HttpStatus.INTERNAL_SERVER_ERROR);
+            }
         }
 
         return new ResponseEntity<Client>(HttpStatus.OK);
     }
 
-    public ResponseEntity<Void> testEndpointParameters(@ApiParam(value = "None", required=true) @RequestPart(value="number", required=true)  BigDecimal number,
-        @ApiParam(value = "None", required=true) @RequestPart(value="double", required=true)  Double _double,
-        @ApiParam(value = "None", required=true) @RequestPart(value="pattern_without_delimiter", required=true)  String patternWithoutDelimiter,
-        @ApiParam(value = "None", required=true) @RequestPart(value="byte", required=true)  byte[] _byte,
-        @ApiParam(value = "None") @RequestPart(value="integer", required=false)  Integer integer,
-        @ApiParam(value = "None") @RequestPart(value="int32", required=false)  Integer int32,
-        @ApiParam(value = "None") @RequestPart(value="int64", required=false)  Long int64,
-        @ApiParam(value = "None") @RequestPart(value="float", required=false)  Float _float,
-        @ApiParam(value = "None") @RequestPart(value="string", required=false)  String string,
-        @ApiParam(value = "None") @RequestPart(value="binary", required=false)  byte[] binary,
-        @ApiParam(value = "None") @RequestPart(value="date", required=false)  LocalDate date,
-        @ApiParam(value = "None") @RequestPart(value="dateTime", required=false)  OffsetDateTime dateTime,
-        @ApiParam(value = "None") @RequestPart(value="password", required=false)  String password,
-        @ApiParam(value = "None") @RequestPart(value="callback", required=false)  String paramCallback,
-        @RequestHeader(value = "Accept", required = false) String accept) throws Exception {
+    public ResponseEntity<Void> testEndpointParameters(@ApiParam(value = "None", required=true) @RequestPart(value="number", required=true)  BigDecimal number,@ApiParam(value = "None", required=true) @RequestPart(value="double", required=true)  Double _double,@ApiParam(value = "None", required=true) @RequestPart(value="pattern_without_delimiter", required=true)  String patternWithoutDelimiter,@ApiParam(value = "None", required=true) @RequestPart(value="byte", required=true)  byte[] _byte,@ApiParam(value = "None") @RequestPart(value="integer", required=false)  Integer integer,@ApiParam(value = "None") @RequestPart(value="int32", required=false)  Integer int32,@ApiParam(value = "None") @RequestPart(value="int64", required=false)  Long int64,@ApiParam(value = "None") @RequestPart(value="float", required=false)  Float _float,@ApiParam(value = "None") @RequestPart(value="string", required=false)  String string,@ApiParam(value = "None") @RequestPart(value="binary", required=false)  byte[] binary,@ApiParam(value = "None") @RequestPart(value="date", required=false)  LocalDate date,@ApiParam(value = "None") @RequestPart(value="dateTime", required=false)  OffsetDateTime dateTime,@ApiParam(value = "None") @RequestPart(value="password", required=false)  String password,@ApiParam(value = "None") @RequestPart(value="callback", required=false)  String paramCallback) {
         // do some magic!
+        String accept = ((ServletRequestAttributes)RequestContextHolder.getRequestAttributes()).getRequest().getHeader("Accept");
         return new ResponseEntity<Void>(HttpStatus.OK);
     }
 
-    public ResponseEntity<Void> testEnumParameters(@ApiParam(value = "Form parameter enum test (string array)", allowableValues=">, $") @RequestPart(value="enum_form_string_array", required=false)  List<String> enumFormStringArray,
-        @ApiParam(value = "Form parameter enum test (string)", allowableValues="_abc, -efg, (xyz)", defaultValue="-efg") @RequestPart(value="enum_form_string", required=false)  String enumFormString,
-        @ApiParam(value = "Header parameter enum test (string array)" , allowableValues=">, $") @RequestHeader(value="enum_header_string_array", required=false) Optional<List<String>> enumHeaderStringArray,
-        @ApiParam(value = "Header parameter enum test (string)" , allowableValues="_abc, -efg, (xyz)", defaultValue="-efg") @RequestHeader(value="enum_header_string", required=false) Optional<String> enumHeaderString,
-        @ApiParam(value = "Query parameter enum test (string array)", allowableValues = ">, $") @Valid @RequestParam(value = "enum_query_string_array", required = false) Optional<List<String>> enumQueryStringArray,
-        @ApiParam(value = "Query parameter enum test (string)", allowableValues = "_abc, -efg, (xyz)", defaultValue = "-efg") @Valid @RequestParam(value = "enum_query_string", required = false, defaultValue="-efg") Optional<String> enumQueryString,
-        @ApiParam(value = "Query parameter enum test (double)", allowableValues = "1, -2") @Valid @RequestParam(value = "enum_query_integer", required = false) Optional<Integer> enumQueryInteger,
-        @ApiParam(value = "Query parameter enum test (double)", allowableValues="1.1, -1.2") @RequestPart(value="enum_query_double", required=false)  Double enumQueryDouble,
-        @RequestHeader(value = "Accept", required = false) String accept) throws Exception {
+    public ResponseEntity<Void> testEnumParameters(@ApiParam(value = "Form parameter enum test (string array)", allowableValues=">, $") @RequestPart(value="enum_form_string_array", required=false)  List<String> enumFormStringArray,@ApiParam(value = "Form parameter enum test (string)", allowableValues="_abc, -efg, (xyz)", defaultValue="-efg") @RequestPart(value="enum_form_string", required=false)  String enumFormString,@ApiParam(value = "Header parameter enum test (string array)" , allowableValues=">, $") @RequestHeader(value="enum_header_string_array", required=false) Optional<List<String>> enumHeaderStringArray,@ApiParam(value = "Header parameter enum test (string)" , allowableValues="_abc, -efg, (xyz)", defaultValue="-efg") @RequestHeader(value="enum_header_string", required=false) Optional<String> enumHeaderString,@ApiParam(value = "Query parameter enum test (string array)", allowableValues = ">, $") @Valid @RequestParam(value = "enum_query_string_array", required = false) Optional<List<String>> enumQueryStringArray,@ApiParam(value = "Query parameter enum test (string)", allowableValues = "_abc, -efg, (xyz)", defaultValue = "-efg") @Valid @RequestParam(value = "enum_query_string", required = false, defaultValue="-efg") Optional<String> enumQueryString,@ApiParam(value = "Query parameter enum test (double)", allowableValues = "1, -2") @Valid @RequestParam(value = "enum_query_integer", required = false) Optional<Integer> enumQueryInteger,@ApiParam(value = "Query parameter enum test (double)", allowableValues="1.1, -1.2") @RequestPart(value="enum_query_double", required=false)  Double enumQueryDouble) {
         // do some magic!
+        String accept = ((ServletRequestAttributes)RequestContextHolder.getRequestAttributes()).getRequest().getHeader("Accept");
         return new ResponseEntity<Void>(HttpStatus.OK);
     }
 
-    public ResponseEntity<Void> testInlineAdditionalProperties(@ApiParam(value = "request body" ,required=true )  @Valid @RequestBody Object param,
-        @RequestHeader(value = "Accept", required = false) String accept) throws Exception {
+    public ResponseEntity<Void> testInlineAdditionalProperties(@ApiParam(value = "request body" ,required=true )  @Valid @RequestBody Object param) {
         // do some magic!
+        String accept = ((ServletRequestAttributes)RequestContextHolder.getRequestAttributes()).getRequest().getHeader("Accept");
         return new ResponseEntity<Void>(HttpStatus.OK);
     }
 
-    public ResponseEntity<Void> testJsonFormData(@ApiParam(value = "field1", required=true) @RequestPart(value="param", required=true)  String param,
-        @ApiParam(value = "field2", required=true) @RequestPart(value="param2", required=true)  String param2,
-        @RequestHeader(value = "Accept", required = false) String accept) throws Exception {
+    public ResponseEntity<Void> testJsonFormData(@ApiParam(value = "field1", required=true) @RequestPart(value="param", required=true)  String param,@ApiParam(value = "field2", required=true) @RequestPart(value="param2", required=true)  String param2) {
         // do some magic!
+        String accept = ((ServletRequestAttributes)RequestContextHolder.getRequestAttributes()).getRequest().getHeader("Accept");
         return new ResponseEntity<Void>(HttpStatus.OK);
     }
 

--- a/samples/server/petstore/springboot-useoptional/src/main/java/io/swagger/api/FakeClassnameTestApi.java
+++ b/samples/server/petstore/springboot-useoptional/src/main/java/io/swagger/api/FakeClassnameTestApi.java
@@ -37,6 +37,6 @@ public interface FakeClassnameTestApi {
         produces = { "application/json" }, 
         consumes = { "application/json" },
         method = RequestMethod.PATCH)
-    ResponseEntity<Client> testClassname(@ApiParam(value = "client model" ,required=true )  @Valid @RequestBody Client body, @RequestHeader(value = "Accept", required = false) String accept) throws Exception;
+    ResponseEntity<Client> testClassname(@ApiParam(value = "client model" ,required=true )  @Valid @RequestBody Client body);
 
 }

--- a/samples/server/petstore/springboot-useoptional/src/main/java/io/swagger/api/FakeClassnameTestApi.java
+++ b/samples/server/petstore/springboot-useoptional/src/main/java/io/swagger/api/FakeClassnameTestApi.java
@@ -6,9 +6,9 @@
 package io.swagger.api;
 
 import io.swagger.model.Client;
-
 import io.swagger.annotations.*;
 import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
@@ -17,13 +17,11 @@ import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.multipart.MultipartFile;
-import java.io.IOException;
 
+import javax.validation.Valid;
+import javax.validation.constraints.*;
 import java.util.List;
 import java.util.Optional;
-import org.springframework.validation.annotation.Validated;
-import javax.validation.constraints.*;
-import javax.validation.Valid;
 
 @Api(value = "fake_classname_test", description = "the fake_classname_test API")
 public interface FakeClassnameTestApi {

--- a/samples/server/petstore/springboot-useoptional/src/main/java/io/swagger/api/FakeClassnameTestApiController.java
+++ b/samples/server/petstore/springboot-useoptional/src/main/java/io/swagger/api/FakeClassnameTestApiController.java
@@ -33,12 +33,12 @@ public class FakeClassnameTestApiController implements FakeClassnameTestApi {
 
     private final ObjectMapper objectMapper;
 
-    @org.springframework.beans.factory.annotation.Autowired
-    private HttpServletRequest request;
+    private final HttpServletRequest request;
 
     @org.springframework.beans.factory.annotation.Autowired
-    public FakeClassnameTestApiController(ObjectMapper objectMapper) {
+    public FakeClassnameTestApiController(ObjectMapper objectMapper, HttpServletRequest request) {
         this.objectMapper = objectMapper;
+        this.request = request;
     }
 
     public ResponseEntity<Client> testClassname(@ApiParam(value = "client model" ,required=true )  @Valid @RequestBody Client body) {

--- a/samples/server/petstore/springboot-useoptional/src/main/java/io/swagger/api/FakeClassnameTestApiController.java
+++ b/samples/server/petstore/springboot-useoptional/src/main/java/io/swagger/api/FakeClassnameTestApiController.java
@@ -22,23 +22,28 @@ import java.util.List;
 import java.util.Optional;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.IOException;
+import javax.servlet.http.HttpServletRequest;
 import javax.validation.constraints.*;
 import javax.validation.Valid;
 
 @Controller
 public class FakeClassnameTestApiController implements FakeClassnameTestApi {
 
-    private final Logger log = LoggerFactory.getLogger(AnotherFakeApiController.class);
+    private static final Logger log = LoggerFactory.getLogger(FakeClassnameTestApiController.class);
 
     private final ObjectMapper objectMapper;
 
+    @org.springframework.beans.factory.annotation.Autowired
+    private HttpServletRequest request;
+
+    @org.springframework.beans.factory.annotation.Autowired
     public FakeClassnameTestApiController(ObjectMapper objectMapper) {
         this.objectMapper = objectMapper;
     }
 
     public ResponseEntity<Client> testClassname(@ApiParam(value = "client model" ,required=true )  @Valid @RequestBody Client body) {
         // do some magic!
-        String accept = ((ServletRequestAttributes)RequestContextHolder.getRequestAttributes()).getRequest().getHeader("Accept");
+        String accept = request.getHeader("Accept");
         if (accept != null && accept.contains("application/json")) {
             try {
                 return new ResponseEntity<Client>(objectMapper.readValue("{  \"client\" : \"client\"}", Client.class), HttpStatus.NOT_IMPLEMENTED);

--- a/samples/server/petstore/springboot-useoptional/src/main/java/io/swagger/api/FakeClassnameTestApiController.java
+++ b/samples/server/petstore/springboot-useoptional/src/main/java/io/swagger/api/FakeClassnameTestApiController.java
@@ -4,6 +4,8 @@ import io.swagger.model.Client;
 
 import io.swagger.annotations.*;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
@@ -12,6 +14,8 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RequestPart;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.util.List;
@@ -23,18 +27,25 @@ import javax.validation.Valid;
 
 @Controller
 public class FakeClassnameTestApiController implements FakeClassnameTestApi {
+
+    private final Logger log = LoggerFactory.getLogger(AnotherFakeApiController.class);
+
     private final ObjectMapper objectMapper;
 
     public FakeClassnameTestApiController(ObjectMapper objectMapper) {
         this.objectMapper = objectMapper;
     }
 
-    public ResponseEntity<Client> testClassname(@ApiParam(value = "client model" ,required=true )  @Valid @RequestBody Client body,
-        @RequestHeader(value = "Accept", required = false) String accept) throws Exception {
+    public ResponseEntity<Client> testClassname(@ApiParam(value = "client model" ,required=true )  @Valid @RequestBody Client body) {
         // do some magic!
-
+        String accept = ((ServletRequestAttributes)RequestContextHolder.getRequestAttributes()).getRequest().getHeader("Accept");
         if (accept != null && accept.contains("application/json")) {
-            return new ResponseEntity<Client>(objectMapper.readValue("{  \"client\" : \"client\"}", Client.class), HttpStatus.OK);
+            try {
+                return new ResponseEntity<Client>(objectMapper.readValue("{  \"client\" : \"client\"}", Client.class), HttpStatus.NOT_IMPLEMENTED);
+            } catch (IOException e) {
+                log.error("Couldn't serialize response for content type application/json", e);
+                return new ResponseEntity<Client>(HttpStatus.INTERNAL_SERVER_ERROR);
+            }
         }
 
         return new ResponseEntity<Client>(HttpStatus.OK);

--- a/samples/server/petstore/springboot-useoptional/src/main/java/io/swagger/api/FakeClassnameTestApiController.java
+++ b/samples/server/petstore/springboot-useoptional/src/main/java/io/swagger/api/FakeClassnameTestApiController.java
@@ -1,9 +1,8 @@
 package io.swagger.api;
 
 import io.swagger.model.Client;
-
+import com.fasterxml.jackson.databind.ObjectMapper;
 import io.swagger.annotations.*;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpStatus;
@@ -14,17 +13,14 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RequestPart;
-import org.springframework.web.context.request.RequestContextHolder;
-import org.springframework.web.context.request.ServletRequestAttributes;
 import org.springframework.web.multipart.MultipartFile;
 
-import java.util.List;
-import java.util.Optional;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import java.io.IOException;
-import javax.servlet.http.HttpServletRequest;
 import javax.validation.constraints.*;
 import javax.validation.Valid;
+import javax.servlet.http.HttpServletRequest;
+import java.util.Optional;
+import java.io.IOException;
+import java.util.List;
 
 @Controller
 public class FakeClassnameTestApiController implements FakeClassnameTestApi {
@@ -42,7 +38,6 @@ public class FakeClassnameTestApiController implements FakeClassnameTestApi {
     }
 
     public ResponseEntity<Client> testClassname(@ApiParam(value = "client model" ,required=true )  @Valid @RequestBody Client body) {
-        // do some magic!
         String accept = request.getHeader("Accept");
         if (accept != null && accept.contains("application/json")) {
             try {
@@ -53,7 +48,7 @@ public class FakeClassnameTestApiController implements FakeClassnameTestApi {
             }
         }
 
-        return new ResponseEntity<Client>(HttpStatus.OK);
+        return new ResponseEntity<Client>(HttpStatus.NOT_IMPLEMENTED);
     }
 
 }

--- a/samples/server/petstore/springboot-useoptional/src/main/java/io/swagger/api/PetApi.java
+++ b/samples/server/petstore/springboot-useoptional/src/main/java/io/swagger/api/PetApi.java
@@ -8,9 +8,9 @@ package io.swagger.api;
 import io.swagger.model.ModelApiResponse;
 import io.swagger.model.Pet;
 import org.springframework.core.io.Resource;
-
 import io.swagger.annotations.*;
 import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
@@ -19,13 +19,11 @@ import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.multipart.MultipartFile;
-import java.io.IOException;
 
+import javax.validation.Valid;
+import javax.validation.constraints.*;
 import java.util.List;
 import java.util.Optional;
-import org.springframework.validation.annotation.Validated;
-import javax.validation.constraints.*;
-import javax.validation.Valid;
 
 @Api(value = "pet", description = "the pet API")
 public interface PetApi {

--- a/samples/server/petstore/springboot-useoptional/src/main/java/io/swagger/api/PetApi.java
+++ b/samples/server/petstore/springboot-useoptional/src/main/java/io/swagger/api/PetApi.java
@@ -42,7 +42,7 @@ public interface PetApi {
         produces = { "application/xml", "application/json" }, 
         consumes = { "application/json", "application/xml" },
         method = RequestMethod.POST)
-    ResponseEntity<Void> addPet(@ApiParam(value = "Pet object that needs to be added to the store" ,required=true )  @Valid @RequestBody Pet body, @RequestHeader(value = "Accept", required = false) String accept) throws Exception;
+    ResponseEntity<Void> addPet(@ApiParam(value = "Pet object that needs to be added to the store" ,required=true )  @Valid @RequestBody Pet body);
 
 
     @ApiOperation(value = "Deletes a pet", nickname = "deletePet", notes = "", authorizations = {
@@ -56,7 +56,7 @@ public interface PetApi {
     @RequestMapping(value = "/pet/{petId}",
         produces = { "application/xml", "application/json" }, 
         method = RequestMethod.DELETE)
-    ResponseEntity<Void> deletePet(@ApiParam(value = "Pet id to delete",required=true) @PathVariable("petId") Long petId,@ApiParam(value = "" ) @RequestHeader(value="api_key", required=false) Optional<String> apiKey, @RequestHeader(value = "Accept", required = false) String accept) throws Exception;
+    ResponseEntity<Void> deletePet(@ApiParam(value = "Pet id to delete",required=true) @PathVariable("petId") Long petId,@ApiParam(value = "" ) @RequestHeader(value="api_key", required=false) Optional<String> apiKey);
 
 
     @ApiOperation(value = "Finds Pets by status", nickname = "findPetsByStatus", notes = "Multiple status values can be provided with comma separated strings", response = Pet.class, responseContainer = "List", authorizations = {
@@ -71,7 +71,7 @@ public interface PetApi {
     @RequestMapping(value = "/pet/findByStatus",
         produces = { "application/xml", "application/json" }, 
         method = RequestMethod.GET)
-    ResponseEntity<List<Pet>> findPetsByStatus( @NotNull@ApiParam(value = "Status values that need to be considered for filter", required = true, allowableValues = "available, pending, sold") @Valid @RequestParam(value = "status", required = true) List<String> status, @RequestHeader(value = "Accept", required = false) String accept) throws Exception;
+    ResponseEntity<List<Pet>> findPetsByStatus(@NotNull @ApiParam(value = "Status values that need to be considered for filter", required = true, allowableValues = "available, pending, sold") @Valid @RequestParam(value = "status", required = true) List<String> status);
 
 
     @ApiOperation(value = "Finds Pets by tags", nickname = "findPetsByTags", notes = "Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.", response = Pet.class, responseContainer = "List", authorizations = {
@@ -86,7 +86,7 @@ public interface PetApi {
     @RequestMapping(value = "/pet/findByTags",
         produces = { "application/xml", "application/json" }, 
         method = RequestMethod.GET)
-    ResponseEntity<List<Pet>> findPetsByTags( @NotNull@ApiParam(value = "Tags to filter by", required = true) @Valid @RequestParam(value = "tags", required = true) List<String> tags, @RequestHeader(value = "Accept", required = false) String accept) throws Exception;
+    ResponseEntity<List<Pet>> findPetsByTags(@NotNull @ApiParam(value = "Tags to filter by", required = true) @Valid @RequestParam(value = "tags", required = true) List<String> tags);
 
 
     @ApiOperation(value = "Find pet by ID", nickname = "getPetById", notes = "Returns a single pet", response = Pet.class, authorizations = {
@@ -99,7 +99,7 @@ public interface PetApi {
     @RequestMapping(value = "/pet/{petId}",
         produces = { "application/xml", "application/json" }, 
         method = RequestMethod.GET)
-    ResponseEntity<Pet> getPetById(@ApiParam(value = "ID of pet to return",required=true) @PathVariable("petId") Long petId, @RequestHeader(value = "Accept", required = false) String accept) throws Exception;
+    ResponseEntity<Pet> getPetById(@ApiParam(value = "ID of pet to return",required=true) @PathVariable("petId") Long petId);
 
 
     @ApiOperation(value = "Update an existing pet", nickname = "updatePet", notes = "", authorizations = {
@@ -116,7 +116,7 @@ public interface PetApi {
         produces = { "application/xml", "application/json" }, 
         consumes = { "application/json", "application/xml" },
         method = RequestMethod.PUT)
-    ResponseEntity<Void> updatePet(@ApiParam(value = "Pet object that needs to be added to the store" ,required=true )  @Valid @RequestBody Pet body, @RequestHeader(value = "Accept", required = false) String accept) throws Exception;
+    ResponseEntity<Void> updatePet(@ApiParam(value = "Pet object that needs to be added to the store" ,required=true )  @Valid @RequestBody Pet body);
 
 
     @ApiOperation(value = "Updates a pet in the store with form data", nickname = "updatePetWithForm", notes = "", authorizations = {
@@ -131,7 +131,7 @@ public interface PetApi {
         produces = { "application/xml", "application/json" }, 
         consumes = { "application/x-www-form-urlencoded" },
         method = RequestMethod.POST)
-    ResponseEntity<Void> updatePetWithForm(@ApiParam(value = "ID of pet that needs to be updated",required=true) @PathVariable("petId") Long petId,@ApiParam(value = "Updated name of the pet") @RequestPart(value="name", required=false)  String name,@ApiParam(value = "Updated status of the pet") @RequestPart(value="status", required=false)  String status, @RequestHeader(value = "Accept", required = false) String accept) throws Exception;
+    ResponseEntity<Void> updatePetWithForm(@ApiParam(value = "ID of pet that needs to be updated",required=true) @PathVariable("petId") Long petId,@ApiParam(value = "Updated name of the pet") @RequestPart(value="name", required=false)  String name,@ApiParam(value = "Updated status of the pet") @RequestPart(value="status", required=false)  String status);
 
 
     @ApiOperation(value = "uploads an image", nickname = "uploadFile", notes = "", response = ModelApiResponse.class, authorizations = {
@@ -146,6 +146,6 @@ public interface PetApi {
         produces = { "application/json" }, 
         consumes = { "multipart/form-data" },
         method = RequestMethod.POST)
-    ResponseEntity<ModelApiResponse> uploadFile(@ApiParam(value = "ID of pet to update",required=true) @PathVariable("petId") Long petId,@ApiParam(value = "Additional data to pass to server") @RequestPart(value="additionalMetadata", required=false)  String additionalMetadata,@ApiParam(value = "file detail") @Valid @RequestPart("file") MultipartFile file, @RequestHeader(value = "Accept", required = false) String accept) throws Exception;
+    ResponseEntity<ModelApiResponse> uploadFile(@ApiParam(value = "ID of pet to update",required=true) @PathVariable("petId") Long petId,@ApiParam(value = "Additional data to pass to server") @RequestPart(value="additionalMetadata", required=false)  String additionalMetadata,@ApiParam(value = "file detail") @Valid @RequestPart("file") MultipartFile file);
 
 }

--- a/samples/server/petstore/springboot-useoptional/src/main/java/io/swagger/api/PetApiController.java
+++ b/samples/server/petstore/springboot-useoptional/src/main/java/io/swagger/api/PetApiController.java
@@ -35,12 +35,12 @@ public class PetApiController implements PetApi {
 
     private final ObjectMapper objectMapper;
 
-    @org.springframework.beans.factory.annotation.Autowired
-    private HttpServletRequest request;
+    private final HttpServletRequest request;
 
     @org.springframework.beans.factory.annotation.Autowired
-    public PetApiController(ObjectMapper objectMapper) {
+    public PetApiController(ObjectMapper objectMapper, HttpServletRequest request) {
         this.objectMapper = objectMapper;
+        this.request = request;
     }
 
     public ResponseEntity<Void> addPet(@ApiParam(value = "Pet object that needs to be added to the store" ,required=true )  @Valid @RequestBody Pet body) {

--- a/samples/server/petstore/springboot-useoptional/src/main/java/io/swagger/api/PetApiController.java
+++ b/samples/server/petstore/springboot-useoptional/src/main/java/io/swagger/api/PetApiController.java
@@ -3,9 +3,8 @@ package io.swagger.api;
 import io.swagger.model.ModelApiResponse;
 import io.swagger.model.Pet;
 import org.springframework.core.io.Resource;
-
+import com.fasterxml.jackson.databind.ObjectMapper;
 import io.swagger.annotations.*;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpStatus;
@@ -16,17 +15,14 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RequestPart;
-import org.springframework.web.context.request.RequestContextHolder;
-import org.springframework.web.context.request.ServletRequestAttributes;
 import org.springframework.web.multipart.MultipartFile;
 
-import java.util.List;
-import java.util.Optional;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import java.io.IOException;
-import javax.servlet.http.HttpServletRequest;
 import javax.validation.constraints.*;
 import javax.validation.Valid;
+import javax.servlet.http.HttpServletRequest;
+import java.util.Optional;
+import java.io.IOException;
+import java.util.List;
 
 @Controller
 public class PetApiController implements PetApi {
@@ -44,19 +40,16 @@ public class PetApiController implements PetApi {
     }
 
     public ResponseEntity<Void> addPet(@ApiParam(value = "Pet object that needs to be added to the store" ,required=true )  @Valid @RequestBody Pet body) {
-        // do some magic!
         String accept = request.getHeader("Accept");
-        return new ResponseEntity<Void>(HttpStatus.OK);
+        return new ResponseEntity<Void>(HttpStatus.NOT_IMPLEMENTED);
     }
 
     public ResponseEntity<Void> deletePet(@ApiParam(value = "Pet id to delete",required=true) @PathVariable("petId") Long petId,@ApiParam(value = "" ) @RequestHeader(value="api_key", required=false) Optional<String> apiKey) {
-        // do some magic!
         String accept = request.getHeader("Accept");
-        return new ResponseEntity<Void>(HttpStatus.OK);
+        return new ResponseEntity<Void>(HttpStatus.NOT_IMPLEMENTED);
     }
 
     public ResponseEntity<List<Pet>> findPetsByStatus(@NotNull @ApiParam(value = "Status values that need to be considered for filter", required = true, allowableValues = "available, pending, sold") @Valid @RequestParam(value = "status", required = true) List<String> status) {
-        // do some magic!
         String accept = request.getHeader("Accept");
         if (accept != null && accept.contains("application/xml")) {
             try {
@@ -76,11 +69,10 @@ public class PetApiController implements PetApi {
             }
         }
 
-        return new ResponseEntity<List<Pet>>(HttpStatus.OK);
+        return new ResponseEntity<List<Pet>>(HttpStatus.NOT_IMPLEMENTED);
     }
 
     public ResponseEntity<List<Pet>> findPetsByTags(@NotNull @ApiParam(value = "Tags to filter by", required = true) @Valid @RequestParam(value = "tags", required = true) List<String> tags) {
-        // do some magic!
         String accept = request.getHeader("Accept");
         if (accept != null && accept.contains("application/xml")) {
             try {
@@ -100,11 +92,10 @@ public class PetApiController implements PetApi {
             }
         }
 
-        return new ResponseEntity<List<Pet>>(HttpStatus.OK);
+        return new ResponseEntity<List<Pet>>(HttpStatus.NOT_IMPLEMENTED);
     }
 
     public ResponseEntity<Pet> getPetById(@ApiParam(value = "ID of pet to return",required=true) @PathVariable("petId") Long petId) {
-        // do some magic!
         String accept = request.getHeader("Accept");
         if (accept != null && accept.contains("application/xml")) {
             try {
@@ -124,23 +115,20 @@ public class PetApiController implements PetApi {
             }
         }
 
-        return new ResponseEntity<Pet>(HttpStatus.OK);
+        return new ResponseEntity<Pet>(HttpStatus.NOT_IMPLEMENTED);
     }
 
     public ResponseEntity<Void> updatePet(@ApiParam(value = "Pet object that needs to be added to the store" ,required=true )  @Valid @RequestBody Pet body) {
-        // do some magic!
         String accept = request.getHeader("Accept");
-        return new ResponseEntity<Void>(HttpStatus.OK);
+        return new ResponseEntity<Void>(HttpStatus.NOT_IMPLEMENTED);
     }
 
     public ResponseEntity<Void> updatePetWithForm(@ApiParam(value = "ID of pet that needs to be updated",required=true) @PathVariable("petId") Long petId,@ApiParam(value = "Updated name of the pet") @RequestPart(value="name", required=false)  String name,@ApiParam(value = "Updated status of the pet") @RequestPart(value="status", required=false)  String status) {
-        // do some magic!
         String accept = request.getHeader("Accept");
-        return new ResponseEntity<Void>(HttpStatus.OK);
+        return new ResponseEntity<Void>(HttpStatus.NOT_IMPLEMENTED);
     }
 
     public ResponseEntity<ModelApiResponse> uploadFile(@ApiParam(value = "ID of pet to update",required=true) @PathVariable("petId") Long petId,@ApiParam(value = "Additional data to pass to server") @RequestPart(value="additionalMetadata", required=false)  String additionalMetadata,@ApiParam(value = "file detail") @Valid @RequestPart("file") MultipartFile file) {
-        // do some magic!
         String accept = request.getHeader("Accept");
         if (accept != null && accept.contains("application/json")) {
             try {
@@ -151,7 +139,7 @@ public class PetApiController implements PetApi {
             }
         }
 
-        return new ResponseEntity<ModelApiResponse>(HttpStatus.OK);
+        return new ResponseEntity<ModelApiResponse>(HttpStatus.NOT_IMPLEMENTED);
     }
 
 }

--- a/samples/server/petstore/springboot-useoptional/src/main/java/io/swagger/api/PetApiController.java
+++ b/samples/server/petstore/springboot-useoptional/src/main/java/io/swagger/api/PetApiController.java
@@ -24,35 +24,40 @@ import java.util.List;
 import java.util.Optional;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.IOException;
+import javax.servlet.http.HttpServletRequest;
 import javax.validation.constraints.*;
 import javax.validation.Valid;
 
 @Controller
 public class PetApiController implements PetApi {
 
-    private final Logger log = LoggerFactory.getLogger(AnotherFakeApiController.class);
+    private static final Logger log = LoggerFactory.getLogger(PetApiController.class);
 
     private final ObjectMapper objectMapper;
 
+    @org.springframework.beans.factory.annotation.Autowired
+    private HttpServletRequest request;
+
+    @org.springframework.beans.factory.annotation.Autowired
     public PetApiController(ObjectMapper objectMapper) {
         this.objectMapper = objectMapper;
     }
 
     public ResponseEntity<Void> addPet(@ApiParam(value = "Pet object that needs to be added to the store" ,required=true )  @Valid @RequestBody Pet body) {
         // do some magic!
-        String accept = ((ServletRequestAttributes)RequestContextHolder.getRequestAttributes()).getRequest().getHeader("Accept");
+        String accept = request.getHeader("Accept");
         return new ResponseEntity<Void>(HttpStatus.OK);
     }
 
     public ResponseEntity<Void> deletePet(@ApiParam(value = "Pet id to delete",required=true) @PathVariable("petId") Long petId,@ApiParam(value = "" ) @RequestHeader(value="api_key", required=false) Optional<String> apiKey) {
         // do some magic!
-        String accept = ((ServletRequestAttributes)RequestContextHolder.getRequestAttributes()).getRequest().getHeader("Accept");
+        String accept = request.getHeader("Accept");
         return new ResponseEntity<Void>(HttpStatus.OK);
     }
 
     public ResponseEntity<List<Pet>> findPetsByStatus(@NotNull @ApiParam(value = "Status values that need to be considered for filter", required = true, allowableValues = "available, pending, sold") @Valid @RequestParam(value = "status", required = true) List<String> status) {
         // do some magic!
-        String accept = ((ServletRequestAttributes)RequestContextHolder.getRequestAttributes()).getRequest().getHeader("Accept");
+        String accept = request.getHeader("Accept");
         if (accept != null && accept.contains("application/xml")) {
             try {
                 return new ResponseEntity<List<Pet>>(objectMapper.readValue("<Pet>  <id>123456789</id>  <name>doggie</name>  <photoUrls>    <photoUrls>aeiou</photoUrls>  </photoUrls>  <tags>  </tags>  <status>aeiou</status></Pet>", List.class), HttpStatus.NOT_IMPLEMENTED);
@@ -76,7 +81,7 @@ public class PetApiController implements PetApi {
 
     public ResponseEntity<List<Pet>> findPetsByTags(@NotNull @ApiParam(value = "Tags to filter by", required = true) @Valid @RequestParam(value = "tags", required = true) List<String> tags) {
         // do some magic!
-        String accept = ((ServletRequestAttributes)RequestContextHolder.getRequestAttributes()).getRequest().getHeader("Accept");
+        String accept = request.getHeader("Accept");
         if (accept != null && accept.contains("application/xml")) {
             try {
                 return new ResponseEntity<List<Pet>>(objectMapper.readValue("<Pet>  <id>123456789</id>  <name>doggie</name>  <photoUrls>    <photoUrls>aeiou</photoUrls>  </photoUrls>  <tags>  </tags>  <status>aeiou</status></Pet>", List.class), HttpStatus.NOT_IMPLEMENTED);
@@ -100,7 +105,7 @@ public class PetApiController implements PetApi {
 
     public ResponseEntity<Pet> getPetById(@ApiParam(value = "ID of pet to return",required=true) @PathVariable("petId") Long petId) {
         // do some magic!
-        String accept = ((ServletRequestAttributes)RequestContextHolder.getRequestAttributes()).getRequest().getHeader("Accept");
+        String accept = request.getHeader("Accept");
         if (accept != null && accept.contains("application/xml")) {
             try {
                 return new ResponseEntity<Pet>(objectMapper.readValue("<Pet>  <id>123456789</id>  <name>doggie</name>  <photoUrls>    <photoUrls>aeiou</photoUrls>  </photoUrls>  <tags>  </tags>  <status>aeiou</status></Pet>", Pet.class), HttpStatus.NOT_IMPLEMENTED);
@@ -124,19 +129,19 @@ public class PetApiController implements PetApi {
 
     public ResponseEntity<Void> updatePet(@ApiParam(value = "Pet object that needs to be added to the store" ,required=true )  @Valid @RequestBody Pet body) {
         // do some magic!
-        String accept = ((ServletRequestAttributes)RequestContextHolder.getRequestAttributes()).getRequest().getHeader("Accept");
+        String accept = request.getHeader("Accept");
         return new ResponseEntity<Void>(HttpStatus.OK);
     }
 
     public ResponseEntity<Void> updatePetWithForm(@ApiParam(value = "ID of pet that needs to be updated",required=true) @PathVariable("petId") Long petId,@ApiParam(value = "Updated name of the pet") @RequestPart(value="name", required=false)  String name,@ApiParam(value = "Updated status of the pet") @RequestPart(value="status", required=false)  String status) {
         // do some magic!
-        String accept = ((ServletRequestAttributes)RequestContextHolder.getRequestAttributes()).getRequest().getHeader("Accept");
+        String accept = request.getHeader("Accept");
         return new ResponseEntity<Void>(HttpStatus.OK);
     }
 
     public ResponseEntity<ModelApiResponse> uploadFile(@ApiParam(value = "ID of pet to update",required=true) @PathVariable("petId") Long petId,@ApiParam(value = "Additional data to pass to server") @RequestPart(value="additionalMetadata", required=false)  String additionalMetadata,@ApiParam(value = "file detail") @Valid @RequestPart("file") MultipartFile file) {
         // do some magic!
-        String accept = ((ServletRequestAttributes)RequestContextHolder.getRequestAttributes()).getRequest().getHeader("Accept");
+        String accept = request.getHeader("Accept");
         if (accept != null && accept.contains("application/json")) {
             try {
                 return new ResponseEntity<ModelApiResponse>(objectMapper.readValue("{  \"code\" : 0,  \"type\" : \"type\",  \"message\" : \"message\"}", ModelApiResponse.class), HttpStatus.NOT_IMPLEMENTED);

--- a/samples/server/petstore/springboot-useoptional/src/main/java/io/swagger/api/PetApiController.java
+++ b/samples/server/petstore/springboot-useoptional/src/main/java/io/swagger/api/PetApiController.java
@@ -6,6 +6,8 @@ import org.springframework.core.io.Resource;
 
 import io.swagger.annotations.*;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
@@ -14,6 +16,8 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RequestPart;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.util.List;
@@ -25,95 +29,121 @@ import javax.validation.Valid;
 
 @Controller
 public class PetApiController implements PetApi {
+
+    private final Logger log = LoggerFactory.getLogger(AnotherFakeApiController.class);
+
     private final ObjectMapper objectMapper;
 
     public PetApiController(ObjectMapper objectMapper) {
         this.objectMapper = objectMapper;
     }
 
-    public ResponseEntity<Void> addPet(@ApiParam(value = "Pet object that needs to be added to the store" ,required=true )  @Valid @RequestBody Pet body,
-        @RequestHeader(value = "Accept", required = false) String accept) throws Exception {
+    public ResponseEntity<Void> addPet(@ApiParam(value = "Pet object that needs to be added to the store" ,required=true )  @Valid @RequestBody Pet body) {
         // do some magic!
+        String accept = ((ServletRequestAttributes)RequestContextHolder.getRequestAttributes()).getRequest().getHeader("Accept");
         return new ResponseEntity<Void>(HttpStatus.OK);
     }
 
-    public ResponseEntity<Void> deletePet(@ApiParam(value = "Pet id to delete",required=true) @PathVariable("petId") Long petId,
-        @ApiParam(value = "" ) @RequestHeader(value="api_key", required=false) Optional<String> apiKey,
-        @RequestHeader(value = "Accept", required = false) String accept) throws Exception {
+    public ResponseEntity<Void> deletePet(@ApiParam(value = "Pet id to delete",required=true) @PathVariable("petId") Long petId,@ApiParam(value = "" ) @RequestHeader(value="api_key", required=false) Optional<String> apiKey) {
         // do some magic!
+        String accept = ((ServletRequestAttributes)RequestContextHolder.getRequestAttributes()).getRequest().getHeader("Accept");
         return new ResponseEntity<Void>(HttpStatus.OK);
     }
 
-    public ResponseEntity<List<Pet>> findPetsByStatus( @NotNull@ApiParam(value = "Status values that need to be considered for filter", required = true, allowableValues = "available, pending, sold") @Valid @RequestParam(value = "status", required = true) List<String> status,
-        @RequestHeader(value = "Accept", required = false) String accept) throws Exception {
+    public ResponseEntity<List<Pet>> findPetsByStatus(@NotNull @ApiParam(value = "Status values that need to be considered for filter", required = true, allowableValues = "available, pending, sold") @Valid @RequestParam(value = "status", required = true) List<String> status) {
         // do some magic!
-
+        String accept = ((ServletRequestAttributes)RequestContextHolder.getRequestAttributes()).getRequest().getHeader("Accept");
         if (accept != null && accept.contains("application/xml")) {
-            return new ResponseEntity<List<Pet>>(objectMapper.readValue("<Pet>  <id>123456789</id>  <name>doggie</name>  <photoUrls>    <photoUrls>aeiou</photoUrls>  </photoUrls>  <tags>  </tags>  <status>aeiou</status></Pet>", List.class), HttpStatus.OK);
+            try {
+                return new ResponseEntity<List<Pet>>(objectMapper.readValue("<Pet>  <id>123456789</id>  <name>doggie</name>  <photoUrls>    <photoUrls>aeiou</photoUrls>  </photoUrls>  <tags>  </tags>  <status>aeiou</status></Pet>", List.class), HttpStatus.NOT_IMPLEMENTED);
+            } catch (IOException e) {
+                log.error("Couldn't serialize response for content type application/xml", e);
+                return new ResponseEntity<List<Pet>>(HttpStatus.INTERNAL_SERVER_ERROR);
+            }
         }
 
-
         if (accept != null && accept.contains("application/json")) {
-            return new ResponseEntity<List<Pet>>(objectMapper.readValue("[ {  \"photoUrls\" : [ \"photoUrls\", \"photoUrls\" ],  \"name\" : \"doggie\",  \"id\" : 0,  \"category\" : {    \"name\" : \"name\",    \"id\" : 6  },  \"tags\" : [ {    \"name\" : \"name\",    \"id\" : 1  }, {    \"name\" : \"name\",    \"id\" : 1  } ],  \"status\" : \"available\"}, {  \"photoUrls\" : [ \"photoUrls\", \"photoUrls\" ],  \"name\" : \"doggie\",  \"id\" : 0,  \"category\" : {    \"name\" : \"name\",    \"id\" : 6  },  \"tags\" : [ {    \"name\" : \"name\",    \"id\" : 1  }, {    \"name\" : \"name\",    \"id\" : 1  } ],  \"status\" : \"available\"} ]", List.class), HttpStatus.OK);
+            try {
+                return new ResponseEntity<List<Pet>>(objectMapper.readValue("[ {  \"photoUrls\" : [ \"photoUrls\", \"photoUrls\" ],  \"name\" : \"doggie\",  \"id\" : 0,  \"category\" : {    \"name\" : \"name\",    \"id\" : 6  },  \"tags\" : [ {    \"name\" : \"name\",    \"id\" : 1  }, {    \"name\" : \"name\",    \"id\" : 1  } ],  \"status\" : \"available\"}, {  \"photoUrls\" : [ \"photoUrls\", \"photoUrls\" ],  \"name\" : \"doggie\",  \"id\" : 0,  \"category\" : {    \"name\" : \"name\",    \"id\" : 6  },  \"tags\" : [ {    \"name\" : \"name\",    \"id\" : 1  }, {    \"name\" : \"name\",    \"id\" : 1  } ],  \"status\" : \"available\"} ]", List.class), HttpStatus.NOT_IMPLEMENTED);
+            } catch (IOException e) {
+                log.error("Couldn't serialize response for content type application/json", e);
+                return new ResponseEntity<List<Pet>>(HttpStatus.INTERNAL_SERVER_ERROR);
+            }
         }
 
         return new ResponseEntity<List<Pet>>(HttpStatus.OK);
     }
 
-    public ResponseEntity<List<Pet>> findPetsByTags( @NotNull@ApiParam(value = "Tags to filter by", required = true) @Valid @RequestParam(value = "tags", required = true) List<String> tags,
-        @RequestHeader(value = "Accept", required = false) String accept) throws Exception {
+    public ResponseEntity<List<Pet>> findPetsByTags(@NotNull @ApiParam(value = "Tags to filter by", required = true) @Valid @RequestParam(value = "tags", required = true) List<String> tags) {
         // do some magic!
-
+        String accept = ((ServletRequestAttributes)RequestContextHolder.getRequestAttributes()).getRequest().getHeader("Accept");
         if (accept != null && accept.contains("application/xml")) {
-            return new ResponseEntity<List<Pet>>(objectMapper.readValue("<Pet>  <id>123456789</id>  <name>doggie</name>  <photoUrls>    <photoUrls>aeiou</photoUrls>  </photoUrls>  <tags>  </tags>  <status>aeiou</status></Pet>", List.class), HttpStatus.OK);
+            try {
+                return new ResponseEntity<List<Pet>>(objectMapper.readValue("<Pet>  <id>123456789</id>  <name>doggie</name>  <photoUrls>    <photoUrls>aeiou</photoUrls>  </photoUrls>  <tags>  </tags>  <status>aeiou</status></Pet>", List.class), HttpStatus.NOT_IMPLEMENTED);
+            } catch (IOException e) {
+                log.error("Couldn't serialize response for content type application/xml", e);
+                return new ResponseEntity<List<Pet>>(HttpStatus.INTERNAL_SERVER_ERROR);
+            }
         }
 
-
         if (accept != null && accept.contains("application/json")) {
-            return new ResponseEntity<List<Pet>>(objectMapper.readValue("[ {  \"photoUrls\" : [ \"photoUrls\", \"photoUrls\" ],  \"name\" : \"doggie\",  \"id\" : 0,  \"category\" : {    \"name\" : \"name\",    \"id\" : 6  },  \"tags\" : [ {    \"name\" : \"name\",    \"id\" : 1  }, {    \"name\" : \"name\",    \"id\" : 1  } ],  \"status\" : \"available\"}, {  \"photoUrls\" : [ \"photoUrls\", \"photoUrls\" ],  \"name\" : \"doggie\",  \"id\" : 0,  \"category\" : {    \"name\" : \"name\",    \"id\" : 6  },  \"tags\" : [ {    \"name\" : \"name\",    \"id\" : 1  }, {    \"name\" : \"name\",    \"id\" : 1  } ],  \"status\" : \"available\"} ]", List.class), HttpStatus.OK);
+            try {
+                return new ResponseEntity<List<Pet>>(objectMapper.readValue("[ {  \"photoUrls\" : [ \"photoUrls\", \"photoUrls\" ],  \"name\" : \"doggie\",  \"id\" : 0,  \"category\" : {    \"name\" : \"name\",    \"id\" : 6  },  \"tags\" : [ {    \"name\" : \"name\",    \"id\" : 1  }, {    \"name\" : \"name\",    \"id\" : 1  } ],  \"status\" : \"available\"}, {  \"photoUrls\" : [ \"photoUrls\", \"photoUrls\" ],  \"name\" : \"doggie\",  \"id\" : 0,  \"category\" : {    \"name\" : \"name\",    \"id\" : 6  },  \"tags\" : [ {    \"name\" : \"name\",    \"id\" : 1  }, {    \"name\" : \"name\",    \"id\" : 1  } ],  \"status\" : \"available\"} ]", List.class), HttpStatus.NOT_IMPLEMENTED);
+            } catch (IOException e) {
+                log.error("Couldn't serialize response for content type application/json", e);
+                return new ResponseEntity<List<Pet>>(HttpStatus.INTERNAL_SERVER_ERROR);
+            }
         }
 
         return new ResponseEntity<List<Pet>>(HttpStatus.OK);
     }
 
-    public ResponseEntity<Pet> getPetById(@ApiParam(value = "ID of pet to return",required=true) @PathVariable("petId") Long petId,
-        @RequestHeader(value = "Accept", required = false) String accept) throws Exception {
+    public ResponseEntity<Pet> getPetById(@ApiParam(value = "ID of pet to return",required=true) @PathVariable("petId") Long petId) {
         // do some magic!
-
+        String accept = ((ServletRequestAttributes)RequestContextHolder.getRequestAttributes()).getRequest().getHeader("Accept");
         if (accept != null && accept.contains("application/xml")) {
-            return new ResponseEntity<Pet>(objectMapper.readValue("<Pet>  <id>123456789</id>  <name>doggie</name>  <photoUrls>    <photoUrls>aeiou</photoUrls>  </photoUrls>  <tags>  </tags>  <status>aeiou</status></Pet>", Pet.class), HttpStatus.OK);
+            try {
+                return new ResponseEntity<Pet>(objectMapper.readValue("<Pet>  <id>123456789</id>  <name>doggie</name>  <photoUrls>    <photoUrls>aeiou</photoUrls>  </photoUrls>  <tags>  </tags>  <status>aeiou</status></Pet>", Pet.class), HttpStatus.NOT_IMPLEMENTED);
+            } catch (IOException e) {
+                log.error("Couldn't serialize response for content type application/xml", e);
+                return new ResponseEntity<Pet>(HttpStatus.INTERNAL_SERVER_ERROR);
+            }
         }
 
-
         if (accept != null && accept.contains("application/json")) {
-            return new ResponseEntity<Pet>(objectMapper.readValue("{  \"photoUrls\" : [ \"photoUrls\", \"photoUrls\" ],  \"name\" : \"doggie\",  \"id\" : 0,  \"category\" : {    \"name\" : \"name\",    \"id\" : 6  },  \"tags\" : [ {    \"name\" : \"name\",    \"id\" : 1  }, {    \"name\" : \"name\",    \"id\" : 1  } ],  \"status\" : \"available\"}", Pet.class), HttpStatus.OK);
+            try {
+                return new ResponseEntity<Pet>(objectMapper.readValue("{  \"photoUrls\" : [ \"photoUrls\", \"photoUrls\" ],  \"name\" : \"doggie\",  \"id\" : 0,  \"category\" : {    \"name\" : \"name\",    \"id\" : 6  },  \"tags\" : [ {    \"name\" : \"name\",    \"id\" : 1  }, {    \"name\" : \"name\",    \"id\" : 1  } ],  \"status\" : \"available\"}", Pet.class), HttpStatus.NOT_IMPLEMENTED);
+            } catch (IOException e) {
+                log.error("Couldn't serialize response for content type application/json", e);
+                return new ResponseEntity<Pet>(HttpStatus.INTERNAL_SERVER_ERROR);
+            }
         }
 
         return new ResponseEntity<Pet>(HttpStatus.OK);
     }
 
-    public ResponseEntity<Void> updatePet(@ApiParam(value = "Pet object that needs to be added to the store" ,required=true )  @Valid @RequestBody Pet body,
-        @RequestHeader(value = "Accept", required = false) String accept) throws Exception {
+    public ResponseEntity<Void> updatePet(@ApiParam(value = "Pet object that needs to be added to the store" ,required=true )  @Valid @RequestBody Pet body) {
         // do some magic!
+        String accept = ((ServletRequestAttributes)RequestContextHolder.getRequestAttributes()).getRequest().getHeader("Accept");
         return new ResponseEntity<Void>(HttpStatus.OK);
     }
 
-    public ResponseEntity<Void> updatePetWithForm(@ApiParam(value = "ID of pet that needs to be updated",required=true) @PathVariable("petId") Long petId,
-        @ApiParam(value = "Updated name of the pet") @RequestPart(value="name", required=false)  String name,
-        @ApiParam(value = "Updated status of the pet") @RequestPart(value="status", required=false)  String status,
-        @RequestHeader(value = "Accept", required = false) String accept) throws Exception {
+    public ResponseEntity<Void> updatePetWithForm(@ApiParam(value = "ID of pet that needs to be updated",required=true) @PathVariable("petId") Long petId,@ApiParam(value = "Updated name of the pet") @RequestPart(value="name", required=false)  String name,@ApiParam(value = "Updated status of the pet") @RequestPart(value="status", required=false)  String status) {
         // do some magic!
+        String accept = ((ServletRequestAttributes)RequestContextHolder.getRequestAttributes()).getRequest().getHeader("Accept");
         return new ResponseEntity<Void>(HttpStatus.OK);
     }
 
-    public ResponseEntity<ModelApiResponse> uploadFile(@ApiParam(value = "ID of pet to update",required=true) @PathVariable("petId") Long petId,
-        @ApiParam(value = "Additional data to pass to server") @RequestPart(value="additionalMetadata", required=false)  String additionalMetadata,
-        @ApiParam(value = "file detail") @Valid @RequestPart("file") MultipartFile file,
-        @RequestHeader(value = "Accept", required = false) String accept) throws Exception {
+    public ResponseEntity<ModelApiResponse> uploadFile(@ApiParam(value = "ID of pet to update",required=true) @PathVariable("petId") Long petId,@ApiParam(value = "Additional data to pass to server") @RequestPart(value="additionalMetadata", required=false)  String additionalMetadata,@ApiParam(value = "file detail") @Valid @RequestPart("file") MultipartFile file) {
         // do some magic!
-
+        String accept = ((ServletRequestAttributes)RequestContextHolder.getRequestAttributes()).getRequest().getHeader("Accept");
         if (accept != null && accept.contains("application/json")) {
-            return new ResponseEntity<ModelApiResponse>(objectMapper.readValue("{  \"code\" : 0,  \"type\" : \"type\",  \"message\" : \"message\"}", ModelApiResponse.class), HttpStatus.OK);
+            try {
+                return new ResponseEntity<ModelApiResponse>(objectMapper.readValue("{  \"code\" : 0,  \"type\" : \"type\",  \"message\" : \"message\"}", ModelApiResponse.class), HttpStatus.NOT_IMPLEMENTED);
+            } catch (IOException e) {
+                log.error("Couldn't serialize response for content type application/json", e);
+                return new ResponseEntity<ModelApiResponse>(HttpStatus.INTERNAL_SERVER_ERROR);
+            }
         }
 
         return new ResponseEntity<ModelApiResponse>(HttpStatus.OK);

--- a/samples/server/petstore/springboot-useoptional/src/main/java/io/swagger/api/StoreApi.java
+++ b/samples/server/petstore/springboot-useoptional/src/main/java/io/swagger/api/StoreApi.java
@@ -7,9 +7,9 @@ package io.swagger.api;
 
 import java.util.Map;
 import io.swagger.model.Order;
-
 import io.swagger.annotations.*;
 import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
@@ -18,13 +18,11 @@ import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.multipart.MultipartFile;
-import java.io.IOException;
 
+import javax.validation.Valid;
+import javax.validation.constraints.*;
 import java.util.List;
 import java.util.Optional;
-import org.springframework.validation.annotation.Validated;
-import javax.validation.constraints.*;
-import javax.validation.Valid;
 
 @Api(value = "store", description = "the store API")
 public interface StoreApi {

--- a/samples/server/petstore/springboot-useoptional/src/main/java/io/swagger/api/StoreApi.java
+++ b/samples/server/petstore/springboot-useoptional/src/main/java/io/swagger/api/StoreApi.java
@@ -36,7 +36,7 @@ public interface StoreApi {
     @RequestMapping(value = "/store/order/{order_id}",
         produces = { "application/xml", "application/json" }, 
         method = RequestMethod.DELETE)
-    ResponseEntity<Void> deleteOrder(@ApiParam(value = "ID of the order that needs to be deleted",required=true) @PathVariable("order_id") String orderId, @RequestHeader(value = "Accept", required = false) String accept) throws Exception;
+    ResponseEntity<Void> deleteOrder(@ApiParam(value = "ID of the order that needs to be deleted",required=true) @PathVariable("order_id") String orderId);
 
 
     @ApiOperation(value = "Returns pet inventories by status", nickname = "getInventory", notes = "Returns a map of status codes to quantities", response = Integer.class, responseContainer = "Map", authorizations = {
@@ -47,7 +47,7 @@ public interface StoreApi {
     @RequestMapping(value = "/store/inventory",
         produces = { "application/json" }, 
         method = RequestMethod.GET)
-    ResponseEntity<Map<String, Integer>> getInventory( @RequestHeader(value = "Accept", required = false) String accept) throws Exception;
+    ResponseEntity<Map<String, Integer>> getInventory();
 
 
     @ApiOperation(value = "Find purchase order by ID", nickname = "getOrderById", notes = "For valid response try integer IDs with value <= 5 or > 10. Other values will generated exceptions", response = Order.class, tags={ "store", })
@@ -58,7 +58,7 @@ public interface StoreApi {
     @RequestMapping(value = "/store/order/{order_id}",
         produces = { "application/xml", "application/json" }, 
         method = RequestMethod.GET)
-    ResponseEntity<Order> getOrderById( @Min(1) @Max(5)@ApiParam(value = "ID of pet that needs to be fetched",required=true) @PathVariable("order_id") Long orderId, @RequestHeader(value = "Accept", required = false) String accept) throws Exception;
+    ResponseEntity<Order> getOrderById(@Min(1) @Max(5) @ApiParam(value = "ID of pet that needs to be fetched",required=true) @PathVariable("order_id") Long orderId);
 
 
     @ApiOperation(value = "Place an order for a pet", nickname = "placeOrder", notes = "", response = Order.class, tags={ "store", })
@@ -68,6 +68,6 @@ public interface StoreApi {
     @RequestMapping(value = "/store/order",
         produces = { "application/xml", "application/json" }, 
         method = RequestMethod.POST)
-    ResponseEntity<Order> placeOrder(@ApiParam(value = "order placed for purchasing the pet" ,required=true )  @Valid @RequestBody Order body, @RequestHeader(value = "Accept", required = false) String accept) throws Exception;
+    ResponseEntity<Order> placeOrder(@ApiParam(value = "order placed for purchasing the pet" ,required=true )  @Valid @RequestBody Order body);
 
 }

--- a/samples/server/petstore/springboot-useoptional/src/main/java/io/swagger/api/StoreApiController.java
+++ b/samples/server/petstore/springboot-useoptional/src/main/java/io/swagger/api/StoreApiController.java
@@ -5,6 +5,8 @@ import io.swagger.model.Order;
 
 import io.swagger.annotations.*;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
@@ -13,6 +15,8 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RequestPart;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.util.List;
@@ -24,55 +28,79 @@ import javax.validation.Valid;
 
 @Controller
 public class StoreApiController implements StoreApi {
+
+    private final Logger log = LoggerFactory.getLogger(AnotherFakeApiController.class);
+
     private final ObjectMapper objectMapper;
 
     public StoreApiController(ObjectMapper objectMapper) {
         this.objectMapper = objectMapper;
     }
 
-    public ResponseEntity<Void> deleteOrder(@ApiParam(value = "ID of the order that needs to be deleted",required=true) @PathVariable("order_id") String orderId,
-        @RequestHeader(value = "Accept", required = false) String accept) throws Exception {
+    public ResponseEntity<Void> deleteOrder(@ApiParam(value = "ID of the order that needs to be deleted",required=true) @PathVariable("order_id") String orderId) {
         // do some magic!
+        String accept = ((ServletRequestAttributes)RequestContextHolder.getRequestAttributes()).getRequest().getHeader("Accept");
         return new ResponseEntity<Void>(HttpStatus.OK);
     }
 
-    public ResponseEntity<Map<String, Integer>> getInventory(@RequestHeader(value = "Accept", required = false) String accept) throws Exception {
+    public ResponseEntity<Map<String, Integer>> getInventory() {
         // do some magic!
-
+        String accept = ((ServletRequestAttributes)RequestContextHolder.getRequestAttributes()).getRequest().getHeader("Accept");
         if (accept != null && accept.contains("application/json")) {
-            return new ResponseEntity<Map<String, Integer>>(objectMapper.readValue("{  \"key\" : 0}", Map.class), HttpStatus.OK);
+            try {
+                return new ResponseEntity<Map<String, Integer>>(objectMapper.readValue("{  \"key\" : 0}", Map.class), HttpStatus.NOT_IMPLEMENTED);
+            } catch (IOException e) {
+                log.error("Couldn't serialize response for content type application/json", e);
+                return new ResponseEntity<Map<String, Integer>>(HttpStatus.INTERNAL_SERVER_ERROR);
+            }
         }
 
         return new ResponseEntity<Map<String, Integer>>(HttpStatus.OK);
     }
 
-    public ResponseEntity<Order> getOrderById( @Min(1) @Max(5)@ApiParam(value = "ID of pet that needs to be fetched",required=true) @PathVariable("order_id") Long orderId,
-        @RequestHeader(value = "Accept", required = false) String accept) throws Exception {
+    public ResponseEntity<Order> getOrderById(@Min(1) @Max(5) @ApiParam(value = "ID of pet that needs to be fetched",required=true) @PathVariable("order_id") Long orderId) {
         // do some magic!
-
+        String accept = ((ServletRequestAttributes)RequestContextHolder.getRequestAttributes()).getRequest().getHeader("Accept");
         if (accept != null && accept.contains("application/xml")) {
-            return new ResponseEntity<Order>(objectMapper.readValue("<Order>  <id>123456789</id>  <petId>123456789</petId>  <quantity>123</quantity>  <shipDate>2000-01-23T04:56:07.000Z</shipDate>  <status>aeiou</status>  <complete>true</complete></Order>", Order.class), HttpStatus.OK);
+            try {
+                return new ResponseEntity<Order>(objectMapper.readValue("<Order>  <id>123456789</id>  <petId>123456789</petId>  <quantity>123</quantity>  <shipDate>2000-01-23T04:56:07.000Z</shipDate>  <status>aeiou</status>  <complete>true</complete></Order>", Order.class), HttpStatus.NOT_IMPLEMENTED);
+            } catch (IOException e) {
+                log.error("Couldn't serialize response for content type application/xml", e);
+                return new ResponseEntity<Order>(HttpStatus.INTERNAL_SERVER_ERROR);
+            }
         }
 
-
         if (accept != null && accept.contains("application/json")) {
-            return new ResponseEntity<Order>(objectMapper.readValue("{  \"petId\" : 6,  \"quantity\" : 1,  \"id\" : 0,  \"shipDate\" : \"2000-01-23T04:56:07.000+00:00\",  \"complete\" : false,  \"status\" : \"placed\"}", Order.class), HttpStatus.OK);
+            try {
+                return new ResponseEntity<Order>(objectMapper.readValue("{  \"petId\" : 6,  \"quantity\" : 1,  \"id\" : 0,  \"shipDate\" : \"2000-01-23T04:56:07.000+00:00\",  \"complete\" : false,  \"status\" : \"placed\"}", Order.class), HttpStatus.NOT_IMPLEMENTED);
+            } catch (IOException e) {
+                log.error("Couldn't serialize response for content type application/json", e);
+                return new ResponseEntity<Order>(HttpStatus.INTERNAL_SERVER_ERROR);
+            }
         }
 
         return new ResponseEntity<Order>(HttpStatus.OK);
     }
 
-    public ResponseEntity<Order> placeOrder(@ApiParam(value = "order placed for purchasing the pet" ,required=true )  @Valid @RequestBody Order body,
-        @RequestHeader(value = "Accept", required = false) String accept) throws Exception {
+    public ResponseEntity<Order> placeOrder(@ApiParam(value = "order placed for purchasing the pet" ,required=true )  @Valid @RequestBody Order body) {
         // do some magic!
-
+        String accept = ((ServletRequestAttributes)RequestContextHolder.getRequestAttributes()).getRequest().getHeader("Accept");
         if (accept != null && accept.contains("application/xml")) {
-            return new ResponseEntity<Order>(objectMapper.readValue("<Order>  <id>123456789</id>  <petId>123456789</petId>  <quantity>123</quantity>  <shipDate>2000-01-23T04:56:07.000Z</shipDate>  <status>aeiou</status>  <complete>true</complete></Order>", Order.class), HttpStatus.OK);
+            try {
+                return new ResponseEntity<Order>(objectMapper.readValue("<Order>  <id>123456789</id>  <petId>123456789</petId>  <quantity>123</quantity>  <shipDate>2000-01-23T04:56:07.000Z</shipDate>  <status>aeiou</status>  <complete>true</complete></Order>", Order.class), HttpStatus.NOT_IMPLEMENTED);
+            } catch (IOException e) {
+                log.error("Couldn't serialize response for content type application/xml", e);
+                return new ResponseEntity<Order>(HttpStatus.INTERNAL_SERVER_ERROR);
+            }
         }
 
-
         if (accept != null && accept.contains("application/json")) {
-            return new ResponseEntity<Order>(objectMapper.readValue("{  \"petId\" : 6,  \"quantity\" : 1,  \"id\" : 0,  \"shipDate\" : \"2000-01-23T04:56:07.000+00:00\",  \"complete\" : false,  \"status\" : \"placed\"}", Order.class), HttpStatus.OK);
+            try {
+                return new ResponseEntity<Order>(objectMapper.readValue("{  \"petId\" : 6,  \"quantity\" : 1,  \"id\" : 0,  \"shipDate\" : \"2000-01-23T04:56:07.000+00:00\",  \"complete\" : false,  \"status\" : \"placed\"}", Order.class), HttpStatus.NOT_IMPLEMENTED);
+            } catch (IOException e) {
+                log.error("Couldn't serialize response for content type application/json", e);
+                return new ResponseEntity<Order>(HttpStatus.INTERNAL_SERVER_ERROR);
+            }
         }
 
         return new ResponseEntity<Order>(HttpStatus.OK);

--- a/samples/server/petstore/springboot-useoptional/src/main/java/io/swagger/api/StoreApiController.java
+++ b/samples/server/petstore/springboot-useoptional/src/main/java/io/swagger/api/StoreApiController.java
@@ -2,9 +2,8 @@ package io.swagger.api;
 
 import java.util.Map;
 import io.swagger.model.Order;
-
+import com.fasterxml.jackson.databind.ObjectMapper;
 import io.swagger.annotations.*;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpStatus;
@@ -15,17 +14,14 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RequestPart;
-import org.springframework.web.context.request.RequestContextHolder;
-import org.springframework.web.context.request.ServletRequestAttributes;
 import org.springframework.web.multipart.MultipartFile;
 
-import java.util.List;
-import java.util.Optional;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import java.io.IOException;
-import javax.servlet.http.HttpServletRequest;
 import javax.validation.constraints.*;
 import javax.validation.Valid;
+import javax.servlet.http.HttpServletRequest;
+import java.util.Optional;
+import java.io.IOException;
+import java.util.List;
 
 @Controller
 public class StoreApiController implements StoreApi {
@@ -43,13 +39,11 @@ public class StoreApiController implements StoreApi {
     }
 
     public ResponseEntity<Void> deleteOrder(@ApiParam(value = "ID of the order that needs to be deleted",required=true) @PathVariable("order_id") String orderId) {
-        // do some magic!
         String accept = request.getHeader("Accept");
-        return new ResponseEntity<Void>(HttpStatus.OK);
+        return new ResponseEntity<Void>(HttpStatus.NOT_IMPLEMENTED);
     }
 
     public ResponseEntity<Map<String, Integer>> getInventory() {
-        // do some magic!
         String accept = request.getHeader("Accept");
         if (accept != null && accept.contains("application/json")) {
             try {
@@ -60,11 +54,10 @@ public class StoreApiController implements StoreApi {
             }
         }
 
-        return new ResponseEntity<Map<String, Integer>>(HttpStatus.OK);
+        return new ResponseEntity<Map<String, Integer>>(HttpStatus.NOT_IMPLEMENTED);
     }
 
     public ResponseEntity<Order> getOrderById(@Min(1) @Max(5) @ApiParam(value = "ID of pet that needs to be fetched",required=true) @PathVariable("order_id") Long orderId) {
-        // do some magic!
         String accept = request.getHeader("Accept");
         if (accept != null && accept.contains("application/xml")) {
             try {
@@ -84,11 +77,10 @@ public class StoreApiController implements StoreApi {
             }
         }
 
-        return new ResponseEntity<Order>(HttpStatus.OK);
+        return new ResponseEntity<Order>(HttpStatus.NOT_IMPLEMENTED);
     }
 
     public ResponseEntity<Order> placeOrder(@ApiParam(value = "order placed for purchasing the pet" ,required=true )  @Valid @RequestBody Order body) {
-        // do some magic!
         String accept = request.getHeader("Accept");
         if (accept != null && accept.contains("application/xml")) {
             try {
@@ -108,7 +100,7 @@ public class StoreApiController implements StoreApi {
             }
         }
 
-        return new ResponseEntity<Order>(HttpStatus.OK);
+        return new ResponseEntity<Order>(HttpStatus.NOT_IMPLEMENTED);
     }
 
 }

--- a/samples/server/petstore/springboot-useoptional/src/main/java/io/swagger/api/StoreApiController.java
+++ b/samples/server/petstore/springboot-useoptional/src/main/java/io/swagger/api/StoreApiController.java
@@ -23,29 +23,34 @@ import java.util.List;
 import java.util.Optional;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.IOException;
+import javax.servlet.http.HttpServletRequest;
 import javax.validation.constraints.*;
 import javax.validation.Valid;
 
 @Controller
 public class StoreApiController implements StoreApi {
 
-    private final Logger log = LoggerFactory.getLogger(AnotherFakeApiController.class);
+    private static final Logger log = LoggerFactory.getLogger(StoreApiController.class);
 
     private final ObjectMapper objectMapper;
 
+    @org.springframework.beans.factory.annotation.Autowired
+    private HttpServletRequest request;
+
+    @org.springframework.beans.factory.annotation.Autowired
     public StoreApiController(ObjectMapper objectMapper) {
         this.objectMapper = objectMapper;
     }
 
     public ResponseEntity<Void> deleteOrder(@ApiParam(value = "ID of the order that needs to be deleted",required=true) @PathVariable("order_id") String orderId) {
         // do some magic!
-        String accept = ((ServletRequestAttributes)RequestContextHolder.getRequestAttributes()).getRequest().getHeader("Accept");
+        String accept = request.getHeader("Accept");
         return new ResponseEntity<Void>(HttpStatus.OK);
     }
 
     public ResponseEntity<Map<String, Integer>> getInventory() {
         // do some magic!
-        String accept = ((ServletRequestAttributes)RequestContextHolder.getRequestAttributes()).getRequest().getHeader("Accept");
+        String accept = request.getHeader("Accept");
         if (accept != null && accept.contains("application/json")) {
             try {
                 return new ResponseEntity<Map<String, Integer>>(objectMapper.readValue("{  \"key\" : 0}", Map.class), HttpStatus.NOT_IMPLEMENTED);
@@ -60,7 +65,7 @@ public class StoreApiController implements StoreApi {
 
     public ResponseEntity<Order> getOrderById(@Min(1) @Max(5) @ApiParam(value = "ID of pet that needs to be fetched",required=true) @PathVariable("order_id") Long orderId) {
         // do some magic!
-        String accept = ((ServletRequestAttributes)RequestContextHolder.getRequestAttributes()).getRequest().getHeader("Accept");
+        String accept = request.getHeader("Accept");
         if (accept != null && accept.contains("application/xml")) {
             try {
                 return new ResponseEntity<Order>(objectMapper.readValue("<Order>  <id>123456789</id>  <petId>123456789</petId>  <quantity>123</quantity>  <shipDate>2000-01-23T04:56:07.000Z</shipDate>  <status>aeiou</status>  <complete>true</complete></Order>", Order.class), HttpStatus.NOT_IMPLEMENTED);
@@ -84,7 +89,7 @@ public class StoreApiController implements StoreApi {
 
     public ResponseEntity<Order> placeOrder(@ApiParam(value = "order placed for purchasing the pet" ,required=true )  @Valid @RequestBody Order body) {
         // do some magic!
-        String accept = ((ServletRequestAttributes)RequestContextHolder.getRequestAttributes()).getRequest().getHeader("Accept");
+        String accept = request.getHeader("Accept");
         if (accept != null && accept.contains("application/xml")) {
             try {
                 return new ResponseEntity<Order>(objectMapper.readValue("<Order>  <id>123456789</id>  <petId>123456789</petId>  <quantity>123</quantity>  <shipDate>2000-01-23T04:56:07.000Z</shipDate>  <status>aeiou</status>  <complete>true</complete></Order>", Order.class), HttpStatus.NOT_IMPLEMENTED);

--- a/samples/server/petstore/springboot-useoptional/src/main/java/io/swagger/api/StoreApiController.java
+++ b/samples/server/petstore/springboot-useoptional/src/main/java/io/swagger/api/StoreApiController.java
@@ -34,12 +34,12 @@ public class StoreApiController implements StoreApi {
 
     private final ObjectMapper objectMapper;
 
-    @org.springframework.beans.factory.annotation.Autowired
-    private HttpServletRequest request;
+    private final HttpServletRequest request;
 
     @org.springframework.beans.factory.annotation.Autowired
-    public StoreApiController(ObjectMapper objectMapper) {
+    public StoreApiController(ObjectMapper objectMapper, HttpServletRequest request) {
         this.objectMapper = objectMapper;
+        this.request = request;
     }
 
     public ResponseEntity<Void> deleteOrder(@ApiParam(value = "ID of the order that needs to be deleted",required=true) @PathVariable("order_id") String orderId) {

--- a/samples/server/petstore/springboot-useoptional/src/main/java/io/swagger/api/UserApi.java
+++ b/samples/server/petstore/springboot-useoptional/src/main/java/io/swagger/api/UserApi.java
@@ -7,9 +7,9 @@ package io.swagger.api;
 
 import java.util.List;
 import io.swagger.model.User;
-
 import io.swagger.annotations.*;
 import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
@@ -18,13 +18,11 @@ import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.multipart.MultipartFile;
-import java.io.IOException;
 
+import javax.validation.Valid;
+import javax.validation.constraints.*;
 import java.util.List;
 import java.util.Optional;
-import org.springframework.validation.annotation.Validated;
-import javax.validation.constraints.*;
-import javax.validation.Valid;
 
 @Api(value = "user", description = "the user API")
 public interface UserApi {

--- a/samples/server/petstore/springboot-useoptional/src/main/java/io/swagger/api/UserApi.java
+++ b/samples/server/petstore/springboot-useoptional/src/main/java/io/swagger/api/UserApi.java
@@ -35,7 +35,7 @@ public interface UserApi {
     @RequestMapping(value = "/user",
         produces = { "application/xml", "application/json" }, 
         method = RequestMethod.POST)
-    ResponseEntity<Void> createUser(@ApiParam(value = "Created user object" ,required=true )  @Valid @RequestBody User body, @RequestHeader(value = "Accept", required = false) String accept) throws Exception;
+    ResponseEntity<Void> createUser(@ApiParam(value = "Created user object" ,required=true )  @Valid @RequestBody User body);
 
 
     @ApiOperation(value = "Creates list of users with given input array", nickname = "createUsersWithArrayInput", notes = "", tags={ "user", })
@@ -44,7 +44,7 @@ public interface UserApi {
     @RequestMapping(value = "/user/createWithArray",
         produces = { "application/xml", "application/json" }, 
         method = RequestMethod.POST)
-    ResponseEntity<Void> createUsersWithArrayInput(@ApiParam(value = "List of user object" ,required=true )  @Valid @RequestBody List<User> body, @RequestHeader(value = "Accept", required = false) String accept) throws Exception;
+    ResponseEntity<Void> createUsersWithArrayInput(@ApiParam(value = "List of user object" ,required=true )  @Valid @RequestBody List<User> body);
 
 
     @ApiOperation(value = "Creates list of users with given input array", nickname = "createUsersWithListInput", notes = "", tags={ "user", })
@@ -53,7 +53,7 @@ public interface UserApi {
     @RequestMapping(value = "/user/createWithList",
         produces = { "application/xml", "application/json" }, 
         method = RequestMethod.POST)
-    ResponseEntity<Void> createUsersWithListInput(@ApiParam(value = "List of user object" ,required=true )  @Valid @RequestBody List<User> body, @RequestHeader(value = "Accept", required = false) String accept) throws Exception;
+    ResponseEntity<Void> createUsersWithListInput(@ApiParam(value = "List of user object" ,required=true )  @Valid @RequestBody List<User> body);
 
 
     @ApiOperation(value = "Delete user", nickname = "deleteUser", notes = "This can only be done by the logged in user.", tags={ "user", })
@@ -63,7 +63,7 @@ public interface UserApi {
     @RequestMapping(value = "/user/{username}",
         produces = { "application/xml", "application/json" }, 
         method = RequestMethod.DELETE)
-    ResponseEntity<Void> deleteUser(@ApiParam(value = "The name that needs to be deleted",required=true) @PathVariable("username") String username, @RequestHeader(value = "Accept", required = false) String accept) throws Exception;
+    ResponseEntity<Void> deleteUser(@ApiParam(value = "The name that needs to be deleted",required=true) @PathVariable("username") String username);
 
 
     @ApiOperation(value = "Get user by user name", nickname = "getUserByName", notes = "", response = User.class, tags={ "user", })
@@ -74,7 +74,7 @@ public interface UserApi {
     @RequestMapping(value = "/user/{username}",
         produces = { "application/xml", "application/json" }, 
         method = RequestMethod.GET)
-    ResponseEntity<User> getUserByName(@ApiParam(value = "The name that needs to be fetched. Use user1 for testing. ",required=true) @PathVariable("username") String username, @RequestHeader(value = "Accept", required = false) String accept) throws Exception;
+    ResponseEntity<User> getUserByName(@ApiParam(value = "The name that needs to be fetched. Use user1 for testing. ",required=true) @PathVariable("username") String username);
 
 
     @ApiOperation(value = "Logs user into the system", nickname = "loginUser", notes = "", response = String.class, tags={ "user", })
@@ -84,7 +84,7 @@ public interface UserApi {
     @RequestMapping(value = "/user/login",
         produces = { "application/xml", "application/json" }, 
         method = RequestMethod.GET)
-    ResponseEntity<String> loginUser( @NotNull@ApiParam(value = "The user name for login", required = true) @Valid @RequestParam(value = "username", required = true) String username, @NotNull@ApiParam(value = "The password for login in clear text", required = true) @Valid @RequestParam(value = "password", required = true) String password, @RequestHeader(value = "Accept", required = false) String accept) throws Exception;
+    ResponseEntity<String> loginUser(@NotNull @ApiParam(value = "The user name for login", required = true) @Valid @RequestParam(value = "username", required = true) String username,@NotNull @ApiParam(value = "The password for login in clear text", required = true) @Valid @RequestParam(value = "password", required = true) String password);
 
 
     @ApiOperation(value = "Logs out current logged in user session", nickname = "logoutUser", notes = "", tags={ "user", })
@@ -93,7 +93,7 @@ public interface UserApi {
     @RequestMapping(value = "/user/logout",
         produces = { "application/xml", "application/json" }, 
         method = RequestMethod.GET)
-    ResponseEntity<Void> logoutUser( @RequestHeader(value = "Accept", required = false) String accept) throws Exception;
+    ResponseEntity<Void> logoutUser();
 
 
     @ApiOperation(value = "Updated user", nickname = "updateUser", notes = "This can only be done by the logged in user.", tags={ "user", })
@@ -103,6 +103,6 @@ public interface UserApi {
     @RequestMapping(value = "/user/{username}",
         produces = { "application/xml", "application/json" }, 
         method = RequestMethod.PUT)
-    ResponseEntity<Void> updateUser(@ApiParam(value = "name that need to be deleted",required=true) @PathVariable("username") String username,@ApiParam(value = "Updated user object" ,required=true )  @Valid @RequestBody User body, @RequestHeader(value = "Accept", required = false) String accept) throws Exception;
+    ResponseEntity<Void> updateUser(@ApiParam(value = "name that need to be deleted",required=true) @PathVariable("username") String username,@ApiParam(value = "Updated user object" ,required=true )  @Valid @RequestBody User body);
 
 }

--- a/samples/server/petstore/springboot-useoptional/src/main/java/io/swagger/api/UserApiController.java
+++ b/samples/server/petstore/springboot-useoptional/src/main/java/io/swagger/api/UserApiController.java
@@ -34,12 +34,12 @@ public class UserApiController implements UserApi {
 
     private final ObjectMapper objectMapper;
 
-    @org.springframework.beans.factory.annotation.Autowired
-    private HttpServletRequest request;
+    private final HttpServletRequest request;
 
     @org.springframework.beans.factory.annotation.Autowired
-    public UserApiController(ObjectMapper objectMapper) {
+    public UserApiController(ObjectMapper objectMapper, HttpServletRequest request) {
         this.objectMapper = objectMapper;
+        this.request = request;
     }
 
     public ResponseEntity<Void> createUser(@ApiParam(value = "Created user object" ,required=true )  @Valid @RequestBody User body) {

--- a/samples/server/petstore/springboot-useoptional/src/main/java/io/swagger/api/UserApiController.java
+++ b/samples/server/petstore/springboot-useoptional/src/main/java/io/swagger/api/UserApiController.java
@@ -2,9 +2,8 @@ package io.swagger.api;
 
 import java.util.List;
 import io.swagger.model.User;
-
+import com.fasterxml.jackson.databind.ObjectMapper;
 import io.swagger.annotations.*;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpStatus;
@@ -15,17 +14,14 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RequestPart;
-import org.springframework.web.context.request.RequestContextHolder;
-import org.springframework.web.context.request.ServletRequestAttributes;
 import org.springframework.web.multipart.MultipartFile;
 
-import java.util.List;
-import java.util.Optional;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import java.io.IOException;
-import javax.servlet.http.HttpServletRequest;
 import javax.validation.constraints.*;
 import javax.validation.Valid;
+import javax.servlet.http.HttpServletRequest;
+import java.util.Optional;
+import java.io.IOException;
+import java.util.List;
 
 @Controller
 public class UserApiController implements UserApi {
@@ -43,31 +39,26 @@ public class UserApiController implements UserApi {
     }
 
     public ResponseEntity<Void> createUser(@ApiParam(value = "Created user object" ,required=true )  @Valid @RequestBody User body) {
-        // do some magic!
         String accept = request.getHeader("Accept");
-        return new ResponseEntity<Void>(HttpStatus.OK);
+        return new ResponseEntity<Void>(HttpStatus.NOT_IMPLEMENTED);
     }
 
     public ResponseEntity<Void> createUsersWithArrayInput(@ApiParam(value = "List of user object" ,required=true )  @Valid @RequestBody List<User> body) {
-        // do some magic!
         String accept = request.getHeader("Accept");
-        return new ResponseEntity<Void>(HttpStatus.OK);
+        return new ResponseEntity<Void>(HttpStatus.NOT_IMPLEMENTED);
     }
 
     public ResponseEntity<Void> createUsersWithListInput(@ApiParam(value = "List of user object" ,required=true )  @Valid @RequestBody List<User> body) {
-        // do some magic!
         String accept = request.getHeader("Accept");
-        return new ResponseEntity<Void>(HttpStatus.OK);
+        return new ResponseEntity<Void>(HttpStatus.NOT_IMPLEMENTED);
     }
 
     public ResponseEntity<Void> deleteUser(@ApiParam(value = "The name that needs to be deleted",required=true) @PathVariable("username") String username) {
-        // do some magic!
         String accept = request.getHeader("Accept");
-        return new ResponseEntity<Void>(HttpStatus.OK);
+        return new ResponseEntity<Void>(HttpStatus.NOT_IMPLEMENTED);
     }
 
     public ResponseEntity<User> getUserByName(@ApiParam(value = "The name that needs to be fetched. Use user1 for testing. ",required=true) @PathVariable("username") String username) {
-        // do some magic!
         String accept = request.getHeader("Accept");
         if (accept != null && accept.contains("application/xml")) {
             try {
@@ -87,11 +78,10 @@ public class UserApiController implements UserApi {
             }
         }
 
-        return new ResponseEntity<User>(HttpStatus.OK);
+        return new ResponseEntity<User>(HttpStatus.NOT_IMPLEMENTED);
     }
 
     public ResponseEntity<String> loginUser(@NotNull @ApiParam(value = "The user name for login", required = true) @Valid @RequestParam(value = "username", required = true) String username,@NotNull @ApiParam(value = "The password for login in clear text", required = true) @Valid @RequestParam(value = "password", required = true) String password) {
-        // do some magic!
         String accept = request.getHeader("Accept");
         if (accept != null && accept.contains("application/xml")) {
             try {
@@ -111,19 +101,17 @@ public class UserApiController implements UserApi {
             }
         }
 
-        return new ResponseEntity<String>(HttpStatus.OK);
+        return new ResponseEntity<String>(HttpStatus.NOT_IMPLEMENTED);
     }
 
     public ResponseEntity<Void> logoutUser() {
-        // do some magic!
         String accept = request.getHeader("Accept");
-        return new ResponseEntity<Void>(HttpStatus.OK);
+        return new ResponseEntity<Void>(HttpStatus.NOT_IMPLEMENTED);
     }
 
     public ResponseEntity<Void> updateUser(@ApiParam(value = "name that need to be deleted",required=true) @PathVariable("username") String username,@ApiParam(value = "Updated user object" ,required=true )  @Valid @RequestBody User body) {
-        // do some magic!
         String accept = request.getHeader("Accept");
-        return new ResponseEntity<Void>(HttpStatus.OK);
+        return new ResponseEntity<Void>(HttpStatus.NOT_IMPLEMENTED);
     }
 
 }

--- a/samples/server/petstore/springboot-useoptional/src/main/java/io/swagger/api/UserApiController.java
+++ b/samples/server/petstore/springboot-useoptional/src/main/java/io/swagger/api/UserApiController.java
@@ -5,6 +5,8 @@ import io.swagger.model.User;
 
 import io.swagger.annotations.*;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
@@ -13,6 +15,8 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RequestPart;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.util.List;
@@ -24,78 +28,96 @@ import javax.validation.Valid;
 
 @Controller
 public class UserApiController implements UserApi {
+
+    private final Logger log = LoggerFactory.getLogger(AnotherFakeApiController.class);
+
     private final ObjectMapper objectMapper;
 
     public UserApiController(ObjectMapper objectMapper) {
         this.objectMapper = objectMapper;
     }
 
-    public ResponseEntity<Void> createUser(@ApiParam(value = "Created user object" ,required=true )  @Valid @RequestBody User body,
-        @RequestHeader(value = "Accept", required = false) String accept) throws Exception {
+    public ResponseEntity<Void> createUser(@ApiParam(value = "Created user object" ,required=true )  @Valid @RequestBody User body) {
         // do some magic!
+        String accept = ((ServletRequestAttributes)RequestContextHolder.getRequestAttributes()).getRequest().getHeader("Accept");
         return new ResponseEntity<Void>(HttpStatus.OK);
     }
 
-    public ResponseEntity<Void> createUsersWithArrayInput(@ApiParam(value = "List of user object" ,required=true )  @Valid @RequestBody List<User> body,
-        @RequestHeader(value = "Accept", required = false) String accept) throws Exception {
+    public ResponseEntity<Void> createUsersWithArrayInput(@ApiParam(value = "List of user object" ,required=true )  @Valid @RequestBody List<User> body) {
         // do some magic!
+        String accept = ((ServletRequestAttributes)RequestContextHolder.getRequestAttributes()).getRequest().getHeader("Accept");
         return new ResponseEntity<Void>(HttpStatus.OK);
     }
 
-    public ResponseEntity<Void> createUsersWithListInput(@ApiParam(value = "List of user object" ,required=true )  @Valid @RequestBody List<User> body,
-        @RequestHeader(value = "Accept", required = false) String accept) throws Exception {
+    public ResponseEntity<Void> createUsersWithListInput(@ApiParam(value = "List of user object" ,required=true )  @Valid @RequestBody List<User> body) {
         // do some magic!
+        String accept = ((ServletRequestAttributes)RequestContextHolder.getRequestAttributes()).getRequest().getHeader("Accept");
         return new ResponseEntity<Void>(HttpStatus.OK);
     }
 
-    public ResponseEntity<Void> deleteUser(@ApiParam(value = "The name that needs to be deleted",required=true) @PathVariable("username") String username,
-        @RequestHeader(value = "Accept", required = false) String accept) throws Exception {
+    public ResponseEntity<Void> deleteUser(@ApiParam(value = "The name that needs to be deleted",required=true) @PathVariable("username") String username) {
         // do some magic!
+        String accept = ((ServletRequestAttributes)RequestContextHolder.getRequestAttributes()).getRequest().getHeader("Accept");
         return new ResponseEntity<Void>(HttpStatus.OK);
     }
 
-    public ResponseEntity<User> getUserByName(@ApiParam(value = "The name that needs to be fetched. Use user1 for testing. ",required=true) @PathVariable("username") String username,
-        @RequestHeader(value = "Accept", required = false) String accept) throws Exception {
+    public ResponseEntity<User> getUserByName(@ApiParam(value = "The name that needs to be fetched. Use user1 for testing. ",required=true) @PathVariable("username") String username) {
         // do some magic!
-
+        String accept = ((ServletRequestAttributes)RequestContextHolder.getRequestAttributes()).getRequest().getHeader("Accept");
         if (accept != null && accept.contains("application/xml")) {
-            return new ResponseEntity<User>(objectMapper.readValue("<User>  <id>123456789</id>  <username>aeiou</username>  <firstName>aeiou</firstName>  <lastName>aeiou</lastName>  <email>aeiou</email>  <password>aeiou</password>  <phone>aeiou</phone>  <userStatus>123</userStatus></User>", User.class), HttpStatus.OK);
+            try {
+                return new ResponseEntity<User>(objectMapper.readValue("<User>  <id>123456789</id>  <username>aeiou</username>  <firstName>aeiou</firstName>  <lastName>aeiou</lastName>  <email>aeiou</email>  <password>aeiou</password>  <phone>aeiou</phone>  <userStatus>123</userStatus></User>", User.class), HttpStatus.NOT_IMPLEMENTED);
+            } catch (IOException e) {
+                log.error("Couldn't serialize response for content type application/xml", e);
+                return new ResponseEntity<User>(HttpStatus.INTERNAL_SERVER_ERROR);
+            }
         }
 
-
         if (accept != null && accept.contains("application/json")) {
-            return new ResponseEntity<User>(objectMapper.readValue("{  \"firstName\" : \"firstName\",  \"lastName\" : \"lastName\",  \"password\" : \"password\",  \"userStatus\" : 6,  \"phone\" : \"phone\",  \"id\" : 0,  \"email\" : \"email\",  \"username\" : \"username\"}", User.class), HttpStatus.OK);
+            try {
+                return new ResponseEntity<User>(objectMapper.readValue("{  \"firstName\" : \"firstName\",  \"lastName\" : \"lastName\",  \"password\" : \"password\",  \"userStatus\" : 6,  \"phone\" : \"phone\",  \"id\" : 0,  \"email\" : \"email\",  \"username\" : \"username\"}", User.class), HttpStatus.NOT_IMPLEMENTED);
+            } catch (IOException e) {
+                log.error("Couldn't serialize response for content type application/json", e);
+                return new ResponseEntity<User>(HttpStatus.INTERNAL_SERVER_ERROR);
+            }
         }
 
         return new ResponseEntity<User>(HttpStatus.OK);
     }
 
-    public ResponseEntity<String> loginUser( @NotNull@ApiParam(value = "The user name for login", required = true) @Valid @RequestParam(value = "username", required = true) String username,
-         @NotNull@ApiParam(value = "The password for login in clear text", required = true) @Valid @RequestParam(value = "password", required = true) String password,
-        @RequestHeader(value = "Accept", required = false) String accept) throws Exception {
+    public ResponseEntity<String> loginUser(@NotNull @ApiParam(value = "The user name for login", required = true) @Valid @RequestParam(value = "username", required = true) String username,@NotNull @ApiParam(value = "The password for login in clear text", required = true) @Valid @RequestParam(value = "password", required = true) String password) {
         // do some magic!
-
+        String accept = ((ServletRequestAttributes)RequestContextHolder.getRequestAttributes()).getRequest().getHeader("Accept");
         if (accept != null && accept.contains("application/xml")) {
-            return new ResponseEntity<String>(objectMapper.readValue("aeiou", String.class), HttpStatus.OK);
+            try {
+                return new ResponseEntity<String>(objectMapper.readValue("aeiou", String.class), HttpStatus.NOT_IMPLEMENTED);
+            } catch (IOException e) {
+                log.error("Couldn't serialize response for content type application/xml", e);
+                return new ResponseEntity<String>(HttpStatus.INTERNAL_SERVER_ERROR);
+            }
         }
 
-
         if (accept != null && accept.contains("application/json")) {
-            return new ResponseEntity<String>(objectMapper.readValue("\"\"", String.class), HttpStatus.OK);
+            try {
+                return new ResponseEntity<String>(objectMapper.readValue("\"\"", String.class), HttpStatus.NOT_IMPLEMENTED);
+            } catch (IOException e) {
+                log.error("Couldn't serialize response for content type application/json", e);
+                return new ResponseEntity<String>(HttpStatus.INTERNAL_SERVER_ERROR);
+            }
         }
 
         return new ResponseEntity<String>(HttpStatus.OK);
     }
 
-    public ResponseEntity<Void> logoutUser(@RequestHeader(value = "Accept", required = false) String accept) throws Exception {
+    public ResponseEntity<Void> logoutUser() {
         // do some magic!
+        String accept = ((ServletRequestAttributes)RequestContextHolder.getRequestAttributes()).getRequest().getHeader("Accept");
         return new ResponseEntity<Void>(HttpStatus.OK);
     }
 
-    public ResponseEntity<Void> updateUser(@ApiParam(value = "name that need to be deleted",required=true) @PathVariable("username") String username,
-        @ApiParam(value = "Updated user object" ,required=true )  @Valid @RequestBody User body,
-        @RequestHeader(value = "Accept", required = false) String accept) throws Exception {
+    public ResponseEntity<Void> updateUser(@ApiParam(value = "name that need to be deleted",required=true) @PathVariable("username") String username,@ApiParam(value = "Updated user object" ,required=true )  @Valid @RequestBody User body) {
         // do some magic!
+        String accept = ((ServletRequestAttributes)RequestContextHolder.getRequestAttributes()).getRequest().getHeader("Accept");
         return new ResponseEntity<Void>(HttpStatus.OK);
     }
 

--- a/samples/server/petstore/springboot-useoptional/src/main/java/io/swagger/api/UserApiController.java
+++ b/samples/server/petstore/springboot-useoptional/src/main/java/io/swagger/api/UserApiController.java
@@ -23,47 +23,52 @@ import java.util.List;
 import java.util.Optional;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.IOException;
+import javax.servlet.http.HttpServletRequest;
 import javax.validation.constraints.*;
 import javax.validation.Valid;
 
 @Controller
 public class UserApiController implements UserApi {
 
-    private final Logger log = LoggerFactory.getLogger(AnotherFakeApiController.class);
+    private static final Logger log = LoggerFactory.getLogger(UserApiController.class);
 
     private final ObjectMapper objectMapper;
 
+    @org.springframework.beans.factory.annotation.Autowired
+    private HttpServletRequest request;
+
+    @org.springframework.beans.factory.annotation.Autowired
     public UserApiController(ObjectMapper objectMapper) {
         this.objectMapper = objectMapper;
     }
 
     public ResponseEntity<Void> createUser(@ApiParam(value = "Created user object" ,required=true )  @Valid @RequestBody User body) {
         // do some magic!
-        String accept = ((ServletRequestAttributes)RequestContextHolder.getRequestAttributes()).getRequest().getHeader("Accept");
+        String accept = request.getHeader("Accept");
         return new ResponseEntity<Void>(HttpStatus.OK);
     }
 
     public ResponseEntity<Void> createUsersWithArrayInput(@ApiParam(value = "List of user object" ,required=true )  @Valid @RequestBody List<User> body) {
         // do some magic!
-        String accept = ((ServletRequestAttributes)RequestContextHolder.getRequestAttributes()).getRequest().getHeader("Accept");
+        String accept = request.getHeader("Accept");
         return new ResponseEntity<Void>(HttpStatus.OK);
     }
 
     public ResponseEntity<Void> createUsersWithListInput(@ApiParam(value = "List of user object" ,required=true )  @Valid @RequestBody List<User> body) {
         // do some magic!
-        String accept = ((ServletRequestAttributes)RequestContextHolder.getRequestAttributes()).getRequest().getHeader("Accept");
+        String accept = request.getHeader("Accept");
         return new ResponseEntity<Void>(HttpStatus.OK);
     }
 
     public ResponseEntity<Void> deleteUser(@ApiParam(value = "The name that needs to be deleted",required=true) @PathVariable("username") String username) {
         // do some magic!
-        String accept = ((ServletRequestAttributes)RequestContextHolder.getRequestAttributes()).getRequest().getHeader("Accept");
+        String accept = request.getHeader("Accept");
         return new ResponseEntity<Void>(HttpStatus.OK);
     }
 
     public ResponseEntity<User> getUserByName(@ApiParam(value = "The name that needs to be fetched. Use user1 for testing. ",required=true) @PathVariable("username") String username) {
         // do some magic!
-        String accept = ((ServletRequestAttributes)RequestContextHolder.getRequestAttributes()).getRequest().getHeader("Accept");
+        String accept = request.getHeader("Accept");
         if (accept != null && accept.contains("application/xml")) {
             try {
                 return new ResponseEntity<User>(objectMapper.readValue("<User>  <id>123456789</id>  <username>aeiou</username>  <firstName>aeiou</firstName>  <lastName>aeiou</lastName>  <email>aeiou</email>  <password>aeiou</password>  <phone>aeiou</phone>  <userStatus>123</userStatus></User>", User.class), HttpStatus.NOT_IMPLEMENTED);
@@ -87,7 +92,7 @@ public class UserApiController implements UserApi {
 
     public ResponseEntity<String> loginUser(@NotNull @ApiParam(value = "The user name for login", required = true) @Valid @RequestParam(value = "username", required = true) String username,@NotNull @ApiParam(value = "The password for login in clear text", required = true) @Valid @RequestParam(value = "password", required = true) String password) {
         // do some magic!
-        String accept = ((ServletRequestAttributes)RequestContextHolder.getRequestAttributes()).getRequest().getHeader("Accept");
+        String accept = request.getHeader("Accept");
         if (accept != null && accept.contains("application/xml")) {
             try {
                 return new ResponseEntity<String>(objectMapper.readValue("aeiou", String.class), HttpStatus.NOT_IMPLEMENTED);
@@ -111,13 +116,13 @@ public class UserApiController implements UserApi {
 
     public ResponseEntity<Void> logoutUser() {
         // do some magic!
-        String accept = ((ServletRequestAttributes)RequestContextHolder.getRequestAttributes()).getRequest().getHeader("Accept");
+        String accept = request.getHeader("Accept");
         return new ResponseEntity<Void>(HttpStatus.OK);
     }
 
     public ResponseEntity<Void> updateUser(@ApiParam(value = "name that need to be deleted",required=true) @PathVariable("username") String username,@ApiParam(value = "Updated user object" ,required=true )  @Valid @RequestBody User body) {
         // do some magic!
-        String accept = ((ServletRequestAttributes)RequestContextHolder.getRequestAttributes()).getRequest().getHeader("Accept");
+        String accept = request.getHeader("Accept");
         return new ResponseEntity<Void>(HttpStatus.OK);
     }
 

--- a/samples/server/petstore/springboot-useoptional/src/main/java/io/swagger/model/FormatTest.java
+++ b/samples/server/petstore/springboot-useoptional/src/main/java/io/swagger/model/FormatTest.java
@@ -71,7 +71,7 @@ public class FormatTest   {
   **/
   @ApiModelProperty(value = "")
 
- @Min(10) @Max(100)
+@Min(10) @Max(100) 
   public Integer getInteger() {
     return integer;
   }
@@ -93,7 +93,7 @@ public class FormatTest   {
   **/
   @ApiModelProperty(value = "")
 
- @Min(20) @Max(200)
+@Min(20) @Max(200) 
   public Integer getInt32() {
     return int32;
   }
@@ -137,7 +137,7 @@ public class FormatTest   {
   @NotNull
 
   @Valid
- @DecimalMin("32.1") @DecimalMax("543.2")
+@DecimalMin("32.1") @DecimalMax("543.2") 
   public BigDecimal getNumber() {
     return number;
   }
@@ -159,7 +159,7 @@ public class FormatTest   {
   **/
   @ApiModelProperty(value = "")
 
- @DecimalMin("54.3") @DecimalMax("987.6")
+@DecimalMin("54.3") @DecimalMax("987.6") 
   public Float getFloat() {
     return _float;
   }
@@ -181,7 +181,7 @@ public class FormatTest   {
   **/
   @ApiModelProperty(value = "")
 
- @DecimalMin("67.8") @DecimalMax("123.4")
+@DecimalMin("67.8") @DecimalMax("123.4") 
   public Double getDouble() {
     return _double;
   }
@@ -201,7 +201,7 @@ public class FormatTest   {
   **/
   @ApiModelProperty(value = "")
 
- @Pattern(regexp="/[a-z]/i")
+@Pattern(regexp="/[a-z]/i") 
   public String getString() {
     return string;
   }
@@ -222,7 +222,7 @@ public class FormatTest   {
   @ApiModelProperty(required = true, value = "")
   @NotNull
 
- @Pattern(regexp="^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$")
+@Pattern(regexp="^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$") 
   public byte[] getByte() {
     return _byte;
   }
@@ -327,7 +327,7 @@ public class FormatTest   {
   @ApiModelProperty(required = true, value = "")
   @NotNull
 
- @Size(min=10,max=64)
+@Size(min=10,max=64) 
   public String getPassword() {
     return password;
   }

--- a/samples/server/petstore/springboot/src/main/java/io/swagger/api/AnotherFakeApi.java
+++ b/samples/server/petstore/springboot/src/main/java/io/swagger/api/AnotherFakeApi.java
@@ -34,6 +34,6 @@ public interface AnotherFakeApi {
         produces = { "application/json" }, 
         consumes = { "application/json" },
         method = RequestMethod.PATCH)
-    ResponseEntity<Client> testSpecialTags(@ApiParam(value = "client model" ,required=true )  @Valid @RequestBody Client body, @RequestHeader(value = "Accept", required = false) String accept) throws Exception;
+    ResponseEntity<Client> testSpecialTags(@ApiParam(value = "client model" ,required=true )  @Valid @RequestBody Client body);
 
 }

--- a/samples/server/petstore/springboot/src/main/java/io/swagger/api/AnotherFakeApi.java
+++ b/samples/server/petstore/springboot/src/main/java/io/swagger/api/AnotherFakeApi.java
@@ -6,9 +6,9 @@
 package io.swagger.api;
 
 import io.swagger.model.Client;
-
 import io.swagger.annotations.*;
 import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
@@ -17,12 +17,10 @@ import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.multipart.MultipartFile;
-import java.io.IOException;
 
-import java.util.List;
-import org.springframework.validation.annotation.Validated;
-import javax.validation.constraints.*;
 import javax.validation.Valid;
+import javax.validation.constraints.*;
+import java.util.List;
 
 @Api(value = "another-fake", description = "the another-fake API")
 public interface AnotherFakeApi {

--- a/samples/server/petstore/springboot/src/main/java/io/swagger/api/AnotherFakeApiController.java
+++ b/samples/server/petstore/springboot/src/main/java/io/swagger/api/AnotherFakeApiController.java
@@ -4,6 +4,8 @@ import io.swagger.model.Client;
 
 import io.swagger.annotations.*;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
@@ -12,6 +14,8 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RequestPart;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.util.List;
@@ -22,18 +26,25 @@ import javax.validation.Valid;
 
 @Controller
 public class AnotherFakeApiController implements AnotherFakeApi {
+
+    private final Logger log = LoggerFactory.getLogger(AnotherFakeApiController.class);
+
     private final ObjectMapper objectMapper;
 
     public AnotherFakeApiController(ObjectMapper objectMapper) {
         this.objectMapper = objectMapper;
     }
 
-    public ResponseEntity<Client> testSpecialTags(@ApiParam(value = "client model" ,required=true )  @Valid @RequestBody Client body,
-        @RequestHeader(value = "Accept", required = false) String accept) throws Exception {
+    public ResponseEntity<Client> testSpecialTags(@ApiParam(value = "client model" ,required=true )  @Valid @RequestBody Client body) {
         // do some magic!
-
+        String accept = ((ServletRequestAttributes)RequestContextHolder.getRequestAttributes()).getRequest().getHeader("Accept");
         if (accept != null && accept.contains("application/json")) {
-            return new ResponseEntity<Client>(objectMapper.readValue("{  \"client\" : \"client\"}", Client.class), HttpStatus.OK);
+            try {
+                return new ResponseEntity<Client>(objectMapper.readValue("{  \"client\" : \"client\"}", Client.class), HttpStatus.NOT_IMPLEMENTED);
+            } catch (IOException e) {
+                log.error("Couldn't serialize response for content type application/json", e);
+                return new ResponseEntity<Client>(HttpStatus.INTERNAL_SERVER_ERROR);
+            }
         }
 
         return new ResponseEntity<Client>(HttpStatus.OK);

--- a/samples/server/petstore/springboot/src/main/java/io/swagger/api/AnotherFakeApiController.java
+++ b/samples/server/petstore/springboot/src/main/java/io/swagger/api/AnotherFakeApiController.java
@@ -32,12 +32,12 @@ public class AnotherFakeApiController implements AnotherFakeApi {
 
     private final ObjectMapper objectMapper;
 
-    @org.springframework.beans.factory.annotation.Autowired
-    private HttpServletRequest request;
+    private final HttpServletRequest request;
 
     @org.springframework.beans.factory.annotation.Autowired
-    public AnotherFakeApiController(ObjectMapper objectMapper) {
+    public AnotherFakeApiController(ObjectMapper objectMapper, HttpServletRequest request) {
         this.objectMapper = objectMapper;
+        this.request = request;
     }
 
     public ResponseEntity<Client> testSpecialTags(@ApiParam(value = "client model" ,required=true )  @Valid @RequestBody Client body) {

--- a/samples/server/petstore/springboot/src/main/java/io/swagger/api/AnotherFakeApiController.java
+++ b/samples/server/petstore/springboot/src/main/java/io/swagger/api/AnotherFakeApiController.java
@@ -21,23 +21,28 @@ import org.springframework.web.multipart.MultipartFile;
 import java.util.List;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.IOException;
+import javax.servlet.http.HttpServletRequest;
 import javax.validation.constraints.*;
 import javax.validation.Valid;
 
 @Controller
 public class AnotherFakeApiController implements AnotherFakeApi {
 
-    private final Logger log = LoggerFactory.getLogger(AnotherFakeApiController.class);
+    private static final Logger log = LoggerFactory.getLogger(AnotherFakeApiController.class);
 
     private final ObjectMapper objectMapper;
 
+    @org.springframework.beans.factory.annotation.Autowired
+    private HttpServletRequest request;
+
+    @org.springframework.beans.factory.annotation.Autowired
     public AnotherFakeApiController(ObjectMapper objectMapper) {
         this.objectMapper = objectMapper;
     }
 
     public ResponseEntity<Client> testSpecialTags(@ApiParam(value = "client model" ,required=true )  @Valid @RequestBody Client body) {
         // do some magic!
-        String accept = ((ServletRequestAttributes)RequestContextHolder.getRequestAttributes()).getRequest().getHeader("Accept");
+        String accept = request.getHeader("Accept");
         if (accept != null && accept.contains("application/json")) {
             try {
                 return new ResponseEntity<Client>(objectMapper.readValue("{  \"client\" : \"client\"}", Client.class), HttpStatus.NOT_IMPLEMENTED);

--- a/samples/server/petstore/springboot/src/main/java/io/swagger/api/AnotherFakeApiController.java
+++ b/samples/server/petstore/springboot/src/main/java/io/swagger/api/AnotherFakeApiController.java
@@ -1,9 +1,8 @@
 package io.swagger.api;
 
 import io.swagger.model.Client;
-
+import com.fasterxml.jackson.databind.ObjectMapper;
 import io.swagger.annotations.*;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpStatus;
@@ -14,16 +13,13 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RequestPart;
-import org.springframework.web.context.request.RequestContextHolder;
-import org.springframework.web.context.request.ServletRequestAttributes;
 import org.springframework.web.multipart.MultipartFile;
 
-import java.util.List;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import java.io.IOException;
-import javax.servlet.http.HttpServletRequest;
 import javax.validation.constraints.*;
 import javax.validation.Valid;
+import javax.servlet.http.HttpServletRequest;
+import java.io.IOException;
+import java.util.List;
 
 @Controller
 public class AnotherFakeApiController implements AnotherFakeApi {
@@ -41,7 +37,6 @@ public class AnotherFakeApiController implements AnotherFakeApi {
     }
 
     public ResponseEntity<Client> testSpecialTags(@ApiParam(value = "client model" ,required=true )  @Valid @RequestBody Client body) {
-        // do some magic!
         String accept = request.getHeader("Accept");
         if (accept != null && accept.contains("application/json")) {
             try {
@@ -52,7 +47,7 @@ public class AnotherFakeApiController implements AnotherFakeApi {
             }
         }
 
-        return new ResponseEntity<Client>(HttpStatus.OK);
+        return new ResponseEntity<Client>(HttpStatus.NOT_IMPLEMENTED);
     }
 
 }

--- a/samples/server/petstore/springboot/src/main/java/io/swagger/api/FakeApi.java
+++ b/samples/server/petstore/springboot/src/main/java/io/swagger/api/FakeApi.java
@@ -10,9 +10,9 @@ import io.swagger.model.Client;
 import org.threeten.bp.LocalDate;
 import org.threeten.bp.OffsetDateTime;
 import io.swagger.model.OuterComposite;
-
 import io.swagger.annotations.*;
 import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
@@ -21,12 +21,10 @@ import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.multipart.MultipartFile;
-import java.io.IOException;
 
-import java.util.List;
-import org.springframework.validation.annotation.Validated;
-import javax.validation.constraints.*;
 import javax.validation.Valid;
+import javax.validation.constraints.*;
+import java.util.List;
 
 @Api(value = "fake", description = "the fake API")
 public interface FakeApi {

--- a/samples/server/petstore/springboot/src/main/java/io/swagger/api/FakeApi.java
+++ b/samples/server/petstore/springboot/src/main/java/io/swagger/api/FakeApi.java
@@ -36,7 +36,7 @@ public interface FakeApi {
         @ApiResponse(code = 200, message = "Output boolean", response = Boolean.class) })
     @RequestMapping(value = "/fake/outer/boolean",
         method = RequestMethod.POST)
-    ResponseEntity<Boolean> fakeOuterBooleanSerialize(@ApiParam(value = "Input boolean as post body"  )  @Valid @RequestBody Boolean body, @RequestHeader(value = "Accept", required = false) String accept) throws Exception;
+    ResponseEntity<Boolean> fakeOuterBooleanSerialize(@ApiParam(value = "Input boolean as post body"  )  @Valid @RequestBody Boolean body);
 
 
     @ApiOperation(value = "", nickname = "fakeOuterCompositeSerialize", notes = "Test serialization of object with outer number type", response = OuterComposite.class, tags={ "fake", })
@@ -44,7 +44,7 @@ public interface FakeApi {
         @ApiResponse(code = 200, message = "Output composite", response = OuterComposite.class) })
     @RequestMapping(value = "/fake/outer/composite",
         method = RequestMethod.POST)
-    ResponseEntity<OuterComposite> fakeOuterCompositeSerialize(@ApiParam(value = "Input composite as post body"  )  @Valid @RequestBody OuterComposite body, @RequestHeader(value = "Accept", required = false) String accept) throws Exception;
+    ResponseEntity<OuterComposite> fakeOuterCompositeSerialize(@ApiParam(value = "Input composite as post body"  )  @Valid @RequestBody OuterComposite body);
 
 
     @ApiOperation(value = "", nickname = "fakeOuterNumberSerialize", notes = "Test serialization of outer number types", response = BigDecimal.class, tags={ "fake", })
@@ -52,7 +52,7 @@ public interface FakeApi {
         @ApiResponse(code = 200, message = "Output number", response = BigDecimal.class) })
     @RequestMapping(value = "/fake/outer/number",
         method = RequestMethod.POST)
-    ResponseEntity<BigDecimal> fakeOuterNumberSerialize(@ApiParam(value = "Input number as post body"  )  @Valid @RequestBody BigDecimal body, @RequestHeader(value = "Accept", required = false) String accept) throws Exception;
+    ResponseEntity<BigDecimal> fakeOuterNumberSerialize(@ApiParam(value = "Input number as post body"  )  @Valid @RequestBody BigDecimal body);
 
 
     @ApiOperation(value = "", nickname = "fakeOuterStringSerialize", notes = "Test serialization of outer string types", response = String.class, tags={ "fake", })
@@ -60,7 +60,7 @@ public interface FakeApi {
         @ApiResponse(code = 200, message = "Output string", response = String.class) })
     @RequestMapping(value = "/fake/outer/string",
         method = RequestMethod.POST)
-    ResponseEntity<String> fakeOuterStringSerialize(@ApiParam(value = "Input string as post body"  )  @Valid @RequestBody String body, @RequestHeader(value = "Accept", required = false) String accept) throws Exception;
+    ResponseEntity<String> fakeOuterStringSerialize(@ApiParam(value = "Input string as post body"  )  @Valid @RequestBody String body);
 
 
     @ApiOperation(value = "To test \"client\" model", nickname = "testClientModel", notes = "To test \"client\" model", response = Client.class, tags={ "fake", })
@@ -70,7 +70,7 @@ public interface FakeApi {
         produces = { "application/json" }, 
         consumes = { "application/json" },
         method = RequestMethod.PATCH)
-    ResponseEntity<Client> testClientModel(@ApiParam(value = "client model" ,required=true )  @Valid @RequestBody Client body, @RequestHeader(value = "Accept", required = false) String accept) throws Exception;
+    ResponseEntity<Client> testClientModel(@ApiParam(value = "client model" ,required=true )  @Valid @RequestBody Client body);
 
 
     @ApiOperation(value = "Fake endpoint for testing various parameters 假端點 偽のエンドポイント 가짜 엔드 포인트 ", nickname = "testEndpointParameters", notes = "Fake endpoint for testing various parameters 假端點 偽のエンドポイント 가짜 엔드 포인트 ", authorizations = {
@@ -83,7 +83,7 @@ public interface FakeApi {
         produces = { "application/xml; charset=utf-8", "application/json; charset=utf-8" }, 
         consumes = { "application/xml; charset=utf-8", "application/json; charset=utf-8" },
         method = RequestMethod.POST)
-    ResponseEntity<Void> testEndpointParameters(@ApiParam(value = "None", required=true) @RequestPart(value="number", required=true)  BigDecimal number,@ApiParam(value = "None", required=true) @RequestPart(value="double", required=true)  Double _double,@ApiParam(value = "None", required=true) @RequestPart(value="pattern_without_delimiter", required=true)  String patternWithoutDelimiter,@ApiParam(value = "None", required=true) @RequestPart(value="byte", required=true)  byte[] _byte,@ApiParam(value = "None") @RequestPart(value="integer", required=false)  Integer integer,@ApiParam(value = "None") @RequestPart(value="int32", required=false)  Integer int32,@ApiParam(value = "None") @RequestPart(value="int64", required=false)  Long int64,@ApiParam(value = "None") @RequestPart(value="float", required=false)  Float _float,@ApiParam(value = "None") @RequestPart(value="string", required=false)  String string,@ApiParam(value = "None") @RequestPart(value="binary", required=false)  byte[] binary,@ApiParam(value = "None") @RequestPart(value="date", required=false)  LocalDate date,@ApiParam(value = "None") @RequestPart(value="dateTime", required=false)  OffsetDateTime dateTime,@ApiParam(value = "None") @RequestPart(value="password", required=false)  String password,@ApiParam(value = "None") @RequestPart(value="callback", required=false)  String paramCallback, @RequestHeader(value = "Accept", required = false) String accept) throws Exception;
+    ResponseEntity<Void> testEndpointParameters(@ApiParam(value = "None", required=true) @RequestPart(value="number", required=true)  BigDecimal number,@ApiParam(value = "None", required=true) @RequestPart(value="double", required=true)  Double _double,@ApiParam(value = "None", required=true) @RequestPart(value="pattern_without_delimiter", required=true)  String patternWithoutDelimiter,@ApiParam(value = "None", required=true) @RequestPart(value="byte", required=true)  byte[] _byte,@ApiParam(value = "None") @RequestPart(value="integer", required=false)  Integer integer,@ApiParam(value = "None") @RequestPart(value="int32", required=false)  Integer int32,@ApiParam(value = "None") @RequestPart(value="int64", required=false)  Long int64,@ApiParam(value = "None") @RequestPart(value="float", required=false)  Float _float,@ApiParam(value = "None") @RequestPart(value="string", required=false)  String string,@ApiParam(value = "None") @RequestPart(value="binary", required=false)  byte[] binary,@ApiParam(value = "None") @RequestPart(value="date", required=false)  LocalDate date,@ApiParam(value = "None") @RequestPart(value="dateTime", required=false)  OffsetDateTime dateTime,@ApiParam(value = "None") @RequestPart(value="password", required=false)  String password,@ApiParam(value = "None") @RequestPart(value="callback", required=false)  String paramCallback);
 
 
     @ApiOperation(value = "To test enum parameters", nickname = "testEnumParameters", notes = "To test enum parameters", tags={ "fake", })
@@ -94,7 +94,7 @@ public interface FakeApi {
         produces = { "*/*" }, 
         consumes = { "*/*" },
         method = RequestMethod.GET)
-    ResponseEntity<Void> testEnumParameters(@ApiParam(value = "Form parameter enum test (string array)", allowableValues=">, $") @RequestPart(value="enum_form_string_array", required=false)  List<String> enumFormStringArray,@ApiParam(value = "Form parameter enum test (string)", allowableValues="_abc, -efg, (xyz)", defaultValue="-efg") @RequestPart(value="enum_form_string", required=false)  String enumFormString,@ApiParam(value = "Header parameter enum test (string array)" , allowableValues=">, $") @RequestHeader(value="enum_header_string_array", required=false) List<String> enumHeaderStringArray,@ApiParam(value = "Header parameter enum test (string)" , allowableValues="_abc, -efg, (xyz)", defaultValue="-efg") @RequestHeader(value="enum_header_string", required=false) String enumHeaderString,@ApiParam(value = "Query parameter enum test (string array)", allowableValues = ">, $") @Valid @RequestParam(value = "enum_query_string_array", required = false) List<String> enumQueryStringArray,@ApiParam(value = "Query parameter enum test (string)", allowableValues = "_abc, -efg, (xyz)", defaultValue = "-efg") @Valid @RequestParam(value = "enum_query_string", required = false, defaultValue="-efg") String enumQueryString,@ApiParam(value = "Query parameter enum test (double)", allowableValues = "1, -2") @Valid @RequestParam(value = "enum_query_integer", required = false) Integer enumQueryInteger,@ApiParam(value = "Query parameter enum test (double)", allowableValues="1.1, -1.2") @RequestPart(value="enum_query_double", required=false)  Double enumQueryDouble, @RequestHeader(value = "Accept", required = false) String accept) throws Exception;
+    ResponseEntity<Void> testEnumParameters(@ApiParam(value = "Form parameter enum test (string array)", allowableValues=">, $") @RequestPart(value="enum_form_string_array", required=false)  List<String> enumFormStringArray,@ApiParam(value = "Form parameter enum test (string)", allowableValues="_abc, -efg, (xyz)", defaultValue="-efg") @RequestPart(value="enum_form_string", required=false)  String enumFormString,@ApiParam(value = "Header parameter enum test (string array)" , allowableValues=">, $") @RequestHeader(value="enum_header_string_array", required=false) List<String> enumHeaderStringArray,@ApiParam(value = "Header parameter enum test (string)" , allowableValues="_abc, -efg, (xyz)", defaultValue="-efg") @RequestHeader(value="enum_header_string", required=false) String enumHeaderString,@ApiParam(value = "Query parameter enum test (string array)", allowableValues = ">, $") @Valid @RequestParam(value = "enum_query_string_array", required = false) List<String> enumQueryStringArray,@ApiParam(value = "Query parameter enum test (string)", allowableValues = "_abc, -efg, (xyz)", defaultValue = "-efg") @Valid @RequestParam(value = "enum_query_string", required = false, defaultValue="-efg") String enumQueryString,@ApiParam(value = "Query parameter enum test (double)", allowableValues = "1, -2") @Valid @RequestParam(value = "enum_query_integer", required = false) Integer enumQueryInteger,@ApiParam(value = "Query parameter enum test (double)", allowableValues="1.1, -1.2") @RequestPart(value="enum_query_double", required=false)  Double enumQueryDouble);
 
 
     @ApiOperation(value = "test inline additionalProperties", nickname = "testInlineAdditionalProperties", notes = "", tags={ "fake", })
@@ -103,7 +103,7 @@ public interface FakeApi {
     @RequestMapping(value = "/fake/inline-additionalProperties",
         consumes = { "application/json" },
         method = RequestMethod.POST)
-    ResponseEntity<Void> testInlineAdditionalProperties(@ApiParam(value = "request body" ,required=true )  @Valid @RequestBody Object param, @RequestHeader(value = "Accept", required = false) String accept) throws Exception;
+    ResponseEntity<Void> testInlineAdditionalProperties(@ApiParam(value = "request body" ,required=true )  @Valid @RequestBody Object param);
 
 
     @ApiOperation(value = "test json serialization of form data", nickname = "testJsonFormData", notes = "", tags={ "fake", })
@@ -112,6 +112,6 @@ public interface FakeApi {
     @RequestMapping(value = "/fake/jsonFormData",
         consumes = { "application/json" },
         method = RequestMethod.GET)
-    ResponseEntity<Void> testJsonFormData(@ApiParam(value = "field1", required=true) @RequestPart(value="param", required=true)  String param,@ApiParam(value = "field2", required=true) @RequestPart(value="param2", required=true)  String param2, @RequestHeader(value = "Accept", required = false) String accept) throws Exception;
+    ResponseEntity<Void> testJsonFormData(@ApiParam(value = "field1", required=true) @RequestPart(value="param", required=true)  String param,@ApiParam(value = "field2", required=true) @RequestPart(value="param2", required=true)  String param2);
 
 }

--- a/samples/server/petstore/springboot/src/main/java/io/swagger/api/FakeApiController.java
+++ b/samples/server/petstore/springboot/src/main/java/io/swagger/api/FakeApiController.java
@@ -36,12 +36,12 @@ public class FakeApiController implements FakeApi {
 
     private final ObjectMapper objectMapper;
 
-    @org.springframework.beans.factory.annotation.Autowired
-    private HttpServletRequest request;
+    private final HttpServletRequest request;
 
     @org.springframework.beans.factory.annotation.Autowired
-    public FakeApiController(ObjectMapper objectMapper) {
+    public FakeApiController(ObjectMapper objectMapper, HttpServletRequest request) {
         this.objectMapper = objectMapper;
+        this.request = request;
     }
 
     public ResponseEntity<Boolean> fakeOuterBooleanSerialize(@ApiParam(value = "Input boolean as post body"  )  @Valid @RequestBody Boolean body) {

--- a/samples/server/petstore/springboot/src/main/java/io/swagger/api/FakeApiController.java
+++ b/samples/server/petstore/springboot/src/main/java/io/swagger/api/FakeApiController.java
@@ -25,23 +25,28 @@ import org.springframework.web.multipart.MultipartFile;
 import java.util.List;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.IOException;
+import javax.servlet.http.HttpServletRequest;
 import javax.validation.constraints.*;
 import javax.validation.Valid;
 
 @Controller
 public class FakeApiController implements FakeApi {
 
-    private final Logger log = LoggerFactory.getLogger(AnotherFakeApiController.class);
+    private static final Logger log = LoggerFactory.getLogger(FakeApiController.class);
 
     private final ObjectMapper objectMapper;
 
+    @org.springframework.beans.factory.annotation.Autowired
+    private HttpServletRequest request;
+
+    @org.springframework.beans.factory.annotation.Autowired
     public FakeApiController(ObjectMapper objectMapper) {
         this.objectMapper = objectMapper;
     }
 
     public ResponseEntity<Boolean> fakeOuterBooleanSerialize(@ApiParam(value = "Input boolean as post body"  )  @Valid @RequestBody Boolean body) {
         // do some magic!
-        String accept = ((ServletRequestAttributes)RequestContextHolder.getRequestAttributes()).getRequest().getHeader("Accept");
+        String accept = request.getHeader("Accept");
         if (accept != null && accept.contains("application/json")) {
             try {
                 return new ResponseEntity<Boolean>(objectMapper.readValue("{ }", Boolean.class), HttpStatus.NOT_IMPLEMENTED);
@@ -56,7 +61,7 @@ public class FakeApiController implements FakeApi {
 
     public ResponseEntity<OuterComposite> fakeOuterCompositeSerialize(@ApiParam(value = "Input composite as post body"  )  @Valid @RequestBody OuterComposite body) {
         // do some magic!
-        String accept = ((ServletRequestAttributes)RequestContextHolder.getRequestAttributes()).getRequest().getHeader("Accept");
+        String accept = request.getHeader("Accept");
         if (accept != null && accept.contains("application/json")) {
             try {
                 return new ResponseEntity<OuterComposite>(objectMapper.readValue("{  \"my_string\" : { },  \"my_number\" : { },  \"my_boolean\" : { }}", OuterComposite.class), HttpStatus.NOT_IMPLEMENTED);
@@ -71,7 +76,7 @@ public class FakeApiController implements FakeApi {
 
     public ResponseEntity<BigDecimal> fakeOuterNumberSerialize(@ApiParam(value = "Input number as post body"  )  @Valid @RequestBody BigDecimal body) {
         // do some magic!
-        String accept = ((ServletRequestAttributes)RequestContextHolder.getRequestAttributes()).getRequest().getHeader("Accept");
+        String accept = request.getHeader("Accept");
         if (accept != null && accept.contains("application/json")) {
             try {
                 return new ResponseEntity<BigDecimal>(objectMapper.readValue("{ }", BigDecimal.class), HttpStatus.NOT_IMPLEMENTED);
@@ -86,7 +91,7 @@ public class FakeApiController implements FakeApi {
 
     public ResponseEntity<String> fakeOuterStringSerialize(@ApiParam(value = "Input string as post body"  )  @Valid @RequestBody String body) {
         // do some magic!
-        String accept = ((ServletRequestAttributes)RequestContextHolder.getRequestAttributes()).getRequest().getHeader("Accept");
+        String accept = request.getHeader("Accept");
         if (accept != null && accept.contains("application/json")) {
             try {
                 return new ResponseEntity<String>(objectMapper.readValue("{ }", String.class), HttpStatus.NOT_IMPLEMENTED);
@@ -101,7 +106,7 @@ public class FakeApiController implements FakeApi {
 
     public ResponseEntity<Client> testClientModel(@ApiParam(value = "client model" ,required=true )  @Valid @RequestBody Client body) {
         // do some magic!
-        String accept = ((ServletRequestAttributes)RequestContextHolder.getRequestAttributes()).getRequest().getHeader("Accept");
+        String accept = request.getHeader("Accept");
         if (accept != null && accept.contains("application/json")) {
             try {
                 return new ResponseEntity<Client>(objectMapper.readValue("{  \"client\" : \"client\"}", Client.class), HttpStatus.NOT_IMPLEMENTED);
@@ -116,25 +121,25 @@ public class FakeApiController implements FakeApi {
 
     public ResponseEntity<Void> testEndpointParameters(@ApiParam(value = "None", required=true) @RequestPart(value="number", required=true)  BigDecimal number,@ApiParam(value = "None", required=true) @RequestPart(value="double", required=true)  Double _double,@ApiParam(value = "None", required=true) @RequestPart(value="pattern_without_delimiter", required=true)  String patternWithoutDelimiter,@ApiParam(value = "None", required=true) @RequestPart(value="byte", required=true)  byte[] _byte,@ApiParam(value = "None") @RequestPart(value="integer", required=false)  Integer integer,@ApiParam(value = "None") @RequestPart(value="int32", required=false)  Integer int32,@ApiParam(value = "None") @RequestPart(value="int64", required=false)  Long int64,@ApiParam(value = "None") @RequestPart(value="float", required=false)  Float _float,@ApiParam(value = "None") @RequestPart(value="string", required=false)  String string,@ApiParam(value = "None") @RequestPart(value="binary", required=false)  byte[] binary,@ApiParam(value = "None") @RequestPart(value="date", required=false)  LocalDate date,@ApiParam(value = "None") @RequestPart(value="dateTime", required=false)  OffsetDateTime dateTime,@ApiParam(value = "None") @RequestPart(value="password", required=false)  String password,@ApiParam(value = "None") @RequestPart(value="callback", required=false)  String paramCallback) {
         // do some magic!
-        String accept = ((ServletRequestAttributes)RequestContextHolder.getRequestAttributes()).getRequest().getHeader("Accept");
+        String accept = request.getHeader("Accept");
         return new ResponseEntity<Void>(HttpStatus.OK);
     }
 
     public ResponseEntity<Void> testEnumParameters(@ApiParam(value = "Form parameter enum test (string array)", allowableValues=">, $") @RequestPart(value="enum_form_string_array", required=false)  List<String> enumFormStringArray,@ApiParam(value = "Form parameter enum test (string)", allowableValues="_abc, -efg, (xyz)", defaultValue="-efg") @RequestPart(value="enum_form_string", required=false)  String enumFormString,@ApiParam(value = "Header parameter enum test (string array)" , allowableValues=">, $") @RequestHeader(value="enum_header_string_array", required=false) List<String> enumHeaderStringArray,@ApiParam(value = "Header parameter enum test (string)" , allowableValues="_abc, -efg, (xyz)", defaultValue="-efg") @RequestHeader(value="enum_header_string", required=false) String enumHeaderString,@ApiParam(value = "Query parameter enum test (string array)", allowableValues = ">, $") @Valid @RequestParam(value = "enum_query_string_array", required = false) List<String> enumQueryStringArray,@ApiParam(value = "Query parameter enum test (string)", allowableValues = "_abc, -efg, (xyz)", defaultValue = "-efg") @Valid @RequestParam(value = "enum_query_string", required = false, defaultValue="-efg") String enumQueryString,@ApiParam(value = "Query parameter enum test (double)", allowableValues = "1, -2") @Valid @RequestParam(value = "enum_query_integer", required = false) Integer enumQueryInteger,@ApiParam(value = "Query parameter enum test (double)", allowableValues="1.1, -1.2") @RequestPart(value="enum_query_double", required=false)  Double enumQueryDouble) {
         // do some magic!
-        String accept = ((ServletRequestAttributes)RequestContextHolder.getRequestAttributes()).getRequest().getHeader("Accept");
+        String accept = request.getHeader("Accept");
         return new ResponseEntity<Void>(HttpStatus.OK);
     }
 
     public ResponseEntity<Void> testInlineAdditionalProperties(@ApiParam(value = "request body" ,required=true )  @Valid @RequestBody Object param) {
         // do some magic!
-        String accept = ((ServletRequestAttributes)RequestContextHolder.getRequestAttributes()).getRequest().getHeader("Accept");
+        String accept = request.getHeader("Accept");
         return new ResponseEntity<Void>(HttpStatus.OK);
     }
 
     public ResponseEntity<Void> testJsonFormData(@ApiParam(value = "field1", required=true) @RequestPart(value="param", required=true)  String param,@ApiParam(value = "field2", required=true) @RequestPart(value="param2", required=true)  String param2) {
         // do some magic!
-        String accept = ((ServletRequestAttributes)RequestContextHolder.getRequestAttributes()).getRequest().getHeader("Accept");
+        String accept = request.getHeader("Accept");
         return new ResponseEntity<Void>(HttpStatus.OK);
     }
 

--- a/samples/server/petstore/springboot/src/main/java/io/swagger/api/FakeApiController.java
+++ b/samples/server/petstore/springboot/src/main/java/io/swagger/api/FakeApiController.java
@@ -8,6 +8,8 @@ import io.swagger.model.OuterComposite;
 
 import io.swagger.annotations.*;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
@@ -16,6 +18,8 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RequestPart;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.util.List;
@@ -26,109 +30,111 @@ import javax.validation.Valid;
 
 @Controller
 public class FakeApiController implements FakeApi {
+
+    private final Logger log = LoggerFactory.getLogger(AnotherFakeApiController.class);
+
     private final ObjectMapper objectMapper;
 
     public FakeApiController(ObjectMapper objectMapper) {
         this.objectMapper = objectMapper;
     }
 
-    public ResponseEntity<Boolean> fakeOuterBooleanSerialize(@ApiParam(value = "Input boolean as post body"  )  @Valid @RequestBody Boolean body,
-        @RequestHeader(value = "Accept", required = false) String accept) throws Exception {
+    public ResponseEntity<Boolean> fakeOuterBooleanSerialize(@ApiParam(value = "Input boolean as post body"  )  @Valid @RequestBody Boolean body) {
         // do some magic!
-
+        String accept = ((ServletRequestAttributes)RequestContextHolder.getRequestAttributes()).getRequest().getHeader("Accept");
         if (accept != null && accept.contains("application/json")) {
-            return new ResponseEntity<Boolean>(objectMapper.readValue("{ }", Boolean.class), HttpStatus.OK);
+            try {
+                return new ResponseEntity<Boolean>(objectMapper.readValue("{ }", Boolean.class), HttpStatus.NOT_IMPLEMENTED);
+            } catch (IOException e) {
+                log.error("Couldn't serialize response for content type application/json", e);
+                return new ResponseEntity<Boolean>(HttpStatus.INTERNAL_SERVER_ERROR);
+            }
         }
 
         return new ResponseEntity<Boolean>(HttpStatus.OK);
     }
 
-    public ResponseEntity<OuterComposite> fakeOuterCompositeSerialize(@ApiParam(value = "Input composite as post body"  )  @Valid @RequestBody OuterComposite body,
-        @RequestHeader(value = "Accept", required = false) String accept) throws Exception {
+    public ResponseEntity<OuterComposite> fakeOuterCompositeSerialize(@ApiParam(value = "Input composite as post body"  )  @Valid @RequestBody OuterComposite body) {
         // do some magic!
-
+        String accept = ((ServletRequestAttributes)RequestContextHolder.getRequestAttributes()).getRequest().getHeader("Accept");
         if (accept != null && accept.contains("application/json")) {
-            return new ResponseEntity<OuterComposite>(objectMapper.readValue("{  \"my_string\" : { },  \"my_number\" : { },  \"my_boolean\" : { }}", OuterComposite.class), HttpStatus.OK);
+            try {
+                return new ResponseEntity<OuterComposite>(objectMapper.readValue("{  \"my_string\" : { },  \"my_number\" : { },  \"my_boolean\" : { }}", OuterComposite.class), HttpStatus.NOT_IMPLEMENTED);
+            } catch (IOException e) {
+                log.error("Couldn't serialize response for content type application/json", e);
+                return new ResponseEntity<OuterComposite>(HttpStatus.INTERNAL_SERVER_ERROR);
+            }
         }
 
         return new ResponseEntity<OuterComposite>(HttpStatus.OK);
     }
 
-    public ResponseEntity<BigDecimal> fakeOuterNumberSerialize(@ApiParam(value = "Input number as post body"  )  @Valid @RequestBody BigDecimal body,
-        @RequestHeader(value = "Accept", required = false) String accept) throws Exception {
+    public ResponseEntity<BigDecimal> fakeOuterNumberSerialize(@ApiParam(value = "Input number as post body"  )  @Valid @RequestBody BigDecimal body) {
         // do some magic!
-
+        String accept = ((ServletRequestAttributes)RequestContextHolder.getRequestAttributes()).getRequest().getHeader("Accept");
         if (accept != null && accept.contains("application/json")) {
-            return new ResponseEntity<BigDecimal>(objectMapper.readValue("{ }", BigDecimal.class), HttpStatus.OK);
+            try {
+                return new ResponseEntity<BigDecimal>(objectMapper.readValue("{ }", BigDecimal.class), HttpStatus.NOT_IMPLEMENTED);
+            } catch (IOException e) {
+                log.error("Couldn't serialize response for content type application/json", e);
+                return new ResponseEntity<BigDecimal>(HttpStatus.INTERNAL_SERVER_ERROR);
+            }
         }
 
         return new ResponseEntity<BigDecimal>(HttpStatus.OK);
     }
 
-    public ResponseEntity<String> fakeOuterStringSerialize(@ApiParam(value = "Input string as post body"  )  @Valid @RequestBody String body,
-        @RequestHeader(value = "Accept", required = false) String accept) throws Exception {
+    public ResponseEntity<String> fakeOuterStringSerialize(@ApiParam(value = "Input string as post body"  )  @Valid @RequestBody String body) {
         // do some magic!
-
+        String accept = ((ServletRequestAttributes)RequestContextHolder.getRequestAttributes()).getRequest().getHeader("Accept");
         if (accept != null && accept.contains("application/json")) {
-            return new ResponseEntity<String>(objectMapper.readValue("{ }", String.class), HttpStatus.OK);
+            try {
+                return new ResponseEntity<String>(objectMapper.readValue("{ }", String.class), HttpStatus.NOT_IMPLEMENTED);
+            } catch (IOException e) {
+                log.error("Couldn't serialize response for content type application/json", e);
+                return new ResponseEntity<String>(HttpStatus.INTERNAL_SERVER_ERROR);
+            }
         }
 
         return new ResponseEntity<String>(HttpStatus.OK);
     }
 
-    public ResponseEntity<Client> testClientModel(@ApiParam(value = "client model" ,required=true )  @Valid @RequestBody Client body,
-        @RequestHeader(value = "Accept", required = false) String accept) throws Exception {
+    public ResponseEntity<Client> testClientModel(@ApiParam(value = "client model" ,required=true )  @Valid @RequestBody Client body) {
         // do some magic!
-
+        String accept = ((ServletRequestAttributes)RequestContextHolder.getRequestAttributes()).getRequest().getHeader("Accept");
         if (accept != null && accept.contains("application/json")) {
-            return new ResponseEntity<Client>(objectMapper.readValue("{  \"client\" : \"client\"}", Client.class), HttpStatus.OK);
+            try {
+                return new ResponseEntity<Client>(objectMapper.readValue("{  \"client\" : \"client\"}", Client.class), HttpStatus.NOT_IMPLEMENTED);
+            } catch (IOException e) {
+                log.error("Couldn't serialize response for content type application/json", e);
+                return new ResponseEntity<Client>(HttpStatus.INTERNAL_SERVER_ERROR);
+            }
         }
 
         return new ResponseEntity<Client>(HttpStatus.OK);
     }
 
-    public ResponseEntity<Void> testEndpointParameters(@ApiParam(value = "None", required=true) @RequestPart(value="number", required=true)  BigDecimal number,
-        @ApiParam(value = "None", required=true) @RequestPart(value="double", required=true)  Double _double,
-        @ApiParam(value = "None", required=true) @RequestPart(value="pattern_without_delimiter", required=true)  String patternWithoutDelimiter,
-        @ApiParam(value = "None", required=true) @RequestPart(value="byte", required=true)  byte[] _byte,
-        @ApiParam(value = "None") @RequestPart(value="integer", required=false)  Integer integer,
-        @ApiParam(value = "None") @RequestPart(value="int32", required=false)  Integer int32,
-        @ApiParam(value = "None") @RequestPart(value="int64", required=false)  Long int64,
-        @ApiParam(value = "None") @RequestPart(value="float", required=false)  Float _float,
-        @ApiParam(value = "None") @RequestPart(value="string", required=false)  String string,
-        @ApiParam(value = "None") @RequestPart(value="binary", required=false)  byte[] binary,
-        @ApiParam(value = "None") @RequestPart(value="date", required=false)  LocalDate date,
-        @ApiParam(value = "None") @RequestPart(value="dateTime", required=false)  OffsetDateTime dateTime,
-        @ApiParam(value = "None") @RequestPart(value="password", required=false)  String password,
-        @ApiParam(value = "None") @RequestPart(value="callback", required=false)  String paramCallback,
-        @RequestHeader(value = "Accept", required = false) String accept) throws Exception {
+    public ResponseEntity<Void> testEndpointParameters(@ApiParam(value = "None", required=true) @RequestPart(value="number", required=true)  BigDecimal number,@ApiParam(value = "None", required=true) @RequestPart(value="double", required=true)  Double _double,@ApiParam(value = "None", required=true) @RequestPart(value="pattern_without_delimiter", required=true)  String patternWithoutDelimiter,@ApiParam(value = "None", required=true) @RequestPart(value="byte", required=true)  byte[] _byte,@ApiParam(value = "None") @RequestPart(value="integer", required=false)  Integer integer,@ApiParam(value = "None") @RequestPart(value="int32", required=false)  Integer int32,@ApiParam(value = "None") @RequestPart(value="int64", required=false)  Long int64,@ApiParam(value = "None") @RequestPart(value="float", required=false)  Float _float,@ApiParam(value = "None") @RequestPart(value="string", required=false)  String string,@ApiParam(value = "None") @RequestPart(value="binary", required=false)  byte[] binary,@ApiParam(value = "None") @RequestPart(value="date", required=false)  LocalDate date,@ApiParam(value = "None") @RequestPart(value="dateTime", required=false)  OffsetDateTime dateTime,@ApiParam(value = "None") @RequestPart(value="password", required=false)  String password,@ApiParam(value = "None") @RequestPart(value="callback", required=false)  String paramCallback) {
         // do some magic!
+        String accept = ((ServletRequestAttributes)RequestContextHolder.getRequestAttributes()).getRequest().getHeader("Accept");
         return new ResponseEntity<Void>(HttpStatus.OK);
     }
 
-    public ResponseEntity<Void> testEnumParameters(@ApiParam(value = "Form parameter enum test (string array)", allowableValues=">, $") @RequestPart(value="enum_form_string_array", required=false)  List<String> enumFormStringArray,
-        @ApiParam(value = "Form parameter enum test (string)", allowableValues="_abc, -efg, (xyz)", defaultValue="-efg") @RequestPart(value="enum_form_string", required=false)  String enumFormString,
-        @ApiParam(value = "Header parameter enum test (string array)" , allowableValues=">, $") @RequestHeader(value="enum_header_string_array", required=false) List<String> enumHeaderStringArray,
-        @ApiParam(value = "Header parameter enum test (string)" , allowableValues="_abc, -efg, (xyz)", defaultValue="-efg") @RequestHeader(value="enum_header_string", required=false) String enumHeaderString,
-        @ApiParam(value = "Query parameter enum test (string array)", allowableValues = ">, $") @Valid @RequestParam(value = "enum_query_string_array", required = false) List<String> enumQueryStringArray,
-        @ApiParam(value = "Query parameter enum test (string)", allowableValues = "_abc, -efg, (xyz)", defaultValue = "-efg") @Valid @RequestParam(value = "enum_query_string", required = false, defaultValue="-efg") String enumQueryString,
-        @ApiParam(value = "Query parameter enum test (double)", allowableValues = "1, -2") @Valid @RequestParam(value = "enum_query_integer", required = false) Integer enumQueryInteger,
-        @ApiParam(value = "Query parameter enum test (double)", allowableValues="1.1, -1.2") @RequestPart(value="enum_query_double", required=false)  Double enumQueryDouble,
-        @RequestHeader(value = "Accept", required = false) String accept) throws Exception {
+    public ResponseEntity<Void> testEnumParameters(@ApiParam(value = "Form parameter enum test (string array)", allowableValues=">, $") @RequestPart(value="enum_form_string_array", required=false)  List<String> enumFormStringArray,@ApiParam(value = "Form parameter enum test (string)", allowableValues="_abc, -efg, (xyz)", defaultValue="-efg") @RequestPart(value="enum_form_string", required=false)  String enumFormString,@ApiParam(value = "Header parameter enum test (string array)" , allowableValues=">, $") @RequestHeader(value="enum_header_string_array", required=false) List<String> enumHeaderStringArray,@ApiParam(value = "Header parameter enum test (string)" , allowableValues="_abc, -efg, (xyz)", defaultValue="-efg") @RequestHeader(value="enum_header_string", required=false) String enumHeaderString,@ApiParam(value = "Query parameter enum test (string array)", allowableValues = ">, $") @Valid @RequestParam(value = "enum_query_string_array", required = false) List<String> enumQueryStringArray,@ApiParam(value = "Query parameter enum test (string)", allowableValues = "_abc, -efg, (xyz)", defaultValue = "-efg") @Valid @RequestParam(value = "enum_query_string", required = false, defaultValue="-efg") String enumQueryString,@ApiParam(value = "Query parameter enum test (double)", allowableValues = "1, -2") @Valid @RequestParam(value = "enum_query_integer", required = false) Integer enumQueryInteger,@ApiParam(value = "Query parameter enum test (double)", allowableValues="1.1, -1.2") @RequestPart(value="enum_query_double", required=false)  Double enumQueryDouble) {
         // do some magic!
+        String accept = ((ServletRequestAttributes)RequestContextHolder.getRequestAttributes()).getRequest().getHeader("Accept");
         return new ResponseEntity<Void>(HttpStatus.OK);
     }
 
-    public ResponseEntity<Void> testInlineAdditionalProperties(@ApiParam(value = "request body" ,required=true )  @Valid @RequestBody Object param,
-        @RequestHeader(value = "Accept", required = false) String accept) throws Exception {
+    public ResponseEntity<Void> testInlineAdditionalProperties(@ApiParam(value = "request body" ,required=true )  @Valid @RequestBody Object param) {
         // do some magic!
+        String accept = ((ServletRequestAttributes)RequestContextHolder.getRequestAttributes()).getRequest().getHeader("Accept");
         return new ResponseEntity<Void>(HttpStatus.OK);
     }
 
-    public ResponseEntity<Void> testJsonFormData(@ApiParam(value = "field1", required=true) @RequestPart(value="param", required=true)  String param,
-        @ApiParam(value = "field2", required=true) @RequestPart(value="param2", required=true)  String param2,
-        @RequestHeader(value = "Accept", required = false) String accept) throws Exception {
+    public ResponseEntity<Void> testJsonFormData(@ApiParam(value = "field1", required=true) @RequestPart(value="param", required=true)  String param,@ApiParam(value = "field2", required=true) @RequestPart(value="param2", required=true)  String param2) {
         // do some magic!
+        String accept = ((ServletRequestAttributes)RequestContextHolder.getRequestAttributes()).getRequest().getHeader("Accept");
         return new ResponseEntity<Void>(HttpStatus.OK);
     }
 

--- a/samples/server/petstore/springboot/src/main/java/io/swagger/api/FakeApiController.java
+++ b/samples/server/petstore/springboot/src/main/java/io/swagger/api/FakeApiController.java
@@ -5,9 +5,8 @@ import io.swagger.model.Client;
 import org.threeten.bp.LocalDate;
 import org.threeten.bp.OffsetDateTime;
 import io.swagger.model.OuterComposite;
-
+import com.fasterxml.jackson.databind.ObjectMapper;
 import io.swagger.annotations.*;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpStatus;
@@ -18,16 +17,13 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RequestPart;
-import org.springframework.web.context.request.RequestContextHolder;
-import org.springframework.web.context.request.ServletRequestAttributes;
 import org.springframework.web.multipart.MultipartFile;
 
-import java.util.List;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import java.io.IOException;
-import javax.servlet.http.HttpServletRequest;
 import javax.validation.constraints.*;
 import javax.validation.Valid;
+import javax.servlet.http.HttpServletRequest;
+import java.io.IOException;
+import java.util.List;
 
 @Controller
 public class FakeApiController implements FakeApi {
@@ -45,7 +41,6 @@ public class FakeApiController implements FakeApi {
     }
 
     public ResponseEntity<Boolean> fakeOuterBooleanSerialize(@ApiParam(value = "Input boolean as post body"  )  @Valid @RequestBody Boolean body) {
-        // do some magic!
         String accept = request.getHeader("Accept");
         if (accept != null && accept.contains("application/json")) {
             try {
@@ -56,11 +51,10 @@ public class FakeApiController implements FakeApi {
             }
         }
 
-        return new ResponseEntity<Boolean>(HttpStatus.OK);
+        return new ResponseEntity<Boolean>(HttpStatus.NOT_IMPLEMENTED);
     }
 
     public ResponseEntity<OuterComposite> fakeOuterCompositeSerialize(@ApiParam(value = "Input composite as post body"  )  @Valid @RequestBody OuterComposite body) {
-        // do some magic!
         String accept = request.getHeader("Accept");
         if (accept != null && accept.contains("application/json")) {
             try {
@@ -71,11 +65,10 @@ public class FakeApiController implements FakeApi {
             }
         }
 
-        return new ResponseEntity<OuterComposite>(HttpStatus.OK);
+        return new ResponseEntity<OuterComposite>(HttpStatus.NOT_IMPLEMENTED);
     }
 
     public ResponseEntity<BigDecimal> fakeOuterNumberSerialize(@ApiParam(value = "Input number as post body"  )  @Valid @RequestBody BigDecimal body) {
-        // do some magic!
         String accept = request.getHeader("Accept");
         if (accept != null && accept.contains("application/json")) {
             try {
@@ -86,11 +79,10 @@ public class FakeApiController implements FakeApi {
             }
         }
 
-        return new ResponseEntity<BigDecimal>(HttpStatus.OK);
+        return new ResponseEntity<BigDecimal>(HttpStatus.NOT_IMPLEMENTED);
     }
 
     public ResponseEntity<String> fakeOuterStringSerialize(@ApiParam(value = "Input string as post body"  )  @Valid @RequestBody String body) {
-        // do some magic!
         String accept = request.getHeader("Accept");
         if (accept != null && accept.contains("application/json")) {
             try {
@@ -101,11 +93,10 @@ public class FakeApiController implements FakeApi {
             }
         }
 
-        return new ResponseEntity<String>(HttpStatus.OK);
+        return new ResponseEntity<String>(HttpStatus.NOT_IMPLEMENTED);
     }
 
     public ResponseEntity<Client> testClientModel(@ApiParam(value = "client model" ,required=true )  @Valid @RequestBody Client body) {
-        // do some magic!
         String accept = request.getHeader("Accept");
         if (accept != null && accept.contains("application/json")) {
             try {
@@ -116,31 +107,27 @@ public class FakeApiController implements FakeApi {
             }
         }
 
-        return new ResponseEntity<Client>(HttpStatus.OK);
+        return new ResponseEntity<Client>(HttpStatus.NOT_IMPLEMENTED);
     }
 
     public ResponseEntity<Void> testEndpointParameters(@ApiParam(value = "None", required=true) @RequestPart(value="number", required=true)  BigDecimal number,@ApiParam(value = "None", required=true) @RequestPart(value="double", required=true)  Double _double,@ApiParam(value = "None", required=true) @RequestPart(value="pattern_without_delimiter", required=true)  String patternWithoutDelimiter,@ApiParam(value = "None", required=true) @RequestPart(value="byte", required=true)  byte[] _byte,@ApiParam(value = "None") @RequestPart(value="integer", required=false)  Integer integer,@ApiParam(value = "None") @RequestPart(value="int32", required=false)  Integer int32,@ApiParam(value = "None") @RequestPart(value="int64", required=false)  Long int64,@ApiParam(value = "None") @RequestPart(value="float", required=false)  Float _float,@ApiParam(value = "None") @RequestPart(value="string", required=false)  String string,@ApiParam(value = "None") @RequestPart(value="binary", required=false)  byte[] binary,@ApiParam(value = "None") @RequestPart(value="date", required=false)  LocalDate date,@ApiParam(value = "None") @RequestPart(value="dateTime", required=false)  OffsetDateTime dateTime,@ApiParam(value = "None") @RequestPart(value="password", required=false)  String password,@ApiParam(value = "None") @RequestPart(value="callback", required=false)  String paramCallback) {
-        // do some magic!
         String accept = request.getHeader("Accept");
-        return new ResponseEntity<Void>(HttpStatus.OK);
+        return new ResponseEntity<Void>(HttpStatus.NOT_IMPLEMENTED);
     }
 
     public ResponseEntity<Void> testEnumParameters(@ApiParam(value = "Form parameter enum test (string array)", allowableValues=">, $") @RequestPart(value="enum_form_string_array", required=false)  List<String> enumFormStringArray,@ApiParam(value = "Form parameter enum test (string)", allowableValues="_abc, -efg, (xyz)", defaultValue="-efg") @RequestPart(value="enum_form_string", required=false)  String enumFormString,@ApiParam(value = "Header parameter enum test (string array)" , allowableValues=">, $") @RequestHeader(value="enum_header_string_array", required=false) List<String> enumHeaderStringArray,@ApiParam(value = "Header parameter enum test (string)" , allowableValues="_abc, -efg, (xyz)", defaultValue="-efg") @RequestHeader(value="enum_header_string", required=false) String enumHeaderString,@ApiParam(value = "Query parameter enum test (string array)", allowableValues = ">, $") @Valid @RequestParam(value = "enum_query_string_array", required = false) List<String> enumQueryStringArray,@ApiParam(value = "Query parameter enum test (string)", allowableValues = "_abc, -efg, (xyz)", defaultValue = "-efg") @Valid @RequestParam(value = "enum_query_string", required = false, defaultValue="-efg") String enumQueryString,@ApiParam(value = "Query parameter enum test (double)", allowableValues = "1, -2") @Valid @RequestParam(value = "enum_query_integer", required = false) Integer enumQueryInteger,@ApiParam(value = "Query parameter enum test (double)", allowableValues="1.1, -1.2") @RequestPart(value="enum_query_double", required=false)  Double enumQueryDouble) {
-        // do some magic!
         String accept = request.getHeader("Accept");
-        return new ResponseEntity<Void>(HttpStatus.OK);
+        return new ResponseEntity<Void>(HttpStatus.NOT_IMPLEMENTED);
     }
 
     public ResponseEntity<Void> testInlineAdditionalProperties(@ApiParam(value = "request body" ,required=true )  @Valid @RequestBody Object param) {
-        // do some magic!
         String accept = request.getHeader("Accept");
-        return new ResponseEntity<Void>(HttpStatus.OK);
+        return new ResponseEntity<Void>(HttpStatus.NOT_IMPLEMENTED);
     }
 
     public ResponseEntity<Void> testJsonFormData(@ApiParam(value = "field1", required=true) @RequestPart(value="param", required=true)  String param,@ApiParam(value = "field2", required=true) @RequestPart(value="param2", required=true)  String param2) {
-        // do some magic!
         String accept = request.getHeader("Accept");
-        return new ResponseEntity<Void>(HttpStatus.OK);
+        return new ResponseEntity<Void>(HttpStatus.NOT_IMPLEMENTED);
     }
 
 }

--- a/samples/server/petstore/springboot/src/main/java/io/swagger/api/FakeClassnameTestApi.java
+++ b/samples/server/petstore/springboot/src/main/java/io/swagger/api/FakeClassnameTestApi.java
@@ -6,9 +6,9 @@
 package io.swagger.api;
 
 import io.swagger.model.Client;
-
 import io.swagger.annotations.*;
 import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
@@ -17,12 +17,10 @@ import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.multipart.MultipartFile;
-import java.io.IOException;
 
-import java.util.List;
-import org.springframework.validation.annotation.Validated;
-import javax.validation.constraints.*;
 import javax.validation.Valid;
+import javax.validation.constraints.*;
+import java.util.List;
 
 @Api(value = "fake_classname_test", description = "the fake_classname_test API")
 public interface FakeClassnameTestApi {

--- a/samples/server/petstore/springboot/src/main/java/io/swagger/api/FakeClassnameTestApi.java
+++ b/samples/server/petstore/springboot/src/main/java/io/swagger/api/FakeClassnameTestApi.java
@@ -36,6 +36,6 @@ public interface FakeClassnameTestApi {
         produces = { "application/json" }, 
         consumes = { "application/json" },
         method = RequestMethod.PATCH)
-    ResponseEntity<Client> testClassname(@ApiParam(value = "client model" ,required=true )  @Valid @RequestBody Client body, @RequestHeader(value = "Accept", required = false) String accept) throws Exception;
+    ResponseEntity<Client> testClassname(@ApiParam(value = "client model" ,required=true )  @Valid @RequestBody Client body);
 
 }

--- a/samples/server/petstore/springboot/src/main/java/io/swagger/api/FakeClassnameTestApiController.java
+++ b/samples/server/petstore/springboot/src/main/java/io/swagger/api/FakeClassnameTestApiController.java
@@ -4,6 +4,8 @@ import io.swagger.model.Client;
 
 import io.swagger.annotations.*;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
@@ -12,6 +14,8 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RequestPart;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.util.List;
@@ -22,18 +26,25 @@ import javax.validation.Valid;
 
 @Controller
 public class FakeClassnameTestApiController implements FakeClassnameTestApi {
+
+    private final Logger log = LoggerFactory.getLogger(AnotherFakeApiController.class);
+
     private final ObjectMapper objectMapper;
 
     public FakeClassnameTestApiController(ObjectMapper objectMapper) {
         this.objectMapper = objectMapper;
     }
 
-    public ResponseEntity<Client> testClassname(@ApiParam(value = "client model" ,required=true )  @Valid @RequestBody Client body,
-        @RequestHeader(value = "Accept", required = false) String accept) throws Exception {
+    public ResponseEntity<Client> testClassname(@ApiParam(value = "client model" ,required=true )  @Valid @RequestBody Client body) {
         // do some magic!
-
+        String accept = ((ServletRequestAttributes)RequestContextHolder.getRequestAttributes()).getRequest().getHeader("Accept");
         if (accept != null && accept.contains("application/json")) {
-            return new ResponseEntity<Client>(objectMapper.readValue("{  \"client\" : \"client\"}", Client.class), HttpStatus.OK);
+            try {
+                return new ResponseEntity<Client>(objectMapper.readValue("{  \"client\" : \"client\"}", Client.class), HttpStatus.NOT_IMPLEMENTED);
+            } catch (IOException e) {
+                log.error("Couldn't serialize response for content type application/json", e);
+                return new ResponseEntity<Client>(HttpStatus.INTERNAL_SERVER_ERROR);
+            }
         }
 
         return new ResponseEntity<Client>(HttpStatus.OK);

--- a/samples/server/petstore/springboot/src/main/java/io/swagger/api/FakeClassnameTestApiController.java
+++ b/samples/server/petstore/springboot/src/main/java/io/swagger/api/FakeClassnameTestApiController.java
@@ -21,23 +21,28 @@ import org.springframework.web.multipart.MultipartFile;
 import java.util.List;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.IOException;
+import javax.servlet.http.HttpServletRequest;
 import javax.validation.constraints.*;
 import javax.validation.Valid;
 
 @Controller
 public class FakeClassnameTestApiController implements FakeClassnameTestApi {
 
-    private final Logger log = LoggerFactory.getLogger(AnotherFakeApiController.class);
+    private static final Logger log = LoggerFactory.getLogger(FakeClassnameTestApiController.class);
 
     private final ObjectMapper objectMapper;
 
+    @org.springframework.beans.factory.annotation.Autowired
+    private HttpServletRequest request;
+
+    @org.springframework.beans.factory.annotation.Autowired
     public FakeClassnameTestApiController(ObjectMapper objectMapper) {
         this.objectMapper = objectMapper;
     }
 
     public ResponseEntity<Client> testClassname(@ApiParam(value = "client model" ,required=true )  @Valid @RequestBody Client body) {
         // do some magic!
-        String accept = ((ServletRequestAttributes)RequestContextHolder.getRequestAttributes()).getRequest().getHeader("Accept");
+        String accept = request.getHeader("Accept");
         if (accept != null && accept.contains("application/json")) {
             try {
                 return new ResponseEntity<Client>(objectMapper.readValue("{  \"client\" : \"client\"}", Client.class), HttpStatus.NOT_IMPLEMENTED);

--- a/samples/server/petstore/springboot/src/main/java/io/swagger/api/FakeClassnameTestApiController.java
+++ b/samples/server/petstore/springboot/src/main/java/io/swagger/api/FakeClassnameTestApiController.java
@@ -32,12 +32,12 @@ public class FakeClassnameTestApiController implements FakeClassnameTestApi {
 
     private final ObjectMapper objectMapper;
 
-    @org.springframework.beans.factory.annotation.Autowired
-    private HttpServletRequest request;
+    private final HttpServletRequest request;
 
     @org.springframework.beans.factory.annotation.Autowired
-    public FakeClassnameTestApiController(ObjectMapper objectMapper) {
+    public FakeClassnameTestApiController(ObjectMapper objectMapper, HttpServletRequest request) {
         this.objectMapper = objectMapper;
+        this.request = request;
     }
 
     public ResponseEntity<Client> testClassname(@ApiParam(value = "client model" ,required=true )  @Valid @RequestBody Client body) {

--- a/samples/server/petstore/springboot/src/main/java/io/swagger/api/FakeClassnameTestApiController.java
+++ b/samples/server/petstore/springboot/src/main/java/io/swagger/api/FakeClassnameTestApiController.java
@@ -1,9 +1,8 @@
 package io.swagger.api;
 
 import io.swagger.model.Client;
-
+import com.fasterxml.jackson.databind.ObjectMapper;
 import io.swagger.annotations.*;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpStatus;
@@ -14,16 +13,13 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RequestPart;
-import org.springframework.web.context.request.RequestContextHolder;
-import org.springframework.web.context.request.ServletRequestAttributes;
 import org.springframework.web.multipart.MultipartFile;
 
-import java.util.List;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import java.io.IOException;
-import javax.servlet.http.HttpServletRequest;
 import javax.validation.constraints.*;
 import javax.validation.Valid;
+import javax.servlet.http.HttpServletRequest;
+import java.io.IOException;
+import java.util.List;
 
 @Controller
 public class FakeClassnameTestApiController implements FakeClassnameTestApi {
@@ -41,7 +37,6 @@ public class FakeClassnameTestApiController implements FakeClassnameTestApi {
     }
 
     public ResponseEntity<Client> testClassname(@ApiParam(value = "client model" ,required=true )  @Valid @RequestBody Client body) {
-        // do some magic!
         String accept = request.getHeader("Accept");
         if (accept != null && accept.contains("application/json")) {
             try {
@@ -52,7 +47,7 @@ public class FakeClassnameTestApiController implements FakeClassnameTestApi {
             }
         }
 
-        return new ResponseEntity<Client>(HttpStatus.OK);
+        return new ResponseEntity<Client>(HttpStatus.NOT_IMPLEMENTED);
     }
 
 }

--- a/samples/server/petstore/springboot/src/main/java/io/swagger/api/PetApi.java
+++ b/samples/server/petstore/springboot/src/main/java/io/swagger/api/PetApi.java
@@ -8,9 +8,9 @@ package io.swagger.api;
 import io.swagger.model.ModelApiResponse;
 import io.swagger.model.Pet;
 import org.springframework.core.io.Resource;
-
 import io.swagger.annotations.*;
 import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
@@ -19,12 +19,10 @@ import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.multipart.MultipartFile;
-import java.io.IOException;
 
-import java.util.List;
-import org.springframework.validation.annotation.Validated;
-import javax.validation.constraints.*;
 import javax.validation.Valid;
+import javax.validation.constraints.*;
+import java.util.List;
 
 @Api(value = "pet", description = "the pet API")
 public interface PetApi {

--- a/samples/server/petstore/springboot/src/main/java/io/swagger/api/PetApi.java
+++ b/samples/server/petstore/springboot/src/main/java/io/swagger/api/PetApi.java
@@ -41,7 +41,7 @@ public interface PetApi {
         produces = { "application/xml", "application/json" }, 
         consumes = { "application/json", "application/xml" },
         method = RequestMethod.POST)
-    ResponseEntity<Void> addPet(@ApiParam(value = "Pet object that needs to be added to the store" ,required=true )  @Valid @RequestBody Pet body, @RequestHeader(value = "Accept", required = false) String accept) throws Exception;
+    ResponseEntity<Void> addPet(@ApiParam(value = "Pet object that needs to be added to the store" ,required=true )  @Valid @RequestBody Pet body);
 
 
     @ApiOperation(value = "Deletes a pet", nickname = "deletePet", notes = "", authorizations = {
@@ -55,7 +55,7 @@ public interface PetApi {
     @RequestMapping(value = "/pet/{petId}",
         produces = { "application/xml", "application/json" }, 
         method = RequestMethod.DELETE)
-    ResponseEntity<Void> deletePet(@ApiParam(value = "Pet id to delete",required=true) @PathVariable("petId") Long petId,@ApiParam(value = "" ) @RequestHeader(value="api_key", required=false) String apiKey, @RequestHeader(value = "Accept", required = false) String accept) throws Exception;
+    ResponseEntity<Void> deletePet(@ApiParam(value = "Pet id to delete",required=true) @PathVariable("petId") Long petId,@ApiParam(value = "" ) @RequestHeader(value="api_key", required=false) String apiKey);
 
 
     @ApiOperation(value = "Finds Pets by status", nickname = "findPetsByStatus", notes = "Multiple status values can be provided with comma separated strings", response = Pet.class, responseContainer = "List", authorizations = {
@@ -70,7 +70,7 @@ public interface PetApi {
     @RequestMapping(value = "/pet/findByStatus",
         produces = { "application/xml", "application/json" }, 
         method = RequestMethod.GET)
-    ResponseEntity<List<Pet>> findPetsByStatus( @NotNull@ApiParam(value = "Status values that need to be considered for filter", required = true, allowableValues = "available, pending, sold") @Valid @RequestParam(value = "status", required = true) List<String> status, @RequestHeader(value = "Accept", required = false) String accept) throws Exception;
+    ResponseEntity<List<Pet>> findPetsByStatus(@NotNull @ApiParam(value = "Status values that need to be considered for filter", required = true, allowableValues = "available, pending, sold") @Valid @RequestParam(value = "status", required = true) List<String> status);
 
 
     @ApiOperation(value = "Finds Pets by tags", nickname = "findPetsByTags", notes = "Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.", response = Pet.class, responseContainer = "List", authorizations = {
@@ -85,7 +85,7 @@ public interface PetApi {
     @RequestMapping(value = "/pet/findByTags",
         produces = { "application/xml", "application/json" }, 
         method = RequestMethod.GET)
-    ResponseEntity<List<Pet>> findPetsByTags( @NotNull@ApiParam(value = "Tags to filter by", required = true) @Valid @RequestParam(value = "tags", required = true) List<String> tags, @RequestHeader(value = "Accept", required = false) String accept) throws Exception;
+    ResponseEntity<List<Pet>> findPetsByTags(@NotNull @ApiParam(value = "Tags to filter by", required = true) @Valid @RequestParam(value = "tags", required = true) List<String> tags);
 
 
     @ApiOperation(value = "Find pet by ID", nickname = "getPetById", notes = "Returns a single pet", response = Pet.class, authorizations = {
@@ -98,7 +98,7 @@ public interface PetApi {
     @RequestMapping(value = "/pet/{petId}",
         produces = { "application/xml", "application/json" }, 
         method = RequestMethod.GET)
-    ResponseEntity<Pet> getPetById(@ApiParam(value = "ID of pet to return",required=true) @PathVariable("petId") Long petId, @RequestHeader(value = "Accept", required = false) String accept) throws Exception;
+    ResponseEntity<Pet> getPetById(@ApiParam(value = "ID of pet to return",required=true) @PathVariable("petId") Long petId);
 
 
     @ApiOperation(value = "Update an existing pet", nickname = "updatePet", notes = "", authorizations = {
@@ -115,7 +115,7 @@ public interface PetApi {
         produces = { "application/xml", "application/json" }, 
         consumes = { "application/json", "application/xml" },
         method = RequestMethod.PUT)
-    ResponseEntity<Void> updatePet(@ApiParam(value = "Pet object that needs to be added to the store" ,required=true )  @Valid @RequestBody Pet body, @RequestHeader(value = "Accept", required = false) String accept) throws Exception;
+    ResponseEntity<Void> updatePet(@ApiParam(value = "Pet object that needs to be added to the store" ,required=true )  @Valid @RequestBody Pet body);
 
 
     @ApiOperation(value = "Updates a pet in the store with form data", nickname = "updatePetWithForm", notes = "", authorizations = {
@@ -130,7 +130,7 @@ public interface PetApi {
         produces = { "application/xml", "application/json" }, 
         consumes = { "application/x-www-form-urlencoded" },
         method = RequestMethod.POST)
-    ResponseEntity<Void> updatePetWithForm(@ApiParam(value = "ID of pet that needs to be updated",required=true) @PathVariable("petId") Long petId,@ApiParam(value = "Updated name of the pet") @RequestPart(value="name", required=false)  String name,@ApiParam(value = "Updated status of the pet") @RequestPart(value="status", required=false)  String status, @RequestHeader(value = "Accept", required = false) String accept) throws Exception;
+    ResponseEntity<Void> updatePetWithForm(@ApiParam(value = "ID of pet that needs to be updated",required=true) @PathVariable("petId") Long petId,@ApiParam(value = "Updated name of the pet") @RequestPart(value="name", required=false)  String name,@ApiParam(value = "Updated status of the pet") @RequestPart(value="status", required=false)  String status);
 
 
     @ApiOperation(value = "uploads an image", nickname = "uploadFile", notes = "", response = ModelApiResponse.class, authorizations = {
@@ -145,6 +145,6 @@ public interface PetApi {
         produces = { "application/json" }, 
         consumes = { "multipart/form-data" },
         method = RequestMethod.POST)
-    ResponseEntity<ModelApiResponse> uploadFile(@ApiParam(value = "ID of pet to update",required=true) @PathVariable("petId") Long petId,@ApiParam(value = "Additional data to pass to server") @RequestPart(value="additionalMetadata", required=false)  String additionalMetadata,@ApiParam(value = "file detail") @Valid @RequestPart("file") MultipartFile file, @RequestHeader(value = "Accept", required = false) String accept) throws Exception;
+    ResponseEntity<ModelApiResponse> uploadFile(@ApiParam(value = "ID of pet to update",required=true) @PathVariable("petId") Long petId,@ApiParam(value = "Additional data to pass to server") @RequestPart(value="additionalMetadata", required=false)  String additionalMetadata,@ApiParam(value = "file detail") @Valid @RequestPart("file") MultipartFile file);
 
 }

--- a/samples/server/petstore/springboot/src/main/java/io/swagger/api/PetApiController.java
+++ b/samples/server/petstore/springboot/src/main/java/io/swagger/api/PetApiController.java
@@ -34,12 +34,12 @@ public class PetApiController implements PetApi {
 
     private final ObjectMapper objectMapper;
 
-    @org.springframework.beans.factory.annotation.Autowired
-    private HttpServletRequest request;
+    private final HttpServletRequest request;
 
     @org.springframework.beans.factory.annotation.Autowired
-    public PetApiController(ObjectMapper objectMapper) {
+    public PetApiController(ObjectMapper objectMapper, HttpServletRequest request) {
         this.objectMapper = objectMapper;
+        this.request = request;
     }
 
     public ResponseEntity<Void> addPet(@ApiParam(value = "Pet object that needs to be added to the store" ,required=true )  @Valid @RequestBody Pet body) {

--- a/samples/server/petstore/springboot/src/main/java/io/swagger/api/PetApiController.java
+++ b/samples/server/petstore/springboot/src/main/java/io/swagger/api/PetApiController.java
@@ -3,9 +3,8 @@ package io.swagger.api;
 import io.swagger.model.ModelApiResponse;
 import io.swagger.model.Pet;
 import org.springframework.core.io.Resource;
-
+import com.fasterxml.jackson.databind.ObjectMapper;
 import io.swagger.annotations.*;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpStatus;
@@ -16,16 +15,13 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RequestPart;
-import org.springframework.web.context.request.RequestContextHolder;
-import org.springframework.web.context.request.ServletRequestAttributes;
 import org.springframework.web.multipart.MultipartFile;
 
-import java.util.List;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import java.io.IOException;
-import javax.servlet.http.HttpServletRequest;
 import javax.validation.constraints.*;
 import javax.validation.Valid;
+import javax.servlet.http.HttpServletRequest;
+import java.io.IOException;
+import java.util.List;
 
 @Controller
 public class PetApiController implements PetApi {
@@ -43,19 +39,16 @@ public class PetApiController implements PetApi {
     }
 
     public ResponseEntity<Void> addPet(@ApiParam(value = "Pet object that needs to be added to the store" ,required=true )  @Valid @RequestBody Pet body) {
-        // do some magic!
         String accept = request.getHeader("Accept");
-        return new ResponseEntity<Void>(HttpStatus.OK);
+        return new ResponseEntity<Void>(HttpStatus.NOT_IMPLEMENTED);
     }
 
     public ResponseEntity<Void> deletePet(@ApiParam(value = "Pet id to delete",required=true) @PathVariable("petId") Long petId,@ApiParam(value = "" ) @RequestHeader(value="api_key", required=false) String apiKey) {
-        // do some magic!
         String accept = request.getHeader("Accept");
-        return new ResponseEntity<Void>(HttpStatus.OK);
+        return new ResponseEntity<Void>(HttpStatus.NOT_IMPLEMENTED);
     }
 
     public ResponseEntity<List<Pet>> findPetsByStatus(@NotNull @ApiParam(value = "Status values that need to be considered for filter", required = true, allowableValues = "available, pending, sold") @Valid @RequestParam(value = "status", required = true) List<String> status) {
-        // do some magic!
         String accept = request.getHeader("Accept");
         if (accept != null && accept.contains("application/xml")) {
             try {
@@ -75,11 +68,10 @@ public class PetApiController implements PetApi {
             }
         }
 
-        return new ResponseEntity<List<Pet>>(HttpStatus.OK);
+        return new ResponseEntity<List<Pet>>(HttpStatus.NOT_IMPLEMENTED);
     }
 
     public ResponseEntity<List<Pet>> findPetsByTags(@NotNull @ApiParam(value = "Tags to filter by", required = true) @Valid @RequestParam(value = "tags", required = true) List<String> tags) {
-        // do some magic!
         String accept = request.getHeader("Accept");
         if (accept != null && accept.contains("application/xml")) {
             try {
@@ -99,11 +91,10 @@ public class PetApiController implements PetApi {
             }
         }
 
-        return new ResponseEntity<List<Pet>>(HttpStatus.OK);
+        return new ResponseEntity<List<Pet>>(HttpStatus.NOT_IMPLEMENTED);
     }
 
     public ResponseEntity<Pet> getPetById(@ApiParam(value = "ID of pet to return",required=true) @PathVariable("petId") Long petId) {
-        // do some magic!
         String accept = request.getHeader("Accept");
         if (accept != null && accept.contains("application/xml")) {
             try {
@@ -123,23 +114,20 @@ public class PetApiController implements PetApi {
             }
         }
 
-        return new ResponseEntity<Pet>(HttpStatus.OK);
+        return new ResponseEntity<Pet>(HttpStatus.NOT_IMPLEMENTED);
     }
 
     public ResponseEntity<Void> updatePet(@ApiParam(value = "Pet object that needs to be added to the store" ,required=true )  @Valid @RequestBody Pet body) {
-        // do some magic!
         String accept = request.getHeader("Accept");
-        return new ResponseEntity<Void>(HttpStatus.OK);
+        return new ResponseEntity<Void>(HttpStatus.NOT_IMPLEMENTED);
     }
 
     public ResponseEntity<Void> updatePetWithForm(@ApiParam(value = "ID of pet that needs to be updated",required=true) @PathVariable("petId") Long petId,@ApiParam(value = "Updated name of the pet") @RequestPart(value="name", required=false)  String name,@ApiParam(value = "Updated status of the pet") @RequestPart(value="status", required=false)  String status) {
-        // do some magic!
         String accept = request.getHeader("Accept");
-        return new ResponseEntity<Void>(HttpStatus.OK);
+        return new ResponseEntity<Void>(HttpStatus.NOT_IMPLEMENTED);
     }
 
     public ResponseEntity<ModelApiResponse> uploadFile(@ApiParam(value = "ID of pet to update",required=true) @PathVariable("petId") Long petId,@ApiParam(value = "Additional data to pass to server") @RequestPart(value="additionalMetadata", required=false)  String additionalMetadata,@ApiParam(value = "file detail") @Valid @RequestPart("file") MultipartFile file) {
-        // do some magic!
         String accept = request.getHeader("Accept");
         if (accept != null && accept.contains("application/json")) {
             try {
@@ -150,7 +138,7 @@ public class PetApiController implements PetApi {
             }
         }
 
-        return new ResponseEntity<ModelApiResponse>(HttpStatus.OK);
+        return new ResponseEntity<ModelApiResponse>(HttpStatus.NOT_IMPLEMENTED);
     }
 
 }

--- a/samples/server/petstore/springboot/src/main/java/io/swagger/api/PetApiController.java
+++ b/samples/server/petstore/springboot/src/main/java/io/swagger/api/PetApiController.java
@@ -23,35 +23,40 @@ import org.springframework.web.multipart.MultipartFile;
 import java.util.List;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.IOException;
+import javax.servlet.http.HttpServletRequest;
 import javax.validation.constraints.*;
 import javax.validation.Valid;
 
 @Controller
 public class PetApiController implements PetApi {
 
-    private final Logger log = LoggerFactory.getLogger(AnotherFakeApiController.class);
+    private static final Logger log = LoggerFactory.getLogger(PetApiController.class);
 
     private final ObjectMapper objectMapper;
 
+    @org.springframework.beans.factory.annotation.Autowired
+    private HttpServletRequest request;
+
+    @org.springframework.beans.factory.annotation.Autowired
     public PetApiController(ObjectMapper objectMapper) {
         this.objectMapper = objectMapper;
     }
 
     public ResponseEntity<Void> addPet(@ApiParam(value = "Pet object that needs to be added to the store" ,required=true )  @Valid @RequestBody Pet body) {
         // do some magic!
-        String accept = ((ServletRequestAttributes)RequestContextHolder.getRequestAttributes()).getRequest().getHeader("Accept");
+        String accept = request.getHeader("Accept");
         return new ResponseEntity<Void>(HttpStatus.OK);
     }
 
     public ResponseEntity<Void> deletePet(@ApiParam(value = "Pet id to delete",required=true) @PathVariable("petId") Long petId,@ApiParam(value = "" ) @RequestHeader(value="api_key", required=false) String apiKey) {
         // do some magic!
-        String accept = ((ServletRequestAttributes)RequestContextHolder.getRequestAttributes()).getRequest().getHeader("Accept");
+        String accept = request.getHeader("Accept");
         return new ResponseEntity<Void>(HttpStatus.OK);
     }
 
     public ResponseEntity<List<Pet>> findPetsByStatus(@NotNull @ApiParam(value = "Status values that need to be considered for filter", required = true, allowableValues = "available, pending, sold") @Valid @RequestParam(value = "status", required = true) List<String> status) {
         // do some magic!
-        String accept = ((ServletRequestAttributes)RequestContextHolder.getRequestAttributes()).getRequest().getHeader("Accept");
+        String accept = request.getHeader("Accept");
         if (accept != null && accept.contains("application/xml")) {
             try {
                 return new ResponseEntity<List<Pet>>(objectMapper.readValue("<Pet>  <id>123456789</id>  <name>doggie</name>  <photoUrls>    <photoUrls>aeiou</photoUrls>  </photoUrls>  <tags>  </tags>  <status>aeiou</status></Pet>", List.class), HttpStatus.NOT_IMPLEMENTED);
@@ -75,7 +80,7 @@ public class PetApiController implements PetApi {
 
     public ResponseEntity<List<Pet>> findPetsByTags(@NotNull @ApiParam(value = "Tags to filter by", required = true) @Valid @RequestParam(value = "tags", required = true) List<String> tags) {
         // do some magic!
-        String accept = ((ServletRequestAttributes)RequestContextHolder.getRequestAttributes()).getRequest().getHeader("Accept");
+        String accept = request.getHeader("Accept");
         if (accept != null && accept.contains("application/xml")) {
             try {
                 return new ResponseEntity<List<Pet>>(objectMapper.readValue("<Pet>  <id>123456789</id>  <name>doggie</name>  <photoUrls>    <photoUrls>aeiou</photoUrls>  </photoUrls>  <tags>  </tags>  <status>aeiou</status></Pet>", List.class), HttpStatus.NOT_IMPLEMENTED);
@@ -99,7 +104,7 @@ public class PetApiController implements PetApi {
 
     public ResponseEntity<Pet> getPetById(@ApiParam(value = "ID of pet to return",required=true) @PathVariable("petId") Long petId) {
         // do some magic!
-        String accept = ((ServletRequestAttributes)RequestContextHolder.getRequestAttributes()).getRequest().getHeader("Accept");
+        String accept = request.getHeader("Accept");
         if (accept != null && accept.contains("application/xml")) {
             try {
                 return new ResponseEntity<Pet>(objectMapper.readValue("<Pet>  <id>123456789</id>  <name>doggie</name>  <photoUrls>    <photoUrls>aeiou</photoUrls>  </photoUrls>  <tags>  </tags>  <status>aeiou</status></Pet>", Pet.class), HttpStatus.NOT_IMPLEMENTED);
@@ -123,19 +128,19 @@ public class PetApiController implements PetApi {
 
     public ResponseEntity<Void> updatePet(@ApiParam(value = "Pet object that needs to be added to the store" ,required=true )  @Valid @RequestBody Pet body) {
         // do some magic!
-        String accept = ((ServletRequestAttributes)RequestContextHolder.getRequestAttributes()).getRequest().getHeader("Accept");
+        String accept = request.getHeader("Accept");
         return new ResponseEntity<Void>(HttpStatus.OK);
     }
 
     public ResponseEntity<Void> updatePetWithForm(@ApiParam(value = "ID of pet that needs to be updated",required=true) @PathVariable("petId") Long petId,@ApiParam(value = "Updated name of the pet") @RequestPart(value="name", required=false)  String name,@ApiParam(value = "Updated status of the pet") @RequestPart(value="status", required=false)  String status) {
         // do some magic!
-        String accept = ((ServletRequestAttributes)RequestContextHolder.getRequestAttributes()).getRequest().getHeader("Accept");
+        String accept = request.getHeader("Accept");
         return new ResponseEntity<Void>(HttpStatus.OK);
     }
 
     public ResponseEntity<ModelApiResponse> uploadFile(@ApiParam(value = "ID of pet to update",required=true) @PathVariable("petId") Long petId,@ApiParam(value = "Additional data to pass to server") @RequestPart(value="additionalMetadata", required=false)  String additionalMetadata,@ApiParam(value = "file detail") @Valid @RequestPart("file") MultipartFile file) {
         // do some magic!
-        String accept = ((ServletRequestAttributes)RequestContextHolder.getRequestAttributes()).getRequest().getHeader("Accept");
+        String accept = request.getHeader("Accept");
         if (accept != null && accept.contains("application/json")) {
             try {
                 return new ResponseEntity<ModelApiResponse>(objectMapper.readValue("{  \"code\" : 0,  \"type\" : \"type\",  \"message\" : \"message\"}", ModelApiResponse.class), HttpStatus.NOT_IMPLEMENTED);

--- a/samples/server/petstore/springboot/src/main/java/io/swagger/api/PetApiController.java
+++ b/samples/server/petstore/springboot/src/main/java/io/swagger/api/PetApiController.java
@@ -6,6 +6,8 @@ import org.springframework.core.io.Resource;
 
 import io.swagger.annotations.*;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
@@ -14,6 +16,8 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RequestPart;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.util.List;
@@ -24,95 +28,121 @@ import javax.validation.Valid;
 
 @Controller
 public class PetApiController implements PetApi {
+
+    private final Logger log = LoggerFactory.getLogger(AnotherFakeApiController.class);
+
     private final ObjectMapper objectMapper;
 
     public PetApiController(ObjectMapper objectMapper) {
         this.objectMapper = objectMapper;
     }
 
-    public ResponseEntity<Void> addPet(@ApiParam(value = "Pet object that needs to be added to the store" ,required=true )  @Valid @RequestBody Pet body,
-        @RequestHeader(value = "Accept", required = false) String accept) throws Exception {
+    public ResponseEntity<Void> addPet(@ApiParam(value = "Pet object that needs to be added to the store" ,required=true )  @Valid @RequestBody Pet body) {
         // do some magic!
+        String accept = ((ServletRequestAttributes)RequestContextHolder.getRequestAttributes()).getRequest().getHeader("Accept");
         return new ResponseEntity<Void>(HttpStatus.OK);
     }
 
-    public ResponseEntity<Void> deletePet(@ApiParam(value = "Pet id to delete",required=true) @PathVariable("petId") Long petId,
-        @ApiParam(value = "" ) @RequestHeader(value="api_key", required=false) String apiKey,
-        @RequestHeader(value = "Accept", required = false) String accept) throws Exception {
+    public ResponseEntity<Void> deletePet(@ApiParam(value = "Pet id to delete",required=true) @PathVariable("petId") Long petId,@ApiParam(value = "" ) @RequestHeader(value="api_key", required=false) String apiKey) {
         // do some magic!
+        String accept = ((ServletRequestAttributes)RequestContextHolder.getRequestAttributes()).getRequest().getHeader("Accept");
         return new ResponseEntity<Void>(HttpStatus.OK);
     }
 
-    public ResponseEntity<List<Pet>> findPetsByStatus( @NotNull@ApiParam(value = "Status values that need to be considered for filter", required = true, allowableValues = "available, pending, sold") @Valid @RequestParam(value = "status", required = true) List<String> status,
-        @RequestHeader(value = "Accept", required = false) String accept) throws Exception {
+    public ResponseEntity<List<Pet>> findPetsByStatus(@NotNull @ApiParam(value = "Status values that need to be considered for filter", required = true, allowableValues = "available, pending, sold") @Valid @RequestParam(value = "status", required = true) List<String> status) {
         // do some magic!
-
+        String accept = ((ServletRequestAttributes)RequestContextHolder.getRequestAttributes()).getRequest().getHeader("Accept");
         if (accept != null && accept.contains("application/xml")) {
-            return new ResponseEntity<List<Pet>>(objectMapper.readValue("<Pet>  <id>123456789</id>  <name>doggie</name>  <photoUrls>    <photoUrls>aeiou</photoUrls>  </photoUrls>  <tags>  </tags>  <status>aeiou</status></Pet>", List.class), HttpStatus.OK);
+            try {
+                return new ResponseEntity<List<Pet>>(objectMapper.readValue("<Pet>  <id>123456789</id>  <name>doggie</name>  <photoUrls>    <photoUrls>aeiou</photoUrls>  </photoUrls>  <tags>  </tags>  <status>aeiou</status></Pet>", List.class), HttpStatus.NOT_IMPLEMENTED);
+            } catch (IOException e) {
+                log.error("Couldn't serialize response for content type application/xml", e);
+                return new ResponseEntity<List<Pet>>(HttpStatus.INTERNAL_SERVER_ERROR);
+            }
         }
 
-
         if (accept != null && accept.contains("application/json")) {
-            return new ResponseEntity<List<Pet>>(objectMapper.readValue("[ {  \"photoUrls\" : [ \"photoUrls\", \"photoUrls\" ],  \"name\" : \"doggie\",  \"id\" : 0,  \"category\" : {    \"name\" : \"name\",    \"id\" : 6  },  \"tags\" : [ {    \"name\" : \"name\",    \"id\" : 1  }, {    \"name\" : \"name\",    \"id\" : 1  } ],  \"status\" : \"available\"}, {  \"photoUrls\" : [ \"photoUrls\", \"photoUrls\" ],  \"name\" : \"doggie\",  \"id\" : 0,  \"category\" : {    \"name\" : \"name\",    \"id\" : 6  },  \"tags\" : [ {    \"name\" : \"name\",    \"id\" : 1  }, {    \"name\" : \"name\",    \"id\" : 1  } ],  \"status\" : \"available\"} ]", List.class), HttpStatus.OK);
+            try {
+                return new ResponseEntity<List<Pet>>(objectMapper.readValue("[ {  \"photoUrls\" : [ \"photoUrls\", \"photoUrls\" ],  \"name\" : \"doggie\",  \"id\" : 0,  \"category\" : {    \"name\" : \"name\",    \"id\" : 6  },  \"tags\" : [ {    \"name\" : \"name\",    \"id\" : 1  }, {    \"name\" : \"name\",    \"id\" : 1  } ],  \"status\" : \"available\"}, {  \"photoUrls\" : [ \"photoUrls\", \"photoUrls\" ],  \"name\" : \"doggie\",  \"id\" : 0,  \"category\" : {    \"name\" : \"name\",    \"id\" : 6  },  \"tags\" : [ {    \"name\" : \"name\",    \"id\" : 1  }, {    \"name\" : \"name\",    \"id\" : 1  } ],  \"status\" : \"available\"} ]", List.class), HttpStatus.NOT_IMPLEMENTED);
+            } catch (IOException e) {
+                log.error("Couldn't serialize response for content type application/json", e);
+                return new ResponseEntity<List<Pet>>(HttpStatus.INTERNAL_SERVER_ERROR);
+            }
         }
 
         return new ResponseEntity<List<Pet>>(HttpStatus.OK);
     }
 
-    public ResponseEntity<List<Pet>> findPetsByTags( @NotNull@ApiParam(value = "Tags to filter by", required = true) @Valid @RequestParam(value = "tags", required = true) List<String> tags,
-        @RequestHeader(value = "Accept", required = false) String accept) throws Exception {
+    public ResponseEntity<List<Pet>> findPetsByTags(@NotNull @ApiParam(value = "Tags to filter by", required = true) @Valid @RequestParam(value = "tags", required = true) List<String> tags) {
         // do some magic!
-
+        String accept = ((ServletRequestAttributes)RequestContextHolder.getRequestAttributes()).getRequest().getHeader("Accept");
         if (accept != null && accept.contains("application/xml")) {
-            return new ResponseEntity<List<Pet>>(objectMapper.readValue("<Pet>  <id>123456789</id>  <name>doggie</name>  <photoUrls>    <photoUrls>aeiou</photoUrls>  </photoUrls>  <tags>  </tags>  <status>aeiou</status></Pet>", List.class), HttpStatus.OK);
+            try {
+                return new ResponseEntity<List<Pet>>(objectMapper.readValue("<Pet>  <id>123456789</id>  <name>doggie</name>  <photoUrls>    <photoUrls>aeiou</photoUrls>  </photoUrls>  <tags>  </tags>  <status>aeiou</status></Pet>", List.class), HttpStatus.NOT_IMPLEMENTED);
+            } catch (IOException e) {
+                log.error("Couldn't serialize response for content type application/xml", e);
+                return new ResponseEntity<List<Pet>>(HttpStatus.INTERNAL_SERVER_ERROR);
+            }
         }
 
-
         if (accept != null && accept.contains("application/json")) {
-            return new ResponseEntity<List<Pet>>(objectMapper.readValue("[ {  \"photoUrls\" : [ \"photoUrls\", \"photoUrls\" ],  \"name\" : \"doggie\",  \"id\" : 0,  \"category\" : {    \"name\" : \"name\",    \"id\" : 6  },  \"tags\" : [ {    \"name\" : \"name\",    \"id\" : 1  }, {    \"name\" : \"name\",    \"id\" : 1  } ],  \"status\" : \"available\"}, {  \"photoUrls\" : [ \"photoUrls\", \"photoUrls\" ],  \"name\" : \"doggie\",  \"id\" : 0,  \"category\" : {    \"name\" : \"name\",    \"id\" : 6  },  \"tags\" : [ {    \"name\" : \"name\",    \"id\" : 1  }, {    \"name\" : \"name\",    \"id\" : 1  } ],  \"status\" : \"available\"} ]", List.class), HttpStatus.OK);
+            try {
+                return new ResponseEntity<List<Pet>>(objectMapper.readValue("[ {  \"photoUrls\" : [ \"photoUrls\", \"photoUrls\" ],  \"name\" : \"doggie\",  \"id\" : 0,  \"category\" : {    \"name\" : \"name\",    \"id\" : 6  },  \"tags\" : [ {    \"name\" : \"name\",    \"id\" : 1  }, {    \"name\" : \"name\",    \"id\" : 1  } ],  \"status\" : \"available\"}, {  \"photoUrls\" : [ \"photoUrls\", \"photoUrls\" ],  \"name\" : \"doggie\",  \"id\" : 0,  \"category\" : {    \"name\" : \"name\",    \"id\" : 6  },  \"tags\" : [ {    \"name\" : \"name\",    \"id\" : 1  }, {    \"name\" : \"name\",    \"id\" : 1  } ],  \"status\" : \"available\"} ]", List.class), HttpStatus.NOT_IMPLEMENTED);
+            } catch (IOException e) {
+                log.error("Couldn't serialize response for content type application/json", e);
+                return new ResponseEntity<List<Pet>>(HttpStatus.INTERNAL_SERVER_ERROR);
+            }
         }
 
         return new ResponseEntity<List<Pet>>(HttpStatus.OK);
     }
 
-    public ResponseEntity<Pet> getPetById(@ApiParam(value = "ID of pet to return",required=true) @PathVariable("petId") Long petId,
-        @RequestHeader(value = "Accept", required = false) String accept) throws Exception {
+    public ResponseEntity<Pet> getPetById(@ApiParam(value = "ID of pet to return",required=true) @PathVariable("petId") Long petId) {
         // do some magic!
-
+        String accept = ((ServletRequestAttributes)RequestContextHolder.getRequestAttributes()).getRequest().getHeader("Accept");
         if (accept != null && accept.contains("application/xml")) {
-            return new ResponseEntity<Pet>(objectMapper.readValue("<Pet>  <id>123456789</id>  <name>doggie</name>  <photoUrls>    <photoUrls>aeiou</photoUrls>  </photoUrls>  <tags>  </tags>  <status>aeiou</status></Pet>", Pet.class), HttpStatus.OK);
+            try {
+                return new ResponseEntity<Pet>(objectMapper.readValue("<Pet>  <id>123456789</id>  <name>doggie</name>  <photoUrls>    <photoUrls>aeiou</photoUrls>  </photoUrls>  <tags>  </tags>  <status>aeiou</status></Pet>", Pet.class), HttpStatus.NOT_IMPLEMENTED);
+            } catch (IOException e) {
+                log.error("Couldn't serialize response for content type application/xml", e);
+                return new ResponseEntity<Pet>(HttpStatus.INTERNAL_SERVER_ERROR);
+            }
         }
 
-
         if (accept != null && accept.contains("application/json")) {
-            return new ResponseEntity<Pet>(objectMapper.readValue("{  \"photoUrls\" : [ \"photoUrls\", \"photoUrls\" ],  \"name\" : \"doggie\",  \"id\" : 0,  \"category\" : {    \"name\" : \"name\",    \"id\" : 6  },  \"tags\" : [ {    \"name\" : \"name\",    \"id\" : 1  }, {    \"name\" : \"name\",    \"id\" : 1  } ],  \"status\" : \"available\"}", Pet.class), HttpStatus.OK);
+            try {
+                return new ResponseEntity<Pet>(objectMapper.readValue("{  \"photoUrls\" : [ \"photoUrls\", \"photoUrls\" ],  \"name\" : \"doggie\",  \"id\" : 0,  \"category\" : {    \"name\" : \"name\",    \"id\" : 6  },  \"tags\" : [ {    \"name\" : \"name\",    \"id\" : 1  }, {    \"name\" : \"name\",    \"id\" : 1  } ],  \"status\" : \"available\"}", Pet.class), HttpStatus.NOT_IMPLEMENTED);
+            } catch (IOException e) {
+                log.error("Couldn't serialize response for content type application/json", e);
+                return new ResponseEntity<Pet>(HttpStatus.INTERNAL_SERVER_ERROR);
+            }
         }
 
         return new ResponseEntity<Pet>(HttpStatus.OK);
     }
 
-    public ResponseEntity<Void> updatePet(@ApiParam(value = "Pet object that needs to be added to the store" ,required=true )  @Valid @RequestBody Pet body,
-        @RequestHeader(value = "Accept", required = false) String accept) throws Exception {
+    public ResponseEntity<Void> updatePet(@ApiParam(value = "Pet object that needs to be added to the store" ,required=true )  @Valid @RequestBody Pet body) {
         // do some magic!
+        String accept = ((ServletRequestAttributes)RequestContextHolder.getRequestAttributes()).getRequest().getHeader("Accept");
         return new ResponseEntity<Void>(HttpStatus.OK);
     }
 
-    public ResponseEntity<Void> updatePetWithForm(@ApiParam(value = "ID of pet that needs to be updated",required=true) @PathVariable("petId") Long petId,
-        @ApiParam(value = "Updated name of the pet") @RequestPart(value="name", required=false)  String name,
-        @ApiParam(value = "Updated status of the pet") @RequestPart(value="status", required=false)  String status,
-        @RequestHeader(value = "Accept", required = false) String accept) throws Exception {
+    public ResponseEntity<Void> updatePetWithForm(@ApiParam(value = "ID of pet that needs to be updated",required=true) @PathVariable("petId") Long petId,@ApiParam(value = "Updated name of the pet") @RequestPart(value="name", required=false)  String name,@ApiParam(value = "Updated status of the pet") @RequestPart(value="status", required=false)  String status) {
         // do some magic!
+        String accept = ((ServletRequestAttributes)RequestContextHolder.getRequestAttributes()).getRequest().getHeader("Accept");
         return new ResponseEntity<Void>(HttpStatus.OK);
     }
 
-    public ResponseEntity<ModelApiResponse> uploadFile(@ApiParam(value = "ID of pet to update",required=true) @PathVariable("petId") Long petId,
-        @ApiParam(value = "Additional data to pass to server") @RequestPart(value="additionalMetadata", required=false)  String additionalMetadata,
-        @ApiParam(value = "file detail") @Valid @RequestPart("file") MultipartFile file,
-        @RequestHeader(value = "Accept", required = false) String accept) throws Exception {
+    public ResponseEntity<ModelApiResponse> uploadFile(@ApiParam(value = "ID of pet to update",required=true) @PathVariable("petId") Long petId,@ApiParam(value = "Additional data to pass to server") @RequestPart(value="additionalMetadata", required=false)  String additionalMetadata,@ApiParam(value = "file detail") @Valid @RequestPart("file") MultipartFile file) {
         // do some magic!
-
+        String accept = ((ServletRequestAttributes)RequestContextHolder.getRequestAttributes()).getRequest().getHeader("Accept");
         if (accept != null && accept.contains("application/json")) {
-            return new ResponseEntity<ModelApiResponse>(objectMapper.readValue("{  \"code\" : 0,  \"type\" : \"type\",  \"message\" : \"message\"}", ModelApiResponse.class), HttpStatus.OK);
+            try {
+                return new ResponseEntity<ModelApiResponse>(objectMapper.readValue("{  \"code\" : 0,  \"type\" : \"type\",  \"message\" : \"message\"}", ModelApiResponse.class), HttpStatus.NOT_IMPLEMENTED);
+            } catch (IOException e) {
+                log.error("Couldn't serialize response for content type application/json", e);
+                return new ResponseEntity<ModelApiResponse>(HttpStatus.INTERNAL_SERVER_ERROR);
+            }
         }
 
         return new ResponseEntity<ModelApiResponse>(HttpStatus.OK);

--- a/samples/server/petstore/springboot/src/main/java/io/swagger/api/StoreApi.java
+++ b/samples/server/petstore/springboot/src/main/java/io/swagger/api/StoreApi.java
@@ -7,9 +7,9 @@ package io.swagger.api;
 
 import java.util.Map;
 import io.swagger.model.Order;
-
 import io.swagger.annotations.*;
 import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
@@ -18,12 +18,10 @@ import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.multipart.MultipartFile;
-import java.io.IOException;
 
-import java.util.List;
-import org.springframework.validation.annotation.Validated;
-import javax.validation.constraints.*;
 import javax.validation.Valid;
+import javax.validation.constraints.*;
+import java.util.List;
 
 @Api(value = "store", description = "the store API")
 public interface StoreApi {

--- a/samples/server/petstore/springboot/src/main/java/io/swagger/api/StoreApi.java
+++ b/samples/server/petstore/springboot/src/main/java/io/swagger/api/StoreApi.java
@@ -35,7 +35,7 @@ public interface StoreApi {
     @RequestMapping(value = "/store/order/{order_id}",
         produces = { "application/xml", "application/json" }, 
         method = RequestMethod.DELETE)
-    ResponseEntity<Void> deleteOrder(@ApiParam(value = "ID of the order that needs to be deleted",required=true) @PathVariable("order_id") String orderId, @RequestHeader(value = "Accept", required = false) String accept) throws Exception;
+    ResponseEntity<Void> deleteOrder(@ApiParam(value = "ID of the order that needs to be deleted",required=true) @PathVariable("order_id") String orderId);
 
 
     @ApiOperation(value = "Returns pet inventories by status", nickname = "getInventory", notes = "Returns a map of status codes to quantities", response = Integer.class, responseContainer = "Map", authorizations = {
@@ -46,7 +46,7 @@ public interface StoreApi {
     @RequestMapping(value = "/store/inventory",
         produces = { "application/json" }, 
         method = RequestMethod.GET)
-    ResponseEntity<Map<String, Integer>> getInventory( @RequestHeader(value = "Accept", required = false) String accept) throws Exception;
+    ResponseEntity<Map<String, Integer>> getInventory();
 
 
     @ApiOperation(value = "Find purchase order by ID", nickname = "getOrderById", notes = "For valid response try integer IDs with value <= 5 or > 10. Other values will generated exceptions", response = Order.class, tags={ "store", })
@@ -57,7 +57,7 @@ public interface StoreApi {
     @RequestMapping(value = "/store/order/{order_id}",
         produces = { "application/xml", "application/json" }, 
         method = RequestMethod.GET)
-    ResponseEntity<Order> getOrderById( @Min(1) @Max(5)@ApiParam(value = "ID of pet that needs to be fetched",required=true) @PathVariable("order_id") Long orderId, @RequestHeader(value = "Accept", required = false) String accept) throws Exception;
+    ResponseEntity<Order> getOrderById(@Min(1) @Max(5) @ApiParam(value = "ID of pet that needs to be fetched",required=true) @PathVariable("order_id") Long orderId);
 
 
     @ApiOperation(value = "Place an order for a pet", nickname = "placeOrder", notes = "", response = Order.class, tags={ "store", })
@@ -67,6 +67,6 @@ public interface StoreApi {
     @RequestMapping(value = "/store/order",
         produces = { "application/xml", "application/json" }, 
         method = RequestMethod.POST)
-    ResponseEntity<Order> placeOrder(@ApiParam(value = "order placed for purchasing the pet" ,required=true )  @Valid @RequestBody Order body, @RequestHeader(value = "Accept", required = false) String accept) throws Exception;
+    ResponseEntity<Order> placeOrder(@ApiParam(value = "order placed for purchasing the pet" ,required=true )  @Valid @RequestBody Order body);
 
 }

--- a/samples/server/petstore/springboot/src/main/java/io/swagger/api/StoreApiController.java
+++ b/samples/server/petstore/springboot/src/main/java/io/swagger/api/StoreApiController.java
@@ -2,9 +2,8 @@ package io.swagger.api;
 
 import java.util.Map;
 import io.swagger.model.Order;
-
+import com.fasterxml.jackson.databind.ObjectMapper;
 import io.swagger.annotations.*;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpStatus;
@@ -15,16 +14,13 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RequestPart;
-import org.springframework.web.context.request.RequestContextHolder;
-import org.springframework.web.context.request.ServletRequestAttributes;
 import org.springframework.web.multipart.MultipartFile;
 
-import java.util.List;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import java.io.IOException;
-import javax.servlet.http.HttpServletRequest;
 import javax.validation.constraints.*;
 import javax.validation.Valid;
+import javax.servlet.http.HttpServletRequest;
+import java.io.IOException;
+import java.util.List;
 
 @Controller
 public class StoreApiController implements StoreApi {
@@ -42,13 +38,11 @@ public class StoreApiController implements StoreApi {
     }
 
     public ResponseEntity<Void> deleteOrder(@ApiParam(value = "ID of the order that needs to be deleted",required=true) @PathVariable("order_id") String orderId) {
-        // do some magic!
         String accept = request.getHeader("Accept");
-        return new ResponseEntity<Void>(HttpStatus.OK);
+        return new ResponseEntity<Void>(HttpStatus.NOT_IMPLEMENTED);
     }
 
     public ResponseEntity<Map<String, Integer>> getInventory() {
-        // do some magic!
         String accept = request.getHeader("Accept");
         if (accept != null && accept.contains("application/json")) {
             try {
@@ -59,11 +53,10 @@ public class StoreApiController implements StoreApi {
             }
         }
 
-        return new ResponseEntity<Map<String, Integer>>(HttpStatus.OK);
+        return new ResponseEntity<Map<String, Integer>>(HttpStatus.NOT_IMPLEMENTED);
     }
 
     public ResponseEntity<Order> getOrderById(@Min(1) @Max(5) @ApiParam(value = "ID of pet that needs to be fetched",required=true) @PathVariable("order_id") Long orderId) {
-        // do some magic!
         String accept = request.getHeader("Accept");
         if (accept != null && accept.contains("application/xml")) {
             try {
@@ -83,11 +76,10 @@ public class StoreApiController implements StoreApi {
             }
         }
 
-        return new ResponseEntity<Order>(HttpStatus.OK);
+        return new ResponseEntity<Order>(HttpStatus.NOT_IMPLEMENTED);
     }
 
     public ResponseEntity<Order> placeOrder(@ApiParam(value = "order placed for purchasing the pet" ,required=true )  @Valid @RequestBody Order body) {
-        // do some magic!
         String accept = request.getHeader("Accept");
         if (accept != null && accept.contains("application/xml")) {
             try {
@@ -107,7 +99,7 @@ public class StoreApiController implements StoreApi {
             }
         }
 
-        return new ResponseEntity<Order>(HttpStatus.OK);
+        return new ResponseEntity<Order>(HttpStatus.NOT_IMPLEMENTED);
     }
 
 }

--- a/samples/server/petstore/springboot/src/main/java/io/swagger/api/StoreApiController.java
+++ b/samples/server/petstore/springboot/src/main/java/io/swagger/api/StoreApiController.java
@@ -33,12 +33,12 @@ public class StoreApiController implements StoreApi {
 
     private final ObjectMapper objectMapper;
 
-    @org.springframework.beans.factory.annotation.Autowired
-    private HttpServletRequest request;
+    private final HttpServletRequest request;
 
     @org.springframework.beans.factory.annotation.Autowired
-    public StoreApiController(ObjectMapper objectMapper) {
+    public StoreApiController(ObjectMapper objectMapper, HttpServletRequest request) {
         this.objectMapper = objectMapper;
+        this.request = request;
     }
 
     public ResponseEntity<Void> deleteOrder(@ApiParam(value = "ID of the order that needs to be deleted",required=true) @PathVariable("order_id") String orderId) {

--- a/samples/server/petstore/springboot/src/main/java/io/swagger/api/StoreApiController.java
+++ b/samples/server/petstore/springboot/src/main/java/io/swagger/api/StoreApiController.java
@@ -5,6 +5,8 @@ import io.swagger.model.Order;
 
 import io.swagger.annotations.*;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
@@ -13,6 +15,8 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RequestPart;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.util.List;
@@ -23,55 +27,79 @@ import javax.validation.Valid;
 
 @Controller
 public class StoreApiController implements StoreApi {
+
+    private final Logger log = LoggerFactory.getLogger(AnotherFakeApiController.class);
+
     private final ObjectMapper objectMapper;
 
     public StoreApiController(ObjectMapper objectMapper) {
         this.objectMapper = objectMapper;
     }
 
-    public ResponseEntity<Void> deleteOrder(@ApiParam(value = "ID of the order that needs to be deleted",required=true) @PathVariable("order_id") String orderId,
-        @RequestHeader(value = "Accept", required = false) String accept) throws Exception {
+    public ResponseEntity<Void> deleteOrder(@ApiParam(value = "ID of the order that needs to be deleted",required=true) @PathVariable("order_id") String orderId) {
         // do some magic!
+        String accept = ((ServletRequestAttributes)RequestContextHolder.getRequestAttributes()).getRequest().getHeader("Accept");
         return new ResponseEntity<Void>(HttpStatus.OK);
     }
 
-    public ResponseEntity<Map<String, Integer>> getInventory(@RequestHeader(value = "Accept", required = false) String accept) throws Exception {
+    public ResponseEntity<Map<String, Integer>> getInventory() {
         // do some magic!
-
+        String accept = ((ServletRequestAttributes)RequestContextHolder.getRequestAttributes()).getRequest().getHeader("Accept");
         if (accept != null && accept.contains("application/json")) {
-            return new ResponseEntity<Map<String, Integer>>(objectMapper.readValue("{  \"key\" : 0}", Map.class), HttpStatus.OK);
+            try {
+                return new ResponseEntity<Map<String, Integer>>(objectMapper.readValue("{  \"key\" : 0}", Map.class), HttpStatus.NOT_IMPLEMENTED);
+            } catch (IOException e) {
+                log.error("Couldn't serialize response for content type application/json", e);
+                return new ResponseEntity<Map<String, Integer>>(HttpStatus.INTERNAL_SERVER_ERROR);
+            }
         }
 
         return new ResponseEntity<Map<String, Integer>>(HttpStatus.OK);
     }
 
-    public ResponseEntity<Order> getOrderById( @Min(1) @Max(5)@ApiParam(value = "ID of pet that needs to be fetched",required=true) @PathVariable("order_id") Long orderId,
-        @RequestHeader(value = "Accept", required = false) String accept) throws Exception {
+    public ResponseEntity<Order> getOrderById(@Min(1) @Max(5) @ApiParam(value = "ID of pet that needs to be fetched",required=true) @PathVariable("order_id") Long orderId) {
         // do some magic!
-
+        String accept = ((ServletRequestAttributes)RequestContextHolder.getRequestAttributes()).getRequest().getHeader("Accept");
         if (accept != null && accept.contains("application/xml")) {
-            return new ResponseEntity<Order>(objectMapper.readValue("<Order>  <id>123456789</id>  <petId>123456789</petId>  <quantity>123</quantity>  <shipDate>2000-01-23T04:56:07.000Z</shipDate>  <status>aeiou</status>  <complete>true</complete></Order>", Order.class), HttpStatus.OK);
+            try {
+                return new ResponseEntity<Order>(objectMapper.readValue("<Order>  <id>123456789</id>  <petId>123456789</petId>  <quantity>123</quantity>  <shipDate>2000-01-23T04:56:07.000Z</shipDate>  <status>aeiou</status>  <complete>true</complete></Order>", Order.class), HttpStatus.NOT_IMPLEMENTED);
+            } catch (IOException e) {
+                log.error("Couldn't serialize response for content type application/xml", e);
+                return new ResponseEntity<Order>(HttpStatus.INTERNAL_SERVER_ERROR);
+            }
         }
 
-
         if (accept != null && accept.contains("application/json")) {
-            return new ResponseEntity<Order>(objectMapper.readValue("{  \"petId\" : 6,  \"quantity\" : 1,  \"id\" : 0,  \"shipDate\" : \"2000-01-23T04:56:07.000+00:00\",  \"complete\" : false,  \"status\" : \"placed\"}", Order.class), HttpStatus.OK);
+            try {
+                return new ResponseEntity<Order>(objectMapper.readValue("{  \"petId\" : 6,  \"quantity\" : 1,  \"id\" : 0,  \"shipDate\" : \"2000-01-23T04:56:07.000+00:00\",  \"complete\" : false,  \"status\" : \"placed\"}", Order.class), HttpStatus.NOT_IMPLEMENTED);
+            } catch (IOException e) {
+                log.error("Couldn't serialize response for content type application/json", e);
+                return new ResponseEntity<Order>(HttpStatus.INTERNAL_SERVER_ERROR);
+            }
         }
 
         return new ResponseEntity<Order>(HttpStatus.OK);
     }
 
-    public ResponseEntity<Order> placeOrder(@ApiParam(value = "order placed for purchasing the pet" ,required=true )  @Valid @RequestBody Order body,
-        @RequestHeader(value = "Accept", required = false) String accept) throws Exception {
+    public ResponseEntity<Order> placeOrder(@ApiParam(value = "order placed for purchasing the pet" ,required=true )  @Valid @RequestBody Order body) {
         // do some magic!
-
+        String accept = ((ServletRequestAttributes)RequestContextHolder.getRequestAttributes()).getRequest().getHeader("Accept");
         if (accept != null && accept.contains("application/xml")) {
-            return new ResponseEntity<Order>(objectMapper.readValue("<Order>  <id>123456789</id>  <petId>123456789</petId>  <quantity>123</quantity>  <shipDate>2000-01-23T04:56:07.000Z</shipDate>  <status>aeiou</status>  <complete>true</complete></Order>", Order.class), HttpStatus.OK);
+            try {
+                return new ResponseEntity<Order>(objectMapper.readValue("<Order>  <id>123456789</id>  <petId>123456789</petId>  <quantity>123</quantity>  <shipDate>2000-01-23T04:56:07.000Z</shipDate>  <status>aeiou</status>  <complete>true</complete></Order>", Order.class), HttpStatus.NOT_IMPLEMENTED);
+            } catch (IOException e) {
+                log.error("Couldn't serialize response for content type application/xml", e);
+                return new ResponseEntity<Order>(HttpStatus.INTERNAL_SERVER_ERROR);
+            }
         }
 
-
         if (accept != null && accept.contains("application/json")) {
-            return new ResponseEntity<Order>(objectMapper.readValue("{  \"petId\" : 6,  \"quantity\" : 1,  \"id\" : 0,  \"shipDate\" : \"2000-01-23T04:56:07.000+00:00\",  \"complete\" : false,  \"status\" : \"placed\"}", Order.class), HttpStatus.OK);
+            try {
+                return new ResponseEntity<Order>(objectMapper.readValue("{  \"petId\" : 6,  \"quantity\" : 1,  \"id\" : 0,  \"shipDate\" : \"2000-01-23T04:56:07.000+00:00\",  \"complete\" : false,  \"status\" : \"placed\"}", Order.class), HttpStatus.NOT_IMPLEMENTED);
+            } catch (IOException e) {
+                log.error("Couldn't serialize response for content type application/json", e);
+                return new ResponseEntity<Order>(HttpStatus.INTERNAL_SERVER_ERROR);
+            }
         }
 
         return new ResponseEntity<Order>(HttpStatus.OK);

--- a/samples/server/petstore/springboot/src/main/java/io/swagger/api/StoreApiController.java
+++ b/samples/server/petstore/springboot/src/main/java/io/swagger/api/StoreApiController.java
@@ -22,29 +22,34 @@ import org.springframework.web.multipart.MultipartFile;
 import java.util.List;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.IOException;
+import javax.servlet.http.HttpServletRequest;
 import javax.validation.constraints.*;
 import javax.validation.Valid;
 
 @Controller
 public class StoreApiController implements StoreApi {
 
-    private final Logger log = LoggerFactory.getLogger(AnotherFakeApiController.class);
+    private static final Logger log = LoggerFactory.getLogger(StoreApiController.class);
 
     private final ObjectMapper objectMapper;
 
+    @org.springframework.beans.factory.annotation.Autowired
+    private HttpServletRequest request;
+
+    @org.springframework.beans.factory.annotation.Autowired
     public StoreApiController(ObjectMapper objectMapper) {
         this.objectMapper = objectMapper;
     }
 
     public ResponseEntity<Void> deleteOrder(@ApiParam(value = "ID of the order that needs to be deleted",required=true) @PathVariable("order_id") String orderId) {
         // do some magic!
-        String accept = ((ServletRequestAttributes)RequestContextHolder.getRequestAttributes()).getRequest().getHeader("Accept");
+        String accept = request.getHeader("Accept");
         return new ResponseEntity<Void>(HttpStatus.OK);
     }
 
     public ResponseEntity<Map<String, Integer>> getInventory() {
         // do some magic!
-        String accept = ((ServletRequestAttributes)RequestContextHolder.getRequestAttributes()).getRequest().getHeader("Accept");
+        String accept = request.getHeader("Accept");
         if (accept != null && accept.contains("application/json")) {
             try {
                 return new ResponseEntity<Map<String, Integer>>(objectMapper.readValue("{  \"key\" : 0}", Map.class), HttpStatus.NOT_IMPLEMENTED);
@@ -59,7 +64,7 @@ public class StoreApiController implements StoreApi {
 
     public ResponseEntity<Order> getOrderById(@Min(1) @Max(5) @ApiParam(value = "ID of pet that needs to be fetched",required=true) @PathVariable("order_id") Long orderId) {
         // do some magic!
-        String accept = ((ServletRequestAttributes)RequestContextHolder.getRequestAttributes()).getRequest().getHeader("Accept");
+        String accept = request.getHeader("Accept");
         if (accept != null && accept.contains("application/xml")) {
             try {
                 return new ResponseEntity<Order>(objectMapper.readValue("<Order>  <id>123456789</id>  <petId>123456789</petId>  <quantity>123</quantity>  <shipDate>2000-01-23T04:56:07.000Z</shipDate>  <status>aeiou</status>  <complete>true</complete></Order>", Order.class), HttpStatus.NOT_IMPLEMENTED);
@@ -83,7 +88,7 @@ public class StoreApiController implements StoreApi {
 
     public ResponseEntity<Order> placeOrder(@ApiParam(value = "order placed for purchasing the pet" ,required=true )  @Valid @RequestBody Order body) {
         // do some magic!
-        String accept = ((ServletRequestAttributes)RequestContextHolder.getRequestAttributes()).getRequest().getHeader("Accept");
+        String accept = request.getHeader("Accept");
         if (accept != null && accept.contains("application/xml")) {
             try {
                 return new ResponseEntity<Order>(objectMapper.readValue("<Order>  <id>123456789</id>  <petId>123456789</petId>  <quantity>123</quantity>  <shipDate>2000-01-23T04:56:07.000Z</shipDate>  <status>aeiou</status>  <complete>true</complete></Order>", Order.class), HttpStatus.NOT_IMPLEMENTED);

--- a/samples/server/petstore/springboot/src/main/java/io/swagger/api/UserApi.java
+++ b/samples/server/petstore/springboot/src/main/java/io/swagger/api/UserApi.java
@@ -7,9 +7,9 @@ package io.swagger.api;
 
 import java.util.List;
 import io.swagger.model.User;
-
 import io.swagger.annotations.*;
 import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
@@ -18,12 +18,10 @@ import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.multipart.MultipartFile;
-import java.io.IOException;
 
-import java.util.List;
-import org.springframework.validation.annotation.Validated;
-import javax.validation.constraints.*;
 import javax.validation.Valid;
+import javax.validation.constraints.*;
+import java.util.List;
 
 @Api(value = "user", description = "the user API")
 public interface UserApi {

--- a/samples/server/petstore/springboot/src/main/java/io/swagger/api/UserApi.java
+++ b/samples/server/petstore/springboot/src/main/java/io/swagger/api/UserApi.java
@@ -34,7 +34,7 @@ public interface UserApi {
     @RequestMapping(value = "/user",
         produces = { "application/xml", "application/json" }, 
         method = RequestMethod.POST)
-    ResponseEntity<Void> createUser(@ApiParam(value = "Created user object" ,required=true )  @Valid @RequestBody User body, @RequestHeader(value = "Accept", required = false) String accept) throws Exception;
+    ResponseEntity<Void> createUser(@ApiParam(value = "Created user object" ,required=true )  @Valid @RequestBody User body);
 
 
     @ApiOperation(value = "Creates list of users with given input array", nickname = "createUsersWithArrayInput", notes = "", tags={ "user", })
@@ -43,7 +43,7 @@ public interface UserApi {
     @RequestMapping(value = "/user/createWithArray",
         produces = { "application/xml", "application/json" }, 
         method = RequestMethod.POST)
-    ResponseEntity<Void> createUsersWithArrayInput(@ApiParam(value = "List of user object" ,required=true )  @Valid @RequestBody List<User> body, @RequestHeader(value = "Accept", required = false) String accept) throws Exception;
+    ResponseEntity<Void> createUsersWithArrayInput(@ApiParam(value = "List of user object" ,required=true )  @Valid @RequestBody List<User> body);
 
 
     @ApiOperation(value = "Creates list of users with given input array", nickname = "createUsersWithListInput", notes = "", tags={ "user", })
@@ -52,7 +52,7 @@ public interface UserApi {
     @RequestMapping(value = "/user/createWithList",
         produces = { "application/xml", "application/json" }, 
         method = RequestMethod.POST)
-    ResponseEntity<Void> createUsersWithListInput(@ApiParam(value = "List of user object" ,required=true )  @Valid @RequestBody List<User> body, @RequestHeader(value = "Accept", required = false) String accept) throws Exception;
+    ResponseEntity<Void> createUsersWithListInput(@ApiParam(value = "List of user object" ,required=true )  @Valid @RequestBody List<User> body);
 
 
     @ApiOperation(value = "Delete user", nickname = "deleteUser", notes = "This can only be done by the logged in user.", tags={ "user", })
@@ -62,7 +62,7 @@ public interface UserApi {
     @RequestMapping(value = "/user/{username}",
         produces = { "application/xml", "application/json" }, 
         method = RequestMethod.DELETE)
-    ResponseEntity<Void> deleteUser(@ApiParam(value = "The name that needs to be deleted",required=true) @PathVariable("username") String username, @RequestHeader(value = "Accept", required = false) String accept) throws Exception;
+    ResponseEntity<Void> deleteUser(@ApiParam(value = "The name that needs to be deleted",required=true) @PathVariable("username") String username);
 
 
     @ApiOperation(value = "Get user by user name", nickname = "getUserByName", notes = "", response = User.class, tags={ "user", })
@@ -73,7 +73,7 @@ public interface UserApi {
     @RequestMapping(value = "/user/{username}",
         produces = { "application/xml", "application/json" }, 
         method = RequestMethod.GET)
-    ResponseEntity<User> getUserByName(@ApiParam(value = "The name that needs to be fetched. Use user1 for testing. ",required=true) @PathVariable("username") String username, @RequestHeader(value = "Accept", required = false) String accept) throws Exception;
+    ResponseEntity<User> getUserByName(@ApiParam(value = "The name that needs to be fetched. Use user1 for testing. ",required=true) @PathVariable("username") String username);
 
 
     @ApiOperation(value = "Logs user into the system", nickname = "loginUser", notes = "", response = String.class, tags={ "user", })
@@ -83,7 +83,7 @@ public interface UserApi {
     @RequestMapping(value = "/user/login",
         produces = { "application/xml", "application/json" }, 
         method = RequestMethod.GET)
-    ResponseEntity<String> loginUser( @NotNull@ApiParam(value = "The user name for login", required = true) @Valid @RequestParam(value = "username", required = true) String username, @NotNull@ApiParam(value = "The password for login in clear text", required = true) @Valid @RequestParam(value = "password", required = true) String password, @RequestHeader(value = "Accept", required = false) String accept) throws Exception;
+    ResponseEntity<String> loginUser(@NotNull @ApiParam(value = "The user name for login", required = true) @Valid @RequestParam(value = "username", required = true) String username,@NotNull @ApiParam(value = "The password for login in clear text", required = true) @Valid @RequestParam(value = "password", required = true) String password);
 
 
     @ApiOperation(value = "Logs out current logged in user session", nickname = "logoutUser", notes = "", tags={ "user", })
@@ -92,7 +92,7 @@ public interface UserApi {
     @RequestMapping(value = "/user/logout",
         produces = { "application/xml", "application/json" }, 
         method = RequestMethod.GET)
-    ResponseEntity<Void> logoutUser( @RequestHeader(value = "Accept", required = false) String accept) throws Exception;
+    ResponseEntity<Void> logoutUser();
 
 
     @ApiOperation(value = "Updated user", nickname = "updateUser", notes = "This can only be done by the logged in user.", tags={ "user", })
@@ -102,6 +102,6 @@ public interface UserApi {
     @RequestMapping(value = "/user/{username}",
         produces = { "application/xml", "application/json" }, 
         method = RequestMethod.PUT)
-    ResponseEntity<Void> updateUser(@ApiParam(value = "name that need to be deleted",required=true) @PathVariable("username") String username,@ApiParam(value = "Updated user object" ,required=true )  @Valid @RequestBody User body, @RequestHeader(value = "Accept", required = false) String accept) throws Exception;
+    ResponseEntity<Void> updateUser(@ApiParam(value = "name that need to be deleted",required=true) @PathVariable("username") String username,@ApiParam(value = "Updated user object" ,required=true )  @Valid @RequestBody User body);
 
 }

--- a/samples/server/petstore/springboot/src/main/java/io/swagger/api/UserApiController.java
+++ b/samples/server/petstore/springboot/src/main/java/io/swagger/api/UserApiController.java
@@ -33,12 +33,12 @@ public class UserApiController implements UserApi {
 
     private final ObjectMapper objectMapper;
 
-    @org.springframework.beans.factory.annotation.Autowired
-    private HttpServletRequest request;
+    private final HttpServletRequest request;
 
     @org.springframework.beans.factory.annotation.Autowired
-    public UserApiController(ObjectMapper objectMapper) {
+    public UserApiController(ObjectMapper objectMapper, HttpServletRequest request) {
         this.objectMapper = objectMapper;
+        this.request = request;
     }
 
     public ResponseEntity<Void> createUser(@ApiParam(value = "Created user object" ,required=true )  @Valid @RequestBody User body) {

--- a/samples/server/petstore/springboot/src/main/java/io/swagger/api/UserApiController.java
+++ b/samples/server/petstore/springboot/src/main/java/io/swagger/api/UserApiController.java
@@ -2,9 +2,8 @@ package io.swagger.api;
 
 import java.util.List;
 import io.swagger.model.User;
-
+import com.fasterxml.jackson.databind.ObjectMapper;
 import io.swagger.annotations.*;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpStatus;
@@ -15,16 +14,13 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RequestPart;
-import org.springframework.web.context.request.RequestContextHolder;
-import org.springframework.web.context.request.ServletRequestAttributes;
 import org.springframework.web.multipart.MultipartFile;
 
-import java.util.List;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import java.io.IOException;
-import javax.servlet.http.HttpServletRequest;
 import javax.validation.constraints.*;
 import javax.validation.Valid;
+import javax.servlet.http.HttpServletRequest;
+import java.io.IOException;
+import java.util.List;
 
 @Controller
 public class UserApiController implements UserApi {
@@ -42,31 +38,26 @@ public class UserApiController implements UserApi {
     }
 
     public ResponseEntity<Void> createUser(@ApiParam(value = "Created user object" ,required=true )  @Valid @RequestBody User body) {
-        // do some magic!
         String accept = request.getHeader("Accept");
-        return new ResponseEntity<Void>(HttpStatus.OK);
+        return new ResponseEntity<Void>(HttpStatus.NOT_IMPLEMENTED);
     }
 
     public ResponseEntity<Void> createUsersWithArrayInput(@ApiParam(value = "List of user object" ,required=true )  @Valid @RequestBody List<User> body) {
-        // do some magic!
         String accept = request.getHeader("Accept");
-        return new ResponseEntity<Void>(HttpStatus.OK);
+        return new ResponseEntity<Void>(HttpStatus.NOT_IMPLEMENTED);
     }
 
     public ResponseEntity<Void> createUsersWithListInput(@ApiParam(value = "List of user object" ,required=true )  @Valid @RequestBody List<User> body) {
-        // do some magic!
         String accept = request.getHeader("Accept");
-        return new ResponseEntity<Void>(HttpStatus.OK);
+        return new ResponseEntity<Void>(HttpStatus.NOT_IMPLEMENTED);
     }
 
     public ResponseEntity<Void> deleteUser(@ApiParam(value = "The name that needs to be deleted",required=true) @PathVariable("username") String username) {
-        // do some magic!
         String accept = request.getHeader("Accept");
-        return new ResponseEntity<Void>(HttpStatus.OK);
+        return new ResponseEntity<Void>(HttpStatus.NOT_IMPLEMENTED);
     }
 
     public ResponseEntity<User> getUserByName(@ApiParam(value = "The name that needs to be fetched. Use user1 for testing. ",required=true) @PathVariable("username") String username) {
-        // do some magic!
         String accept = request.getHeader("Accept");
         if (accept != null && accept.contains("application/xml")) {
             try {
@@ -86,11 +77,10 @@ public class UserApiController implements UserApi {
             }
         }
 
-        return new ResponseEntity<User>(HttpStatus.OK);
+        return new ResponseEntity<User>(HttpStatus.NOT_IMPLEMENTED);
     }
 
     public ResponseEntity<String> loginUser(@NotNull @ApiParam(value = "The user name for login", required = true) @Valid @RequestParam(value = "username", required = true) String username,@NotNull @ApiParam(value = "The password for login in clear text", required = true) @Valid @RequestParam(value = "password", required = true) String password) {
-        // do some magic!
         String accept = request.getHeader("Accept");
         if (accept != null && accept.contains("application/xml")) {
             try {
@@ -110,19 +100,17 @@ public class UserApiController implements UserApi {
             }
         }
 
-        return new ResponseEntity<String>(HttpStatus.OK);
+        return new ResponseEntity<String>(HttpStatus.NOT_IMPLEMENTED);
     }
 
     public ResponseEntity<Void> logoutUser() {
-        // do some magic!
         String accept = request.getHeader("Accept");
-        return new ResponseEntity<Void>(HttpStatus.OK);
+        return new ResponseEntity<Void>(HttpStatus.NOT_IMPLEMENTED);
     }
 
     public ResponseEntity<Void> updateUser(@ApiParam(value = "name that need to be deleted",required=true) @PathVariable("username") String username,@ApiParam(value = "Updated user object" ,required=true )  @Valid @RequestBody User body) {
-        // do some magic!
         String accept = request.getHeader("Accept");
-        return new ResponseEntity<Void>(HttpStatus.OK);
+        return new ResponseEntity<Void>(HttpStatus.NOT_IMPLEMENTED);
     }
 
 }

--- a/samples/server/petstore/springboot/src/main/java/io/swagger/api/UserApiController.java
+++ b/samples/server/petstore/springboot/src/main/java/io/swagger/api/UserApiController.java
@@ -5,6 +5,8 @@ import io.swagger.model.User;
 
 import io.swagger.annotations.*;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
@@ -13,6 +15,8 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RequestPart;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.util.List;
@@ -23,78 +27,96 @@ import javax.validation.Valid;
 
 @Controller
 public class UserApiController implements UserApi {
+
+    private final Logger log = LoggerFactory.getLogger(AnotherFakeApiController.class);
+
     private final ObjectMapper objectMapper;
 
     public UserApiController(ObjectMapper objectMapper) {
         this.objectMapper = objectMapper;
     }
 
-    public ResponseEntity<Void> createUser(@ApiParam(value = "Created user object" ,required=true )  @Valid @RequestBody User body,
-        @RequestHeader(value = "Accept", required = false) String accept) throws Exception {
+    public ResponseEntity<Void> createUser(@ApiParam(value = "Created user object" ,required=true )  @Valid @RequestBody User body) {
         // do some magic!
+        String accept = ((ServletRequestAttributes)RequestContextHolder.getRequestAttributes()).getRequest().getHeader("Accept");
         return new ResponseEntity<Void>(HttpStatus.OK);
     }
 
-    public ResponseEntity<Void> createUsersWithArrayInput(@ApiParam(value = "List of user object" ,required=true )  @Valid @RequestBody List<User> body,
-        @RequestHeader(value = "Accept", required = false) String accept) throws Exception {
+    public ResponseEntity<Void> createUsersWithArrayInput(@ApiParam(value = "List of user object" ,required=true )  @Valid @RequestBody List<User> body) {
         // do some magic!
+        String accept = ((ServletRequestAttributes)RequestContextHolder.getRequestAttributes()).getRequest().getHeader("Accept");
         return new ResponseEntity<Void>(HttpStatus.OK);
     }
 
-    public ResponseEntity<Void> createUsersWithListInput(@ApiParam(value = "List of user object" ,required=true )  @Valid @RequestBody List<User> body,
-        @RequestHeader(value = "Accept", required = false) String accept) throws Exception {
+    public ResponseEntity<Void> createUsersWithListInput(@ApiParam(value = "List of user object" ,required=true )  @Valid @RequestBody List<User> body) {
         // do some magic!
+        String accept = ((ServletRequestAttributes)RequestContextHolder.getRequestAttributes()).getRequest().getHeader("Accept");
         return new ResponseEntity<Void>(HttpStatus.OK);
     }
 
-    public ResponseEntity<Void> deleteUser(@ApiParam(value = "The name that needs to be deleted",required=true) @PathVariable("username") String username,
-        @RequestHeader(value = "Accept", required = false) String accept) throws Exception {
+    public ResponseEntity<Void> deleteUser(@ApiParam(value = "The name that needs to be deleted",required=true) @PathVariable("username") String username) {
         // do some magic!
+        String accept = ((ServletRequestAttributes)RequestContextHolder.getRequestAttributes()).getRequest().getHeader("Accept");
         return new ResponseEntity<Void>(HttpStatus.OK);
     }
 
-    public ResponseEntity<User> getUserByName(@ApiParam(value = "The name that needs to be fetched. Use user1 for testing. ",required=true) @PathVariable("username") String username,
-        @RequestHeader(value = "Accept", required = false) String accept) throws Exception {
+    public ResponseEntity<User> getUserByName(@ApiParam(value = "The name that needs to be fetched. Use user1 for testing. ",required=true) @PathVariable("username") String username) {
         // do some magic!
-
+        String accept = ((ServletRequestAttributes)RequestContextHolder.getRequestAttributes()).getRequest().getHeader("Accept");
         if (accept != null && accept.contains("application/xml")) {
-            return new ResponseEntity<User>(objectMapper.readValue("<User>  <id>123456789</id>  <username>aeiou</username>  <firstName>aeiou</firstName>  <lastName>aeiou</lastName>  <email>aeiou</email>  <password>aeiou</password>  <phone>aeiou</phone>  <userStatus>123</userStatus></User>", User.class), HttpStatus.OK);
+            try {
+                return new ResponseEntity<User>(objectMapper.readValue("<User>  <id>123456789</id>  <username>aeiou</username>  <firstName>aeiou</firstName>  <lastName>aeiou</lastName>  <email>aeiou</email>  <password>aeiou</password>  <phone>aeiou</phone>  <userStatus>123</userStatus></User>", User.class), HttpStatus.NOT_IMPLEMENTED);
+            } catch (IOException e) {
+                log.error("Couldn't serialize response for content type application/xml", e);
+                return new ResponseEntity<User>(HttpStatus.INTERNAL_SERVER_ERROR);
+            }
         }
 
-
         if (accept != null && accept.contains("application/json")) {
-            return new ResponseEntity<User>(objectMapper.readValue("{  \"firstName\" : \"firstName\",  \"lastName\" : \"lastName\",  \"password\" : \"password\",  \"userStatus\" : 6,  \"phone\" : \"phone\",  \"id\" : 0,  \"email\" : \"email\",  \"username\" : \"username\"}", User.class), HttpStatus.OK);
+            try {
+                return new ResponseEntity<User>(objectMapper.readValue("{  \"firstName\" : \"firstName\",  \"lastName\" : \"lastName\",  \"password\" : \"password\",  \"userStatus\" : 6,  \"phone\" : \"phone\",  \"id\" : 0,  \"email\" : \"email\",  \"username\" : \"username\"}", User.class), HttpStatus.NOT_IMPLEMENTED);
+            } catch (IOException e) {
+                log.error("Couldn't serialize response for content type application/json", e);
+                return new ResponseEntity<User>(HttpStatus.INTERNAL_SERVER_ERROR);
+            }
         }
 
         return new ResponseEntity<User>(HttpStatus.OK);
     }
 
-    public ResponseEntity<String> loginUser( @NotNull@ApiParam(value = "The user name for login", required = true) @Valid @RequestParam(value = "username", required = true) String username,
-         @NotNull@ApiParam(value = "The password for login in clear text", required = true) @Valid @RequestParam(value = "password", required = true) String password,
-        @RequestHeader(value = "Accept", required = false) String accept) throws Exception {
+    public ResponseEntity<String> loginUser(@NotNull @ApiParam(value = "The user name for login", required = true) @Valid @RequestParam(value = "username", required = true) String username,@NotNull @ApiParam(value = "The password for login in clear text", required = true) @Valid @RequestParam(value = "password", required = true) String password) {
         // do some magic!
-
+        String accept = ((ServletRequestAttributes)RequestContextHolder.getRequestAttributes()).getRequest().getHeader("Accept");
         if (accept != null && accept.contains("application/xml")) {
-            return new ResponseEntity<String>(objectMapper.readValue("aeiou", String.class), HttpStatus.OK);
+            try {
+                return new ResponseEntity<String>(objectMapper.readValue("aeiou", String.class), HttpStatus.NOT_IMPLEMENTED);
+            } catch (IOException e) {
+                log.error("Couldn't serialize response for content type application/xml", e);
+                return new ResponseEntity<String>(HttpStatus.INTERNAL_SERVER_ERROR);
+            }
         }
 
-
         if (accept != null && accept.contains("application/json")) {
-            return new ResponseEntity<String>(objectMapper.readValue("\"\"", String.class), HttpStatus.OK);
+            try {
+                return new ResponseEntity<String>(objectMapper.readValue("\"\"", String.class), HttpStatus.NOT_IMPLEMENTED);
+            } catch (IOException e) {
+                log.error("Couldn't serialize response for content type application/json", e);
+                return new ResponseEntity<String>(HttpStatus.INTERNAL_SERVER_ERROR);
+            }
         }
 
         return new ResponseEntity<String>(HttpStatus.OK);
     }
 
-    public ResponseEntity<Void> logoutUser(@RequestHeader(value = "Accept", required = false) String accept) throws Exception {
+    public ResponseEntity<Void> logoutUser() {
         // do some magic!
+        String accept = ((ServletRequestAttributes)RequestContextHolder.getRequestAttributes()).getRequest().getHeader("Accept");
         return new ResponseEntity<Void>(HttpStatus.OK);
     }
 
-    public ResponseEntity<Void> updateUser(@ApiParam(value = "name that need to be deleted",required=true) @PathVariable("username") String username,
-        @ApiParam(value = "Updated user object" ,required=true )  @Valid @RequestBody User body,
-        @RequestHeader(value = "Accept", required = false) String accept) throws Exception {
+    public ResponseEntity<Void> updateUser(@ApiParam(value = "name that need to be deleted",required=true) @PathVariable("username") String username,@ApiParam(value = "Updated user object" ,required=true )  @Valid @RequestBody User body) {
         // do some magic!
+        String accept = ((ServletRequestAttributes)RequestContextHolder.getRequestAttributes()).getRequest().getHeader("Accept");
         return new ResponseEntity<Void>(HttpStatus.OK);
     }
 

--- a/samples/server/petstore/springboot/src/main/java/io/swagger/api/UserApiController.java
+++ b/samples/server/petstore/springboot/src/main/java/io/swagger/api/UserApiController.java
@@ -22,47 +22,52 @@ import org.springframework.web.multipart.MultipartFile;
 import java.util.List;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.IOException;
+import javax.servlet.http.HttpServletRequest;
 import javax.validation.constraints.*;
 import javax.validation.Valid;
 
 @Controller
 public class UserApiController implements UserApi {
 
-    private final Logger log = LoggerFactory.getLogger(AnotherFakeApiController.class);
+    private static final Logger log = LoggerFactory.getLogger(UserApiController.class);
 
     private final ObjectMapper objectMapper;
 
+    @org.springframework.beans.factory.annotation.Autowired
+    private HttpServletRequest request;
+
+    @org.springframework.beans.factory.annotation.Autowired
     public UserApiController(ObjectMapper objectMapper) {
         this.objectMapper = objectMapper;
     }
 
     public ResponseEntity<Void> createUser(@ApiParam(value = "Created user object" ,required=true )  @Valid @RequestBody User body) {
         // do some magic!
-        String accept = ((ServletRequestAttributes)RequestContextHolder.getRequestAttributes()).getRequest().getHeader("Accept");
+        String accept = request.getHeader("Accept");
         return new ResponseEntity<Void>(HttpStatus.OK);
     }
 
     public ResponseEntity<Void> createUsersWithArrayInput(@ApiParam(value = "List of user object" ,required=true )  @Valid @RequestBody List<User> body) {
         // do some magic!
-        String accept = ((ServletRequestAttributes)RequestContextHolder.getRequestAttributes()).getRequest().getHeader("Accept");
+        String accept = request.getHeader("Accept");
         return new ResponseEntity<Void>(HttpStatus.OK);
     }
 
     public ResponseEntity<Void> createUsersWithListInput(@ApiParam(value = "List of user object" ,required=true )  @Valid @RequestBody List<User> body) {
         // do some magic!
-        String accept = ((ServletRequestAttributes)RequestContextHolder.getRequestAttributes()).getRequest().getHeader("Accept");
+        String accept = request.getHeader("Accept");
         return new ResponseEntity<Void>(HttpStatus.OK);
     }
 
     public ResponseEntity<Void> deleteUser(@ApiParam(value = "The name that needs to be deleted",required=true) @PathVariable("username") String username) {
         // do some magic!
-        String accept = ((ServletRequestAttributes)RequestContextHolder.getRequestAttributes()).getRequest().getHeader("Accept");
+        String accept = request.getHeader("Accept");
         return new ResponseEntity<Void>(HttpStatus.OK);
     }
 
     public ResponseEntity<User> getUserByName(@ApiParam(value = "The name that needs to be fetched. Use user1 for testing. ",required=true) @PathVariable("username") String username) {
         // do some magic!
-        String accept = ((ServletRequestAttributes)RequestContextHolder.getRequestAttributes()).getRequest().getHeader("Accept");
+        String accept = request.getHeader("Accept");
         if (accept != null && accept.contains("application/xml")) {
             try {
                 return new ResponseEntity<User>(objectMapper.readValue("<User>  <id>123456789</id>  <username>aeiou</username>  <firstName>aeiou</firstName>  <lastName>aeiou</lastName>  <email>aeiou</email>  <password>aeiou</password>  <phone>aeiou</phone>  <userStatus>123</userStatus></User>", User.class), HttpStatus.NOT_IMPLEMENTED);
@@ -86,7 +91,7 @@ public class UserApiController implements UserApi {
 
     public ResponseEntity<String> loginUser(@NotNull @ApiParam(value = "The user name for login", required = true) @Valid @RequestParam(value = "username", required = true) String username,@NotNull @ApiParam(value = "The password for login in clear text", required = true) @Valid @RequestParam(value = "password", required = true) String password) {
         // do some magic!
-        String accept = ((ServletRequestAttributes)RequestContextHolder.getRequestAttributes()).getRequest().getHeader("Accept");
+        String accept = request.getHeader("Accept");
         if (accept != null && accept.contains("application/xml")) {
             try {
                 return new ResponseEntity<String>(objectMapper.readValue("aeiou", String.class), HttpStatus.NOT_IMPLEMENTED);
@@ -110,13 +115,13 @@ public class UserApiController implements UserApi {
 
     public ResponseEntity<Void> logoutUser() {
         // do some magic!
-        String accept = ((ServletRequestAttributes)RequestContextHolder.getRequestAttributes()).getRequest().getHeader("Accept");
+        String accept = request.getHeader("Accept");
         return new ResponseEntity<Void>(HttpStatus.OK);
     }
 
     public ResponseEntity<Void> updateUser(@ApiParam(value = "name that need to be deleted",required=true) @PathVariable("username") String username,@ApiParam(value = "Updated user object" ,required=true )  @Valid @RequestBody User body) {
         // do some magic!
-        String accept = ((ServletRequestAttributes)RequestContextHolder.getRequestAttributes()).getRequest().getHeader("Accept");
+        String accept = request.getHeader("Accept");
         return new ResponseEntity<Void>(HttpStatus.OK);
     }
 

--- a/samples/server/petstore/springboot/src/main/java/io/swagger/model/FormatTest.java
+++ b/samples/server/petstore/springboot/src/main/java/io/swagger/model/FormatTest.java
@@ -71,7 +71,7 @@ public class FormatTest   {
   **/
   @ApiModelProperty(value = "")
 
- @Min(10) @Max(100)
+@Min(10) @Max(100) 
   public Integer getInteger() {
     return integer;
   }
@@ -93,7 +93,7 @@ public class FormatTest   {
   **/
   @ApiModelProperty(value = "")
 
- @Min(20) @Max(200)
+@Min(20) @Max(200) 
   public Integer getInt32() {
     return int32;
   }
@@ -137,7 +137,7 @@ public class FormatTest   {
   @NotNull
 
   @Valid
- @DecimalMin("32.1") @DecimalMax("543.2")
+@DecimalMin("32.1") @DecimalMax("543.2") 
   public BigDecimal getNumber() {
     return number;
   }
@@ -159,7 +159,7 @@ public class FormatTest   {
   **/
   @ApiModelProperty(value = "")
 
- @DecimalMin("54.3") @DecimalMax("987.6")
+@DecimalMin("54.3") @DecimalMax("987.6") 
   public Float getFloat() {
     return _float;
   }
@@ -181,7 +181,7 @@ public class FormatTest   {
   **/
   @ApiModelProperty(value = "")
 
- @DecimalMin("67.8") @DecimalMax("123.4")
+@DecimalMin("67.8") @DecimalMax("123.4") 
   public Double getDouble() {
     return _double;
   }
@@ -201,7 +201,7 @@ public class FormatTest   {
   **/
   @ApiModelProperty(value = "")
 
- @Pattern(regexp="/[a-z]/i")
+@Pattern(regexp="/[a-z]/i") 
   public String getString() {
     return string;
   }
@@ -222,7 +222,7 @@ public class FormatTest   {
   @ApiModelProperty(required = true, value = "")
   @NotNull
 
- @Pattern(regexp="^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$")
+@Pattern(regexp="^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$") 
   public byte[] getByte() {
     return _byte;
   }
@@ -327,7 +327,7 @@ public class FormatTest   {
   @ApiModelProperty(required = true, value = "")
   @NotNull
 
- @Size(min=10,max=64)
+@Size(min=10,max=64) 
   public String getPassword() {
     return password;
   }


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [x] Filed the PR against the correct branch: `3.0.0` branch for changes related to OpenAPI spec 3.0. Default: `master`.
- [x] Copied the [technical committee](https://github.com/swagger-api/swagger-codegen/#swagger-codegen-technical-committee) to review the pull request if your PR is targeting a particular programming langauge.

### Description of the PR

* Removes Accept request header from the api signature and get it from HttpServletRequest
* Treat the ObjectMapper IOException instead of rethrowing
* Use HttpStatus.NOT_IMPLEMENTED (501) as default response status
* Refactor the template and fix some issues

@bbdouglas (2017/07) @JFCote (2017/08) @sreeshas (2017/08) @jfiala (2017/08) @lukoyanov (2017/09) @cbornet (2017/09)

See #6689
See #6691 
Fix #6445 
