### PR TITLE
[Java][JAXRS-CXF] Improve API documentation in the CXF Server stub and Client generation

### DIFF
--- a/modules/swagger-codegen/src/main/resources/JavaJaxRS/cxf/api.mustache
+++ b/modules/swagger-codegen/src/main/resources/JavaJaxRS/cxf/api.mustache
@@ -22,6 +22,16 @@ import javax.validation.constraints.*;
 import javax.validation.Valid;
 {{/useBeanValidation}}
 
+{{#appName}}
+/**
+ * {{{appName}}}
+ *
+ {{#appDescription}}
+ * <p>{{{appDescription}}}
+ *
+ {{/appDescription}}
+ */
+{{/appName}}
 @Path("{{^useAnnotatedBasePath}}/{{/useAnnotatedBasePath}}{{#useAnnotatedBasePath}}{{contextPath}}{{/useAnnotatedBasePath}}")
 @Api(value = "/", description = "{{description}}")
 {{#addConsumesProducesJson}}
@@ -32,6 +42,16 @@ public interface {{classname}}  {
 {{#operations}}
 {{#operation}}
 
+    {{#summary}}
+    /**
+     * {{summary}}
+     *
+     {{#notes}}
+     * {{notes}}
+     *
+     {{/notes}}
+     */
+    {{/summary}}
     @{{httpMethod}}
     {{#subresourceOperation}}@Path("{{{path}}}"){{/subresourceOperation}}
 {{#hasConsumes}}

--- a/modules/swagger-codegen/src/main/resources/JavaJaxRS/cxf/apiServiceImpl.mustache
+++ b/modules/swagger-codegen/src/main/resources/JavaJaxRS/cxf/apiServiceImpl.mustache
@@ -25,9 +25,29 @@ import org.springframework.stereotype.Service;
 {{/useSpringAnnotationConfig}}
 {{#description}}
 {{/description}}
+{{#appName}}
+/**
+ * {{{appName}}}
+ *
+ {{#appDescription}}
+ * <p>{{{appDescription}}}
+ {{/appDescription}}
+ *
+ */
+{{/appName}}
 public class {{classname}}ServiceImpl implements {{classname}} {
 {{#operations}}
 {{#operation}}
+    {{#summary}}
+    /**
+     * {{summary}}
+     *
+     {{#notes}}
+     * {{notes}}
+     *
+     {{/notes}}
+     */
+    {{/summary}}
     public {{>returnTypes}} {{nickname}}({{#allParams}}{{>queryParamsImpl}}{{>pathParamsImpl}}{{>headerParamsImpl}}{{>bodyParamsImpl}}{{>formParamsImpl}}{{#hasMore}}, {{/hasMore}}{{/allParams}}) {
         // TODO: Implement...
         

--- a/modules/swagger-codegen/src/main/resources/JavaJaxRS/cxf/api_test.mustache
+++ b/modules/swagger-codegen/src/main/resources/JavaJaxRS/cxf/api_test.mustache
@@ -42,7 +42,15 @@ import org.springframework.test.context.web.WebAppConfiguration;
 
 
 /**
- * API tests for {{classname}}
+ {{#appName}}
+ * {{{appName}}}
+ *
+ {{/appName}}
+ {{#appDescription}}
+ * <p>{{{appDescription}}}
+ *
+ {{/appDescription}}
+ * API tests for {{classname}} 
  */
 {{#generateSpringBootApplication}}
 @RunWith(SpringJUnit4ClassRunner.class)
@@ -91,10 +99,14 @@ public class {{classname}}Test {
 
     {{#operations}}{{#operation}}
     /**
+     {{#summary}}
      * {{summary}}
      *
+     {{#notes}}
      * {{notes}}
      *
+     {{/notes}}
+     {{/summary}}
      * @throws ApiException
      *          if the Api call fails
      */

--- a/modules/swagger-codegen/src/main/resources/JavaJaxRS/cxf/pojo.mustache
+++ b/modules/swagger-codegen/src/main/resources/JavaJaxRS/cxf/pojo.mustache
@@ -16,6 +16,9 @@ import javax.xml.bind.annotation.XmlEnumValue;
 {{^parent}}@XmlRootElement(name="{{classname}}"){{/parent}}
 {{/withXml}}
 {{#description}}
+/**
+  * {{{description}}}
+ **/
 @ApiModel(description="{{{description}}}")
 {{/description}}
 public class {{classname}} {{#parent}}extends {{{parent}}}{{/parent}} {
@@ -28,6 +31,11 @@ public class {{classname}} {{#parent}}extends {{{parent}}}{{/parent}} {
   @XmlElement(name="{{baseName}}"{{#required}}, required = {{required}}{{/required}})
 {{/withXml}}
   @ApiModelProperty({{#example}}example = "{{{example}}}", {{/example}}{{#required}}required = {{required}}, {{/required}}value = "{{{description}}}")
+{{#description}}
+ /**
+   * {{{description}}}  
+  **/
+{{/description}}
   private {{{datatypeWithEnum}}} {{name}} = {{{defaultValue}}};{{/vars}}
 
   {{#vars}}

--- a/modules/swagger-codegen/src/main/resources/JavaJaxRS/cxf/pom.mustache
+++ b/modules/swagger-codegen/src/main/resources/JavaJaxRS/cxf/pom.mustache
@@ -5,7 +5,7 @@
   <packaging>jar</packaging>
   <name>{{artifactId}}</name>
   {{#appDescription}}
-  <description>{{{appDescription}}}</description>
+  <description>{{appDescription}}</description>
   {{/appDescription}}
   <version>{{artifactVersion}}</version>
   <build>

--- a/modules/swagger-codegen/src/main/resources/JavaJaxRS/cxf/pom.mustache
+++ b/modules/swagger-codegen/src/main/resources/JavaJaxRS/cxf/pom.mustache
@@ -4,6 +4,9 @@
   <artifactId>{{artifactId}}</artifactId>
   <packaging>jar</packaging>
   <name>{{artifactId}}</name>
+  {{#appDescription}}
+  <description>{{{appDescription}}}</description>
+  {{/appDescription}}
   <version>{{artifactVersion}}</version>
   <build>
     <sourceDirectory>src/main/java</sourceDirectory>

--- a/modules/swagger-codegen/src/main/resources/JavaJaxRS/cxf/server/pom.mustache
+++ b/modules/swagger-codegen/src/main/resources/JavaJaxRS/cxf/server/pom.mustache
@@ -5,7 +5,7 @@
   <packaging>war</packaging>
   <name>{{artifactId}}</name>
   {{#appDescription}}
-  <description>{{{appDescription}}}</description>
+  <description>{{appDescription}}</description>
   {{/appDescription}}
   <version>{{artifactVersion}}</version>
   <build>

--- a/modules/swagger-codegen/src/main/resources/JavaJaxRS/cxf/server/pom.mustache
+++ b/modules/swagger-codegen/src/main/resources/JavaJaxRS/cxf/server/pom.mustache
@@ -4,6 +4,9 @@
   <artifactId>{{artifactId}}</artifactId>
   <packaging>war</packaging>
   <name>{{artifactId}}</name>
+  {{#appDescription}}
+  <description>{{{appDescription}}}</description>
+  {{/appDescription}}
   <version>{{artifactVersion}}</version>
   <build>
     <sourceDirectory>src/main/java</sourceDirectory>

--- a/samples/client/petstore/jaxrs-cxf-client/pom.xml
+++ b/samples/client/petstore/jaxrs-cxf-client/pom.xml
@@ -4,7 +4,7 @@
   <artifactId>jaxrs-cxf-petstore-client</artifactId>
   <packaging>war</packaging>
   <name>jaxrs-cxf-petstore-client</name>
-  <description>This is a sample server Petstore server.  You can find out more about Swagger at [http://swagger.io](http://swagger.io) or on [irc.freenode.net, #swagger](http://swagger.io/irc/).  For this sample, you can use the api key `special-key` to test the authorization filters.</description>
+  <description>This is a sample server Petstore server.  You can find out more about Swagger at [http://swagger.io](http://swagger.io) or on [irc.freenode.net, #swagger](http://swagger.io/irc/).  For this sample, you can use the api key &#x60;special-key&#x60; to test the authorization filters.</description>
   <version>1.0.0</version>
   <build>
     <sourceDirectory>src/main/java</sourceDirectory>

--- a/samples/client/petstore/jaxrs-cxf-client/pom.xml
+++ b/samples/client/petstore/jaxrs-cxf-client/pom.xml
@@ -4,6 +4,7 @@
   <artifactId>jaxrs-cxf-petstore-client</artifactId>
   <packaging>war</packaging>
   <name>jaxrs-cxf-petstore-client</name>
+  <description>This is a sample server Petstore server.  You can find out more about Swagger at [http://swagger.io](http://swagger.io) or on [irc.freenode.net, #swagger](http://swagger.io/irc/).  For this sample, you can use the api key `special-key` to test the authorization filters.</description>
   <version>1.0.0</version>
   <build>
     <sourceDirectory>src/main/java</sourceDirectory>

--- a/samples/client/petstore/jaxrs-cxf-client/src/gen/java/io/swagger/api/PetApi.java
+++ b/samples/client/petstore/jaxrs-cxf-client/src/gen/java/io/swagger/api/PetApi.java
@@ -21,10 +21,22 @@ import io.swagger.jaxrs.PATCH;
 import javax.validation.constraints.*;
 import javax.validation.Valid;
 
+/**
+ * Swagger Petstore
+ *
+ * <p>This is a sample server Petstore server.  You can find out more about Swagger at [http://swagger.io](http://swagger.io) or on [irc.freenode.net, #swagger](http://swagger.io/irc/).  For this sample, you can use the api key `special-key` to test the authorization filters.
+ *
+ */
 @Path("/")
 @Api(value = "/", description = "")
 public interface PetApi  {
 
+    /**
+     * Add a new pet to the store
+     *
+     * 
+     *
+     */
     @POST
     @Path("/pet")
     @Consumes({ "application/json", "application/xml" })
@@ -34,6 +46,12 @@ public interface PetApi  {
         @ApiResponse(code = 405, message = "Invalid input") })
     public void addPet(@Valid Pet body);
 
+    /**
+     * Deletes a pet
+     *
+     * 
+     *
+     */
     @DELETE
     @Path("/pet/{petId}")
     @Produces({ "application/xml", "application/json" })
@@ -42,6 +60,12 @@ public interface PetApi  {
         @ApiResponse(code = 400, message = "Invalid pet value") })
     public void deletePet(@PathParam("petId") Long petId, @HeaderParam("api_key") String apiKey);
 
+    /**
+     * Finds Pets by status
+     *
+     * Multiple status values can be provided with comma separated strings
+     *
+     */
     @GET
     @Path("/pet/findByStatus")
     @Produces({ "application/xml", "application/json" })
@@ -51,6 +75,12 @@ public interface PetApi  {
         @ApiResponse(code = 400, message = "Invalid status value") })
     public List<Pet> findPetsByStatus(@QueryParam("status") @NotNull List<String> status);
 
+    /**
+     * Finds Pets by tags
+     *
+     * Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
+     *
+     */
     @GET
     @Path("/pet/findByTags")
     @Produces({ "application/xml", "application/json" })
@@ -60,6 +90,12 @@ public interface PetApi  {
         @ApiResponse(code = 400, message = "Invalid tag value") })
     public List<Pet> findPetsByTags(@QueryParam("tags") @NotNull List<String> tags);
 
+    /**
+     * Find pet by ID
+     *
+     * Returns a single pet
+     *
+     */
     @GET
     @Path("/pet/{petId}")
     @Produces({ "application/xml", "application/json" })
@@ -70,6 +106,12 @@ public interface PetApi  {
         @ApiResponse(code = 404, message = "Pet not found") })
     public Pet getPetById(@PathParam("petId") Long petId);
 
+    /**
+     * Update an existing pet
+     *
+     * 
+     *
+     */
     @PUT
     @Path("/pet")
     @Consumes({ "application/json", "application/xml" })
@@ -81,6 +123,12 @@ public interface PetApi  {
         @ApiResponse(code = 405, message = "Validation exception") })
     public void updatePet(@Valid Pet body);
 
+    /**
+     * Updates a pet in the store with form data
+     *
+     * 
+     *
+     */
     @POST
     @Path("/pet/{petId}")
     @Consumes({ "application/x-www-form-urlencoded" })
@@ -90,6 +138,12 @@ public interface PetApi  {
         @ApiResponse(code = 405, message = "Invalid input") })
     public void updatePetWithForm(@PathParam("petId") Long petId, @Multipart(value = "name", required = false)  String name, @Multipart(value = "status", required = false)  String status);
 
+    /**
+     * uploads an image
+     *
+     * 
+     *
+     */
     @POST
     @Path("/pet/{petId}/uploadImage")
     @Consumes({ "multipart/form-data" })

--- a/samples/client/petstore/jaxrs-cxf-client/src/gen/java/io/swagger/api/StoreApi.java
+++ b/samples/client/petstore/jaxrs-cxf-client/src/gen/java/io/swagger/api/StoreApi.java
@@ -20,10 +20,22 @@ import io.swagger.jaxrs.PATCH;
 import javax.validation.constraints.*;
 import javax.validation.Valid;
 
+/**
+ * Swagger Petstore
+ *
+ * <p>This is a sample server Petstore server.  You can find out more about Swagger at [http://swagger.io](http://swagger.io) or on [irc.freenode.net, #swagger](http://swagger.io/irc/).  For this sample, you can use the api key `special-key` to test the authorization filters.
+ *
+ */
 @Path("/")
 @Api(value = "/", description = "")
 public interface StoreApi  {
 
+    /**
+     * Delete purchase order by ID
+     *
+     * For valid response try integer IDs with value &lt; 1000. Anything above 1000 or nonintegers will generate API errors
+     *
+     */
     @DELETE
     @Path("/store/order/{orderId}")
     @Produces({ "application/xml", "application/json" })
@@ -33,6 +45,12 @@ public interface StoreApi  {
         @ApiResponse(code = 404, message = "Order not found") })
     public void deleteOrder(@PathParam("orderId") String orderId);
 
+    /**
+     * Returns pet inventories by status
+     *
+     * Returns a map of status codes to quantities
+     *
+     */
     @GET
     @Path("/store/inventory")
     @Produces({ "application/json" })
@@ -41,6 +59,12 @@ public interface StoreApi  {
         @ApiResponse(code = 200, message = "successful operation", response = Map.class, responseContainer = "Map") })
     public Map<String, Integer> getInventory();
 
+    /**
+     * Find purchase order by ID
+     *
+     * For valid response try integer IDs with value &lt;&#x3D; 5 or &gt; 10. Other values will generated exceptions
+     *
+     */
     @GET
     @Path("/store/order/{orderId}")
     @Produces({ "application/xml", "application/json" })
@@ -51,6 +75,12 @@ public interface StoreApi  {
         @ApiResponse(code = 404, message = "Order not found") })
     public Order getOrderById(@PathParam("orderId") @Min(1) @Max(5) Long orderId);
 
+    /**
+     * Place an order for a pet
+     *
+     * 
+     *
+     */
     @POST
     @Path("/store/order")
     @Produces({ "application/xml", "application/json" })

--- a/samples/client/petstore/jaxrs-cxf-client/src/gen/java/io/swagger/api/UserApi.java
+++ b/samples/client/petstore/jaxrs-cxf-client/src/gen/java/io/swagger/api/UserApi.java
@@ -20,10 +20,22 @@ import io.swagger.jaxrs.PATCH;
 import javax.validation.constraints.*;
 import javax.validation.Valid;
 
+/**
+ * Swagger Petstore
+ *
+ * <p>This is a sample server Petstore server.  You can find out more about Swagger at [http://swagger.io](http://swagger.io) or on [irc.freenode.net, #swagger](http://swagger.io/irc/).  For this sample, you can use the api key `special-key` to test the authorization filters.
+ *
+ */
 @Path("/")
 @Api(value = "/", description = "")
 public interface UserApi  {
 
+    /**
+     * Create user
+     *
+     * This can only be done by the logged in user.
+     *
+     */
     @POST
     @Path("/user")
     @Produces({ "application/xml", "application/json" })
@@ -32,6 +44,12 @@ public interface UserApi  {
         @ApiResponse(code = 200, message = "successful operation") })
     public void createUser(@Valid User body);
 
+    /**
+     * Creates list of users with given input array
+     *
+     * 
+     *
+     */
     @POST
     @Path("/user/createWithArray")
     @Produces({ "application/xml", "application/json" })
@@ -40,6 +58,12 @@ public interface UserApi  {
         @ApiResponse(code = 200, message = "successful operation") })
     public void createUsersWithArrayInput(@Valid List<User> body);
 
+    /**
+     * Creates list of users with given input array
+     *
+     * 
+     *
+     */
     @POST
     @Path("/user/createWithList")
     @Produces({ "application/xml", "application/json" })
@@ -48,6 +72,12 @@ public interface UserApi  {
         @ApiResponse(code = 200, message = "successful operation") })
     public void createUsersWithListInput(@Valid List<User> body);
 
+    /**
+     * Delete user
+     *
+     * This can only be done by the logged in user.
+     *
+     */
     @DELETE
     @Path("/user/{username}")
     @Produces({ "application/xml", "application/json" })
@@ -57,6 +87,12 @@ public interface UserApi  {
         @ApiResponse(code = 404, message = "User not found") })
     public void deleteUser(@PathParam("username") String username);
 
+    /**
+     * Get user by user name
+     *
+     * 
+     *
+     */
     @GET
     @Path("/user/{username}")
     @Produces({ "application/xml", "application/json" })
@@ -67,6 +103,12 @@ public interface UserApi  {
         @ApiResponse(code = 404, message = "User not found") })
     public User getUserByName(@PathParam("username") String username);
 
+    /**
+     * Logs user into the system
+     *
+     * 
+     *
+     */
     @GET
     @Path("/user/login")
     @Produces({ "application/xml", "application/json" })
@@ -76,6 +118,12 @@ public interface UserApi  {
         @ApiResponse(code = 400, message = "Invalid username/password supplied") })
     public String loginUser(@QueryParam("username") @NotNull String username, @QueryParam("password") @NotNull String password);
 
+    /**
+     * Logs out current logged in user session
+     *
+     * 
+     *
+     */
     @GET
     @Path("/user/logout")
     @Produces({ "application/xml", "application/json" })
@@ -84,6 +132,12 @@ public interface UserApi  {
         @ApiResponse(code = 200, message = "successful operation") })
     public void logoutUser();
 
+    /**
+     * Updated user
+     *
+     * This can only be done by the logged in user.
+     *
+     */
     @PUT
     @Path("/user/{username}")
     @Produces({ "application/xml", "application/json" })

--- a/samples/client/petstore/jaxrs-cxf-client/src/gen/java/io/swagger/model/Category.java
+++ b/samples/client/petstore/jaxrs-cxf-client/src/gen/java/io/swagger/model/Category.java
@@ -12,6 +12,9 @@ import javax.xml.bind.annotation.XmlType;
 import javax.xml.bind.annotation.XmlEnum;
 import javax.xml.bind.annotation.XmlEnumValue;
 
+/**
+  * A category for a pet
+ **/
 @ApiModel(description="A category for a pet")
 public class Category  {
   

--- a/samples/client/petstore/jaxrs-cxf-client/src/gen/java/io/swagger/model/ModelApiResponse.java
+++ b/samples/client/petstore/jaxrs-cxf-client/src/gen/java/io/swagger/model/ModelApiResponse.java
@@ -12,6 +12,9 @@ import javax.xml.bind.annotation.XmlType;
 import javax.xml.bind.annotation.XmlEnum;
 import javax.xml.bind.annotation.XmlEnumValue;
 
+/**
+  * Describes the result of uploading an image resource
+ **/
 @ApiModel(description="Describes the result of uploading an image resource")
 public class ModelApiResponse  {
   

--- a/samples/client/petstore/jaxrs-cxf-client/src/gen/java/io/swagger/model/Order.java
+++ b/samples/client/petstore/jaxrs-cxf-client/src/gen/java/io/swagger/model/Order.java
@@ -13,6 +13,9 @@ import javax.xml.bind.annotation.XmlType;
 import javax.xml.bind.annotation.XmlEnum;
 import javax.xml.bind.annotation.XmlEnumValue;
 
+/**
+  * An order for a pets from the pet store
+ **/
 @ApiModel(description="An order for a pets from the pet store")
 public class Order  {
   
@@ -58,6 +61,9 @@ public enum StatusEnum {
 }
 
   @ApiModelProperty(value = "Order Status")
+ /**
+   * Order Status  
+  **/
   private StatusEnum status = null;
   @ApiModelProperty(value = "")
   private Boolean complete = false;

--- a/samples/client/petstore/jaxrs-cxf-client/src/gen/java/io/swagger/model/Pet.java
+++ b/samples/client/petstore/jaxrs-cxf-client/src/gen/java/io/swagger/model/Pet.java
@@ -16,6 +16,9 @@ import javax.xml.bind.annotation.XmlType;
 import javax.xml.bind.annotation.XmlEnum;
 import javax.xml.bind.annotation.XmlEnumValue;
 
+/**
+  * A pet for sale in the pet store
+ **/
 @ApiModel(description="A pet for sale in the pet store")
 public class Pet  {
   
@@ -63,6 +66,9 @@ public enum StatusEnum {
 }
 
   @ApiModelProperty(value = "pet status in the store")
+ /**
+   * pet status in the store  
+  **/
   private StatusEnum status = null;
 
  /**

--- a/samples/client/petstore/jaxrs-cxf-client/src/gen/java/io/swagger/model/Tag.java
+++ b/samples/client/petstore/jaxrs-cxf-client/src/gen/java/io/swagger/model/Tag.java
@@ -12,6 +12,9 @@ import javax.xml.bind.annotation.XmlType;
 import javax.xml.bind.annotation.XmlEnum;
 import javax.xml.bind.annotation.XmlEnumValue;
 
+/**
+  * A tag for a pet
+ **/
 @ApiModel(description="A tag for a pet")
 public class Tag  {
   

--- a/samples/client/petstore/jaxrs-cxf-client/src/gen/java/io/swagger/model/User.java
+++ b/samples/client/petstore/jaxrs-cxf-client/src/gen/java/io/swagger/model/User.java
@@ -12,6 +12,9 @@ import javax.xml.bind.annotation.XmlType;
 import javax.xml.bind.annotation.XmlEnum;
 import javax.xml.bind.annotation.XmlEnumValue;
 
+/**
+  * A User who is purchasing from the pet store
+ **/
 @ApiModel(description="A User who is purchasing from the pet store")
 public class User  {
   
@@ -30,6 +33,9 @@ public class User  {
   @ApiModelProperty(value = "")
   private String phone = null;
   @ApiModelProperty(value = "User Status")
+ /**
+   * User Status  
+  **/
   private Integer userStatus = null;
 
  /**

--- a/samples/server/petstore/jaxrs-cxf-annotated-base-path/pom.xml
+++ b/samples/server/petstore/jaxrs-cxf-annotated-base-path/pom.xml
@@ -4,6 +4,7 @@
   <artifactId>swagger-cxf-annotated-basepath</artifactId>
   <packaging>war</packaging>
   <name>swagger-cxf-annotated-basepath</name>
+  <description>This is a sample server Petstore server.  You can find out more about Swagger at [http://swagger.io](http://swagger.io) or on [irc.freenode.net, #swagger](http://swagger.io/irc/).  For this sample, you can use the api key `special-key` to test the authorization filters.</description>
   <version>1.0.0</version>
   <build>
     <sourceDirectory>src/main/java</sourceDirectory>

--- a/samples/server/petstore/jaxrs-cxf-annotated-base-path/pom.xml
+++ b/samples/server/petstore/jaxrs-cxf-annotated-base-path/pom.xml
@@ -4,7 +4,7 @@
   <artifactId>swagger-cxf-annotated-basepath</artifactId>
   <packaging>war</packaging>
   <name>swagger-cxf-annotated-basepath</name>
-  <description>This is a sample server Petstore server.  You can find out more about Swagger at [http://swagger.io](http://swagger.io) or on [irc.freenode.net, #swagger](http://swagger.io/irc/).  For this sample, you can use the api key `special-key` to test the authorization filters.</description>
+  <description>This is a sample server Petstore server.  You can find out more about Swagger at [http://swagger.io](http://swagger.io) or on [irc.freenode.net, #swagger](http://swagger.io/irc/).  For this sample, you can use the api key &#x60;special-key&#x60; to test the authorization filters.</description>
   <version>1.0.0</version>
   <build>
     <sourceDirectory>src/main/java</sourceDirectory>

--- a/samples/server/petstore/jaxrs-cxf-annotated-base-path/src/gen/java/io/swagger/api/PetApi.java
+++ b/samples/server/petstore/jaxrs-cxf-annotated-base-path/src/gen/java/io/swagger/api/PetApi.java
@@ -21,10 +21,22 @@ import io.swagger.jaxrs.PATCH;
 import javax.validation.constraints.*;
 import javax.validation.Valid;
 
+/**
+ * Swagger Petstore
+ *
+ * <p>This is a sample server Petstore server.  You can find out more about Swagger at [http://swagger.io](http://swagger.io) or on [irc.freenode.net, #swagger](http://swagger.io/irc/).  For this sample, you can use the api key `special-key` to test the authorization filters.
+ *
+ */
 @Path("/v2")
 @Api(value = "/", description = "")
 public interface PetApi  {
 
+    /**
+     * Add a new pet to the store
+     *
+     * 
+     *
+     */
     @POST
     @Path("/pet")
     @Consumes({ "application/json", "application/xml" })
@@ -34,6 +46,12 @@ public interface PetApi  {
         @ApiResponse(code = 405, message = "Invalid input") })
     public void addPet(@Valid Pet body);
 
+    /**
+     * Deletes a pet
+     *
+     * 
+     *
+     */
     @DELETE
     @Path("/pet/{petId}")
     @Produces({ "application/xml", "application/json" })
@@ -42,6 +60,12 @@ public interface PetApi  {
         @ApiResponse(code = 400, message = "Invalid pet value") })
     public void deletePet(@PathParam("petId") Long petId, @HeaderParam("api_key") String apiKey);
 
+    /**
+     * Finds Pets by status
+     *
+     * Multiple status values can be provided with comma separated strings
+     *
+     */
     @GET
     @Path("/pet/findByStatus")
     @Produces({ "application/xml", "application/json" })
@@ -51,6 +75,12 @@ public interface PetApi  {
         @ApiResponse(code = 400, message = "Invalid status value") })
     public List<Pet> findPetsByStatus(@QueryParam("status") @NotNull List<String> status);
 
+    /**
+     * Finds Pets by tags
+     *
+     * Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
+     *
+     */
     @GET
     @Path("/pet/findByTags")
     @Produces({ "application/xml", "application/json" })
@@ -60,6 +90,12 @@ public interface PetApi  {
         @ApiResponse(code = 400, message = "Invalid tag value") })
     public List<Pet> findPetsByTags(@QueryParam("tags") @NotNull List<String> tags);
 
+    /**
+     * Find pet by ID
+     *
+     * Returns a single pet
+     *
+     */
     @GET
     @Path("/pet/{petId}")
     @Produces({ "application/xml", "application/json" })
@@ -70,6 +106,12 @@ public interface PetApi  {
         @ApiResponse(code = 404, message = "Pet not found") })
     public Pet getPetById(@PathParam("petId") Long petId);
 
+    /**
+     * Update an existing pet
+     *
+     * 
+     *
+     */
     @PUT
     @Path("/pet")
     @Consumes({ "application/json", "application/xml" })
@@ -81,6 +123,12 @@ public interface PetApi  {
         @ApiResponse(code = 405, message = "Validation exception") })
     public void updatePet(@Valid Pet body);
 
+    /**
+     * Updates a pet in the store with form data
+     *
+     * 
+     *
+     */
     @POST
     @Path("/pet/{petId}")
     @Consumes({ "application/x-www-form-urlencoded" })
@@ -90,6 +138,12 @@ public interface PetApi  {
         @ApiResponse(code = 405, message = "Invalid input") })
     public void updatePetWithForm(@PathParam("petId") Long petId, @Multipart(value = "name", required = false)  String name, @Multipart(value = "status", required = false)  String status);
 
+    /**
+     * uploads an image
+     *
+     * 
+     *
+     */
     @POST
     @Path("/pet/{petId}/uploadImage")
     @Consumes({ "multipart/form-data" })

--- a/samples/server/petstore/jaxrs-cxf-annotated-base-path/src/gen/java/io/swagger/api/StoreApi.java
+++ b/samples/server/petstore/jaxrs-cxf-annotated-base-path/src/gen/java/io/swagger/api/StoreApi.java
@@ -20,10 +20,22 @@ import io.swagger.jaxrs.PATCH;
 import javax.validation.constraints.*;
 import javax.validation.Valid;
 
+/**
+ * Swagger Petstore
+ *
+ * <p>This is a sample server Petstore server.  You can find out more about Swagger at [http://swagger.io](http://swagger.io) or on [irc.freenode.net, #swagger](http://swagger.io/irc/).  For this sample, you can use the api key `special-key` to test the authorization filters.
+ *
+ */
 @Path("/v2")
 @Api(value = "/", description = "")
 public interface StoreApi  {
 
+    /**
+     * Delete purchase order by ID
+     *
+     * For valid response try integer IDs with value &lt; 1000. Anything above 1000 or nonintegers will generate API errors
+     *
+     */
     @DELETE
     @Path("/store/order/{orderId}")
     @Produces({ "application/xml", "application/json" })
@@ -33,6 +45,12 @@ public interface StoreApi  {
         @ApiResponse(code = 404, message = "Order not found") })
     public void deleteOrder(@PathParam("orderId") String orderId);
 
+    /**
+     * Returns pet inventories by status
+     *
+     * Returns a map of status codes to quantities
+     *
+     */
     @GET
     @Path("/store/inventory")
     @Produces({ "application/json" })
@@ -41,6 +59,12 @@ public interface StoreApi  {
         @ApiResponse(code = 200, message = "successful operation", response = Map.class, responseContainer = "Map") })
     public Map<String, Integer> getInventory();
 
+    /**
+     * Find purchase order by ID
+     *
+     * For valid response try integer IDs with value &lt;&#x3D; 5 or &gt; 10. Other values will generated exceptions
+     *
+     */
     @GET
     @Path("/store/order/{orderId}")
     @Produces({ "application/xml", "application/json" })
@@ -51,6 +75,12 @@ public interface StoreApi  {
         @ApiResponse(code = 404, message = "Order not found") })
     public Order getOrderById(@PathParam("orderId") @Min(1) @Max(5) Long orderId);
 
+    /**
+     * Place an order for a pet
+     *
+     * 
+     *
+     */
     @POST
     @Path("/store/order")
     @Produces({ "application/xml", "application/json" })

--- a/samples/server/petstore/jaxrs-cxf-annotated-base-path/src/gen/java/io/swagger/api/UserApi.java
+++ b/samples/server/petstore/jaxrs-cxf-annotated-base-path/src/gen/java/io/swagger/api/UserApi.java
@@ -20,10 +20,22 @@ import io.swagger.jaxrs.PATCH;
 import javax.validation.constraints.*;
 import javax.validation.Valid;
 
+/**
+ * Swagger Petstore
+ *
+ * <p>This is a sample server Petstore server.  You can find out more about Swagger at [http://swagger.io](http://swagger.io) or on [irc.freenode.net, #swagger](http://swagger.io/irc/).  For this sample, you can use the api key `special-key` to test the authorization filters.
+ *
+ */
 @Path("/v2")
 @Api(value = "/", description = "")
 public interface UserApi  {
 
+    /**
+     * Create user
+     *
+     * This can only be done by the logged in user.
+     *
+     */
     @POST
     @Path("/user")
     @Produces({ "application/xml", "application/json" })
@@ -32,6 +44,12 @@ public interface UserApi  {
         @ApiResponse(code = 200, message = "successful operation") })
     public void createUser(@Valid User body);
 
+    /**
+     * Creates list of users with given input array
+     *
+     * 
+     *
+     */
     @POST
     @Path("/user/createWithArray")
     @Produces({ "application/xml", "application/json" })
@@ -40,6 +58,12 @@ public interface UserApi  {
         @ApiResponse(code = 200, message = "successful operation") })
     public void createUsersWithArrayInput(@Valid List<User> body);
 
+    /**
+     * Creates list of users with given input array
+     *
+     * 
+     *
+     */
     @POST
     @Path("/user/createWithList")
     @Produces({ "application/xml", "application/json" })
@@ -48,6 +72,12 @@ public interface UserApi  {
         @ApiResponse(code = 200, message = "successful operation") })
     public void createUsersWithListInput(@Valid List<User> body);
 
+    /**
+     * Delete user
+     *
+     * This can only be done by the logged in user.
+     *
+     */
     @DELETE
     @Path("/user/{username}")
     @Produces({ "application/xml", "application/json" })
@@ -57,6 +87,12 @@ public interface UserApi  {
         @ApiResponse(code = 404, message = "User not found") })
     public void deleteUser(@PathParam("username") String username);
 
+    /**
+     * Get user by user name
+     *
+     * 
+     *
+     */
     @GET
     @Path("/user/{username}")
     @Produces({ "application/xml", "application/json" })
@@ -67,6 +103,12 @@ public interface UserApi  {
         @ApiResponse(code = 404, message = "User not found") })
     public User getUserByName(@PathParam("username") String username);
 
+    /**
+     * Logs user into the system
+     *
+     * 
+     *
+     */
     @GET
     @Path("/user/login")
     @Produces({ "application/xml", "application/json" })
@@ -76,6 +118,12 @@ public interface UserApi  {
         @ApiResponse(code = 400, message = "Invalid username/password supplied") })
     public String loginUser(@QueryParam("username") @NotNull String username, @QueryParam("password") @NotNull String password);
 
+    /**
+     * Logs out current logged in user session
+     *
+     * 
+     *
+     */
     @GET
     @Path("/user/logout")
     @Produces({ "application/xml", "application/json" })
@@ -84,6 +132,12 @@ public interface UserApi  {
         @ApiResponse(code = 200, message = "successful operation") })
     public void logoutUser();
 
+    /**
+     * Updated user
+     *
+     * This can only be done by the logged in user.
+     *
+     */
     @PUT
     @Path("/user/{username}")
     @Produces({ "application/xml", "application/json" })

--- a/samples/server/petstore/jaxrs-cxf-annotated-base-path/src/gen/java/io/swagger/model/Category.java
+++ b/samples/server/petstore/jaxrs-cxf-annotated-base-path/src/gen/java/io/swagger/model/Category.java
@@ -12,6 +12,9 @@ import javax.xml.bind.annotation.XmlType;
 import javax.xml.bind.annotation.XmlEnum;
 import javax.xml.bind.annotation.XmlEnumValue;
 
+/**
+  * A category for a pet
+ **/
 @ApiModel(description="A category for a pet")
 public class Category  {
   

--- a/samples/server/petstore/jaxrs-cxf-annotated-base-path/src/gen/java/io/swagger/model/ModelApiResponse.java
+++ b/samples/server/petstore/jaxrs-cxf-annotated-base-path/src/gen/java/io/swagger/model/ModelApiResponse.java
@@ -12,6 +12,9 @@ import javax.xml.bind.annotation.XmlType;
 import javax.xml.bind.annotation.XmlEnum;
 import javax.xml.bind.annotation.XmlEnumValue;
 
+/**
+  * Describes the result of uploading an image resource
+ **/
 @ApiModel(description="Describes the result of uploading an image resource")
 public class ModelApiResponse  {
   

--- a/samples/server/petstore/jaxrs-cxf-annotated-base-path/src/gen/java/io/swagger/model/Order.java
+++ b/samples/server/petstore/jaxrs-cxf-annotated-base-path/src/gen/java/io/swagger/model/Order.java
@@ -13,6 +13,9 @@ import javax.xml.bind.annotation.XmlType;
 import javax.xml.bind.annotation.XmlEnum;
 import javax.xml.bind.annotation.XmlEnumValue;
 
+/**
+  * An order for a pets from the pet store
+ **/
 @ApiModel(description="An order for a pets from the pet store")
 public class Order  {
   
@@ -58,6 +61,9 @@ public enum StatusEnum {
 }
 
   @ApiModelProperty(value = "Order Status")
+ /**
+   * Order Status  
+  **/
   private StatusEnum status = null;
   @ApiModelProperty(value = "")
   private Boolean complete = false;

--- a/samples/server/petstore/jaxrs-cxf-annotated-base-path/src/gen/java/io/swagger/model/Pet.java
+++ b/samples/server/petstore/jaxrs-cxf-annotated-base-path/src/gen/java/io/swagger/model/Pet.java
@@ -16,6 +16,9 @@ import javax.xml.bind.annotation.XmlType;
 import javax.xml.bind.annotation.XmlEnum;
 import javax.xml.bind.annotation.XmlEnumValue;
 
+/**
+  * A pet for sale in the pet store
+ **/
 @ApiModel(description="A pet for sale in the pet store")
 public class Pet  {
   
@@ -63,6 +66,9 @@ public enum StatusEnum {
 }
 
   @ApiModelProperty(value = "pet status in the store")
+ /**
+   * pet status in the store  
+  **/
   private StatusEnum status = null;
 
  /**

--- a/samples/server/petstore/jaxrs-cxf-annotated-base-path/src/gen/java/io/swagger/model/Tag.java
+++ b/samples/server/petstore/jaxrs-cxf-annotated-base-path/src/gen/java/io/swagger/model/Tag.java
@@ -12,6 +12,9 @@ import javax.xml.bind.annotation.XmlType;
 import javax.xml.bind.annotation.XmlEnum;
 import javax.xml.bind.annotation.XmlEnumValue;
 
+/**
+  * A tag for a pet
+ **/
 @ApiModel(description="A tag for a pet")
 public class Tag  {
   

--- a/samples/server/petstore/jaxrs-cxf-annotated-base-path/src/gen/java/io/swagger/model/User.java
+++ b/samples/server/petstore/jaxrs-cxf-annotated-base-path/src/gen/java/io/swagger/model/User.java
@@ -12,6 +12,9 @@ import javax.xml.bind.annotation.XmlType;
 import javax.xml.bind.annotation.XmlEnum;
 import javax.xml.bind.annotation.XmlEnumValue;
 
+/**
+  * A User who is purchasing from the pet store
+ **/
 @ApiModel(description="A User who is purchasing from the pet store")
 public class User  {
   
@@ -30,6 +33,9 @@ public class User  {
   @ApiModelProperty(value = "")
   private String phone = null;
   @ApiModelProperty(value = "User Status")
+ /**
+   * User Status  
+  **/
   private Integer userStatus = null;
 
  /**

--- a/samples/server/petstore/jaxrs-cxf-annotated-base-path/src/main/java/io/swagger/api/impl/PetApiServiceImpl.java
+++ b/samples/server/petstore/jaxrs-cxf-annotated-base-path/src/main/java/io/swagger/api/impl/PetApiServiceImpl.java
@@ -18,49 +18,103 @@ import org.apache.cxf.jaxrs.ext.multipart.*;
 
 import io.swagger.annotations.Api;
 
+/**
+ * Swagger Petstore
+ *
+ * <p>This is a sample server Petstore server.  You can find out more about Swagger at [http://swagger.io](http://swagger.io) or on [irc.freenode.net, #swagger](http://swagger.io/irc/).  For this sample, you can use the api key `special-key` to test the authorization filters.
+ *
+ */
 public class PetApiServiceImpl implements PetApi {
+    /**
+     * Add a new pet to the store
+     *
+     * 
+     *
+     */
     public void addPet(Pet body) {
         // TODO: Implement...
         
         
     }
     
+    /**
+     * Deletes a pet
+     *
+     * 
+     *
+     */
     public void deletePet(Long petId, String apiKey) {
         // TODO: Implement...
         
         
     }
     
+    /**
+     * Finds Pets by status
+     *
+     * Multiple status values can be provided with comma separated strings
+     *
+     */
     public List<Pet> findPetsByStatus(List<String> status) {
         // TODO: Implement...
         
         return null;
     }
     
+    /**
+     * Finds Pets by tags
+     *
+     * Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
+     *
+     */
     public List<Pet> findPetsByTags(List<String> tags) {
         // TODO: Implement...
         
         return null;
     }
     
+    /**
+     * Find pet by ID
+     *
+     * Returns a single pet
+     *
+     */
     public Pet getPetById(Long petId) {
         // TODO: Implement...
         
         return null;
     }
     
+    /**
+     * Update an existing pet
+     *
+     * 
+     *
+     */
     public void updatePet(Pet body) {
         // TODO: Implement...
         
         
     }
     
+    /**
+     * Updates a pet in the store with form data
+     *
+     * 
+     *
+     */
     public void updatePetWithForm(Long petId, String name, String status) {
         // TODO: Implement...
         
         
     }
     
+    /**
+     * uploads an image
+     *
+     * 
+     *
+     */
     public ModelApiResponse uploadFile(Long petId, String additionalMetadata,  Attachment fileDetail) {
         // TODO: Implement...
         

--- a/samples/server/petstore/jaxrs-cxf-annotated-base-path/src/main/java/io/swagger/api/impl/StoreApiServiceImpl.java
+++ b/samples/server/petstore/jaxrs-cxf-annotated-base-path/src/main/java/io/swagger/api/impl/StoreApiServiceImpl.java
@@ -17,25 +17,55 @@ import org.apache.cxf.jaxrs.ext.multipart.*;
 
 import io.swagger.annotations.Api;
 
+/**
+ * Swagger Petstore
+ *
+ * <p>This is a sample server Petstore server.  You can find out more about Swagger at [http://swagger.io](http://swagger.io) or on [irc.freenode.net, #swagger](http://swagger.io/irc/).  For this sample, you can use the api key `special-key` to test the authorization filters.
+ *
+ */
 public class StoreApiServiceImpl implements StoreApi {
+    /**
+     * Delete purchase order by ID
+     *
+     * For valid response try integer IDs with value &lt; 1000. Anything above 1000 or nonintegers will generate API errors
+     *
+     */
     public void deleteOrder(String orderId) {
         // TODO: Implement...
         
         
     }
     
+    /**
+     * Returns pet inventories by status
+     *
+     * Returns a map of status codes to quantities
+     *
+     */
     public Map<String, Integer> getInventory() {
         // TODO: Implement...
         
         return null;
     }
     
+    /**
+     * Find purchase order by ID
+     *
+     * For valid response try integer IDs with value &lt;&#x3D; 5 or &gt; 10. Other values will generated exceptions
+     *
+     */
     public Order getOrderById(Long orderId) {
         // TODO: Implement...
         
         return null;
     }
     
+    /**
+     * Place an order for a pet
+     *
+     * 
+     *
+     */
     public Order placeOrder(Order body) {
         // TODO: Implement...
         

--- a/samples/server/petstore/jaxrs-cxf-annotated-base-path/src/main/java/io/swagger/api/impl/UserApiServiceImpl.java
+++ b/samples/server/petstore/jaxrs-cxf-annotated-base-path/src/main/java/io/swagger/api/impl/UserApiServiceImpl.java
@@ -17,49 +17,103 @@ import org.apache.cxf.jaxrs.ext.multipart.*;
 
 import io.swagger.annotations.Api;
 
+/**
+ * Swagger Petstore
+ *
+ * <p>This is a sample server Petstore server.  You can find out more about Swagger at [http://swagger.io](http://swagger.io) or on [irc.freenode.net, #swagger](http://swagger.io/irc/).  For this sample, you can use the api key `special-key` to test the authorization filters.
+ *
+ */
 public class UserApiServiceImpl implements UserApi {
+    /**
+     * Create user
+     *
+     * This can only be done by the logged in user.
+     *
+     */
     public void createUser(User body) {
         // TODO: Implement...
         
         
     }
     
+    /**
+     * Creates list of users with given input array
+     *
+     * 
+     *
+     */
     public void createUsersWithArrayInput(List<User> body) {
         // TODO: Implement...
         
         
     }
     
+    /**
+     * Creates list of users with given input array
+     *
+     * 
+     *
+     */
     public void createUsersWithListInput(List<User> body) {
         // TODO: Implement...
         
         
     }
     
+    /**
+     * Delete user
+     *
+     * This can only be done by the logged in user.
+     *
+     */
     public void deleteUser(String username) {
         // TODO: Implement...
         
         
     }
     
+    /**
+     * Get user by user name
+     *
+     * 
+     *
+     */
     public User getUserByName(String username) {
         // TODO: Implement...
         
         return null;
     }
     
+    /**
+     * Logs user into the system
+     *
+     * 
+     *
+     */
     public String loginUser(String username, String password) {
         // TODO: Implement...
         
         return null;
     }
     
+    /**
+     * Logs out current logged in user session
+     *
+     * 
+     *
+     */
     public void logoutUser() {
         // TODO: Implement...
         
         
     }
     
+    /**
+     * Updated user
+     *
+     * This can only be done by the logged in user.
+     *
+     */
     public void updateUser(String username, User body) {
         // TODO: Implement...
         

--- a/samples/server/petstore/jaxrs-cxf-non-spring-app/pom.xml
+++ b/samples/server/petstore/jaxrs-cxf-non-spring-app/pom.xml
@@ -4,7 +4,7 @@
   <artifactId>swagger-cxf-server-non-spring</artifactId>
   <packaging>war</packaging>
   <name>swagger-cxf-server-non-spring</name>
-  <description>This is a sample server Petstore server.  You can find out more about Swagger at [http://swagger.io](http://swagger.io) or on [irc.freenode.net, #swagger](http://swagger.io/irc/).  For this sample, you can use the api key `special-key` to test the authorization filters.</description>
+  <description>This is a sample server Petstore server.  You can find out more about Swagger at [http://swagger.io](http://swagger.io) or on [irc.freenode.net, #swagger](http://swagger.io/irc/).  For this sample, you can use the api key &#x60;special-key&#x60; to test the authorization filters.</description>
   <version>1.0.0</version>
   <build>
     <sourceDirectory>src/main/java</sourceDirectory>

--- a/samples/server/petstore/jaxrs-cxf-non-spring-app/pom.xml
+++ b/samples/server/petstore/jaxrs-cxf-non-spring-app/pom.xml
@@ -4,6 +4,7 @@
   <artifactId>swagger-cxf-server-non-spring</artifactId>
   <packaging>war</packaging>
   <name>swagger-cxf-server-non-spring</name>
+  <description>This is a sample server Petstore server.  You can find out more about Swagger at [http://swagger.io](http://swagger.io) or on [irc.freenode.net, #swagger](http://swagger.io/irc/).  For this sample, you can use the api key `special-key` to test the authorization filters.</description>
   <version>1.0.0</version>
   <build>
     <sourceDirectory>src/main/java</sourceDirectory>

--- a/samples/server/petstore/jaxrs-cxf-non-spring-app/src/gen/java/io/swagger/api/PetApi.java
+++ b/samples/server/petstore/jaxrs-cxf-non-spring-app/src/gen/java/io/swagger/api/PetApi.java
@@ -21,10 +21,22 @@ import io.swagger.jaxrs.PATCH;
 import javax.validation.constraints.*;
 import javax.validation.Valid;
 
+/**
+ * Swagger Petstore
+ *
+ * <p>This is a sample server Petstore server.  You can find out more about Swagger at [http://swagger.io](http://swagger.io) or on [irc.freenode.net, #swagger](http://swagger.io/irc/).  For this sample, you can use the api key `special-key` to test the authorization filters.
+ *
+ */
 @Path("/")
 @Api(value = "/", description = "")
 public interface PetApi  {
 
+    /**
+     * Add a new pet to the store
+     *
+     * 
+     *
+     */
     @POST
     @Path("/pet")
     @Consumes({ "application/json", "application/xml" })
@@ -34,6 +46,12 @@ public interface PetApi  {
         @ApiResponse(code = 405, message = "Invalid input") })
     public void addPet(@Valid Pet body);
 
+    /**
+     * Deletes a pet
+     *
+     * 
+     *
+     */
     @DELETE
     @Path("/pet/{petId}")
     @Produces({ "application/xml", "application/json" })
@@ -42,6 +60,12 @@ public interface PetApi  {
         @ApiResponse(code = 400, message = "Invalid pet value") })
     public void deletePet(@PathParam("petId") Long petId, @HeaderParam("api_key") String apiKey);
 
+    /**
+     * Finds Pets by status
+     *
+     * Multiple status values can be provided with comma separated strings
+     *
+     */
     @GET
     @Path("/pet/findByStatus")
     @Produces({ "application/xml", "application/json" })
@@ -51,6 +75,12 @@ public interface PetApi  {
         @ApiResponse(code = 400, message = "Invalid status value") })
     public List<Pet> findPetsByStatus(@QueryParam("status") @NotNull List<String> status);
 
+    /**
+     * Finds Pets by tags
+     *
+     * Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
+     *
+     */
     @GET
     @Path("/pet/findByTags")
     @Produces({ "application/xml", "application/json" })
@@ -60,6 +90,12 @@ public interface PetApi  {
         @ApiResponse(code = 400, message = "Invalid tag value") })
     public List<Pet> findPetsByTags(@QueryParam("tags") @NotNull List<String> tags);
 
+    /**
+     * Find pet by ID
+     *
+     * Returns a single pet
+     *
+     */
     @GET
     @Path("/pet/{petId}")
     @Produces({ "application/xml", "application/json" })
@@ -70,6 +106,12 @@ public interface PetApi  {
         @ApiResponse(code = 404, message = "Pet not found") })
     public Pet getPetById(@PathParam("petId") Long petId);
 
+    /**
+     * Update an existing pet
+     *
+     * 
+     *
+     */
     @PUT
     @Path("/pet")
     @Consumes({ "application/json", "application/xml" })
@@ -81,6 +123,12 @@ public interface PetApi  {
         @ApiResponse(code = 405, message = "Validation exception") })
     public void updatePet(@Valid Pet body);
 
+    /**
+     * Updates a pet in the store with form data
+     *
+     * 
+     *
+     */
     @POST
     @Path("/pet/{petId}")
     @Consumes({ "application/x-www-form-urlencoded" })
@@ -90,6 +138,12 @@ public interface PetApi  {
         @ApiResponse(code = 405, message = "Invalid input") })
     public void updatePetWithForm(@PathParam("petId") Long petId, @Multipart(value = "name", required = false)  String name, @Multipart(value = "status", required = false)  String status);
 
+    /**
+     * uploads an image
+     *
+     * 
+     *
+     */
     @POST
     @Path("/pet/{petId}/uploadImage")
     @Consumes({ "multipart/form-data" })

--- a/samples/server/petstore/jaxrs-cxf-non-spring-app/src/gen/java/io/swagger/api/StoreApi.java
+++ b/samples/server/petstore/jaxrs-cxf-non-spring-app/src/gen/java/io/swagger/api/StoreApi.java
@@ -20,10 +20,22 @@ import io.swagger.jaxrs.PATCH;
 import javax.validation.constraints.*;
 import javax.validation.Valid;
 
+/**
+ * Swagger Petstore
+ *
+ * <p>This is a sample server Petstore server.  You can find out more about Swagger at [http://swagger.io](http://swagger.io) or on [irc.freenode.net, #swagger](http://swagger.io/irc/).  For this sample, you can use the api key `special-key` to test the authorization filters.
+ *
+ */
 @Path("/")
 @Api(value = "/", description = "")
 public interface StoreApi  {
 
+    /**
+     * Delete purchase order by ID
+     *
+     * For valid response try integer IDs with value &lt; 1000. Anything above 1000 or nonintegers will generate API errors
+     *
+     */
     @DELETE
     @Path("/store/order/{orderId}")
     @Produces({ "application/xml", "application/json" })
@@ -33,6 +45,12 @@ public interface StoreApi  {
         @ApiResponse(code = 404, message = "Order not found") })
     public void deleteOrder(@PathParam("orderId") String orderId);
 
+    /**
+     * Returns pet inventories by status
+     *
+     * Returns a map of status codes to quantities
+     *
+     */
     @GET
     @Path("/store/inventory")
     @Produces({ "application/json" })
@@ -41,6 +59,12 @@ public interface StoreApi  {
         @ApiResponse(code = 200, message = "successful operation", response = Map.class, responseContainer = "Map") })
     public Map<String, Integer> getInventory();
 
+    /**
+     * Find purchase order by ID
+     *
+     * For valid response try integer IDs with value &lt;&#x3D; 5 or &gt; 10. Other values will generated exceptions
+     *
+     */
     @GET
     @Path("/store/order/{orderId}")
     @Produces({ "application/xml", "application/json" })
@@ -51,6 +75,12 @@ public interface StoreApi  {
         @ApiResponse(code = 404, message = "Order not found") })
     public Order getOrderById(@PathParam("orderId") @Min(1) @Max(5) Long orderId);
 
+    /**
+     * Place an order for a pet
+     *
+     * 
+     *
+     */
     @POST
     @Path("/store/order")
     @Produces({ "application/xml", "application/json" })

--- a/samples/server/petstore/jaxrs-cxf-non-spring-app/src/gen/java/io/swagger/api/UserApi.java
+++ b/samples/server/petstore/jaxrs-cxf-non-spring-app/src/gen/java/io/swagger/api/UserApi.java
@@ -20,10 +20,22 @@ import io.swagger.jaxrs.PATCH;
 import javax.validation.constraints.*;
 import javax.validation.Valid;
 
+/**
+ * Swagger Petstore
+ *
+ * <p>This is a sample server Petstore server.  You can find out more about Swagger at [http://swagger.io](http://swagger.io) or on [irc.freenode.net, #swagger](http://swagger.io/irc/).  For this sample, you can use the api key `special-key` to test the authorization filters.
+ *
+ */
 @Path("/")
 @Api(value = "/", description = "")
 public interface UserApi  {
 
+    /**
+     * Create user
+     *
+     * This can only be done by the logged in user.
+     *
+     */
     @POST
     @Path("/user")
     @Produces({ "application/xml", "application/json" })
@@ -32,6 +44,12 @@ public interface UserApi  {
         @ApiResponse(code = 200, message = "successful operation") })
     public void createUser(@Valid User body);
 
+    /**
+     * Creates list of users with given input array
+     *
+     * 
+     *
+     */
     @POST
     @Path("/user/createWithArray")
     @Produces({ "application/xml", "application/json" })
@@ -40,6 +58,12 @@ public interface UserApi  {
         @ApiResponse(code = 200, message = "successful operation") })
     public void createUsersWithArrayInput(@Valid List<User> body);
 
+    /**
+     * Creates list of users with given input array
+     *
+     * 
+     *
+     */
     @POST
     @Path("/user/createWithList")
     @Produces({ "application/xml", "application/json" })
@@ -48,6 +72,12 @@ public interface UserApi  {
         @ApiResponse(code = 200, message = "successful operation") })
     public void createUsersWithListInput(@Valid List<User> body);
 
+    /**
+     * Delete user
+     *
+     * This can only be done by the logged in user.
+     *
+     */
     @DELETE
     @Path("/user/{username}")
     @Produces({ "application/xml", "application/json" })
@@ -57,6 +87,12 @@ public interface UserApi  {
         @ApiResponse(code = 404, message = "User not found") })
     public void deleteUser(@PathParam("username") String username);
 
+    /**
+     * Get user by user name
+     *
+     * 
+     *
+     */
     @GET
     @Path("/user/{username}")
     @Produces({ "application/xml", "application/json" })
@@ -67,6 +103,12 @@ public interface UserApi  {
         @ApiResponse(code = 404, message = "User not found") })
     public User getUserByName(@PathParam("username") String username);
 
+    /**
+     * Logs user into the system
+     *
+     * 
+     *
+     */
     @GET
     @Path("/user/login")
     @Produces({ "application/xml", "application/json" })
@@ -76,6 +118,12 @@ public interface UserApi  {
         @ApiResponse(code = 400, message = "Invalid username/password supplied") })
     public String loginUser(@QueryParam("username") @NotNull String username, @QueryParam("password") @NotNull String password);
 
+    /**
+     * Logs out current logged in user session
+     *
+     * 
+     *
+     */
     @GET
     @Path("/user/logout")
     @Produces({ "application/xml", "application/json" })
@@ -84,6 +132,12 @@ public interface UserApi  {
         @ApiResponse(code = 200, message = "successful operation") })
     public void logoutUser();
 
+    /**
+     * Updated user
+     *
+     * This can only be done by the logged in user.
+     *
+     */
     @PUT
     @Path("/user/{username}")
     @Produces({ "application/xml", "application/json" })

--- a/samples/server/petstore/jaxrs-cxf-non-spring-app/src/gen/java/io/swagger/model/Category.java
+++ b/samples/server/petstore/jaxrs-cxf-non-spring-app/src/gen/java/io/swagger/model/Category.java
@@ -12,6 +12,9 @@ import javax.xml.bind.annotation.XmlType;
 import javax.xml.bind.annotation.XmlEnum;
 import javax.xml.bind.annotation.XmlEnumValue;
 
+/**
+  * A category for a pet
+ **/
 @ApiModel(description="A category for a pet")
 public class Category  {
   

--- a/samples/server/petstore/jaxrs-cxf-non-spring-app/src/gen/java/io/swagger/model/ModelApiResponse.java
+++ b/samples/server/petstore/jaxrs-cxf-non-spring-app/src/gen/java/io/swagger/model/ModelApiResponse.java
@@ -12,6 +12,9 @@ import javax.xml.bind.annotation.XmlType;
 import javax.xml.bind.annotation.XmlEnum;
 import javax.xml.bind.annotation.XmlEnumValue;
 
+/**
+  * Describes the result of uploading an image resource
+ **/
 @ApiModel(description="Describes the result of uploading an image resource")
 public class ModelApiResponse  {
   

--- a/samples/server/petstore/jaxrs-cxf-non-spring-app/src/gen/java/io/swagger/model/Order.java
+++ b/samples/server/petstore/jaxrs-cxf-non-spring-app/src/gen/java/io/swagger/model/Order.java
@@ -13,6 +13,9 @@ import javax.xml.bind.annotation.XmlType;
 import javax.xml.bind.annotation.XmlEnum;
 import javax.xml.bind.annotation.XmlEnumValue;
 
+/**
+  * An order for a pets from the pet store
+ **/
 @ApiModel(description="An order for a pets from the pet store")
 public class Order  {
   
@@ -58,6 +61,9 @@ public enum StatusEnum {
 }
 
   @ApiModelProperty(value = "Order Status")
+ /**
+   * Order Status  
+  **/
   private StatusEnum status = null;
   @ApiModelProperty(value = "")
   private Boolean complete = false;

--- a/samples/server/petstore/jaxrs-cxf-non-spring-app/src/gen/java/io/swagger/model/Pet.java
+++ b/samples/server/petstore/jaxrs-cxf-non-spring-app/src/gen/java/io/swagger/model/Pet.java
@@ -16,6 +16,9 @@ import javax.xml.bind.annotation.XmlType;
 import javax.xml.bind.annotation.XmlEnum;
 import javax.xml.bind.annotation.XmlEnumValue;
 
+/**
+  * A pet for sale in the pet store
+ **/
 @ApiModel(description="A pet for sale in the pet store")
 public class Pet  {
   
@@ -63,6 +66,9 @@ public enum StatusEnum {
 }
 
   @ApiModelProperty(value = "pet status in the store")
+ /**
+   * pet status in the store  
+  **/
   private StatusEnum status = null;
 
  /**

--- a/samples/server/petstore/jaxrs-cxf-non-spring-app/src/gen/java/io/swagger/model/Tag.java
+++ b/samples/server/petstore/jaxrs-cxf-non-spring-app/src/gen/java/io/swagger/model/Tag.java
@@ -12,6 +12,9 @@ import javax.xml.bind.annotation.XmlType;
 import javax.xml.bind.annotation.XmlEnum;
 import javax.xml.bind.annotation.XmlEnumValue;
 
+/**
+  * A tag for a pet
+ **/
 @ApiModel(description="A tag for a pet")
 public class Tag  {
   

--- a/samples/server/petstore/jaxrs-cxf-non-spring-app/src/gen/java/io/swagger/model/User.java
+++ b/samples/server/petstore/jaxrs-cxf-non-spring-app/src/gen/java/io/swagger/model/User.java
@@ -12,6 +12,9 @@ import javax.xml.bind.annotation.XmlType;
 import javax.xml.bind.annotation.XmlEnum;
 import javax.xml.bind.annotation.XmlEnumValue;
 
+/**
+  * A User who is purchasing from the pet store
+ **/
 @ApiModel(description="A User who is purchasing from the pet store")
 public class User  {
   
@@ -30,6 +33,9 @@ public class User  {
   @ApiModelProperty(value = "")
   private String phone = null;
   @ApiModelProperty(value = "User Status")
+ /**
+   * User Status  
+  **/
   private Integer userStatus = null;
 
  /**

--- a/samples/server/petstore/jaxrs-cxf-non-spring-app/src/main/java/io/swagger/api/impl/PetApiServiceImpl.java
+++ b/samples/server/petstore/jaxrs-cxf-non-spring-app/src/main/java/io/swagger/api/impl/PetApiServiceImpl.java
@@ -18,49 +18,103 @@ import org.apache.cxf.jaxrs.ext.multipart.*;
 
 import io.swagger.annotations.Api;
 
+/**
+ * Swagger Petstore
+ *
+ * <p>This is a sample server Petstore server.  You can find out more about Swagger at [http://swagger.io](http://swagger.io) or on [irc.freenode.net, #swagger](http://swagger.io/irc/).  For this sample, you can use the api key `special-key` to test the authorization filters.
+ *
+ */
 public class PetApiServiceImpl implements PetApi {
+    /**
+     * Add a new pet to the store
+     *
+     * 
+     *
+     */
     public void addPet(Pet body) {
         // TODO: Implement...
         
         
     }
     
+    /**
+     * Deletes a pet
+     *
+     * 
+     *
+     */
     public void deletePet(Long petId, String apiKey) {
         // TODO: Implement...
         
         
     }
     
+    /**
+     * Finds Pets by status
+     *
+     * Multiple status values can be provided with comma separated strings
+     *
+     */
     public List<Pet> findPetsByStatus(List<String> status) {
         // TODO: Implement...
         
         return null;
     }
     
+    /**
+     * Finds Pets by tags
+     *
+     * Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
+     *
+     */
     public List<Pet> findPetsByTags(List<String> tags) {
         // TODO: Implement...
         
         return null;
     }
     
+    /**
+     * Find pet by ID
+     *
+     * Returns a single pet
+     *
+     */
     public Pet getPetById(Long petId) {
         // TODO: Implement...
         
         return null;
     }
     
+    /**
+     * Update an existing pet
+     *
+     * 
+     *
+     */
     public void updatePet(Pet body) {
         // TODO: Implement...
         
         
     }
     
+    /**
+     * Updates a pet in the store with form data
+     *
+     * 
+     *
+     */
     public void updatePetWithForm(Long petId, String name, String status) {
         // TODO: Implement...
         
         
     }
     
+    /**
+     * uploads an image
+     *
+     * 
+     *
+     */
     public ModelApiResponse uploadFile(Long petId, String additionalMetadata,  Attachment fileDetail) {
         // TODO: Implement...
         

--- a/samples/server/petstore/jaxrs-cxf-non-spring-app/src/main/java/io/swagger/api/impl/StoreApiServiceImpl.java
+++ b/samples/server/petstore/jaxrs-cxf-non-spring-app/src/main/java/io/swagger/api/impl/StoreApiServiceImpl.java
@@ -17,25 +17,55 @@ import org.apache.cxf.jaxrs.ext.multipart.*;
 
 import io.swagger.annotations.Api;
 
+/**
+ * Swagger Petstore
+ *
+ * <p>This is a sample server Petstore server.  You can find out more about Swagger at [http://swagger.io](http://swagger.io) or on [irc.freenode.net, #swagger](http://swagger.io/irc/).  For this sample, you can use the api key `special-key` to test the authorization filters.
+ *
+ */
 public class StoreApiServiceImpl implements StoreApi {
+    /**
+     * Delete purchase order by ID
+     *
+     * For valid response try integer IDs with value &lt; 1000. Anything above 1000 or nonintegers will generate API errors
+     *
+     */
     public void deleteOrder(String orderId) {
         // TODO: Implement...
         
         
     }
     
+    /**
+     * Returns pet inventories by status
+     *
+     * Returns a map of status codes to quantities
+     *
+     */
     public Map<String, Integer> getInventory() {
         // TODO: Implement...
         
         return null;
     }
     
+    /**
+     * Find purchase order by ID
+     *
+     * For valid response try integer IDs with value &lt;&#x3D; 5 or &gt; 10. Other values will generated exceptions
+     *
+     */
     public Order getOrderById(Long orderId) {
         // TODO: Implement...
         
         return null;
     }
     
+    /**
+     * Place an order for a pet
+     *
+     * 
+     *
+     */
     public Order placeOrder(Order body) {
         // TODO: Implement...
         

--- a/samples/server/petstore/jaxrs-cxf-non-spring-app/src/main/java/io/swagger/api/impl/UserApiServiceImpl.java
+++ b/samples/server/petstore/jaxrs-cxf-non-spring-app/src/main/java/io/swagger/api/impl/UserApiServiceImpl.java
@@ -17,49 +17,103 @@ import org.apache.cxf.jaxrs.ext.multipart.*;
 
 import io.swagger.annotations.Api;
 
+/**
+ * Swagger Petstore
+ *
+ * <p>This is a sample server Petstore server.  You can find out more about Swagger at [http://swagger.io](http://swagger.io) or on [irc.freenode.net, #swagger](http://swagger.io/irc/).  For this sample, you can use the api key `special-key` to test the authorization filters.
+ *
+ */
 public class UserApiServiceImpl implements UserApi {
+    /**
+     * Create user
+     *
+     * This can only be done by the logged in user.
+     *
+     */
     public void createUser(User body) {
         // TODO: Implement...
         
         
     }
     
+    /**
+     * Creates list of users with given input array
+     *
+     * 
+     *
+     */
     public void createUsersWithArrayInput(List<User> body) {
         // TODO: Implement...
         
         
     }
     
+    /**
+     * Creates list of users with given input array
+     *
+     * 
+     *
+     */
     public void createUsersWithListInput(List<User> body) {
         // TODO: Implement...
         
         
     }
     
+    /**
+     * Delete user
+     *
+     * This can only be done by the logged in user.
+     *
+     */
     public void deleteUser(String username) {
         // TODO: Implement...
         
         
     }
     
+    /**
+     * Get user by user name
+     *
+     * 
+     *
+     */
     public User getUserByName(String username) {
         // TODO: Implement...
         
         return null;
     }
     
+    /**
+     * Logs user into the system
+     *
+     * 
+     *
+     */
     public String loginUser(String username, String password) {
         // TODO: Implement...
         
         return null;
     }
     
+    /**
+     * Logs out current logged in user session
+     *
+     * 
+     *
+     */
     public void logoutUser() {
         // TODO: Implement...
         
         
     }
     
+    /**
+     * Updated user
+     *
+     * This can only be done by the logged in user.
+     *
+     */
     public void updateUser(String username, User body) {
         // TODO: Implement...
         

--- a/samples/server/petstore/jaxrs-cxf/pom.xml
+++ b/samples/server/petstore/jaxrs-cxf/pom.xml
@@ -4,6 +4,7 @@
   <artifactId>swagger-cxf-server</artifactId>
   <packaging>war</packaging>
   <name>swagger-cxf-server</name>
+  <description>This spec is mainly for testing Petstore server and contains fake endpoints, models. Please do not use this for any other purpose. Special characters: \" \\</description>
   <version>1.0.0</version>
   <build>
     <sourceDirectory>src/main/java</sourceDirectory>

--- a/samples/server/petstore/jaxrs-cxf/pom.xml
+++ b/samples/server/petstore/jaxrs-cxf/pom.xml
@@ -4,7 +4,7 @@
   <artifactId>swagger-cxf-server</artifactId>
   <packaging>war</packaging>
   <name>swagger-cxf-server</name>
-  <description>This spec is mainly for testing Petstore server and contains fake endpoints, models. Please do not use this for any other purpose. Special characters: \" \\</description>
+  <description>This spec is mainly for testing Petstore server and contains fake endpoints, models. Please do not use this for any other purpose. Special characters: \&quot; \\</description>
   <version>1.0.0</version>
   <build>
     <sourceDirectory>src/main/java</sourceDirectory>
@@ -33,7 +33,7 @@
           <stopPort>8079</stopPort>
           <stopKey>stopit</stopKey>
           <httpConnector>
-            <port>8080</port>
+            <port>80</port>
             <idleTimeout>60000</idleTimeout>
           </httpConnector>
         </configuration>

--- a/samples/server/petstore/jaxrs-cxf/src/gen/java/io/swagger/api/AnotherFakeApi.java
+++ b/samples/server/petstore/jaxrs-cxf/src/gen/java/io/swagger/api/AnotherFakeApi.java
@@ -19,10 +19,22 @@ import io.swagger.jaxrs.PATCH;
 import javax.validation.constraints.*;
 import javax.validation.Valid;
 
+/**
+ * Swagger Petstore
+ *
+ * <p>This spec is mainly for testing Petstore server and contains fake endpoints, models. Please do not use this for any other purpose. Special characters: \" \\
+ *
+ */
 @Path("/")
 @Api(value = "/", description = "")
 public interface AnotherFakeApi  {
 
+    /**
+     * To test special tags
+     *
+     * To test special tags
+     *
+     */
     @PATCH
     @Path("/another-fake/dummy")
     @Consumes({ "application/json" })

--- a/samples/server/petstore/jaxrs-cxf/src/gen/java/io/swagger/api/FakeApi.java
+++ b/samples/server/petstore/jaxrs-cxf/src/gen/java/io/swagger/api/FakeApi.java
@@ -23,6 +23,12 @@ import io.swagger.jaxrs.PATCH;
 import javax.validation.constraints.*;
 import javax.validation.Valid;
 
+/**
+ * Swagger Petstore
+ *
+ * <p>This spec is mainly for testing Petstore server and contains fake endpoints, models. Please do not use this for any other purpose. Special characters: \" \\
+ *
+ */
 @Path("/")
 @Api(value = "/", description = "")
 public interface FakeApi  {
@@ -55,6 +61,12 @@ public interface FakeApi  {
         @ApiResponse(code = 200, message = "Output string", response = String.class) })
     public String fakeOuterStringSerialize(@Valid String body);
 
+    /**
+     * To test \&quot;client\&quot; model
+     *
+     * To test \&quot;client\&quot; model
+     *
+     */
     @PATCH
     @Path("/fake")
     @Consumes({ "application/json" })
@@ -64,6 +76,12 @@ public interface FakeApi  {
         @ApiResponse(code = 200, message = "successful operation", response = Client.class) })
     public Client testClientModel(@Valid Client body);
 
+    /**
+     * Fake endpoint for testing various parameters 假端點 偽のエンドポイント 가짜 엔드 포인트 
+     *
+     * Fake endpoint for testing various parameters 假端點 偽のエンドポイント 가짜 엔드 포인트 
+     *
+     */
     @POST
     @Path("/fake")
     @Consumes({ "application/xml; charset=utf-8", "application/json; charset=utf-8" })
@@ -74,6 +92,12 @@ public interface FakeApi  {
         @ApiResponse(code = 404, message = "User not found") })
     public void testEndpointParameters(@Multipart(value = "number")  BigDecimal number, @Multipart(value = "double")  Double _double, @Multipart(value = "pattern_without_delimiter")  String patternWithoutDelimiter, @Multipart(value = "byte")  byte[] _byte, @Multipart(value = "integer", required = false)  Integer integer, @Multipart(value = "int32", required = false)  Integer int32, @Multipart(value = "int64", required = false)  Long int64, @Multipart(value = "float", required = false)  Float _float, @Multipart(value = "string", required = false)  String string, @Multipart(value = "binary", required = false)  byte[] binary, @Multipart(value = "date", required = false)  LocalDate date, @Multipart(value = "dateTime", required = false)  Date dateTime, @Multipart(value = "password", required = false)  String password, @Multipart(value = "callback", required = false)  String paramCallback);
 
+    /**
+     * To test enum parameters
+     *
+     * To test enum parameters
+     *
+     */
     @GET
     @Path("/fake")
     @Consumes({ "*/*" })
@@ -84,6 +108,12 @@ public interface FakeApi  {
         @ApiResponse(code = 404, message = "Not found") })
     public void testEnumParameters(@Multipart(value = "enum_form_string_array", required = false)  List<String> enumFormStringArray, @Multipart(value = "enum_form_string", required = false)  String enumFormString, @HeaderParam("enum_header_string_array") List<String> enumHeaderStringArray, @HeaderParam("enum_header_string") String enumHeaderString, @QueryParam("enum_query_string_array") List<String> enumQueryStringArray, @QueryParam("enum_query_string") @DefaultValue("-efg") String enumQueryString, @QueryParam("enum_query_integer") Integer enumQueryInteger, @Multipart(value = "enum_query_double", required = false)  Double enumQueryDouble);
 
+    /**
+     * test json serialization of form data
+     *
+     * 
+     *
+     */
     @GET
     @Path("/fake/jsonFormData")
     @Consumes({ "application/json" })

--- a/samples/server/petstore/jaxrs-cxf/src/gen/java/io/swagger/api/FakeClassnameTags123Api.java
+++ b/samples/server/petstore/jaxrs-cxf/src/gen/java/io/swagger/api/FakeClassnameTags123Api.java
@@ -19,10 +19,20 @@ import io.swagger.jaxrs.PATCH;
 import javax.validation.constraints.*;
 import javax.validation.Valid;
 
+/**
+ * Swagger Petstore
+ *
+ * <p>This spec is mainly for testing Petstore server and contains fake endpoints, models. Please do not use this for any other purpose. Special characters: \" \\
+ *
+ */
 @Path("/")
 @Api(value = "/", description = "")
 public interface FakeClassnameTags123Api  {
 
+    /**
+     * To test class name in snake case
+     *
+     */
     @PATCH
     @Path("/fake_classname_test")
     @Consumes({ "application/json" })

--- a/samples/server/petstore/jaxrs-cxf/src/gen/java/io/swagger/api/PetApi.java
+++ b/samples/server/petstore/jaxrs-cxf/src/gen/java/io/swagger/api/PetApi.java
@@ -21,10 +21,22 @@ import io.swagger.jaxrs.PATCH;
 import javax.validation.constraints.*;
 import javax.validation.Valid;
 
+/**
+ * Swagger Petstore
+ *
+ * <p>This spec is mainly for testing Petstore server and contains fake endpoints, models. Please do not use this for any other purpose. Special characters: \" \\
+ *
+ */
 @Path("/")
 @Api(value = "/", description = "")
 public interface PetApi  {
 
+    /**
+     * Add a new pet to the store
+     *
+     * 
+     *
+     */
     @POST
     @Path("/pet")
     @Consumes({ "application/json", "application/xml" })
@@ -34,6 +46,12 @@ public interface PetApi  {
         @ApiResponse(code = 405, message = "Invalid input") })
     public void addPet(@Valid Pet body);
 
+    /**
+     * Deletes a pet
+     *
+     * 
+     *
+     */
     @DELETE
     @Path("/pet/{petId}")
     @Produces({ "application/xml", "application/json" })
@@ -42,6 +60,12 @@ public interface PetApi  {
         @ApiResponse(code = 400, message = "Invalid pet value") })
     public void deletePet(@PathParam("petId") Long petId, @HeaderParam("api_key") String apiKey);
 
+    /**
+     * Finds Pets by status
+     *
+     * Multiple status values can be provided with comma separated strings
+     *
+     */
     @GET
     @Path("/pet/findByStatus")
     @Produces({ "application/xml", "application/json" })
@@ -51,6 +75,12 @@ public interface PetApi  {
         @ApiResponse(code = 400, message = "Invalid status value") })
     public List<Pet> findPetsByStatus(@QueryParam("status") @NotNull List<String> status);
 
+    /**
+     * Finds Pets by tags
+     *
+     * Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
+     *
+     */
     @GET
     @Path("/pet/findByTags")
     @Produces({ "application/xml", "application/json" })
@@ -60,6 +90,12 @@ public interface PetApi  {
         @ApiResponse(code = 400, message = "Invalid tag value") })
     public List<Pet> findPetsByTags(@QueryParam("tags") @NotNull List<String> tags);
 
+    /**
+     * Find pet by ID
+     *
+     * Returns a single pet
+     *
+     */
     @GET
     @Path("/pet/{petId}")
     @Produces({ "application/xml", "application/json" })
@@ -70,6 +106,12 @@ public interface PetApi  {
         @ApiResponse(code = 404, message = "Pet not found") })
     public Pet getPetById(@PathParam("petId") Long petId);
 
+    /**
+     * Update an existing pet
+     *
+     * 
+     *
+     */
     @PUT
     @Path("/pet")
     @Consumes({ "application/json", "application/xml" })
@@ -81,6 +123,12 @@ public interface PetApi  {
         @ApiResponse(code = 405, message = "Validation exception") })
     public void updatePet(@Valid Pet body);
 
+    /**
+     * Updates a pet in the store with form data
+     *
+     * 
+     *
+     */
     @POST
     @Path("/pet/{petId}")
     @Consumes({ "application/x-www-form-urlencoded" })
@@ -90,6 +138,12 @@ public interface PetApi  {
         @ApiResponse(code = 405, message = "Invalid input") })
     public void updatePetWithForm(@PathParam("petId") Long petId, @Multipart(value = "name", required = false)  String name, @Multipart(value = "status", required = false)  String status);
 
+    /**
+     * uploads an image
+     *
+     * 
+     *
+     */
     @POST
     @Path("/pet/{petId}/uploadImage")
     @Consumes({ "multipart/form-data" })

--- a/samples/server/petstore/jaxrs-cxf/src/gen/java/io/swagger/api/StoreApi.java
+++ b/samples/server/petstore/jaxrs-cxf/src/gen/java/io/swagger/api/StoreApi.java
@@ -20,10 +20,22 @@ import io.swagger.jaxrs.PATCH;
 import javax.validation.constraints.*;
 import javax.validation.Valid;
 
+/**
+ * Swagger Petstore
+ *
+ * <p>This spec is mainly for testing Petstore server and contains fake endpoints, models. Please do not use this for any other purpose. Special characters: \" \\
+ *
+ */
 @Path("/")
 @Api(value = "/", description = "")
 public interface StoreApi  {
 
+    /**
+     * Delete purchase order by ID
+     *
+     * For valid response try integer IDs with value &lt; 1000. Anything above 1000 or nonintegers will generate API errors
+     *
+     */
     @DELETE
     @Path("/store/order/{order_id}")
     @Produces({ "application/xml", "application/json" })
@@ -33,6 +45,12 @@ public interface StoreApi  {
         @ApiResponse(code = 404, message = "Order not found") })
     public void deleteOrder(@PathParam("order_id") String orderId);
 
+    /**
+     * Returns pet inventories by status
+     *
+     * Returns a map of status codes to quantities
+     *
+     */
     @GET
     @Path("/store/inventory")
     @Produces({ "application/json" })
@@ -41,6 +59,12 @@ public interface StoreApi  {
         @ApiResponse(code = 200, message = "successful operation", response = Map.class, responseContainer = "Map") })
     public Map<String, Integer> getInventory();
 
+    /**
+     * Find purchase order by ID
+     *
+     * For valid response try integer IDs with value &lt;&#x3D; 5 or &gt; 10. Other values will generated exceptions
+     *
+     */
     @GET
     @Path("/store/order/{order_id}")
     @Produces({ "application/xml", "application/json" })
@@ -51,6 +75,12 @@ public interface StoreApi  {
         @ApiResponse(code = 404, message = "Order not found") })
     public Order getOrderById(@PathParam("order_id") @Min(1) @Max(5) Long orderId);
 
+    /**
+     * Place an order for a pet
+     *
+     * 
+     *
+     */
     @POST
     @Path("/store/order")
     @Produces({ "application/xml", "application/json" })

--- a/samples/server/petstore/jaxrs-cxf/src/gen/java/io/swagger/api/UserApi.java
+++ b/samples/server/petstore/jaxrs-cxf/src/gen/java/io/swagger/api/UserApi.java
@@ -20,10 +20,22 @@ import io.swagger.jaxrs.PATCH;
 import javax.validation.constraints.*;
 import javax.validation.Valid;
 
+/**
+ * Swagger Petstore
+ *
+ * <p>This spec is mainly for testing Petstore server and contains fake endpoints, models. Please do not use this for any other purpose. Special characters: \" \\
+ *
+ */
 @Path("/")
 @Api(value = "/", description = "")
 public interface UserApi  {
 
+    /**
+     * Create user
+     *
+     * This can only be done by the logged in user.
+     *
+     */
     @POST
     @Path("/user")
     @Produces({ "application/xml", "application/json" })
@@ -32,6 +44,12 @@ public interface UserApi  {
         @ApiResponse(code = 200, message = "successful operation") })
     public void createUser(@Valid User body);
 
+    /**
+     * Creates list of users with given input array
+     *
+     * 
+     *
+     */
     @POST
     @Path("/user/createWithArray")
     @Produces({ "application/xml", "application/json" })
@@ -40,6 +58,12 @@ public interface UserApi  {
         @ApiResponse(code = 200, message = "successful operation") })
     public void createUsersWithArrayInput(@Valid List<User> body);
 
+    /**
+     * Creates list of users with given input array
+     *
+     * 
+     *
+     */
     @POST
     @Path("/user/createWithList")
     @Produces({ "application/xml", "application/json" })
@@ -48,6 +72,12 @@ public interface UserApi  {
         @ApiResponse(code = 200, message = "successful operation") })
     public void createUsersWithListInput(@Valid List<User> body);
 
+    /**
+     * Delete user
+     *
+     * This can only be done by the logged in user.
+     *
+     */
     @DELETE
     @Path("/user/{username}")
     @Produces({ "application/xml", "application/json" })
@@ -57,6 +87,12 @@ public interface UserApi  {
         @ApiResponse(code = 404, message = "User not found") })
     public void deleteUser(@PathParam("username") String username);
 
+    /**
+     * Get user by user name
+     *
+     * 
+     *
+     */
     @GET
     @Path("/user/{username}")
     @Produces({ "application/xml", "application/json" })
@@ -67,6 +103,12 @@ public interface UserApi  {
         @ApiResponse(code = 404, message = "User not found") })
     public User getUserByName(@PathParam("username") String username);
 
+    /**
+     * Logs user into the system
+     *
+     * 
+     *
+     */
     @GET
     @Path("/user/login")
     @Produces({ "application/xml", "application/json" })
@@ -76,6 +118,12 @@ public interface UserApi  {
         @ApiResponse(code = 400, message = "Invalid username/password supplied") })
     public String loginUser(@QueryParam("username") @NotNull String username, @QueryParam("password") @NotNull String password);
 
+    /**
+     * Logs out current logged in user session
+     *
+     * 
+     *
+     */
     @GET
     @Path("/user/logout")
     @Produces({ "application/xml", "application/json" })
@@ -84,6 +132,12 @@ public interface UserApi  {
         @ApiResponse(code = 200, message = "successful operation") })
     public void logoutUser();
 
+    /**
+     * Updated user
+     *
+     * This can only be done by the logged in user.
+     *
+     */
     @PUT
     @Path("/user/{username}")
     @Produces({ "application/xml", "application/json" })

--- a/samples/server/petstore/jaxrs-cxf/src/gen/java/io/swagger/model/Capitalization.java
+++ b/samples/server/petstore/jaxrs-cxf/src/gen/java/io/swagger/model/Capitalization.java
@@ -24,6 +24,9 @@ public class Capitalization  {
   @ApiModelProperty(value = "")
   private String scAETHFlowPoints = null;
   @ApiModelProperty(value = "Name of the pet ")
+ /**
+   * Name of the pet   
+  **/
   private String ATT_NAME = null;
 
  /**

--- a/samples/server/petstore/jaxrs-cxf/src/gen/java/io/swagger/model/ClassModel.java
+++ b/samples/server/petstore/jaxrs-cxf/src/gen/java/io/swagger/model/ClassModel.java
@@ -12,6 +12,9 @@ import javax.xml.bind.annotation.XmlType;
 import javax.xml.bind.annotation.XmlEnum;
 import javax.xml.bind.annotation.XmlEnumValue;
 
+/**
+  * Model for testing model with \"_class\" property
+ **/
 @ApiModel(description="Model for testing model with \"_class\" property")
 public class ClassModel  {
   

--- a/samples/server/petstore/jaxrs-cxf/src/gen/java/io/swagger/model/Model200Response.java
+++ b/samples/server/petstore/jaxrs-cxf/src/gen/java/io/swagger/model/Model200Response.java
@@ -12,6 +12,9 @@ import javax.xml.bind.annotation.XmlType;
 import javax.xml.bind.annotation.XmlEnum;
 import javax.xml.bind.annotation.XmlEnumValue;
 
+/**
+  * Model for testing model name starting with number
+ **/
 @ApiModel(description="Model for testing model name starting with number")
 public class Model200Response  {
   

--- a/samples/server/petstore/jaxrs-cxf/src/gen/java/io/swagger/model/ModelReturn.java
+++ b/samples/server/petstore/jaxrs-cxf/src/gen/java/io/swagger/model/ModelReturn.java
@@ -12,6 +12,9 @@ import javax.xml.bind.annotation.XmlType;
 import javax.xml.bind.annotation.XmlEnum;
 import javax.xml.bind.annotation.XmlEnumValue;
 
+/**
+  * Model for testing reserved words
+ **/
 @ApiModel(description="Model for testing reserved words")
 public class ModelReturn  {
   

--- a/samples/server/petstore/jaxrs-cxf/src/gen/java/io/swagger/model/Name.java
+++ b/samples/server/petstore/jaxrs-cxf/src/gen/java/io/swagger/model/Name.java
@@ -12,6 +12,9 @@ import javax.xml.bind.annotation.XmlType;
 import javax.xml.bind.annotation.XmlEnum;
 import javax.xml.bind.annotation.XmlEnumValue;
 
+/**
+  * Model for testing model name same as property name
+ **/
 @ApiModel(description="Model for testing model name same as property name")
 public class Name  {
   

--- a/samples/server/petstore/jaxrs-cxf/src/gen/java/io/swagger/model/Order.java
+++ b/samples/server/petstore/jaxrs-cxf/src/gen/java/io/swagger/model/Order.java
@@ -56,6 +56,9 @@ public enum StatusEnum {
 }
 
   @ApiModelProperty(value = "Order Status")
+ /**
+   * Order Status  
+  **/
   private StatusEnum status = null;
   @ApiModelProperty(value = "")
   private Boolean complete = false;

--- a/samples/server/petstore/jaxrs-cxf/src/gen/java/io/swagger/model/Pet.java
+++ b/samples/server/petstore/jaxrs-cxf/src/gen/java/io/swagger/model/Pet.java
@@ -61,6 +61,9 @@ public enum StatusEnum {
 }
 
   @ApiModelProperty(value = "pet status in the store")
+ /**
+   * pet status in the store  
+  **/
   private StatusEnum status = null;
 
  /**

--- a/samples/server/petstore/jaxrs-cxf/src/gen/java/io/swagger/model/User.java
+++ b/samples/server/petstore/jaxrs-cxf/src/gen/java/io/swagger/model/User.java
@@ -28,6 +28,9 @@ public class User  {
   @ApiModelProperty(value = "")
   private String phone = null;
   @ApiModelProperty(value = "User Status")
+ /**
+   * User Status  
+  **/
   private Integer userStatus = null;
 
  /**

--- a/samples/server/petstore/jaxrs-cxf/src/main/java/io/swagger/api/impl/AnotherFakeApiServiceImpl.java
+++ b/samples/server/petstore/jaxrs-cxf/src/main/java/io/swagger/api/impl/AnotherFakeApiServiceImpl.java
@@ -16,7 +16,19 @@ import org.apache.cxf.jaxrs.ext.multipart.*;
 
 import io.swagger.annotations.Api;
 
+/**
+ * Swagger Petstore
+ *
+ * <p>This spec is mainly for testing Petstore server and contains fake endpoints, models. Please do not use this for any other purpose. Special characters: \" \\
+ *
+ */
 public class AnotherFakeApiServiceImpl implements AnotherFakeApi {
+    /**
+     * To test special tags
+     *
+     * To test special tags
+     *
+     */
     public Client testSpecialTags(Client body) {
         // TODO: Implement...
         

--- a/samples/server/petstore/jaxrs-cxf/src/main/java/io/swagger/api/impl/FakeApiServiceImpl.java
+++ b/samples/server/petstore/jaxrs-cxf/src/main/java/io/swagger/api/impl/FakeApiServiceImpl.java
@@ -20,6 +20,12 @@ import org.apache.cxf.jaxrs.ext.multipart.*;
 
 import io.swagger.annotations.Api;
 
+/**
+ * Swagger Petstore
+ *
+ * <p>This spec is mainly for testing Petstore server and contains fake endpoints, models. Please do not use this for any other purpose. Special characters: \" \\
+ *
+ */
 public class FakeApiServiceImpl implements FakeApi {
     public Boolean fakeOuterBooleanSerialize(Boolean body) {
         // TODO: Implement...
@@ -45,24 +51,48 @@ public class FakeApiServiceImpl implements FakeApi {
         return null;
     }
     
+    /**
+     * To test \&quot;client\&quot; model
+     *
+     * To test \&quot;client\&quot; model
+     *
+     */
     public Client testClientModel(Client body) {
         // TODO: Implement...
         
         return null;
     }
     
+    /**
+     * Fake endpoint for testing various parameters 假端點 偽のエンドポイント 가짜 엔드 포인트 
+     *
+     * Fake endpoint for testing various parameters 假端點 偽のエンドポイント 가짜 엔드 포인트 
+     *
+     */
     public void testEndpointParameters(BigDecimal number, Double _double, String patternWithoutDelimiter, byte[] _byte, Integer integer, Integer int32, Long int64, Float _float, String string, byte[] binary, LocalDate date, Date dateTime, String password, String paramCallback) {
         // TODO: Implement...
         
         
     }
     
+    /**
+     * To test enum parameters
+     *
+     * To test enum parameters
+     *
+     */
     public void testEnumParameters(List<String> enumFormStringArray, String enumFormString, List<String> enumHeaderStringArray, String enumHeaderString, List<String> enumQueryStringArray, String enumQueryString, Integer enumQueryInteger, Double enumQueryDouble) {
         // TODO: Implement...
         
         
     }
     
+    /**
+     * test json serialization of form data
+     *
+     * 
+     *
+     */
     public void testJsonFormData(String param, String param2) {
         // TODO: Implement...
         

--- a/samples/server/petstore/jaxrs-cxf/src/main/java/io/swagger/api/impl/FakeClassnameTags123ApiServiceImpl.java
+++ b/samples/server/petstore/jaxrs-cxf/src/main/java/io/swagger/api/impl/FakeClassnameTags123ApiServiceImpl.java
@@ -16,7 +16,17 @@ import org.apache.cxf.jaxrs.ext.multipart.*;
 
 import io.swagger.annotations.Api;
 
+/**
+ * Swagger Petstore
+ *
+ * <p>This spec is mainly for testing Petstore server and contains fake endpoints, models. Please do not use this for any other purpose. Special characters: \" \\
+ *
+ */
 public class FakeClassnameTags123ApiServiceImpl implements FakeClassnameTags123Api {
+    /**
+     * To test class name in snake case
+     *
+     */
     public Client testClassname(Client body) {
         // TODO: Implement...
         

--- a/samples/server/petstore/jaxrs-cxf/src/main/java/io/swagger/api/impl/PetApiServiceImpl.java
+++ b/samples/server/petstore/jaxrs-cxf/src/main/java/io/swagger/api/impl/PetApiServiceImpl.java
@@ -18,49 +18,103 @@ import org.apache.cxf.jaxrs.ext.multipart.*;
 
 import io.swagger.annotations.Api;
 
+/**
+ * Swagger Petstore
+ *
+ * <p>This spec is mainly for testing Petstore server and contains fake endpoints, models. Please do not use this for any other purpose. Special characters: \" \\
+ *
+ */
 public class PetApiServiceImpl implements PetApi {
+    /**
+     * Add a new pet to the store
+     *
+     * 
+     *
+     */
     public void addPet(Pet body) {
         // TODO: Implement...
         
         
     }
     
+    /**
+     * Deletes a pet
+     *
+     * 
+     *
+     */
     public void deletePet(Long petId, String apiKey) {
         // TODO: Implement...
         
         
     }
     
+    /**
+     * Finds Pets by status
+     *
+     * Multiple status values can be provided with comma separated strings
+     *
+     */
     public List<Pet> findPetsByStatus(List<String> status) {
         // TODO: Implement...
         
         return null;
     }
     
+    /**
+     * Finds Pets by tags
+     *
+     * Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
+     *
+     */
     public List<Pet> findPetsByTags(List<String> tags) {
         // TODO: Implement...
         
         return null;
     }
     
+    /**
+     * Find pet by ID
+     *
+     * Returns a single pet
+     *
+     */
     public Pet getPetById(Long petId) {
         // TODO: Implement...
         
         return null;
     }
     
+    /**
+     * Update an existing pet
+     *
+     * 
+     *
+     */
     public void updatePet(Pet body) {
         // TODO: Implement...
         
         
     }
     
+    /**
+     * Updates a pet in the store with form data
+     *
+     * 
+     *
+     */
     public void updatePetWithForm(Long petId, String name, String status) {
         // TODO: Implement...
         
         
     }
     
+    /**
+     * uploads an image
+     *
+     * 
+     *
+     */
     public ModelApiResponse uploadFile(Long petId, String additionalMetadata,  Attachment fileDetail) {
         // TODO: Implement...
         

--- a/samples/server/petstore/jaxrs-cxf/src/main/java/io/swagger/api/impl/StoreApiServiceImpl.java
+++ b/samples/server/petstore/jaxrs-cxf/src/main/java/io/swagger/api/impl/StoreApiServiceImpl.java
@@ -17,25 +17,55 @@ import org.apache.cxf.jaxrs.ext.multipart.*;
 
 import io.swagger.annotations.Api;
 
+/**
+ * Swagger Petstore
+ *
+ * <p>This spec is mainly for testing Petstore server and contains fake endpoints, models. Please do not use this for any other purpose. Special characters: \" \\
+ *
+ */
 public class StoreApiServiceImpl implements StoreApi {
+    /**
+     * Delete purchase order by ID
+     *
+     * For valid response try integer IDs with value &lt; 1000. Anything above 1000 or nonintegers will generate API errors
+     *
+     */
     public void deleteOrder(String orderId) {
         // TODO: Implement...
         
         
     }
     
+    /**
+     * Returns pet inventories by status
+     *
+     * Returns a map of status codes to quantities
+     *
+     */
     public Map<String, Integer> getInventory() {
         // TODO: Implement...
         
         return null;
     }
     
+    /**
+     * Find purchase order by ID
+     *
+     * For valid response try integer IDs with value &lt;&#x3D; 5 or &gt; 10. Other values will generated exceptions
+     *
+     */
     public Order getOrderById(Long orderId) {
         // TODO: Implement...
         
         return null;
     }
     
+    /**
+     * Place an order for a pet
+     *
+     * 
+     *
+     */
     public Order placeOrder(Order body) {
         // TODO: Implement...
         

--- a/samples/server/petstore/jaxrs-cxf/src/main/java/io/swagger/api/impl/UserApiServiceImpl.java
+++ b/samples/server/petstore/jaxrs-cxf/src/main/java/io/swagger/api/impl/UserApiServiceImpl.java
@@ -17,49 +17,103 @@ import org.apache.cxf.jaxrs.ext.multipart.*;
 
 import io.swagger.annotations.Api;
 
+/**
+ * Swagger Petstore
+ *
+ * <p>This spec is mainly for testing Petstore server and contains fake endpoints, models. Please do not use this for any other purpose. Special characters: \" \\
+ *
+ */
 public class UserApiServiceImpl implements UserApi {
+    /**
+     * Create user
+     *
+     * This can only be done by the logged in user.
+     *
+     */
     public void createUser(User body) {
         // TODO: Implement...
         
         
     }
     
+    /**
+     * Creates list of users with given input array
+     *
+     * 
+     *
+     */
     public void createUsersWithArrayInput(List<User> body) {
         // TODO: Implement...
         
         
     }
     
+    /**
+     * Creates list of users with given input array
+     *
+     * 
+     *
+     */
     public void createUsersWithListInput(List<User> body) {
         // TODO: Implement...
         
         
     }
     
+    /**
+     * Delete user
+     *
+     * This can only be done by the logged in user.
+     *
+     */
     public void deleteUser(String username) {
         // TODO: Implement...
         
         
     }
     
+    /**
+     * Get user by user name
+     *
+     * 
+     *
+     */
     public User getUserByName(String username) {
         // TODO: Implement...
         
         return null;
     }
     
+    /**
+     * Logs user into the system
+     *
+     * 
+     *
+     */
     public String loginUser(String username, String password) {
         // TODO: Implement...
         
         return null;
     }
     
+    /**
+     * Logs out current logged in user session
+     *
+     * 
+     *
+     */
     public void logoutUser() {
         // TODO: Implement...
         
         
     }
     
+    /**
+     * Updated user
+     *
+     * This can only be done by the logged in user.
+     *
+     */
     public void updateUser(String username, User body) {
         // TODO: Implement...
         


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [x] Filed the PR against the correct branch: `3.0.0` branch for changes related to OpenAPI spec 3.0. Default: `master`.
- [x] Copied the [technical committee](https://github.com/swagger-api/swagger-codegen/#swagger-codegen-technical-committee) to review the pull request if your PR is targeting a particular programming langauge.

### Description of the PR

I included more of the API documentation in the CXF Server stub and Client generation. 

fix #6696

@bbdouglas, @JFCote, @sreeshas, @jfiala, @lukoyanov, @cbornet, @wing328 

