### PR TITLE
[angular-typescript] imports HttpClientModule

### DIFF
--- a/modules/swagger-codegen/src/main/resources/typescript-angular/api.module.mustache
+++ b/modules/swagger-codegen/src/main/resources/typescript-angular/api.module.mustache
@@ -1,6 +1,6 @@
 import { NgModule, ModuleWithProviders } from '@angular/core';
 import { CommonModule } from '@angular/common';
-import { HttpModule } from '@angular/http';
+import { HttpClientModule } from '@angular/common/http';
 import { Configuration } from './configuration';
 
 {{#apiInfo}}
@@ -10,7 +10,7 @@ import { {{classname}} } from './{{importPath}}';
 {{/apiInfo}}
 
 @NgModule({
-  imports:      [ CommonModule, HttpModule ],
+  imports:      [ CommonModule, HttpClientModule ],
   declarations: [],
   exports:      [],
   providers:    [ {{#apiInfo}}{{#apis}}{{classname}}{{#hasMore}}, {{/hasMore}}{{/apis}}{{/apiInfo}} ]


### PR DESCRIPTION
HttpModule has no effect, since the new `HttpClient` is now used. fixes #6727

### PR checklist

Done via the web-interface. I guarantee nothing. I'm not disappointed if you are not going merge it, but I'm pretty sure it works since the change trivial.



