### PR TITLE
Initial step towards an AOT-compatible API client.

### DIFF
--- a/modules/swagger-codegen/src/main/resources/typescript-angular/package.mustache
+++ b/modules/swagger-codegen/src/main/resources/typescript-angular/package.mustache
@@ -8,10 +8,11 @@
   ],
   "license": "Unlicense",
   "main": "dist/index.js",
+  "module": "dist/index.js",  
   "typings": "dist/index.d.ts",
   "scripts": {
-    "build": "tsc --outDir dist/",
-    "postinstall": "npm run build"
+    "build": "ngc",
+    "prepublish": "npm run build"
   },
   "peerDependencies": {
     "@angular/core": "^{{ngVersion}}",
@@ -28,6 +29,7 @@
     "@angular/http": "^{{ngVersion}}",
     "@angular/common": "^{{ngVersion}}",
     "@angular/compiler": "^{{ngVersion}}",
+    "@angular/compiler-cli": "^{{ngVersion}}",
     "@angular/platform-browser": "^{{ngVersion}}",
     "reflect-metadata": "^0.1.3",
     "rxjs": "^5.4.0",

--- a/modules/swagger-codegen/src/main/resources/typescript-angular/tsconfig.mustache
+++ b/modules/swagger-codegen/src/main/resources/typescript-angular/tsconfig.mustache
@@ -5,14 +5,14 @@
         "noImplicitAny": false,
         "suppressImplicitAnyIndexErrors": true,
         "target": "es5",
-        "module": "es6",
+        "module": "es2015",
         "moduleResolution": "node",
         "removeComments": true,
         "sourceMap": true,
         "outDir": "./dist",
         "noLib": false,
         "declaration": true,
-        "lib": [ "es6", "dom" ]
+        "lib": [ "es2015", "dom" ]
     },
     "exclude": [
         "node_modules",
@@ -21,5 +21,9 @@
     "filesGlob": [
         "./model/*.ts",
         "./api/*.ts"
-    ]
+    ],
+      "angularCompilerOptions": {
+        "genDir": "dist",
+        "skipTemplateCodegen": true
+    }
 }

--- a/samples/client/petstore/typescript-angular-v4.3/npm/model/apiResponse.ts
+++ b/samples/client/petstore/typescript-angular-v4.3/npm/model/apiResponse.ts
@@ -23,3 +23,5 @@ export interface ApiResponse {
     message?: string;
 
 }
+
+

--- a/samples/client/petstore/typescript-angular-v4.3/npm/model/category.ts
+++ b/samples/client/petstore/typescript-angular-v4.3/npm/model/category.ts
@@ -21,3 +21,5 @@ export interface Category {
     name?: string;
 
 }
+
+

--- a/samples/client/petstore/typescript-angular-v4.3/npm/model/order.ts
+++ b/samples/client/petstore/typescript-angular-v4.3/npm/model/order.ts
@@ -33,9 +33,7 @@ export interface Order {
 
 }
 export namespace Order {
-    export enum StatusEnum {
-        Placed = <any> 'placed',
-        Approved = <any> 'approved',
-        Delivered = <any> 'delivered'
-    }
+    export type StatusEnum = 'placed' | 'approved' | 'delivered';
 }
+
+

--- a/samples/client/petstore/typescript-angular-v4.3/npm/model/pet.ts
+++ b/samples/client/petstore/typescript-angular-v4.3/npm/model/pet.ts
@@ -35,9 +35,7 @@ export interface Pet {
 
 }
 export namespace Pet {
-    export enum StatusEnum {
-        Available = <any> 'available',
-        Pending = <any> 'pending',
-        Sold = <any> 'sold'
-    }
+    export type StatusEnum = 'available' | 'pending' | 'sold';
 }
+
+

--- a/samples/client/petstore/typescript-angular-v4.3/npm/model/tag.ts
+++ b/samples/client/petstore/typescript-angular-v4.3/npm/model/tag.ts
@@ -21,3 +21,5 @@ export interface Tag {
     name?: string;
 
 }
+
+

--- a/samples/client/petstore/typescript-angular-v4.3/npm/model/user.ts
+++ b/samples/client/petstore/typescript-angular-v4.3/npm/model/user.ts
@@ -36,3 +36,5 @@ export interface User {
     userStatus?: number;
 
 }
+
+

--- a/samples/client/petstore/typescript-angular-v4.3/npm/package.json
+++ b/samples/client/petstore/typescript-angular-v4.3/npm/package.json
@@ -8,10 +8,11 @@
   ],
   "license": "Unlicense",
   "main": "dist/index.js",
+  "module": "dist/index.js",
   "typings": "dist/index.d.ts",
   "scripts": {
-    "build": "tsc --outDir dist/",
-    "postinstall": "npm run build"
+    "build": "ngc",
+    "prepublish": "npm run build"
   },
   "peerDependencies": {
     "@angular/core": "^4.3.0",
@@ -28,6 +29,7 @@
     "@angular/http": "^4.3.0",
     "@angular/common": "^4.3.0",
     "@angular/compiler": "^4.3.0",
+    "@angular/compiler-cli": "^4.3.0",
     "@angular/platform-browser": "^4.3.0",
     "reflect-metadata": "^0.1.3",
     "rxjs": "^5.4.0",
@@ -35,6 +37,6 @@
     "typescript": "^2.1.5"
   },
   "publishConfig": {
-    "registry":"https://skimdb.npmjs.com/registry"
+    "registry": "https://skimdb.npmjs.com/registry"
   }
 }

--- a/samples/client/petstore/typescript-angular-v4.3/npm/tsconfig.json
+++ b/samples/client/petstore/typescript-angular-v4.3/npm/tsconfig.json
@@ -5,14 +5,14 @@
         "noImplicitAny": false,
         "suppressImplicitAnyIndexErrors": true,
         "target": "es5",
-        "module": "es6",
+        "module": "es2015",
         "moduleResolution": "node",
         "removeComments": true,
         "sourceMap": true,
         "outDir": "./dist",
         "noLib": false,
         "declaration": true,
-        "lib": [ "es6", "dom" ]
+        "lib": [ "es2015", "dom" ]
     },
     "exclude": [
         "node_modules",
@@ -21,5 +21,9 @@
     "filesGlob": [
         "./model/*.ts",
         "./api/*.ts"
-    ]
+    ],
+      "angularCompilerOptions": {
+        "genDir": "dist",
+        "skipTemplateCodegen": true
+    }
 }


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [x] Filed the PR against the correct branch: `3.0.0` branch for changes related to OpenAPI spec 3.0. Default: `master`.
- [x] Copied the [technical committee](https://github.com/swagger-api/swagger-codegen/#swagger-codegen-technical-committee) to review the pull request if your PR is targeting a particular programming langauge.

### Description of the PR

See discussion at #6722. Basically this is about making the codegen output ready for use in an AOT build (e.g. `ngc --build --aot`).

This is _not_ really ready for merging yet, I would love to gather feedback from other people first, but I thought it might be easier to discuss over some actual code.

@taxpon @kenisteward @TiFu @Vrolijkx and obviously also @JohannesHoppe who finally brought this up.

#### What is missing
- [ ] We need to make sure that `ngc` is invoked during automated tests to prevent problems at an early stage
- [ ] We need to include `dist` into the bundled npm package (result of `npm pack`). However, there is no `.npmignore` as of today so I guess it will use `.gitignore`, where we want to exclude the `dist` directory.

