### PR TITLE
Fixing body json string in R client generator

### DIFF
--- a/modules/swagger-codegen/src/main/resources/r/api.mustache
+++ b/modules/swagger-codegen/src/main/resources/r/api.mustache
@@ -67,7 +67,7 @@
       {{#hasBodyParam}}
       {{#bodyParams}}
       if (!missing(`{{paramName}}`)) {
-        body <- `{{paramName}}`$toJSON()
+        body <- `{{paramName}}`$toJSONString()
       }
       {{/bodyParams}}
       {{/hasBodyParam}}

--- a/modules/swagger-codegen/src/main/resources/r/model.mustache
+++ b/modules/swagger-codegen/src/main/resources/r/model.mustache
@@ -98,7 +98,7 @@
        sprintf(
         '{
            {{#vars}}
-           "{{baseName}}": {{#isListContainer}}[{{/isListContainer}}{{#isPrimitiveType}}{{#isNumeric}}%d{{/isNumeric}}{{^isNumeric}}"%s"{{/isNumeric}}{{/isPrimitiveType}}{{^isPrimitiveType}}%s{{/isPrimitiveType}}{{#isListContainer}}]{{/isListContainer}}{{#hasMore}},{{/hasMore}}
+           "{{baseName}}": {{#isListContainer}}[{{/isListContainer}}{{#isPrimitiveType}}{{#isNumeric}}%d{{/isNumeric}}{{^isNumeric}}%s{{/isNumeric}}{{/isPrimitiveType}}{{^isPrimitiveType}}%s{{/isPrimitiveType}}{{#isListContainer}}]{{/isListContainer}}{{#hasMore}},{{/hasMore}}
            {{/vars}}
         }',
         {{#vars}}


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [x] Filed the PR against the correct branch: `3.0.0` branch for changes related to OpenAPI spec 3.0. Default: `master`.
- [x] Copied the [technical committee](https://github.com/swagger-api/swagger-codegen/#swagger-codegen-technical-committee) to review the pull request if your PR is targeting a particular programming langauge.

### Description of the PR
Fixing body json string in R client generator
Fixing model string replacement for list of strings
(details of the change, additional tests that have been done, reference to the issue for tracking, etc)

