### PR TITLE
Fix required bug

### DIFF
--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/InlineModelResolver.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/InlineModelResolver.java
@@ -68,9 +68,13 @@ public class InlineModelResolver {
                                                 Model innerModel = modelFromProperty(op, modelName);
                                                 String existing = matchGenerated(innerModel);
                                                 if (existing != null) {
-                                                    am.setItems(new RefProperty(existing));
+                                                    RefProperty refProperty = new RefProperty(existing);
+                                                    refProperty.setRequired(op.getRequired());
+                                                    am.setItems(refProperty);
                                                 } else {
-                                                    am.setItems(new RefProperty(modelName));
+                                                    RefProperty refProperty = new RefProperty(modelName);
+                                                    refProperty.setRequired(op.getRequired());
+                                                    am.setItems(refProperty);
                                                     addGenerated(modelName, innerModel);
                                                     swagger.addDefinition(modelName, innerModel);
                                                 }
@@ -94,9 +98,13 @@ public class InlineModelResolver {
                                         Model model = modelFromProperty(op, modelName);
                                         String existing = matchGenerated(model);
                                         if (existing != null) {
-                                            response.setSchema(this.makeRefProperty(existing, property));
+                                            Property refProperty = this.makeRefProperty(existing, property);
+                                            refProperty.setRequired(op.getRequired());
+                                            response.setSchema(refProperty);
                                         } else {
-                                            response.setSchema(this.makeRefProperty(modelName, property));
+                                            Property refProperty = this.makeRefProperty(modelName, property);
+                                            refProperty.setRequired(op.getRequired());
+                                            response.setSchema(refProperty);
                                             addGenerated(modelName, model);
                                             swagger.addDefinition(modelName, model);
                                         }
@@ -114,9 +122,13 @@ public class InlineModelResolver {
                                             Model innerModel = modelFromProperty(op, modelName);
                                             String existing = matchGenerated(innerModel);
                                             if (existing != null) {
-                                                ap.setItems(this.makeRefProperty(existing, op));
+                                                Property refProperty = this.makeRefProperty(existing, op);
+                                                refProperty.setRequired(op.getRequired());
+                                                ap.setItems(refProperty);
                                             } else {
-                                                ap.setItems(this.makeRefProperty(modelName, op));
+                                                Property refProperty = this.makeRefProperty(modelName, op);
+                                                refProperty.setRequired(op.getRequired());
+                                                ap.setItems(refProperty);
                                                 addGenerated(modelName, innerModel);
                                                 swagger.addDefinition(modelName, innerModel);
                                             }
@@ -135,9 +147,13 @@ public class InlineModelResolver {
                                             Model innerModel = modelFromProperty(op, modelName);
                                             String existing = matchGenerated(innerModel);
                                             if (existing != null) {
-                                                mp.setAdditionalProperties(new RefProperty(existing));
+                                                RefProperty refProperty = new RefProperty(existing);
+                                                refProperty.setRequired(op.getRequired());
+                                                mp.setAdditionalProperties(refProperty);
                                             } else {
-                                                mp.setAdditionalProperties(new RefProperty(modelName));
+                                                RefProperty refProperty = new RefProperty(modelName);
+                                                refProperty.setRequired(op.getRequired());
+                                                mp.setAdditionalProperties(refProperty);
                                                 addGenerated(modelName, innerModel);
                                                 swagger.addDefinition(modelName, innerModel);
                                             }
@@ -174,9 +190,13 @@ public class InlineModelResolver {
                             if (existing == null) {
                                 swagger.addDefinition(innerModelName, innerModel);
                                 addGenerated(innerModelName, innerModel);
-                                m.setItems(new RefProperty(innerModelName));
+                                RefProperty refProperty = new RefProperty(innerModelName);
+                                refProperty.setRequired(op.getRequired());
+                                m.setItems(refProperty);
                             } else {
-                                m.setItems(new RefProperty(existing));
+                                RefProperty refProperty = new RefProperty(existing);
+                                refProperty.setRequired(op.getRequired());
+                                m.setItems(refProperty);
                             }
                         }
                     }
@@ -271,9 +291,13 @@ public class InlineModelResolver {
                 String existing = matchGenerated(model);
 
                 if (existing != null) {
-                    propsToUpdate.put(key, new RefProperty(existing));
+                    RefProperty refProperty = new RefProperty(existing);
+                    refProperty.setRequired(op.getRequired());
+                    propsToUpdate.put(key, refProperty);
                 } else {
-                    propsToUpdate.put(key, new RefProperty(modelName));
+                    RefProperty refProperty = new RefProperty(modelName);
+                    refProperty.setRequired(op.getRequired());
+                    propsToUpdate.put(key, refProperty);
                     modelsToAdd.put(modelName, model);
                     addGenerated(modelName, model);
                     swagger.addDefinition(modelName, model);
@@ -290,9 +314,13 @@ public class InlineModelResolver {
                         Model innerModel = modelFromProperty(op, modelName);
                         String existing = matchGenerated(innerModel);
                         if (existing != null) {
-                            ap.setItems(new RefProperty(existing));
+                            RefProperty refProperty = new RefProperty(existing);
+                            refProperty.setRequired(op.getRequired());
+                            ap.setItems(refProperty);
                         } else {
-                            ap.setItems(new RefProperty(modelName));
+                            RefProperty refProperty = new RefProperty(modelName);
+                            refProperty.setRequired(op.getRequired());
+                            ap.setItems(refProperty);
                             addGenerated(modelName, innerModel);
                             swagger.addDefinition(modelName, innerModel);
                         }
@@ -310,9 +338,13 @@ public class InlineModelResolver {
                         Model innerModel = modelFromProperty(op, modelName);
                         String existing = matchGenerated(innerModel);
                         if (existing != null) {
-                            mp.setAdditionalProperties(new RefProperty(existing));
+                            RefProperty refProperty = new RefProperty(existing);
+                            refProperty.setRequired(op.getRequired());
+                            mp.setAdditionalProperties(refProperty);
                         } else {
-                            mp.setAdditionalProperties(new RefProperty(modelName));
+                            RefProperty refProperty = new RefProperty(existing);
+                            refProperty.setRequired(op.getRequired());
+                            mp.setAdditionalProperties(refProperty);
                             addGenerated(modelName, innerModel);
                             swagger.addDefinition(modelName, innerModel);
                         }
@@ -399,7 +431,7 @@ public class InlineModelResolver {
 
     /**
      * Make a RefProperty
-     * 
+     *
      * @param ref new property name
      * @param property Property
      * @return
@@ -412,7 +444,7 @@ public class InlineModelResolver {
 
     /**
      * Copy vendor extensions from Property to another Property
-     * 
+     *
      * @param source source property
      * @param target target property
      */

--- a/modules/swagger-codegen/src/test/java/io/swagger/codegen/InlineModelResolverTest.java
+++ b/modules/swagger-codegen/src/test/java/io/swagger/codegen/InlineModelResolverTest.java
@@ -328,6 +328,48 @@ public class InlineModelResolverTest {
         ModelImpl impl = (ModelImpl) body;
         assertNotNull(impl.getProperties().get("address"));
     }
+
+    @Test
+    public void resolveInlineBodyParameterWithRequired() throws Exception {
+        Swagger swagger = new Swagger();
+
+        swagger.path("/hello", new Path()
+                .get(new Operation()
+                        .parameter(new BodyParameter()
+                                .name("body")
+                                .schema(new ModelImpl()
+                                        .property("address", new ObjectProperty()
+                                                .property("street", new StringProperty()
+                                                        .required(true))
+                                                .required(true))
+                                        .property("name", new StringProperty())))));
+
+        new InlineModelResolver().flatten(swagger);
+
+        Operation operation = swagger.getPaths().get("/hello").getGet();
+        BodyParameter bp = (BodyParameter)operation.getParameters().get(0);
+        assertTrue(bp.getSchema() instanceof RefModel);
+
+        Model body = swagger.getDefinitions().get("body");
+        assertTrue(body instanceof ModelImpl);
+
+        ModelImpl impl = (ModelImpl) body;
+        assertNotNull(impl.getProperties().get("address"));
+
+        Property addressProperty = impl.getProperties().get("address");
+        assertTrue(addressProperty instanceof RefProperty);
+        assertTrue(addressProperty.getRequired());
+
+        Model helloAddress = swagger.getDefinitions().get("hello_address");
+        assertTrue(helloAddress instanceof ModelImpl);
+
+        ModelImpl addressImpl = (ModelImpl) helloAddress;
+        assertNotNull(addressImpl);
+
+        Property streetProperty = addressImpl.getProperties().get("street");
+        assertTrue(streetProperty instanceof  StringProperty);
+        assertTrue(streetProperty.getRequired());
+    }
     
     @Test
     public void resolveInlineBodyParameterWithTitle() throws Exception {


### PR DESCRIPTION
flatten methods replaces original ObjectProperty objects with new
RefProperty objects which required variables are false as default.
Newly created objects' required variables are set as the original
property.

### PR checklist

- [x] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [x] Filed the PR against the correct branch: `3.0.0` branch for changes related to OpenAPI spec 3.0. Default: `master`.
- [x] Copied the [technical committee](https://github.com/swagger-api/swagger-codegen/#swagger-codegen-technical-committee) to review the pull request if your PR is targeting a particular programming langauge.

### Description of the PR

(details of the change, additional tests that have been done, reference to the issue for tracking, etc)

