### PR TITLE
Bugfix/6750 name clash between npm request and parameter called request

### DIFF
--- a/modules/swagger-codegen/src/main/resources/typescript-node/api.mustache
+++ b/modules/swagger-codegen/src/main/resources/typescript-node/api.mustache
@@ -1,5 +1,5 @@
 {{>licenseInfo}}
-import $request = require('request');
+import localVarRequest = require('request');
 import http = require('http');
 {{^supportsES6}}
 import Promise = require('bluebird');
@@ -216,13 +216,13 @@ export interface Authentication {
     /**
     * Apply authentication settings to header and query params.
     */
-    applyToRequest(requestOptions: $request.Options): void;
+    applyToRequest(requestOptions: localVarRequest.Options): void;
 }
 
 export class HttpBasicAuth implements Authentication {
     public username: string;
     public password: string;
-    applyToRequest(requestOptions: $request.Options): void {
+    applyToRequest(requestOptions: localVarRequest.Options): void {
         requestOptions.auth = {
             username: this.username, password: this.password
         }
@@ -235,7 +235,7 @@ export class ApiKeyAuth implements Authentication {
     constructor(private location: string, private paramName: string) {
     }
 
-    applyToRequest(requestOptions: $request.Options): void {
+    applyToRequest(requestOptions: localVarRequest.Options): void {
         if (this.location == "query") {
             (<any>requestOptions.qs)[this.paramName] = this.apiKey;
         } else if (this.location == "header" && requestOptions && requestOptions.headers) {
@@ -247,7 +247,7 @@ export class ApiKeyAuth implements Authentication {
 export class OAuth implements Authentication {
     public accessToken: string;
 
-    applyToRequest(requestOptions: $request.Options): void {
+    applyToRequest(requestOptions: localVarRequest.Options): void {
         if (requestOptions && requestOptions.headers) {
             requestOptions.headers["Authorization"] = "Bearer " + this.accessToken;
         }
@@ -257,7 +257,7 @@ export class OAuth implements Authentication {
 export class VoidAuth implements Authentication {
     public username: string;
     public password: string;
-    applyToRequest(_: $request.Options): void {
+    applyToRequest(_: localVarRequest.Options): void {
         // Do nothing
     }
 }
@@ -410,7 +410,7 @@ export class {{classname}} {
 {{/isFile}}
 
 {{/formParams}}
-        let requestOptions: $request.Options = {
+        let requestOptions: localVarRequest.Options = {
             method: '{{httpMethod}}',
             qs: queryParameters,
             headers: headerParams,
@@ -441,7 +441,7 @@ export class {{classname}} {
             }
         }
         return new Promise<{ response: http.{{#supportsES6}}IncomingMessage{{/supportsES6}}{{^supportsES6}}ClientResponse{{/supportsES6}}; {{#returnType}}body: {{{returnType}}}; {{/returnType}}{{^returnType}}body?: any; {{/returnType}} }>((resolve, reject) => {
-            $request(requestOptions, (error, response, body) => {
+            localVarRequest(requestOptions, (error, response, body) => {
                 if (error) {
                     reject(error);
                 } else {

--- a/modules/swagger-codegen/src/main/resources/typescript-node/api.mustache
+++ b/modules/swagger-codegen/src/main/resources/typescript-node/api.mustache
@@ -371,9 +371,9 @@ export class {{classname}} {
     public {{nickname}} ({{#allParams}}{{paramName}}{{^required}}?{{/required}}: {{{dataType}}}{{#hasMore}}, {{/hasMore}}{{/allParams}}) : Promise<{ response: http.{{#supportsES6}}IncomingMessage{{/supportsES6}}{{^supportsES6}}ClientResponse{{/supportsES6}}; {{#returnType}}body: {{{returnType}}}; {{/returnType}}{{^returnType}}body?: any; {{/returnType}} }> {
         const localVarPath = this.basePath + '{{{path}}}'{{#pathParams}}
             .replace('{' + '{{baseName}}' + '}', encodeURIComponent(String({{paramName}}))){{/pathParams}};
-        let queryParameters: any = {};
-        let headerParams: any = (<any>Object).assign({}, this.defaultHeaders);
-        let formParams: any = {};
+        let localVarQueryParameters: any = {};
+        let localVarHeaderParams: any = (<any>Object).assign({}, this.defaultHeaders);
+        let localVarFormParams: any = {};
 
 {{#allParams}}
 {{#required}}
@@ -386,34 +386,34 @@ export class {{classname}} {
 {{/allParams}}
 {{#queryParams}}
         if ({{paramName}} !== undefined) {
-            queryParameters['{{baseName}}'] = ObjectSerializer.serialize({{paramName}}, "{{{dataType}}}");
+            localVarQueryParameters['{{baseName}}'] = ObjectSerializer.serialize({{paramName}}, "{{{dataType}}}");
         }
 
 {{/queryParams}}
 {{#headerParams}}
-        headerParams['{{baseName}}'] = ObjectSerializer.serialize({{paramName}}, "{{{dataType}}}");
+        localVarHeaderParams['{{baseName}}'] = ObjectSerializer.serialize({{paramName}}, "{{{dataType}}}");
 {{/headerParams}}
 
-        let useFormData = false;
+        let localVarUseFormData = false;
 
 {{#formParams}}
         if ({{paramName}} !== undefined) {
             {{#isFile}}
-            formParams['{{baseName}}'] = {{paramName}};
+            localVarFormParams['{{baseName}}'] = {{paramName}};
             {{/isFile}}
             {{^isFile}}
-            formParams['{{baseName}}'] = ObjectSerializer.serialize({{paramName}}, "{{{dataType}}}");
+            localVarFormParams['{{baseName}}'] = ObjectSerializer.serialize({{paramName}}, "{{{dataType}}}");
             {{/isFile}}
         }
 {{#isFile}}
-        useFormData = true;
+        localVarUseFormData = true;
 {{/isFile}}
 
 {{/formParams}}
-        let requestOptions: localVarRequest.Options = {
+        let localVarRequestOptions: localVarRequest.Options = {
             method: '{{httpMethod}}',
-            qs: queryParameters,
-            headers: headerParams,
+            qs: localVarQueryParameters,
+            headers: localVarHeaderParams,
             uri: localVarPath,
             useQuerystring: this._useQuerystring,
 {{^isResponseFile}}
@@ -428,20 +428,20 @@ export class {{classname}} {
         };
 
 {{#authMethods}}
-        this.authentications.{{name}}.applyToRequest(requestOptions);
+        this.authentications.{{name}}.applyToRequest(localVarRequestOptions);
 
 {{/authMethods}}
-        this.authentications.default.applyToRequest(requestOptions);
+        this.authentications.default.applyToRequest(localVarRequestOptions);
 
-        if (Object.keys(formParams).length) {
-            if (useFormData) {
-                (<any>requestOptions).formData = formParams;
+        if (Object.keys(localVarFormParams).length) {
+            if (localVarUseFormData) {
+                (<any>localVarRequestOptions).formData = localVarFormParams;
             } else {
-                requestOptions.form = formParams;
+                localVarRequestOptions.form = localVarFormParams;
             }
         }
         return new Promise<{ response: http.{{#supportsES6}}IncomingMessage{{/supportsES6}}{{^supportsES6}}ClientResponse{{/supportsES6}}; {{#returnType}}body: {{{returnType}}}; {{/returnType}}{{^returnType}}body?: any; {{/returnType}} }>((resolve, reject) => {
-            localVarRequest(requestOptions, (error, response, body) => {
+            localVarRequest(localVarRequestOptions, (error, response, body) => {
                 if (error) {
                     reject(error);
                 } else {

--- a/modules/swagger-codegen/src/main/resources/typescript-node/api.mustache
+++ b/modules/swagger-codegen/src/main/resources/typescript-node/api.mustache
@@ -1,5 +1,5 @@
 {{>licenseInfo}}
-import request = require('request');
+import $request = require('request');
 import http = require('http');
 {{^supportsES6}}
 import Promise = require('bluebird');
@@ -216,13 +216,13 @@ export interface Authentication {
     /**
     * Apply authentication settings to header and query params.
     */
-    applyToRequest(requestOptions: request.Options): void;
+    applyToRequest(requestOptions: $request.Options): void;
 }
 
 export class HttpBasicAuth implements Authentication {
     public username: string;
     public password: string;
-    applyToRequest(requestOptions: request.Options): void {
+    applyToRequest(requestOptions: $request.Options): void {
         requestOptions.auth = {
             username: this.username, password: this.password
         }
@@ -235,7 +235,7 @@ export class ApiKeyAuth implements Authentication {
     constructor(private location: string, private paramName: string) {
     }
 
-    applyToRequest(requestOptions: request.Options): void {
+    applyToRequest(requestOptions: $request.Options): void {
         if (this.location == "query") {
             (<any>requestOptions.qs)[this.paramName] = this.apiKey;
         } else if (this.location == "header" && requestOptions && requestOptions.headers) {
@@ -247,7 +247,7 @@ export class ApiKeyAuth implements Authentication {
 export class OAuth implements Authentication {
     public accessToken: string;
 
-    applyToRequest(requestOptions: request.Options): void {
+    applyToRequest(requestOptions: $request.Options): void {
         if (requestOptions && requestOptions.headers) {
             requestOptions.headers["Authorization"] = "Bearer " + this.accessToken;
         }
@@ -257,7 +257,7 @@ export class OAuth implements Authentication {
 export class VoidAuth implements Authentication {
     public username: string;
     public password: string;
-    applyToRequest(_: request.Options): void {
+    applyToRequest(_: $request.Options): void {
         // Do nothing
     }
 }
@@ -410,7 +410,7 @@ export class {{classname}} {
 {{/isFile}}
 
 {{/formParams}}
-        let requestOptions: request.Options = {
+        let requestOptions: $request.Options = {
             method: '{{httpMethod}}',
             qs: queryParameters,
             headers: headerParams,
@@ -441,7 +441,7 @@ export class {{classname}} {
             }
         }
         return new Promise<{ response: http.{{#supportsES6}}IncomingMessage{{/supportsES6}}{{^supportsES6}}ClientResponse{{/supportsES6}}; {{#returnType}}body: {{{returnType}}}; {{/returnType}}{{^returnType}}body?: any; {{/returnType}} }>((resolve, reject) => {
-            request(requestOptions, (error, response, body) => {
+            $request(requestOptions, (error, response, body) => {
                 if (error) {
                     reject(error);
                 } else {

--- a/samples/client/petstore/typescript-node/default/api.ts
+++ b/samples/client/petstore/typescript-node/default/api.ts
@@ -10,7 +10,7 @@
  * Do not edit the class manually.
  */
 
-import request = require('request');
+import $request = require('request');
 import http = require('http');
 import Promise = require('bluebird');
 
@@ -424,13 +424,13 @@ export interface Authentication {
     /**
     * Apply authentication settings to header and query params.
     */
-    applyToRequest(requestOptions: request.Options): void;
+    applyToRequest(requestOptions: $request.Options): void;
 }
 
 export class HttpBasicAuth implements Authentication {
     public username: string;
     public password: string;
-    applyToRequest(requestOptions: request.Options): void {
+    applyToRequest(requestOptions: $request.Options): void {
         requestOptions.auth = {
             username: this.username, password: this.password
         }
@@ -443,7 +443,7 @@ export class ApiKeyAuth implements Authentication {
     constructor(private location: string, private paramName: string) {
     }
 
-    applyToRequest(requestOptions: request.Options): void {
+    applyToRequest(requestOptions: $request.Options): void {
         if (this.location == "query") {
             (<any>requestOptions.qs)[this.paramName] = this.apiKey;
         } else if (this.location == "header" && requestOptions && requestOptions.headers) {
@@ -455,7 +455,7 @@ export class ApiKeyAuth implements Authentication {
 export class OAuth implements Authentication {
     public accessToken: string;
 
-    applyToRequest(requestOptions: request.Options): void {
+    applyToRequest(requestOptions: $request.Options): void {
         if (requestOptions && requestOptions.headers) {
             requestOptions.headers["Authorization"] = "Bearer " + this.accessToken;
         }
@@ -465,7 +465,7 @@ export class OAuth implements Authentication {
 export class VoidAuth implements Authentication {
     public username: string;
     public password: string;
-    applyToRequest(_: request.Options): void {
+    applyToRequest(_: $request.Options): void {
         // Do nothing
     }
 }
@@ -540,7 +540,7 @@ export class PetApi {
 
         let useFormData = false;
 
-        let requestOptions: request.Options = {
+        let requestOptions: $request.Options = {
             method: 'POST',
             qs: queryParameters,
             headers: headerParams,
@@ -562,7 +562,7 @@ export class PetApi {
             }
         }
         return new Promise<{ response: http.ClientResponse; body?: any;  }>((resolve, reject) => {
-            request(requestOptions, (error, response, body) => {
+            $request(requestOptions, (error, response, body) => {
                 if (error) {
                     reject(error);
                 } else {
@@ -597,7 +597,7 @@ export class PetApi {
 
         let useFormData = false;
 
-        let requestOptions: request.Options = {
+        let requestOptions: $request.Options = {
             method: 'DELETE',
             qs: queryParameters,
             headers: headerParams,
@@ -618,7 +618,7 @@ export class PetApi {
             }
         }
         return new Promise<{ response: http.ClientResponse; body?: any;  }>((resolve, reject) => {
-            request(requestOptions, (error, response, body) => {
+            $request(requestOptions, (error, response, body) => {
                 if (error) {
                     reject(error);
                 } else {
@@ -654,7 +654,7 @@ export class PetApi {
 
         let useFormData = false;
 
-        let requestOptions: request.Options = {
+        let requestOptions: $request.Options = {
             method: 'GET',
             qs: queryParameters,
             headers: headerParams,
@@ -675,7 +675,7 @@ export class PetApi {
             }
         }
         return new Promise<{ response: http.ClientResponse; body: Array<Pet>;  }>((resolve, reject) => {
-            request(requestOptions, (error, response, body) => {
+            $request(requestOptions, (error, response, body) => {
                 if (error) {
                     reject(error);
                 } else {
@@ -712,7 +712,7 @@ export class PetApi {
 
         let useFormData = false;
 
-        let requestOptions: request.Options = {
+        let requestOptions: $request.Options = {
             method: 'GET',
             qs: queryParameters,
             headers: headerParams,
@@ -733,7 +733,7 @@ export class PetApi {
             }
         }
         return new Promise<{ response: http.ClientResponse; body: Array<Pet>;  }>((resolve, reject) => {
-            request(requestOptions, (error, response, body) => {
+            $request(requestOptions, (error, response, body) => {
                 if (error) {
                     reject(error);
                 } else {
@@ -767,7 +767,7 @@ export class PetApi {
 
         let useFormData = false;
 
-        let requestOptions: request.Options = {
+        let requestOptions: $request.Options = {
             method: 'GET',
             qs: queryParameters,
             headers: headerParams,
@@ -788,7 +788,7 @@ export class PetApi {
             }
         }
         return new Promise<{ response: http.ClientResponse; body: Pet;  }>((resolve, reject) => {
-            request(requestOptions, (error, response, body) => {
+            $request(requestOptions, (error, response, body) => {
                 if (error) {
                     reject(error);
                 } else {
@@ -821,7 +821,7 @@ export class PetApi {
 
         let useFormData = false;
 
-        let requestOptions: request.Options = {
+        let requestOptions: $request.Options = {
             method: 'PUT',
             qs: queryParameters,
             headers: headerParams,
@@ -843,7 +843,7 @@ export class PetApi {
             }
         }
         return new Promise<{ response: http.ClientResponse; body?: any;  }>((resolve, reject) => {
-            request(requestOptions, (error, response, body) => {
+            $request(requestOptions, (error, response, body) => {
                 if (error) {
                     reject(error);
                 } else {
@@ -886,7 +886,7 @@ export class PetApi {
             formParams['status'] = ObjectSerializer.serialize(status, "string");
         }
 
-        let requestOptions: request.Options = {
+        let requestOptions: $request.Options = {
             method: 'POST',
             qs: queryParameters,
             headers: headerParams,
@@ -907,7 +907,7 @@ export class PetApi {
             }
         }
         return new Promise<{ response: http.ClientResponse; body?: any;  }>((resolve, reject) => {
-            request(requestOptions, (error, response, body) => {
+            $request(requestOptions, (error, response, body) => {
                 if (error) {
                     reject(error);
                 } else {
@@ -951,7 +951,7 @@ export class PetApi {
         }
         useFormData = true;
 
-        let requestOptions: request.Options = {
+        let requestOptions: $request.Options = {
             method: 'POST',
             qs: queryParameters,
             headers: headerParams,
@@ -972,7 +972,7 @@ export class PetApi {
             }
         }
         return new Promise<{ response: http.ClientResponse; body: ApiResponse;  }>((resolve, reject) => {
-            request(requestOptions, (error, response, body) => {
+            $request(requestOptions, (error, response, body) => {
                 if (error) {
                     reject(error);
                 } else {
@@ -1058,7 +1058,7 @@ export class StoreApi {
 
         let useFormData = false;
 
-        let requestOptions: request.Options = {
+        let requestOptions: $request.Options = {
             method: 'DELETE',
             qs: queryParameters,
             headers: headerParams,
@@ -1077,7 +1077,7 @@ export class StoreApi {
             }
         }
         return new Promise<{ response: http.ClientResponse; body?: any;  }>((resolve, reject) => {
-            request(requestOptions, (error, response, body) => {
+            $request(requestOptions, (error, response, body) => {
                 if (error) {
                     reject(error);
                 } else {
@@ -1103,7 +1103,7 @@ export class StoreApi {
 
         let useFormData = false;
 
-        let requestOptions: request.Options = {
+        let requestOptions: $request.Options = {
             method: 'GET',
             qs: queryParameters,
             headers: headerParams,
@@ -1124,7 +1124,7 @@ export class StoreApi {
             }
         }
         return new Promise<{ response: http.ClientResponse; body: { [key: string]: number; };  }>((resolve, reject) => {
-            request(requestOptions, (error, response, body) => {
+            $request(requestOptions, (error, response, body) => {
                 if (error) {
                     reject(error);
                 } else {
@@ -1158,7 +1158,7 @@ export class StoreApi {
 
         let useFormData = false;
 
-        let requestOptions: request.Options = {
+        let requestOptions: $request.Options = {
             method: 'GET',
             qs: queryParameters,
             headers: headerParams,
@@ -1177,7 +1177,7 @@ export class StoreApi {
             }
         }
         return new Promise<{ response: http.ClientResponse; body: Order;  }>((resolve, reject) => {
-            request(requestOptions, (error, response, body) => {
+            $request(requestOptions, (error, response, body) => {
                 if (error) {
                     reject(error);
                 } else {
@@ -1210,7 +1210,7 @@ export class StoreApi {
 
         let useFormData = false;
 
-        let requestOptions: request.Options = {
+        let requestOptions: $request.Options = {
             method: 'POST',
             qs: queryParameters,
             headers: headerParams,
@@ -1230,7 +1230,7 @@ export class StoreApi {
             }
         }
         return new Promise<{ response: http.ClientResponse; body: Order;  }>((resolve, reject) => {
-            request(requestOptions, (error, response, body) => {
+            $request(requestOptions, (error, response, body) => {
                 if (error) {
                     reject(error);
                 } else {
@@ -1315,7 +1315,7 @@ export class UserApi {
 
         let useFormData = false;
 
-        let requestOptions: request.Options = {
+        let requestOptions: $request.Options = {
             method: 'POST',
             qs: queryParameters,
             headers: headerParams,
@@ -1335,7 +1335,7 @@ export class UserApi {
             }
         }
         return new Promise<{ response: http.ClientResponse; body?: any;  }>((resolve, reject) => {
-            request(requestOptions, (error, response, body) => {
+            $request(requestOptions, (error, response, body) => {
                 if (error) {
                     reject(error);
                 } else {
@@ -1367,7 +1367,7 @@ export class UserApi {
 
         let useFormData = false;
 
-        let requestOptions: request.Options = {
+        let requestOptions: $request.Options = {
             method: 'POST',
             qs: queryParameters,
             headers: headerParams,
@@ -1387,7 +1387,7 @@ export class UserApi {
             }
         }
         return new Promise<{ response: http.ClientResponse; body?: any;  }>((resolve, reject) => {
-            request(requestOptions, (error, response, body) => {
+            $request(requestOptions, (error, response, body) => {
                 if (error) {
                     reject(error);
                 } else {
@@ -1419,7 +1419,7 @@ export class UserApi {
 
         let useFormData = false;
 
-        let requestOptions: request.Options = {
+        let requestOptions: $request.Options = {
             method: 'POST',
             qs: queryParameters,
             headers: headerParams,
@@ -1439,7 +1439,7 @@ export class UserApi {
             }
         }
         return new Promise<{ response: http.ClientResponse; body?: any;  }>((resolve, reject) => {
-            request(requestOptions, (error, response, body) => {
+            $request(requestOptions, (error, response, body) => {
                 if (error) {
                     reject(error);
                 } else {
@@ -1472,7 +1472,7 @@ export class UserApi {
 
         let useFormData = false;
 
-        let requestOptions: request.Options = {
+        let requestOptions: $request.Options = {
             method: 'DELETE',
             qs: queryParameters,
             headers: headerParams,
@@ -1491,7 +1491,7 @@ export class UserApi {
             }
         }
         return new Promise<{ response: http.ClientResponse; body?: any;  }>((resolve, reject) => {
-            request(requestOptions, (error, response, body) => {
+            $request(requestOptions, (error, response, body) => {
                 if (error) {
                     reject(error);
                 } else {
@@ -1524,7 +1524,7 @@ export class UserApi {
 
         let useFormData = false;
 
-        let requestOptions: request.Options = {
+        let requestOptions: $request.Options = {
             method: 'GET',
             qs: queryParameters,
             headers: headerParams,
@@ -1543,7 +1543,7 @@ export class UserApi {
             }
         }
         return new Promise<{ response: http.ClientResponse; body: User;  }>((resolve, reject) => {
-            request(requestOptions, (error, response, body) => {
+            $request(requestOptions, (error, response, body) => {
                 if (error) {
                     reject(error);
                 } else {
@@ -1590,7 +1590,7 @@ export class UserApi {
 
         let useFormData = false;
 
-        let requestOptions: request.Options = {
+        let requestOptions: $request.Options = {
             method: 'GET',
             qs: queryParameters,
             headers: headerParams,
@@ -1609,7 +1609,7 @@ export class UserApi {
             }
         }
         return new Promise<{ response: http.ClientResponse; body: string;  }>((resolve, reject) => {
-            request(requestOptions, (error, response, body) => {
+            $request(requestOptions, (error, response, body) => {
                 if (error) {
                     reject(error);
                 } else {
@@ -1636,7 +1636,7 @@ export class UserApi {
 
         let useFormData = false;
 
-        let requestOptions: request.Options = {
+        let requestOptions: $request.Options = {
             method: 'GET',
             qs: queryParameters,
             headers: headerParams,
@@ -1655,7 +1655,7 @@ export class UserApi {
             }
         }
         return new Promise<{ response: http.ClientResponse; body?: any;  }>((resolve, reject) => {
-            request(requestOptions, (error, response, body) => {
+            $request(requestOptions, (error, response, body) => {
                 if (error) {
                     reject(error);
                 } else {
@@ -1694,7 +1694,7 @@ export class UserApi {
 
         let useFormData = false;
 
-        let requestOptions: request.Options = {
+        let requestOptions: $request.Options = {
             method: 'PUT',
             qs: queryParameters,
             headers: headerParams,
@@ -1714,7 +1714,7 @@ export class UserApi {
             }
         }
         return new Promise<{ response: http.ClientResponse; body?: any;  }>((resolve, reject) => {
-            request(requestOptions, (error, response, body) => {
+            $request(requestOptions, (error, response, body) => {
                 if (error) {
                     reject(error);
                 } else {

--- a/samples/client/petstore/typescript-node/default/api.ts
+++ b/samples/client/petstore/typescript-node/default/api.ts
@@ -528,9 +528,9 @@ export class PetApi {
      */
     public addPet (body: Pet) : Promise<{ response: http.ClientResponse; body?: any;  }> {
         const localVarPath = this.basePath + '/pet';
-        let queryParameters: any = {};
-        let headerParams: any = (<any>Object).assign({}, this.defaultHeaders);
-        let formParams: any = {};
+        let localVarQueryParameters: any = {};
+        let localVarHeaderParams: any = (<any>Object).assign({}, this.defaultHeaders);
+        let localVarFormParams: any = {};
 
         // verify required parameter 'body' is not null or undefined
         if (body === null || body === undefined) {
@@ -538,31 +538,31 @@ export class PetApi {
         }
 
 
-        let useFormData = false;
+        let localVarUseFormData = false;
 
-        let requestOptions: localVarRequest.Options = {
+        let localVarRequestOptions: localVarRequest.Options = {
             method: 'POST',
-            qs: queryParameters,
-            headers: headerParams,
+            qs: localVarQueryParameters,
+            headers: localVarHeaderParams,
             uri: localVarPath,
             useQuerystring: this._useQuerystring,
             json: true,
             body: ObjectSerializer.serialize(body, "Pet")
         };
 
-        this.authentications.petstore_auth.applyToRequest(requestOptions);
+        this.authentications.petstore_auth.applyToRequest(localVarRequestOptions);
 
-        this.authentications.default.applyToRequest(requestOptions);
+        this.authentications.default.applyToRequest(localVarRequestOptions);
 
-        if (Object.keys(formParams).length) {
-            if (useFormData) {
-                (<any>requestOptions).formData = formParams;
+        if (Object.keys(localVarFormParams).length) {
+            if (localVarUseFormData) {
+                (<any>localVarRequestOptions).formData = localVarFormParams;
             } else {
-                requestOptions.form = formParams;
+                localVarRequestOptions.form = localVarFormParams;
             }
         }
         return new Promise<{ response: http.ClientResponse; body?: any;  }>((resolve, reject) => {
-            localVarRequest(requestOptions, (error, response, body) => {
+            localVarRequest(localVarRequestOptions, (error, response, body) => {
                 if (error) {
                     reject(error);
                 } else {
@@ -584,41 +584,41 @@ export class PetApi {
     public deletePet (petId: number, apiKey?: string) : Promise<{ response: http.ClientResponse; body?: any;  }> {
         const localVarPath = this.basePath + '/pet/{petId}'
             .replace('{' + 'petId' + '}', encodeURIComponent(String(petId)));
-        let queryParameters: any = {};
-        let headerParams: any = (<any>Object).assign({}, this.defaultHeaders);
-        let formParams: any = {};
+        let localVarQueryParameters: any = {};
+        let localVarHeaderParams: any = (<any>Object).assign({}, this.defaultHeaders);
+        let localVarFormParams: any = {};
 
         // verify required parameter 'petId' is not null or undefined
         if (petId === null || petId === undefined) {
             throw new Error('Required parameter petId was null or undefined when calling deletePet.');
         }
 
-        headerParams['api_key'] = ObjectSerializer.serialize(apiKey, "string");
+        localVarHeaderParams['api_key'] = ObjectSerializer.serialize(apiKey, "string");
 
-        let useFormData = false;
+        let localVarUseFormData = false;
 
-        let requestOptions: localVarRequest.Options = {
+        let localVarRequestOptions: localVarRequest.Options = {
             method: 'DELETE',
-            qs: queryParameters,
-            headers: headerParams,
+            qs: localVarQueryParameters,
+            headers: localVarHeaderParams,
             uri: localVarPath,
             useQuerystring: this._useQuerystring,
             json: true,
         };
 
-        this.authentications.petstore_auth.applyToRequest(requestOptions);
+        this.authentications.petstore_auth.applyToRequest(localVarRequestOptions);
 
-        this.authentications.default.applyToRequest(requestOptions);
+        this.authentications.default.applyToRequest(localVarRequestOptions);
 
-        if (Object.keys(formParams).length) {
-            if (useFormData) {
-                (<any>requestOptions).formData = formParams;
+        if (Object.keys(localVarFormParams).length) {
+            if (localVarUseFormData) {
+                (<any>localVarRequestOptions).formData = localVarFormParams;
             } else {
-                requestOptions.form = formParams;
+                localVarRequestOptions.form = localVarFormParams;
             }
         }
         return new Promise<{ response: http.ClientResponse; body?: any;  }>((resolve, reject) => {
-            localVarRequest(requestOptions, (error, response, body) => {
+            localVarRequest(localVarRequestOptions, (error, response, body) => {
                 if (error) {
                     reject(error);
                 } else {
@@ -638,9 +638,9 @@ export class PetApi {
      */
     public findPetsByStatus (status: Array<string>) : Promise<{ response: http.ClientResponse; body: Array<Pet>;  }> {
         const localVarPath = this.basePath + '/pet/findByStatus';
-        let queryParameters: any = {};
-        let headerParams: any = (<any>Object).assign({}, this.defaultHeaders);
-        let formParams: any = {};
+        let localVarQueryParameters: any = {};
+        let localVarHeaderParams: any = (<any>Object).assign({}, this.defaultHeaders);
+        let localVarFormParams: any = {};
 
         // verify required parameter 'status' is not null or undefined
         if (status === null || status === undefined) {
@@ -648,34 +648,34 @@ export class PetApi {
         }
 
         if (status !== undefined) {
-            queryParameters['status'] = ObjectSerializer.serialize(status, "Array<string>");
+            localVarQueryParameters['status'] = ObjectSerializer.serialize(status, "Array<string>");
         }
 
 
-        let useFormData = false;
+        let localVarUseFormData = false;
 
-        let requestOptions: localVarRequest.Options = {
+        let localVarRequestOptions: localVarRequest.Options = {
             method: 'GET',
-            qs: queryParameters,
-            headers: headerParams,
+            qs: localVarQueryParameters,
+            headers: localVarHeaderParams,
             uri: localVarPath,
             useQuerystring: this._useQuerystring,
             json: true,
         };
 
-        this.authentications.petstore_auth.applyToRequest(requestOptions);
+        this.authentications.petstore_auth.applyToRequest(localVarRequestOptions);
 
-        this.authentications.default.applyToRequest(requestOptions);
+        this.authentications.default.applyToRequest(localVarRequestOptions);
 
-        if (Object.keys(formParams).length) {
-            if (useFormData) {
-                (<any>requestOptions).formData = formParams;
+        if (Object.keys(localVarFormParams).length) {
+            if (localVarUseFormData) {
+                (<any>localVarRequestOptions).formData = localVarFormParams;
             } else {
-                requestOptions.form = formParams;
+                localVarRequestOptions.form = localVarFormParams;
             }
         }
         return new Promise<{ response: http.ClientResponse; body: Array<Pet>;  }>((resolve, reject) => {
-            localVarRequest(requestOptions, (error, response, body) => {
+            localVarRequest(localVarRequestOptions, (error, response, body) => {
                 if (error) {
                     reject(error);
                 } else {
@@ -696,9 +696,9 @@ export class PetApi {
      */
     public findPetsByTags (tags: Array<string>) : Promise<{ response: http.ClientResponse; body: Array<Pet>;  }> {
         const localVarPath = this.basePath + '/pet/findByTags';
-        let queryParameters: any = {};
-        let headerParams: any = (<any>Object).assign({}, this.defaultHeaders);
-        let formParams: any = {};
+        let localVarQueryParameters: any = {};
+        let localVarHeaderParams: any = (<any>Object).assign({}, this.defaultHeaders);
+        let localVarFormParams: any = {};
 
         // verify required parameter 'tags' is not null or undefined
         if (tags === null || tags === undefined) {
@@ -706,34 +706,34 @@ export class PetApi {
         }
 
         if (tags !== undefined) {
-            queryParameters['tags'] = ObjectSerializer.serialize(tags, "Array<string>");
+            localVarQueryParameters['tags'] = ObjectSerializer.serialize(tags, "Array<string>");
         }
 
 
-        let useFormData = false;
+        let localVarUseFormData = false;
 
-        let requestOptions: localVarRequest.Options = {
+        let localVarRequestOptions: localVarRequest.Options = {
             method: 'GET',
-            qs: queryParameters,
-            headers: headerParams,
+            qs: localVarQueryParameters,
+            headers: localVarHeaderParams,
             uri: localVarPath,
             useQuerystring: this._useQuerystring,
             json: true,
         };
 
-        this.authentications.petstore_auth.applyToRequest(requestOptions);
+        this.authentications.petstore_auth.applyToRequest(localVarRequestOptions);
 
-        this.authentications.default.applyToRequest(requestOptions);
+        this.authentications.default.applyToRequest(localVarRequestOptions);
 
-        if (Object.keys(formParams).length) {
-            if (useFormData) {
-                (<any>requestOptions).formData = formParams;
+        if (Object.keys(localVarFormParams).length) {
+            if (localVarUseFormData) {
+                (<any>localVarRequestOptions).formData = localVarFormParams;
             } else {
-                requestOptions.form = formParams;
+                localVarRequestOptions.form = localVarFormParams;
             }
         }
         return new Promise<{ response: http.ClientResponse; body: Array<Pet>;  }>((resolve, reject) => {
-            localVarRequest(requestOptions, (error, response, body) => {
+            localVarRequest(localVarRequestOptions, (error, response, body) => {
                 if (error) {
                     reject(error);
                 } else {
@@ -755,9 +755,9 @@ export class PetApi {
     public getPetById (petId: number) : Promise<{ response: http.ClientResponse; body: Pet;  }> {
         const localVarPath = this.basePath + '/pet/{petId}'
             .replace('{' + 'petId' + '}', encodeURIComponent(String(petId)));
-        let queryParameters: any = {};
-        let headerParams: any = (<any>Object).assign({}, this.defaultHeaders);
-        let formParams: any = {};
+        let localVarQueryParameters: any = {};
+        let localVarHeaderParams: any = (<any>Object).assign({}, this.defaultHeaders);
+        let localVarFormParams: any = {};
 
         // verify required parameter 'petId' is not null or undefined
         if (petId === null || petId === undefined) {
@@ -765,30 +765,30 @@ export class PetApi {
         }
 
 
-        let useFormData = false;
+        let localVarUseFormData = false;
 
-        let requestOptions: localVarRequest.Options = {
+        let localVarRequestOptions: localVarRequest.Options = {
             method: 'GET',
-            qs: queryParameters,
-            headers: headerParams,
+            qs: localVarQueryParameters,
+            headers: localVarHeaderParams,
             uri: localVarPath,
             useQuerystring: this._useQuerystring,
             json: true,
         };
 
-        this.authentications.api_key.applyToRequest(requestOptions);
+        this.authentications.api_key.applyToRequest(localVarRequestOptions);
 
-        this.authentications.default.applyToRequest(requestOptions);
+        this.authentications.default.applyToRequest(localVarRequestOptions);
 
-        if (Object.keys(formParams).length) {
-            if (useFormData) {
-                (<any>requestOptions).formData = formParams;
+        if (Object.keys(localVarFormParams).length) {
+            if (localVarUseFormData) {
+                (<any>localVarRequestOptions).formData = localVarFormParams;
             } else {
-                requestOptions.form = formParams;
+                localVarRequestOptions.form = localVarFormParams;
             }
         }
         return new Promise<{ response: http.ClientResponse; body: Pet;  }>((resolve, reject) => {
-            localVarRequest(requestOptions, (error, response, body) => {
+            localVarRequest(localVarRequestOptions, (error, response, body) => {
                 if (error) {
                     reject(error);
                 } else {
@@ -809,9 +809,9 @@ export class PetApi {
      */
     public updatePet (body: Pet) : Promise<{ response: http.ClientResponse; body?: any;  }> {
         const localVarPath = this.basePath + '/pet';
-        let queryParameters: any = {};
-        let headerParams: any = (<any>Object).assign({}, this.defaultHeaders);
-        let formParams: any = {};
+        let localVarQueryParameters: any = {};
+        let localVarHeaderParams: any = (<any>Object).assign({}, this.defaultHeaders);
+        let localVarFormParams: any = {};
 
         // verify required parameter 'body' is not null or undefined
         if (body === null || body === undefined) {
@@ -819,31 +819,31 @@ export class PetApi {
         }
 
 
-        let useFormData = false;
+        let localVarUseFormData = false;
 
-        let requestOptions: localVarRequest.Options = {
+        let localVarRequestOptions: localVarRequest.Options = {
             method: 'PUT',
-            qs: queryParameters,
-            headers: headerParams,
+            qs: localVarQueryParameters,
+            headers: localVarHeaderParams,
             uri: localVarPath,
             useQuerystring: this._useQuerystring,
             json: true,
             body: ObjectSerializer.serialize(body, "Pet")
         };
 
-        this.authentications.petstore_auth.applyToRequest(requestOptions);
+        this.authentications.petstore_auth.applyToRequest(localVarRequestOptions);
 
-        this.authentications.default.applyToRequest(requestOptions);
+        this.authentications.default.applyToRequest(localVarRequestOptions);
 
-        if (Object.keys(formParams).length) {
-            if (useFormData) {
-                (<any>requestOptions).formData = formParams;
+        if (Object.keys(localVarFormParams).length) {
+            if (localVarUseFormData) {
+                (<any>localVarRequestOptions).formData = localVarFormParams;
             } else {
-                requestOptions.form = formParams;
+                localVarRequestOptions.form = localVarFormParams;
             }
         }
         return new Promise<{ response: http.ClientResponse; body?: any;  }>((resolve, reject) => {
-            localVarRequest(requestOptions, (error, response, body) => {
+            localVarRequest(localVarRequestOptions, (error, response, body) => {
                 if (error) {
                     reject(error);
                 } else {
@@ -866,9 +866,9 @@ export class PetApi {
     public updatePetWithForm (petId: number, name?: string, status?: string) : Promise<{ response: http.ClientResponse; body?: any;  }> {
         const localVarPath = this.basePath + '/pet/{petId}'
             .replace('{' + 'petId' + '}', encodeURIComponent(String(petId)));
-        let queryParameters: any = {};
-        let headerParams: any = (<any>Object).assign({}, this.defaultHeaders);
-        let formParams: any = {};
+        let localVarQueryParameters: any = {};
+        let localVarHeaderParams: any = (<any>Object).assign({}, this.defaultHeaders);
+        let localVarFormParams: any = {};
 
         // verify required parameter 'petId' is not null or undefined
         if (petId === null || petId === undefined) {
@@ -876,38 +876,38 @@ export class PetApi {
         }
 
 
-        let useFormData = false;
+        let localVarUseFormData = false;
 
         if (name !== undefined) {
-            formParams['name'] = ObjectSerializer.serialize(name, "string");
+            localVarFormParams['name'] = ObjectSerializer.serialize(name, "string");
         }
 
         if (status !== undefined) {
-            formParams['status'] = ObjectSerializer.serialize(status, "string");
+            localVarFormParams['status'] = ObjectSerializer.serialize(status, "string");
         }
 
-        let requestOptions: localVarRequest.Options = {
+        let localVarRequestOptions: localVarRequest.Options = {
             method: 'POST',
-            qs: queryParameters,
-            headers: headerParams,
+            qs: localVarQueryParameters,
+            headers: localVarHeaderParams,
             uri: localVarPath,
             useQuerystring: this._useQuerystring,
             json: true,
         };
 
-        this.authentications.petstore_auth.applyToRequest(requestOptions);
+        this.authentications.petstore_auth.applyToRequest(localVarRequestOptions);
 
-        this.authentications.default.applyToRequest(requestOptions);
+        this.authentications.default.applyToRequest(localVarRequestOptions);
 
-        if (Object.keys(formParams).length) {
-            if (useFormData) {
-                (<any>requestOptions).formData = formParams;
+        if (Object.keys(localVarFormParams).length) {
+            if (localVarUseFormData) {
+                (<any>localVarRequestOptions).formData = localVarFormParams;
             } else {
-                requestOptions.form = formParams;
+                localVarRequestOptions.form = localVarFormParams;
             }
         }
         return new Promise<{ response: http.ClientResponse; body?: any;  }>((resolve, reject) => {
-            localVarRequest(requestOptions, (error, response, body) => {
+            localVarRequest(localVarRequestOptions, (error, response, body) => {
                 if (error) {
                     reject(error);
                 } else {
@@ -930,9 +930,9 @@ export class PetApi {
     public uploadFile (petId: number, additionalMetadata?: string, file?: Buffer) : Promise<{ response: http.ClientResponse; body: ApiResponse;  }> {
         const localVarPath = this.basePath + '/pet/{petId}/uploadImage'
             .replace('{' + 'petId' + '}', encodeURIComponent(String(petId)));
-        let queryParameters: any = {};
-        let headerParams: any = (<any>Object).assign({}, this.defaultHeaders);
-        let formParams: any = {};
+        let localVarQueryParameters: any = {};
+        let localVarHeaderParams: any = (<any>Object).assign({}, this.defaultHeaders);
+        let localVarFormParams: any = {};
 
         // verify required parameter 'petId' is not null or undefined
         if (petId === null || petId === undefined) {
@@ -940,39 +940,39 @@ export class PetApi {
         }
 
 
-        let useFormData = false;
+        let localVarUseFormData = false;
 
         if (additionalMetadata !== undefined) {
-            formParams['additionalMetadata'] = ObjectSerializer.serialize(additionalMetadata, "string");
+            localVarFormParams['additionalMetadata'] = ObjectSerializer.serialize(additionalMetadata, "string");
         }
 
         if (file !== undefined) {
-            formParams['file'] = file;
+            localVarFormParams['file'] = file;
         }
-        useFormData = true;
+        localVarUseFormData = true;
 
-        let requestOptions: localVarRequest.Options = {
+        let localVarRequestOptions: localVarRequest.Options = {
             method: 'POST',
-            qs: queryParameters,
-            headers: headerParams,
+            qs: localVarQueryParameters,
+            headers: localVarHeaderParams,
             uri: localVarPath,
             useQuerystring: this._useQuerystring,
             json: true,
         };
 
-        this.authentications.petstore_auth.applyToRequest(requestOptions);
+        this.authentications.petstore_auth.applyToRequest(localVarRequestOptions);
 
-        this.authentications.default.applyToRequest(requestOptions);
+        this.authentications.default.applyToRequest(localVarRequestOptions);
 
-        if (Object.keys(formParams).length) {
-            if (useFormData) {
-                (<any>requestOptions).formData = formParams;
+        if (Object.keys(localVarFormParams).length) {
+            if (localVarUseFormData) {
+                (<any>localVarRequestOptions).formData = localVarFormParams;
             } else {
-                requestOptions.form = formParams;
+                localVarRequestOptions.form = localVarFormParams;
             }
         }
         return new Promise<{ response: http.ClientResponse; body: ApiResponse;  }>((resolve, reject) => {
-            localVarRequest(requestOptions, (error, response, body) => {
+            localVarRequest(localVarRequestOptions, (error, response, body) => {
                 if (error) {
                     reject(error);
                 } else {
@@ -1046,9 +1046,9 @@ export class StoreApi {
     public deleteOrder (orderId: string) : Promise<{ response: http.ClientResponse; body?: any;  }> {
         const localVarPath = this.basePath + '/store/order/{orderId}'
             .replace('{' + 'orderId' + '}', encodeURIComponent(String(orderId)));
-        let queryParameters: any = {};
-        let headerParams: any = (<any>Object).assign({}, this.defaultHeaders);
-        let formParams: any = {};
+        let localVarQueryParameters: any = {};
+        let localVarHeaderParams: any = (<any>Object).assign({}, this.defaultHeaders);
+        let localVarFormParams: any = {};
 
         // verify required parameter 'orderId' is not null or undefined
         if (orderId === null || orderId === undefined) {
@@ -1056,28 +1056,28 @@ export class StoreApi {
         }
 
 
-        let useFormData = false;
+        let localVarUseFormData = false;
 
-        let requestOptions: localVarRequest.Options = {
+        let localVarRequestOptions: localVarRequest.Options = {
             method: 'DELETE',
-            qs: queryParameters,
-            headers: headerParams,
+            qs: localVarQueryParameters,
+            headers: localVarHeaderParams,
             uri: localVarPath,
             useQuerystring: this._useQuerystring,
             json: true,
         };
 
-        this.authentications.default.applyToRequest(requestOptions);
+        this.authentications.default.applyToRequest(localVarRequestOptions);
 
-        if (Object.keys(formParams).length) {
-            if (useFormData) {
-                (<any>requestOptions).formData = formParams;
+        if (Object.keys(localVarFormParams).length) {
+            if (localVarUseFormData) {
+                (<any>localVarRequestOptions).formData = localVarFormParams;
             } else {
-                requestOptions.form = formParams;
+                localVarRequestOptions.form = localVarFormParams;
             }
         }
         return new Promise<{ response: http.ClientResponse; body?: any;  }>((resolve, reject) => {
-            localVarRequest(requestOptions, (error, response, body) => {
+            localVarRequest(localVarRequestOptions, (error, response, body) => {
                 if (error) {
                     reject(error);
                 } else {
@@ -1096,35 +1096,35 @@ export class StoreApi {
      */
     public getInventory () : Promise<{ response: http.ClientResponse; body: { [key: string]: number; };  }> {
         const localVarPath = this.basePath + '/store/inventory';
-        let queryParameters: any = {};
-        let headerParams: any = (<any>Object).assign({}, this.defaultHeaders);
-        let formParams: any = {};
+        let localVarQueryParameters: any = {};
+        let localVarHeaderParams: any = (<any>Object).assign({}, this.defaultHeaders);
+        let localVarFormParams: any = {};
 
 
-        let useFormData = false;
+        let localVarUseFormData = false;
 
-        let requestOptions: localVarRequest.Options = {
+        let localVarRequestOptions: localVarRequest.Options = {
             method: 'GET',
-            qs: queryParameters,
-            headers: headerParams,
+            qs: localVarQueryParameters,
+            headers: localVarHeaderParams,
             uri: localVarPath,
             useQuerystring: this._useQuerystring,
             json: true,
         };
 
-        this.authentications.api_key.applyToRequest(requestOptions);
+        this.authentications.api_key.applyToRequest(localVarRequestOptions);
 
-        this.authentications.default.applyToRequest(requestOptions);
+        this.authentications.default.applyToRequest(localVarRequestOptions);
 
-        if (Object.keys(formParams).length) {
-            if (useFormData) {
-                (<any>requestOptions).formData = formParams;
+        if (Object.keys(localVarFormParams).length) {
+            if (localVarUseFormData) {
+                (<any>localVarRequestOptions).formData = localVarFormParams;
             } else {
-                requestOptions.form = formParams;
+                localVarRequestOptions.form = localVarFormParams;
             }
         }
         return new Promise<{ response: http.ClientResponse; body: { [key: string]: number; };  }>((resolve, reject) => {
-            localVarRequest(requestOptions, (error, response, body) => {
+            localVarRequest(localVarRequestOptions, (error, response, body) => {
                 if (error) {
                     reject(error);
                 } else {
@@ -1146,9 +1146,9 @@ export class StoreApi {
     public getOrderById (orderId: number) : Promise<{ response: http.ClientResponse; body: Order;  }> {
         const localVarPath = this.basePath + '/store/order/{orderId}'
             .replace('{' + 'orderId' + '}', encodeURIComponent(String(orderId)));
-        let queryParameters: any = {};
-        let headerParams: any = (<any>Object).assign({}, this.defaultHeaders);
-        let formParams: any = {};
+        let localVarQueryParameters: any = {};
+        let localVarHeaderParams: any = (<any>Object).assign({}, this.defaultHeaders);
+        let localVarFormParams: any = {};
 
         // verify required parameter 'orderId' is not null or undefined
         if (orderId === null || orderId === undefined) {
@@ -1156,28 +1156,28 @@ export class StoreApi {
         }
 
 
-        let useFormData = false;
+        let localVarUseFormData = false;
 
-        let requestOptions: localVarRequest.Options = {
+        let localVarRequestOptions: localVarRequest.Options = {
             method: 'GET',
-            qs: queryParameters,
-            headers: headerParams,
+            qs: localVarQueryParameters,
+            headers: localVarHeaderParams,
             uri: localVarPath,
             useQuerystring: this._useQuerystring,
             json: true,
         };
 
-        this.authentications.default.applyToRequest(requestOptions);
+        this.authentications.default.applyToRequest(localVarRequestOptions);
 
-        if (Object.keys(formParams).length) {
-            if (useFormData) {
-                (<any>requestOptions).formData = formParams;
+        if (Object.keys(localVarFormParams).length) {
+            if (localVarUseFormData) {
+                (<any>localVarRequestOptions).formData = localVarFormParams;
             } else {
-                requestOptions.form = formParams;
+                localVarRequestOptions.form = localVarFormParams;
             }
         }
         return new Promise<{ response: http.ClientResponse; body: Order;  }>((resolve, reject) => {
-            localVarRequest(requestOptions, (error, response, body) => {
+            localVarRequest(localVarRequestOptions, (error, response, body) => {
                 if (error) {
                     reject(error);
                 } else {
@@ -1198,9 +1198,9 @@ export class StoreApi {
      */
     public placeOrder (body: Order) : Promise<{ response: http.ClientResponse; body: Order;  }> {
         const localVarPath = this.basePath + '/store/order';
-        let queryParameters: any = {};
-        let headerParams: any = (<any>Object).assign({}, this.defaultHeaders);
-        let formParams: any = {};
+        let localVarQueryParameters: any = {};
+        let localVarHeaderParams: any = (<any>Object).assign({}, this.defaultHeaders);
+        let localVarFormParams: any = {};
 
         // verify required parameter 'body' is not null or undefined
         if (body === null || body === undefined) {
@@ -1208,29 +1208,29 @@ export class StoreApi {
         }
 
 
-        let useFormData = false;
+        let localVarUseFormData = false;
 
-        let requestOptions: localVarRequest.Options = {
+        let localVarRequestOptions: localVarRequest.Options = {
             method: 'POST',
-            qs: queryParameters,
-            headers: headerParams,
+            qs: localVarQueryParameters,
+            headers: localVarHeaderParams,
             uri: localVarPath,
             useQuerystring: this._useQuerystring,
             json: true,
             body: ObjectSerializer.serialize(body, "Order")
         };
 
-        this.authentications.default.applyToRequest(requestOptions);
+        this.authentications.default.applyToRequest(localVarRequestOptions);
 
-        if (Object.keys(formParams).length) {
-            if (useFormData) {
-                (<any>requestOptions).formData = formParams;
+        if (Object.keys(localVarFormParams).length) {
+            if (localVarUseFormData) {
+                (<any>localVarRequestOptions).formData = localVarFormParams;
             } else {
-                requestOptions.form = formParams;
+                localVarRequestOptions.form = localVarFormParams;
             }
         }
         return new Promise<{ response: http.ClientResponse; body: Order;  }>((resolve, reject) => {
-            localVarRequest(requestOptions, (error, response, body) => {
+            localVarRequest(localVarRequestOptions, (error, response, body) => {
                 if (error) {
                     reject(error);
                 } else {
@@ -1303,9 +1303,9 @@ export class UserApi {
      */
     public createUser (body: User) : Promise<{ response: http.ClientResponse; body?: any;  }> {
         const localVarPath = this.basePath + '/user';
-        let queryParameters: any = {};
-        let headerParams: any = (<any>Object).assign({}, this.defaultHeaders);
-        let formParams: any = {};
+        let localVarQueryParameters: any = {};
+        let localVarHeaderParams: any = (<any>Object).assign({}, this.defaultHeaders);
+        let localVarFormParams: any = {};
 
         // verify required parameter 'body' is not null or undefined
         if (body === null || body === undefined) {
@@ -1313,29 +1313,29 @@ export class UserApi {
         }
 
 
-        let useFormData = false;
+        let localVarUseFormData = false;
 
-        let requestOptions: localVarRequest.Options = {
+        let localVarRequestOptions: localVarRequest.Options = {
             method: 'POST',
-            qs: queryParameters,
-            headers: headerParams,
+            qs: localVarQueryParameters,
+            headers: localVarHeaderParams,
             uri: localVarPath,
             useQuerystring: this._useQuerystring,
             json: true,
             body: ObjectSerializer.serialize(body, "User")
         };
 
-        this.authentications.default.applyToRequest(requestOptions);
+        this.authentications.default.applyToRequest(localVarRequestOptions);
 
-        if (Object.keys(formParams).length) {
-            if (useFormData) {
-                (<any>requestOptions).formData = formParams;
+        if (Object.keys(localVarFormParams).length) {
+            if (localVarUseFormData) {
+                (<any>localVarRequestOptions).formData = localVarFormParams;
             } else {
-                requestOptions.form = formParams;
+                localVarRequestOptions.form = localVarFormParams;
             }
         }
         return new Promise<{ response: http.ClientResponse; body?: any;  }>((resolve, reject) => {
-            localVarRequest(requestOptions, (error, response, body) => {
+            localVarRequest(localVarRequestOptions, (error, response, body) => {
                 if (error) {
                     reject(error);
                 } else {
@@ -1355,9 +1355,9 @@ export class UserApi {
      */
     public createUsersWithArrayInput (body: Array<User>) : Promise<{ response: http.ClientResponse; body?: any;  }> {
         const localVarPath = this.basePath + '/user/createWithArray';
-        let queryParameters: any = {};
-        let headerParams: any = (<any>Object).assign({}, this.defaultHeaders);
-        let formParams: any = {};
+        let localVarQueryParameters: any = {};
+        let localVarHeaderParams: any = (<any>Object).assign({}, this.defaultHeaders);
+        let localVarFormParams: any = {};
 
         // verify required parameter 'body' is not null or undefined
         if (body === null || body === undefined) {
@@ -1365,29 +1365,29 @@ export class UserApi {
         }
 
 
-        let useFormData = false;
+        let localVarUseFormData = false;
 
-        let requestOptions: localVarRequest.Options = {
+        let localVarRequestOptions: localVarRequest.Options = {
             method: 'POST',
-            qs: queryParameters,
-            headers: headerParams,
+            qs: localVarQueryParameters,
+            headers: localVarHeaderParams,
             uri: localVarPath,
             useQuerystring: this._useQuerystring,
             json: true,
             body: ObjectSerializer.serialize(body, "Array<User>")
         };
 
-        this.authentications.default.applyToRequest(requestOptions);
+        this.authentications.default.applyToRequest(localVarRequestOptions);
 
-        if (Object.keys(formParams).length) {
-            if (useFormData) {
-                (<any>requestOptions).formData = formParams;
+        if (Object.keys(localVarFormParams).length) {
+            if (localVarUseFormData) {
+                (<any>localVarRequestOptions).formData = localVarFormParams;
             } else {
-                requestOptions.form = formParams;
+                localVarRequestOptions.form = localVarFormParams;
             }
         }
         return new Promise<{ response: http.ClientResponse; body?: any;  }>((resolve, reject) => {
-            localVarRequest(requestOptions, (error, response, body) => {
+            localVarRequest(localVarRequestOptions, (error, response, body) => {
                 if (error) {
                     reject(error);
                 } else {
@@ -1407,9 +1407,9 @@ export class UserApi {
      */
     public createUsersWithListInput (body: Array<User>) : Promise<{ response: http.ClientResponse; body?: any;  }> {
         const localVarPath = this.basePath + '/user/createWithList';
-        let queryParameters: any = {};
-        let headerParams: any = (<any>Object).assign({}, this.defaultHeaders);
-        let formParams: any = {};
+        let localVarQueryParameters: any = {};
+        let localVarHeaderParams: any = (<any>Object).assign({}, this.defaultHeaders);
+        let localVarFormParams: any = {};
 
         // verify required parameter 'body' is not null or undefined
         if (body === null || body === undefined) {
@@ -1417,29 +1417,29 @@ export class UserApi {
         }
 
 
-        let useFormData = false;
+        let localVarUseFormData = false;
 
-        let requestOptions: localVarRequest.Options = {
+        let localVarRequestOptions: localVarRequest.Options = {
             method: 'POST',
-            qs: queryParameters,
-            headers: headerParams,
+            qs: localVarQueryParameters,
+            headers: localVarHeaderParams,
             uri: localVarPath,
             useQuerystring: this._useQuerystring,
             json: true,
             body: ObjectSerializer.serialize(body, "Array<User>")
         };
 
-        this.authentications.default.applyToRequest(requestOptions);
+        this.authentications.default.applyToRequest(localVarRequestOptions);
 
-        if (Object.keys(formParams).length) {
-            if (useFormData) {
-                (<any>requestOptions).formData = formParams;
+        if (Object.keys(localVarFormParams).length) {
+            if (localVarUseFormData) {
+                (<any>localVarRequestOptions).formData = localVarFormParams;
             } else {
-                requestOptions.form = formParams;
+                localVarRequestOptions.form = localVarFormParams;
             }
         }
         return new Promise<{ response: http.ClientResponse; body?: any;  }>((resolve, reject) => {
-            localVarRequest(requestOptions, (error, response, body) => {
+            localVarRequest(localVarRequestOptions, (error, response, body) => {
                 if (error) {
                     reject(error);
                 } else {
@@ -1460,9 +1460,9 @@ export class UserApi {
     public deleteUser (username: string) : Promise<{ response: http.ClientResponse; body?: any;  }> {
         const localVarPath = this.basePath + '/user/{username}'
             .replace('{' + 'username' + '}', encodeURIComponent(String(username)));
-        let queryParameters: any = {};
-        let headerParams: any = (<any>Object).assign({}, this.defaultHeaders);
-        let formParams: any = {};
+        let localVarQueryParameters: any = {};
+        let localVarHeaderParams: any = (<any>Object).assign({}, this.defaultHeaders);
+        let localVarFormParams: any = {};
 
         // verify required parameter 'username' is not null or undefined
         if (username === null || username === undefined) {
@@ -1470,28 +1470,28 @@ export class UserApi {
         }
 
 
-        let useFormData = false;
+        let localVarUseFormData = false;
 
-        let requestOptions: localVarRequest.Options = {
+        let localVarRequestOptions: localVarRequest.Options = {
             method: 'DELETE',
-            qs: queryParameters,
-            headers: headerParams,
+            qs: localVarQueryParameters,
+            headers: localVarHeaderParams,
             uri: localVarPath,
             useQuerystring: this._useQuerystring,
             json: true,
         };
 
-        this.authentications.default.applyToRequest(requestOptions);
+        this.authentications.default.applyToRequest(localVarRequestOptions);
 
-        if (Object.keys(formParams).length) {
-            if (useFormData) {
-                (<any>requestOptions).formData = formParams;
+        if (Object.keys(localVarFormParams).length) {
+            if (localVarUseFormData) {
+                (<any>localVarRequestOptions).formData = localVarFormParams;
             } else {
-                requestOptions.form = formParams;
+                localVarRequestOptions.form = localVarFormParams;
             }
         }
         return new Promise<{ response: http.ClientResponse; body?: any;  }>((resolve, reject) => {
-            localVarRequest(requestOptions, (error, response, body) => {
+            localVarRequest(localVarRequestOptions, (error, response, body) => {
                 if (error) {
                     reject(error);
                 } else {
@@ -1512,9 +1512,9 @@ export class UserApi {
     public getUserByName (username: string) : Promise<{ response: http.ClientResponse; body: User;  }> {
         const localVarPath = this.basePath + '/user/{username}'
             .replace('{' + 'username' + '}', encodeURIComponent(String(username)));
-        let queryParameters: any = {};
-        let headerParams: any = (<any>Object).assign({}, this.defaultHeaders);
-        let formParams: any = {};
+        let localVarQueryParameters: any = {};
+        let localVarHeaderParams: any = (<any>Object).assign({}, this.defaultHeaders);
+        let localVarFormParams: any = {};
 
         // verify required parameter 'username' is not null or undefined
         if (username === null || username === undefined) {
@@ -1522,28 +1522,28 @@ export class UserApi {
         }
 
 
-        let useFormData = false;
+        let localVarUseFormData = false;
 
-        let requestOptions: localVarRequest.Options = {
+        let localVarRequestOptions: localVarRequest.Options = {
             method: 'GET',
-            qs: queryParameters,
-            headers: headerParams,
+            qs: localVarQueryParameters,
+            headers: localVarHeaderParams,
             uri: localVarPath,
             useQuerystring: this._useQuerystring,
             json: true,
         };
 
-        this.authentications.default.applyToRequest(requestOptions);
+        this.authentications.default.applyToRequest(localVarRequestOptions);
 
-        if (Object.keys(formParams).length) {
-            if (useFormData) {
-                (<any>requestOptions).formData = formParams;
+        if (Object.keys(localVarFormParams).length) {
+            if (localVarUseFormData) {
+                (<any>localVarRequestOptions).formData = localVarFormParams;
             } else {
-                requestOptions.form = formParams;
+                localVarRequestOptions.form = localVarFormParams;
             }
         }
         return new Promise<{ response: http.ClientResponse; body: User;  }>((resolve, reject) => {
-            localVarRequest(requestOptions, (error, response, body) => {
+            localVarRequest(localVarRequestOptions, (error, response, body) => {
                 if (error) {
                     reject(error);
                 } else {
@@ -1565,9 +1565,9 @@ export class UserApi {
      */
     public loginUser (username: string, password: string) : Promise<{ response: http.ClientResponse; body: string;  }> {
         const localVarPath = this.basePath + '/user/login';
-        let queryParameters: any = {};
-        let headerParams: any = (<any>Object).assign({}, this.defaultHeaders);
-        let formParams: any = {};
+        let localVarQueryParameters: any = {};
+        let localVarHeaderParams: any = (<any>Object).assign({}, this.defaultHeaders);
+        let localVarFormParams: any = {};
 
         // verify required parameter 'username' is not null or undefined
         if (username === null || username === undefined) {
@@ -1580,36 +1580,36 @@ export class UserApi {
         }
 
         if (username !== undefined) {
-            queryParameters['username'] = ObjectSerializer.serialize(username, "string");
+            localVarQueryParameters['username'] = ObjectSerializer.serialize(username, "string");
         }
 
         if (password !== undefined) {
-            queryParameters['password'] = ObjectSerializer.serialize(password, "string");
+            localVarQueryParameters['password'] = ObjectSerializer.serialize(password, "string");
         }
 
 
-        let useFormData = false;
+        let localVarUseFormData = false;
 
-        let requestOptions: localVarRequest.Options = {
+        let localVarRequestOptions: localVarRequest.Options = {
             method: 'GET',
-            qs: queryParameters,
-            headers: headerParams,
+            qs: localVarQueryParameters,
+            headers: localVarHeaderParams,
             uri: localVarPath,
             useQuerystring: this._useQuerystring,
             json: true,
         };
 
-        this.authentications.default.applyToRequest(requestOptions);
+        this.authentications.default.applyToRequest(localVarRequestOptions);
 
-        if (Object.keys(formParams).length) {
-            if (useFormData) {
-                (<any>requestOptions).formData = formParams;
+        if (Object.keys(localVarFormParams).length) {
+            if (localVarUseFormData) {
+                (<any>localVarRequestOptions).formData = localVarFormParams;
             } else {
-                requestOptions.form = formParams;
+                localVarRequestOptions.form = localVarFormParams;
             }
         }
         return new Promise<{ response: http.ClientResponse; body: string;  }>((resolve, reject) => {
-            localVarRequest(requestOptions, (error, response, body) => {
+            localVarRequest(localVarRequestOptions, (error, response, body) => {
                 if (error) {
                     reject(error);
                 } else {
@@ -1629,33 +1629,33 @@ export class UserApi {
      */
     public logoutUser () : Promise<{ response: http.ClientResponse; body?: any;  }> {
         const localVarPath = this.basePath + '/user/logout';
-        let queryParameters: any = {};
-        let headerParams: any = (<any>Object).assign({}, this.defaultHeaders);
-        let formParams: any = {};
+        let localVarQueryParameters: any = {};
+        let localVarHeaderParams: any = (<any>Object).assign({}, this.defaultHeaders);
+        let localVarFormParams: any = {};
 
 
-        let useFormData = false;
+        let localVarUseFormData = false;
 
-        let requestOptions: localVarRequest.Options = {
+        let localVarRequestOptions: localVarRequest.Options = {
             method: 'GET',
-            qs: queryParameters,
-            headers: headerParams,
+            qs: localVarQueryParameters,
+            headers: localVarHeaderParams,
             uri: localVarPath,
             useQuerystring: this._useQuerystring,
             json: true,
         };
 
-        this.authentications.default.applyToRequest(requestOptions);
+        this.authentications.default.applyToRequest(localVarRequestOptions);
 
-        if (Object.keys(formParams).length) {
-            if (useFormData) {
-                (<any>requestOptions).formData = formParams;
+        if (Object.keys(localVarFormParams).length) {
+            if (localVarUseFormData) {
+                (<any>localVarRequestOptions).formData = localVarFormParams;
             } else {
-                requestOptions.form = formParams;
+                localVarRequestOptions.form = localVarFormParams;
             }
         }
         return new Promise<{ response: http.ClientResponse; body?: any;  }>((resolve, reject) => {
-            localVarRequest(requestOptions, (error, response, body) => {
+            localVarRequest(localVarRequestOptions, (error, response, body) => {
                 if (error) {
                     reject(error);
                 } else {
@@ -1677,9 +1677,9 @@ export class UserApi {
     public updateUser (username: string, body: User) : Promise<{ response: http.ClientResponse; body?: any;  }> {
         const localVarPath = this.basePath + '/user/{username}'
             .replace('{' + 'username' + '}', encodeURIComponent(String(username)));
-        let queryParameters: any = {};
-        let headerParams: any = (<any>Object).assign({}, this.defaultHeaders);
-        let formParams: any = {};
+        let localVarQueryParameters: any = {};
+        let localVarHeaderParams: any = (<any>Object).assign({}, this.defaultHeaders);
+        let localVarFormParams: any = {};
 
         // verify required parameter 'username' is not null or undefined
         if (username === null || username === undefined) {
@@ -1692,29 +1692,29 @@ export class UserApi {
         }
 
 
-        let useFormData = false;
+        let localVarUseFormData = false;
 
-        let requestOptions: localVarRequest.Options = {
+        let localVarRequestOptions: localVarRequest.Options = {
             method: 'PUT',
-            qs: queryParameters,
-            headers: headerParams,
+            qs: localVarQueryParameters,
+            headers: localVarHeaderParams,
             uri: localVarPath,
             useQuerystring: this._useQuerystring,
             json: true,
             body: ObjectSerializer.serialize(body, "User")
         };
 
-        this.authentications.default.applyToRequest(requestOptions);
+        this.authentications.default.applyToRequest(localVarRequestOptions);
 
-        if (Object.keys(formParams).length) {
-            if (useFormData) {
-                (<any>requestOptions).formData = formParams;
+        if (Object.keys(localVarFormParams).length) {
+            if (localVarUseFormData) {
+                (<any>localVarRequestOptions).formData = localVarFormParams;
             } else {
-                requestOptions.form = formParams;
+                localVarRequestOptions.form = localVarFormParams;
             }
         }
         return new Promise<{ response: http.ClientResponse; body?: any;  }>((resolve, reject) => {
-            localVarRequest(requestOptions, (error, response, body) => {
+            localVarRequest(localVarRequestOptions, (error, response, body) => {
                 if (error) {
                     reject(error);
                 } else {

--- a/samples/client/petstore/typescript-node/default/api.ts
+++ b/samples/client/petstore/typescript-node/default/api.ts
@@ -10,7 +10,7 @@
  * Do not edit the class manually.
  */
 
-import $request = require('request');
+import localVarRequest = require('request');
 import http = require('http');
 import Promise = require('bluebird');
 
@@ -424,13 +424,13 @@ export interface Authentication {
     /**
     * Apply authentication settings to header and query params.
     */
-    applyToRequest(requestOptions: $request.Options): void;
+    applyToRequest(requestOptions: localVarRequest.Options): void;
 }
 
 export class HttpBasicAuth implements Authentication {
     public username: string;
     public password: string;
-    applyToRequest(requestOptions: $request.Options): void {
+    applyToRequest(requestOptions: localVarRequest.Options): void {
         requestOptions.auth = {
             username: this.username, password: this.password
         }
@@ -443,7 +443,7 @@ export class ApiKeyAuth implements Authentication {
     constructor(private location: string, private paramName: string) {
     }
 
-    applyToRequest(requestOptions: $request.Options): void {
+    applyToRequest(requestOptions: localVarRequest.Options): void {
         if (this.location == "query") {
             (<any>requestOptions.qs)[this.paramName] = this.apiKey;
         } else if (this.location == "header" && requestOptions && requestOptions.headers) {
@@ -455,7 +455,7 @@ export class ApiKeyAuth implements Authentication {
 export class OAuth implements Authentication {
     public accessToken: string;
 
-    applyToRequest(requestOptions: $request.Options): void {
+    applyToRequest(requestOptions: localVarRequest.Options): void {
         if (requestOptions && requestOptions.headers) {
             requestOptions.headers["Authorization"] = "Bearer " + this.accessToken;
         }
@@ -465,7 +465,7 @@ export class OAuth implements Authentication {
 export class VoidAuth implements Authentication {
     public username: string;
     public password: string;
-    applyToRequest(_: $request.Options): void {
+    applyToRequest(_: localVarRequest.Options): void {
         // Do nothing
     }
 }
@@ -540,7 +540,7 @@ export class PetApi {
 
         let useFormData = false;
 
-        let requestOptions: $request.Options = {
+        let requestOptions: localVarRequest.Options = {
             method: 'POST',
             qs: queryParameters,
             headers: headerParams,
@@ -562,7 +562,7 @@ export class PetApi {
             }
         }
         return new Promise<{ response: http.ClientResponse; body?: any;  }>((resolve, reject) => {
-            $request(requestOptions, (error, response, body) => {
+            localVarRequest(requestOptions, (error, response, body) => {
                 if (error) {
                     reject(error);
                 } else {
@@ -597,7 +597,7 @@ export class PetApi {
 
         let useFormData = false;
 
-        let requestOptions: $request.Options = {
+        let requestOptions: localVarRequest.Options = {
             method: 'DELETE',
             qs: queryParameters,
             headers: headerParams,
@@ -618,7 +618,7 @@ export class PetApi {
             }
         }
         return new Promise<{ response: http.ClientResponse; body?: any;  }>((resolve, reject) => {
-            $request(requestOptions, (error, response, body) => {
+            localVarRequest(requestOptions, (error, response, body) => {
                 if (error) {
                     reject(error);
                 } else {
@@ -654,7 +654,7 @@ export class PetApi {
 
         let useFormData = false;
 
-        let requestOptions: $request.Options = {
+        let requestOptions: localVarRequest.Options = {
             method: 'GET',
             qs: queryParameters,
             headers: headerParams,
@@ -675,7 +675,7 @@ export class PetApi {
             }
         }
         return new Promise<{ response: http.ClientResponse; body: Array<Pet>;  }>((resolve, reject) => {
-            $request(requestOptions, (error, response, body) => {
+            localVarRequest(requestOptions, (error, response, body) => {
                 if (error) {
                     reject(error);
                 } else {
@@ -712,7 +712,7 @@ export class PetApi {
 
         let useFormData = false;
 
-        let requestOptions: $request.Options = {
+        let requestOptions: localVarRequest.Options = {
             method: 'GET',
             qs: queryParameters,
             headers: headerParams,
@@ -733,7 +733,7 @@ export class PetApi {
             }
         }
         return new Promise<{ response: http.ClientResponse; body: Array<Pet>;  }>((resolve, reject) => {
-            $request(requestOptions, (error, response, body) => {
+            localVarRequest(requestOptions, (error, response, body) => {
                 if (error) {
                     reject(error);
                 } else {
@@ -767,7 +767,7 @@ export class PetApi {
 
         let useFormData = false;
 
-        let requestOptions: $request.Options = {
+        let requestOptions: localVarRequest.Options = {
             method: 'GET',
             qs: queryParameters,
             headers: headerParams,
@@ -788,7 +788,7 @@ export class PetApi {
             }
         }
         return new Promise<{ response: http.ClientResponse; body: Pet;  }>((resolve, reject) => {
-            $request(requestOptions, (error, response, body) => {
+            localVarRequest(requestOptions, (error, response, body) => {
                 if (error) {
                     reject(error);
                 } else {
@@ -821,7 +821,7 @@ export class PetApi {
 
         let useFormData = false;
 
-        let requestOptions: $request.Options = {
+        let requestOptions: localVarRequest.Options = {
             method: 'PUT',
             qs: queryParameters,
             headers: headerParams,
@@ -843,7 +843,7 @@ export class PetApi {
             }
         }
         return new Promise<{ response: http.ClientResponse; body?: any;  }>((resolve, reject) => {
-            $request(requestOptions, (error, response, body) => {
+            localVarRequest(requestOptions, (error, response, body) => {
                 if (error) {
                     reject(error);
                 } else {
@@ -886,7 +886,7 @@ export class PetApi {
             formParams['status'] = ObjectSerializer.serialize(status, "string");
         }
 
-        let requestOptions: $request.Options = {
+        let requestOptions: localVarRequest.Options = {
             method: 'POST',
             qs: queryParameters,
             headers: headerParams,
@@ -907,7 +907,7 @@ export class PetApi {
             }
         }
         return new Promise<{ response: http.ClientResponse; body?: any;  }>((resolve, reject) => {
-            $request(requestOptions, (error, response, body) => {
+            localVarRequest(requestOptions, (error, response, body) => {
                 if (error) {
                     reject(error);
                 } else {
@@ -951,7 +951,7 @@ export class PetApi {
         }
         useFormData = true;
 
-        let requestOptions: $request.Options = {
+        let requestOptions: localVarRequest.Options = {
             method: 'POST',
             qs: queryParameters,
             headers: headerParams,
@@ -972,7 +972,7 @@ export class PetApi {
             }
         }
         return new Promise<{ response: http.ClientResponse; body: ApiResponse;  }>((resolve, reject) => {
-            $request(requestOptions, (error, response, body) => {
+            localVarRequest(requestOptions, (error, response, body) => {
                 if (error) {
                     reject(error);
                 } else {
@@ -1058,7 +1058,7 @@ export class StoreApi {
 
         let useFormData = false;
 
-        let requestOptions: $request.Options = {
+        let requestOptions: localVarRequest.Options = {
             method: 'DELETE',
             qs: queryParameters,
             headers: headerParams,
@@ -1077,7 +1077,7 @@ export class StoreApi {
             }
         }
         return new Promise<{ response: http.ClientResponse; body?: any;  }>((resolve, reject) => {
-            $request(requestOptions, (error, response, body) => {
+            localVarRequest(requestOptions, (error, response, body) => {
                 if (error) {
                     reject(error);
                 } else {
@@ -1103,7 +1103,7 @@ export class StoreApi {
 
         let useFormData = false;
 
-        let requestOptions: $request.Options = {
+        let requestOptions: localVarRequest.Options = {
             method: 'GET',
             qs: queryParameters,
             headers: headerParams,
@@ -1124,7 +1124,7 @@ export class StoreApi {
             }
         }
         return new Promise<{ response: http.ClientResponse; body: { [key: string]: number; };  }>((resolve, reject) => {
-            $request(requestOptions, (error, response, body) => {
+            localVarRequest(requestOptions, (error, response, body) => {
                 if (error) {
                     reject(error);
                 } else {
@@ -1158,7 +1158,7 @@ export class StoreApi {
 
         let useFormData = false;
 
-        let requestOptions: $request.Options = {
+        let requestOptions: localVarRequest.Options = {
             method: 'GET',
             qs: queryParameters,
             headers: headerParams,
@@ -1177,7 +1177,7 @@ export class StoreApi {
             }
         }
         return new Promise<{ response: http.ClientResponse; body: Order;  }>((resolve, reject) => {
-            $request(requestOptions, (error, response, body) => {
+            localVarRequest(requestOptions, (error, response, body) => {
                 if (error) {
                     reject(error);
                 } else {
@@ -1210,7 +1210,7 @@ export class StoreApi {
 
         let useFormData = false;
 
-        let requestOptions: $request.Options = {
+        let requestOptions: localVarRequest.Options = {
             method: 'POST',
             qs: queryParameters,
             headers: headerParams,
@@ -1230,7 +1230,7 @@ export class StoreApi {
             }
         }
         return new Promise<{ response: http.ClientResponse; body: Order;  }>((resolve, reject) => {
-            $request(requestOptions, (error, response, body) => {
+            localVarRequest(requestOptions, (error, response, body) => {
                 if (error) {
                     reject(error);
                 } else {
@@ -1315,7 +1315,7 @@ export class UserApi {
 
         let useFormData = false;
 
-        let requestOptions: $request.Options = {
+        let requestOptions: localVarRequest.Options = {
             method: 'POST',
             qs: queryParameters,
             headers: headerParams,
@@ -1335,7 +1335,7 @@ export class UserApi {
             }
         }
         return new Promise<{ response: http.ClientResponse; body?: any;  }>((resolve, reject) => {
-            $request(requestOptions, (error, response, body) => {
+            localVarRequest(requestOptions, (error, response, body) => {
                 if (error) {
                     reject(error);
                 } else {
@@ -1367,7 +1367,7 @@ export class UserApi {
 
         let useFormData = false;
 
-        let requestOptions: $request.Options = {
+        let requestOptions: localVarRequest.Options = {
             method: 'POST',
             qs: queryParameters,
             headers: headerParams,
@@ -1387,7 +1387,7 @@ export class UserApi {
             }
         }
         return new Promise<{ response: http.ClientResponse; body?: any;  }>((resolve, reject) => {
-            $request(requestOptions, (error, response, body) => {
+            localVarRequest(requestOptions, (error, response, body) => {
                 if (error) {
                     reject(error);
                 } else {
@@ -1419,7 +1419,7 @@ export class UserApi {
 
         let useFormData = false;
 
-        let requestOptions: $request.Options = {
+        let requestOptions: localVarRequest.Options = {
             method: 'POST',
             qs: queryParameters,
             headers: headerParams,
@@ -1439,7 +1439,7 @@ export class UserApi {
             }
         }
         return new Promise<{ response: http.ClientResponse; body?: any;  }>((resolve, reject) => {
-            $request(requestOptions, (error, response, body) => {
+            localVarRequest(requestOptions, (error, response, body) => {
                 if (error) {
                     reject(error);
                 } else {
@@ -1472,7 +1472,7 @@ export class UserApi {
 
         let useFormData = false;
 
-        let requestOptions: $request.Options = {
+        let requestOptions: localVarRequest.Options = {
             method: 'DELETE',
             qs: queryParameters,
             headers: headerParams,
@@ -1491,7 +1491,7 @@ export class UserApi {
             }
         }
         return new Promise<{ response: http.ClientResponse; body?: any;  }>((resolve, reject) => {
-            $request(requestOptions, (error, response, body) => {
+            localVarRequest(requestOptions, (error, response, body) => {
                 if (error) {
                     reject(error);
                 } else {
@@ -1524,7 +1524,7 @@ export class UserApi {
 
         let useFormData = false;
 
-        let requestOptions: $request.Options = {
+        let requestOptions: localVarRequest.Options = {
             method: 'GET',
             qs: queryParameters,
             headers: headerParams,
@@ -1543,7 +1543,7 @@ export class UserApi {
             }
         }
         return new Promise<{ response: http.ClientResponse; body: User;  }>((resolve, reject) => {
-            $request(requestOptions, (error, response, body) => {
+            localVarRequest(requestOptions, (error, response, body) => {
                 if (error) {
                     reject(error);
                 } else {
@@ -1590,7 +1590,7 @@ export class UserApi {
 
         let useFormData = false;
 
-        let requestOptions: $request.Options = {
+        let requestOptions: localVarRequest.Options = {
             method: 'GET',
             qs: queryParameters,
             headers: headerParams,
@@ -1609,7 +1609,7 @@ export class UserApi {
             }
         }
         return new Promise<{ response: http.ClientResponse; body: string;  }>((resolve, reject) => {
-            $request(requestOptions, (error, response, body) => {
+            localVarRequest(requestOptions, (error, response, body) => {
                 if (error) {
                     reject(error);
                 } else {
@@ -1636,7 +1636,7 @@ export class UserApi {
 
         let useFormData = false;
 
-        let requestOptions: $request.Options = {
+        let requestOptions: localVarRequest.Options = {
             method: 'GET',
             qs: queryParameters,
             headers: headerParams,
@@ -1655,7 +1655,7 @@ export class UserApi {
             }
         }
         return new Promise<{ response: http.ClientResponse; body?: any;  }>((resolve, reject) => {
-            $request(requestOptions, (error, response, body) => {
+            localVarRequest(requestOptions, (error, response, body) => {
                 if (error) {
                     reject(error);
                 } else {
@@ -1694,7 +1694,7 @@ export class UserApi {
 
         let useFormData = false;
 
-        let requestOptions: $request.Options = {
+        let requestOptions: localVarRequest.Options = {
             method: 'PUT',
             qs: queryParameters,
             headers: headerParams,
@@ -1714,7 +1714,7 @@ export class UserApi {
             }
         }
         return new Promise<{ response: http.ClientResponse; body?: any;  }>((resolve, reject) => {
-            $request(requestOptions, (error, response, body) => {
+            localVarRequest(requestOptions, (error, response, body) => {
                 if (error) {
                     reject(error);
                 } else {

--- a/samples/client/petstore/typescript-node/npm/api.ts
+++ b/samples/client/petstore/typescript-node/npm/api.ts
@@ -10,7 +10,7 @@
  * Do not edit the class manually.
  */
 
-import request = require('request');
+import $request = require('request');
 import http = require('http');
 import Promise = require('bluebird');
 
@@ -424,13 +424,13 @@ export interface Authentication {
     /**
     * Apply authentication settings to header and query params.
     */
-    applyToRequest(requestOptions: request.Options): void;
+    applyToRequest(requestOptions: $request.Options): void;
 }
 
 export class HttpBasicAuth implements Authentication {
     public username: string;
     public password: string;
-    applyToRequest(requestOptions: request.Options): void {
+    applyToRequest(requestOptions: $request.Options): void {
         requestOptions.auth = {
             username: this.username, password: this.password
         }
@@ -443,7 +443,7 @@ export class ApiKeyAuth implements Authentication {
     constructor(private location: string, private paramName: string) {
     }
 
-    applyToRequest(requestOptions: request.Options): void {
+    applyToRequest(requestOptions: $request.Options): void {
         if (this.location == "query") {
             (<any>requestOptions.qs)[this.paramName] = this.apiKey;
         } else if (this.location == "header" && requestOptions && requestOptions.headers) {
@@ -455,7 +455,7 @@ export class ApiKeyAuth implements Authentication {
 export class OAuth implements Authentication {
     public accessToken: string;
 
-    applyToRequest(requestOptions: request.Options): void {
+    applyToRequest(requestOptions: $request.Options): void {
         if (requestOptions && requestOptions.headers) {
             requestOptions.headers["Authorization"] = "Bearer " + this.accessToken;
         }
@@ -465,7 +465,7 @@ export class OAuth implements Authentication {
 export class VoidAuth implements Authentication {
     public username: string;
     public password: string;
-    applyToRequest(_: request.Options): void {
+    applyToRequest(_: $request.Options): void {
         // Do nothing
     }
 }
@@ -540,7 +540,7 @@ export class PetApi {
 
         let useFormData = false;
 
-        let requestOptions: request.Options = {
+        let requestOptions: $request.Options = {
             method: 'POST',
             qs: queryParameters,
             headers: headerParams,
@@ -562,7 +562,7 @@ export class PetApi {
             }
         }
         return new Promise<{ response: http.ClientResponse; body?: any;  }>((resolve, reject) => {
-            request(requestOptions, (error, response, body) => {
+            $request(requestOptions, (error, response, body) => {
                 if (error) {
                     reject(error);
                 } else {
@@ -597,7 +597,7 @@ export class PetApi {
 
         let useFormData = false;
 
-        let requestOptions: request.Options = {
+        let requestOptions: $request.Options = {
             method: 'DELETE',
             qs: queryParameters,
             headers: headerParams,
@@ -618,7 +618,7 @@ export class PetApi {
             }
         }
         return new Promise<{ response: http.ClientResponse; body?: any;  }>((resolve, reject) => {
-            request(requestOptions, (error, response, body) => {
+            $request(requestOptions, (error, response, body) => {
                 if (error) {
                     reject(error);
                 } else {
@@ -654,7 +654,7 @@ export class PetApi {
 
         let useFormData = false;
 
-        let requestOptions: request.Options = {
+        let requestOptions: $request.Options = {
             method: 'GET',
             qs: queryParameters,
             headers: headerParams,
@@ -675,7 +675,7 @@ export class PetApi {
             }
         }
         return new Promise<{ response: http.ClientResponse; body: Array<Pet>;  }>((resolve, reject) => {
-            request(requestOptions, (error, response, body) => {
+            $request(requestOptions, (error, response, body) => {
                 if (error) {
                     reject(error);
                 } else {
@@ -712,7 +712,7 @@ export class PetApi {
 
         let useFormData = false;
 
-        let requestOptions: request.Options = {
+        let requestOptions: $request.Options = {
             method: 'GET',
             qs: queryParameters,
             headers: headerParams,
@@ -733,7 +733,7 @@ export class PetApi {
             }
         }
         return new Promise<{ response: http.ClientResponse; body: Array<Pet>;  }>((resolve, reject) => {
-            request(requestOptions, (error, response, body) => {
+            $request(requestOptions, (error, response, body) => {
                 if (error) {
                     reject(error);
                 } else {
@@ -767,7 +767,7 @@ export class PetApi {
 
         let useFormData = false;
 
-        let requestOptions: request.Options = {
+        let requestOptions: $request.Options = {
             method: 'GET',
             qs: queryParameters,
             headers: headerParams,
@@ -788,7 +788,7 @@ export class PetApi {
             }
         }
         return new Promise<{ response: http.ClientResponse; body: Pet;  }>((resolve, reject) => {
-            request(requestOptions, (error, response, body) => {
+            $request(requestOptions, (error, response, body) => {
                 if (error) {
                     reject(error);
                 } else {
@@ -821,7 +821,7 @@ export class PetApi {
 
         let useFormData = false;
 
-        let requestOptions: request.Options = {
+        let requestOptions: $request.Options = {
             method: 'PUT',
             qs: queryParameters,
             headers: headerParams,
@@ -843,7 +843,7 @@ export class PetApi {
             }
         }
         return new Promise<{ response: http.ClientResponse; body?: any;  }>((resolve, reject) => {
-            request(requestOptions, (error, response, body) => {
+            $request(requestOptions, (error, response, body) => {
                 if (error) {
                     reject(error);
                 } else {
@@ -886,7 +886,7 @@ export class PetApi {
             formParams['status'] = ObjectSerializer.serialize(status, "string");
         }
 
-        let requestOptions: request.Options = {
+        let requestOptions: $request.Options = {
             method: 'POST',
             qs: queryParameters,
             headers: headerParams,
@@ -907,7 +907,7 @@ export class PetApi {
             }
         }
         return new Promise<{ response: http.ClientResponse; body?: any;  }>((resolve, reject) => {
-            request(requestOptions, (error, response, body) => {
+            $request(requestOptions, (error, response, body) => {
                 if (error) {
                     reject(error);
                 } else {
@@ -951,7 +951,7 @@ export class PetApi {
         }
         useFormData = true;
 
-        let requestOptions: request.Options = {
+        let requestOptions: $request.Options = {
             method: 'POST',
             qs: queryParameters,
             headers: headerParams,
@@ -972,7 +972,7 @@ export class PetApi {
             }
         }
         return new Promise<{ response: http.ClientResponse; body: ApiResponse;  }>((resolve, reject) => {
-            request(requestOptions, (error, response, body) => {
+            $request(requestOptions, (error, response, body) => {
                 if (error) {
                     reject(error);
                 } else {
@@ -1058,7 +1058,7 @@ export class StoreApi {
 
         let useFormData = false;
 
-        let requestOptions: request.Options = {
+        let requestOptions: $request.Options = {
             method: 'DELETE',
             qs: queryParameters,
             headers: headerParams,
@@ -1077,7 +1077,7 @@ export class StoreApi {
             }
         }
         return new Promise<{ response: http.ClientResponse; body?: any;  }>((resolve, reject) => {
-            request(requestOptions, (error, response, body) => {
+            $request(requestOptions, (error, response, body) => {
                 if (error) {
                     reject(error);
                 } else {
@@ -1103,7 +1103,7 @@ export class StoreApi {
 
         let useFormData = false;
 
-        let requestOptions: request.Options = {
+        let requestOptions: $request.Options = {
             method: 'GET',
             qs: queryParameters,
             headers: headerParams,
@@ -1124,7 +1124,7 @@ export class StoreApi {
             }
         }
         return new Promise<{ response: http.ClientResponse; body: { [key: string]: number; };  }>((resolve, reject) => {
-            request(requestOptions, (error, response, body) => {
+            $request(requestOptions, (error, response, body) => {
                 if (error) {
                     reject(error);
                 } else {
@@ -1158,7 +1158,7 @@ export class StoreApi {
 
         let useFormData = false;
 
-        let requestOptions: request.Options = {
+        let requestOptions: $request.Options = {
             method: 'GET',
             qs: queryParameters,
             headers: headerParams,
@@ -1177,7 +1177,7 @@ export class StoreApi {
             }
         }
         return new Promise<{ response: http.ClientResponse; body: Order;  }>((resolve, reject) => {
-            request(requestOptions, (error, response, body) => {
+            $request(requestOptions, (error, response, body) => {
                 if (error) {
                     reject(error);
                 } else {
@@ -1210,7 +1210,7 @@ export class StoreApi {
 
         let useFormData = false;
 
-        let requestOptions: request.Options = {
+        let requestOptions: $request.Options = {
             method: 'POST',
             qs: queryParameters,
             headers: headerParams,
@@ -1230,7 +1230,7 @@ export class StoreApi {
             }
         }
         return new Promise<{ response: http.ClientResponse; body: Order;  }>((resolve, reject) => {
-            request(requestOptions, (error, response, body) => {
+            $request(requestOptions, (error, response, body) => {
                 if (error) {
                     reject(error);
                 } else {
@@ -1315,7 +1315,7 @@ export class UserApi {
 
         let useFormData = false;
 
-        let requestOptions: request.Options = {
+        let requestOptions: $request.Options = {
             method: 'POST',
             qs: queryParameters,
             headers: headerParams,
@@ -1335,7 +1335,7 @@ export class UserApi {
             }
         }
         return new Promise<{ response: http.ClientResponse; body?: any;  }>((resolve, reject) => {
-            request(requestOptions, (error, response, body) => {
+            $request(requestOptions, (error, response, body) => {
                 if (error) {
                     reject(error);
                 } else {
@@ -1367,7 +1367,7 @@ export class UserApi {
 
         let useFormData = false;
 
-        let requestOptions: request.Options = {
+        let requestOptions: $request.Options = {
             method: 'POST',
             qs: queryParameters,
             headers: headerParams,
@@ -1387,7 +1387,7 @@ export class UserApi {
             }
         }
         return new Promise<{ response: http.ClientResponse; body?: any;  }>((resolve, reject) => {
-            request(requestOptions, (error, response, body) => {
+            $request(requestOptions, (error, response, body) => {
                 if (error) {
                     reject(error);
                 } else {
@@ -1419,7 +1419,7 @@ export class UserApi {
 
         let useFormData = false;
 
-        let requestOptions: request.Options = {
+        let requestOptions: $request.Options = {
             method: 'POST',
             qs: queryParameters,
             headers: headerParams,
@@ -1439,7 +1439,7 @@ export class UserApi {
             }
         }
         return new Promise<{ response: http.ClientResponse; body?: any;  }>((resolve, reject) => {
-            request(requestOptions, (error, response, body) => {
+            $request(requestOptions, (error, response, body) => {
                 if (error) {
                     reject(error);
                 } else {
@@ -1472,7 +1472,7 @@ export class UserApi {
 
         let useFormData = false;
 
-        let requestOptions: request.Options = {
+        let requestOptions: $request.Options = {
             method: 'DELETE',
             qs: queryParameters,
             headers: headerParams,
@@ -1491,7 +1491,7 @@ export class UserApi {
             }
         }
         return new Promise<{ response: http.ClientResponse; body?: any;  }>((resolve, reject) => {
-            request(requestOptions, (error, response, body) => {
+            $request(requestOptions, (error, response, body) => {
                 if (error) {
                     reject(error);
                 } else {
@@ -1524,7 +1524,7 @@ export class UserApi {
 
         let useFormData = false;
 
-        let requestOptions: request.Options = {
+        let requestOptions: $request.Options = {
             method: 'GET',
             qs: queryParameters,
             headers: headerParams,
@@ -1543,7 +1543,7 @@ export class UserApi {
             }
         }
         return new Promise<{ response: http.ClientResponse; body: User;  }>((resolve, reject) => {
-            request(requestOptions, (error, response, body) => {
+            $request(requestOptions, (error, response, body) => {
                 if (error) {
                     reject(error);
                 } else {
@@ -1590,7 +1590,7 @@ export class UserApi {
 
         let useFormData = false;
 
-        let requestOptions: request.Options = {
+        let requestOptions: $request.Options = {
             method: 'GET',
             qs: queryParameters,
             headers: headerParams,
@@ -1609,7 +1609,7 @@ export class UserApi {
             }
         }
         return new Promise<{ response: http.ClientResponse; body: string;  }>((resolve, reject) => {
-            request(requestOptions, (error, response, body) => {
+            $request(requestOptions, (error, response, body) => {
                 if (error) {
                     reject(error);
                 } else {
@@ -1636,7 +1636,7 @@ export class UserApi {
 
         let useFormData = false;
 
-        let requestOptions: request.Options = {
+        let requestOptions: $request.Options = {
             method: 'GET',
             qs: queryParameters,
             headers: headerParams,
@@ -1655,7 +1655,7 @@ export class UserApi {
             }
         }
         return new Promise<{ response: http.ClientResponse; body?: any;  }>((resolve, reject) => {
-            request(requestOptions, (error, response, body) => {
+            $request(requestOptions, (error, response, body) => {
                 if (error) {
                     reject(error);
                 } else {
@@ -1694,7 +1694,7 @@ export class UserApi {
 
         let useFormData = false;
 
-        let requestOptions: request.Options = {
+        let requestOptions: $request.Options = {
             method: 'PUT',
             qs: queryParameters,
             headers: headerParams,
@@ -1714,7 +1714,7 @@ export class UserApi {
             }
         }
         return new Promise<{ response: http.ClientResponse; body?: any;  }>((resolve, reject) => {
-            request(requestOptions, (error, response, body) => {
+            $request(requestOptions, (error, response, body) => {
                 if (error) {
                     reject(error);
                 } else {

--- a/samples/client/petstore/typescript-node/npm/api.ts
+++ b/samples/client/petstore/typescript-node/npm/api.ts
@@ -528,9 +528,9 @@ export class PetApi {
      */
     public addPet (body: Pet) : Promise<{ response: http.ClientResponse; body?: any;  }> {
         const localVarPath = this.basePath + '/pet';
-        let queryParameters: any = {};
-        let headerParams: any = (<any>Object).assign({}, this.defaultHeaders);
-        let formParams: any = {};
+        let localVarQueryParameters: any = {};
+        let localVarHeaderParams: any = (<any>Object).assign({}, this.defaultHeaders);
+        let localVarFormParams: any = {};
 
         // verify required parameter 'body' is not null or undefined
         if (body === null || body === undefined) {
@@ -538,31 +538,31 @@ export class PetApi {
         }
 
 
-        let useFormData = false;
+        let localVarUseFormData = false;
 
-        let requestOptions: localVarRequest.Options = {
+        let localVarRequestOptions: localVarRequest.Options = {
             method: 'POST',
-            qs: queryParameters,
-            headers: headerParams,
+            qs: localVarQueryParameters,
+            headers: localVarHeaderParams,
             uri: localVarPath,
             useQuerystring: this._useQuerystring,
             json: true,
             body: ObjectSerializer.serialize(body, "Pet")
         };
 
-        this.authentications.petstore_auth.applyToRequest(requestOptions);
+        this.authentications.petstore_auth.applyToRequest(localVarRequestOptions);
 
-        this.authentications.default.applyToRequest(requestOptions);
+        this.authentications.default.applyToRequest(localVarRequestOptions);
 
-        if (Object.keys(formParams).length) {
-            if (useFormData) {
-                (<any>requestOptions).formData = formParams;
+        if (Object.keys(localVarFormParams).length) {
+            if (localVarUseFormData) {
+                (<any>localVarRequestOptions).formData = localVarFormParams;
             } else {
-                requestOptions.form = formParams;
+                localVarRequestOptions.form = localVarFormParams;
             }
         }
         return new Promise<{ response: http.ClientResponse; body?: any;  }>((resolve, reject) => {
-            localVarRequest(requestOptions, (error, response, body) => {
+            localVarRequest(localVarRequestOptions, (error, response, body) => {
                 if (error) {
                     reject(error);
                 } else {
@@ -584,41 +584,41 @@ export class PetApi {
     public deletePet (petId: number, apiKey?: string) : Promise<{ response: http.ClientResponse; body?: any;  }> {
         const localVarPath = this.basePath + '/pet/{petId}'
             .replace('{' + 'petId' + '}', encodeURIComponent(String(petId)));
-        let queryParameters: any = {};
-        let headerParams: any = (<any>Object).assign({}, this.defaultHeaders);
-        let formParams: any = {};
+        let localVarQueryParameters: any = {};
+        let localVarHeaderParams: any = (<any>Object).assign({}, this.defaultHeaders);
+        let localVarFormParams: any = {};
 
         // verify required parameter 'petId' is not null or undefined
         if (petId === null || petId === undefined) {
             throw new Error('Required parameter petId was null or undefined when calling deletePet.');
         }
 
-        headerParams['api_key'] = ObjectSerializer.serialize(apiKey, "string");
+        localVarHeaderParams['api_key'] = ObjectSerializer.serialize(apiKey, "string");
 
-        let useFormData = false;
+        let localVarUseFormData = false;
 
-        let requestOptions: localVarRequest.Options = {
+        let localVarRequestOptions: localVarRequest.Options = {
             method: 'DELETE',
-            qs: queryParameters,
-            headers: headerParams,
+            qs: localVarQueryParameters,
+            headers: localVarHeaderParams,
             uri: localVarPath,
             useQuerystring: this._useQuerystring,
             json: true,
         };
 
-        this.authentications.petstore_auth.applyToRequest(requestOptions);
+        this.authentications.petstore_auth.applyToRequest(localVarRequestOptions);
 
-        this.authentications.default.applyToRequest(requestOptions);
+        this.authentications.default.applyToRequest(localVarRequestOptions);
 
-        if (Object.keys(formParams).length) {
-            if (useFormData) {
-                (<any>requestOptions).formData = formParams;
+        if (Object.keys(localVarFormParams).length) {
+            if (localVarUseFormData) {
+                (<any>localVarRequestOptions).formData = localVarFormParams;
             } else {
-                requestOptions.form = formParams;
+                localVarRequestOptions.form = localVarFormParams;
             }
         }
         return new Promise<{ response: http.ClientResponse; body?: any;  }>((resolve, reject) => {
-            localVarRequest(requestOptions, (error, response, body) => {
+            localVarRequest(localVarRequestOptions, (error, response, body) => {
                 if (error) {
                     reject(error);
                 } else {
@@ -638,9 +638,9 @@ export class PetApi {
      */
     public findPetsByStatus (status: Array<string>) : Promise<{ response: http.ClientResponse; body: Array<Pet>;  }> {
         const localVarPath = this.basePath + '/pet/findByStatus';
-        let queryParameters: any = {};
-        let headerParams: any = (<any>Object).assign({}, this.defaultHeaders);
-        let formParams: any = {};
+        let localVarQueryParameters: any = {};
+        let localVarHeaderParams: any = (<any>Object).assign({}, this.defaultHeaders);
+        let localVarFormParams: any = {};
 
         // verify required parameter 'status' is not null or undefined
         if (status === null || status === undefined) {
@@ -648,34 +648,34 @@ export class PetApi {
         }
 
         if (status !== undefined) {
-            queryParameters['status'] = ObjectSerializer.serialize(status, "Array<string>");
+            localVarQueryParameters['status'] = ObjectSerializer.serialize(status, "Array<string>");
         }
 
 
-        let useFormData = false;
+        let localVarUseFormData = false;
 
-        let requestOptions: localVarRequest.Options = {
+        let localVarRequestOptions: localVarRequest.Options = {
             method: 'GET',
-            qs: queryParameters,
-            headers: headerParams,
+            qs: localVarQueryParameters,
+            headers: localVarHeaderParams,
             uri: localVarPath,
             useQuerystring: this._useQuerystring,
             json: true,
         };
 
-        this.authentications.petstore_auth.applyToRequest(requestOptions);
+        this.authentications.petstore_auth.applyToRequest(localVarRequestOptions);
 
-        this.authentications.default.applyToRequest(requestOptions);
+        this.authentications.default.applyToRequest(localVarRequestOptions);
 
-        if (Object.keys(formParams).length) {
-            if (useFormData) {
-                (<any>requestOptions).formData = formParams;
+        if (Object.keys(localVarFormParams).length) {
+            if (localVarUseFormData) {
+                (<any>localVarRequestOptions).formData = localVarFormParams;
             } else {
-                requestOptions.form = formParams;
+                localVarRequestOptions.form = localVarFormParams;
             }
         }
         return new Promise<{ response: http.ClientResponse; body: Array<Pet>;  }>((resolve, reject) => {
-            localVarRequest(requestOptions, (error, response, body) => {
+            localVarRequest(localVarRequestOptions, (error, response, body) => {
                 if (error) {
                     reject(error);
                 } else {
@@ -696,9 +696,9 @@ export class PetApi {
      */
     public findPetsByTags (tags: Array<string>) : Promise<{ response: http.ClientResponse; body: Array<Pet>;  }> {
         const localVarPath = this.basePath + '/pet/findByTags';
-        let queryParameters: any = {};
-        let headerParams: any = (<any>Object).assign({}, this.defaultHeaders);
-        let formParams: any = {};
+        let localVarQueryParameters: any = {};
+        let localVarHeaderParams: any = (<any>Object).assign({}, this.defaultHeaders);
+        let localVarFormParams: any = {};
 
         // verify required parameter 'tags' is not null or undefined
         if (tags === null || tags === undefined) {
@@ -706,34 +706,34 @@ export class PetApi {
         }
 
         if (tags !== undefined) {
-            queryParameters['tags'] = ObjectSerializer.serialize(tags, "Array<string>");
+            localVarQueryParameters['tags'] = ObjectSerializer.serialize(tags, "Array<string>");
         }
 
 
-        let useFormData = false;
+        let localVarUseFormData = false;
 
-        let requestOptions: localVarRequest.Options = {
+        let localVarRequestOptions: localVarRequest.Options = {
             method: 'GET',
-            qs: queryParameters,
-            headers: headerParams,
+            qs: localVarQueryParameters,
+            headers: localVarHeaderParams,
             uri: localVarPath,
             useQuerystring: this._useQuerystring,
             json: true,
         };
 
-        this.authentications.petstore_auth.applyToRequest(requestOptions);
+        this.authentications.petstore_auth.applyToRequest(localVarRequestOptions);
 
-        this.authentications.default.applyToRequest(requestOptions);
+        this.authentications.default.applyToRequest(localVarRequestOptions);
 
-        if (Object.keys(formParams).length) {
-            if (useFormData) {
-                (<any>requestOptions).formData = formParams;
+        if (Object.keys(localVarFormParams).length) {
+            if (localVarUseFormData) {
+                (<any>localVarRequestOptions).formData = localVarFormParams;
             } else {
-                requestOptions.form = formParams;
+                localVarRequestOptions.form = localVarFormParams;
             }
         }
         return new Promise<{ response: http.ClientResponse; body: Array<Pet>;  }>((resolve, reject) => {
-            localVarRequest(requestOptions, (error, response, body) => {
+            localVarRequest(localVarRequestOptions, (error, response, body) => {
                 if (error) {
                     reject(error);
                 } else {
@@ -755,9 +755,9 @@ export class PetApi {
     public getPetById (petId: number) : Promise<{ response: http.ClientResponse; body: Pet;  }> {
         const localVarPath = this.basePath + '/pet/{petId}'
             .replace('{' + 'petId' + '}', encodeURIComponent(String(petId)));
-        let queryParameters: any = {};
-        let headerParams: any = (<any>Object).assign({}, this.defaultHeaders);
-        let formParams: any = {};
+        let localVarQueryParameters: any = {};
+        let localVarHeaderParams: any = (<any>Object).assign({}, this.defaultHeaders);
+        let localVarFormParams: any = {};
 
         // verify required parameter 'petId' is not null or undefined
         if (petId === null || petId === undefined) {
@@ -765,30 +765,30 @@ export class PetApi {
         }
 
 
-        let useFormData = false;
+        let localVarUseFormData = false;
 
-        let requestOptions: localVarRequest.Options = {
+        let localVarRequestOptions: localVarRequest.Options = {
             method: 'GET',
-            qs: queryParameters,
-            headers: headerParams,
+            qs: localVarQueryParameters,
+            headers: localVarHeaderParams,
             uri: localVarPath,
             useQuerystring: this._useQuerystring,
             json: true,
         };
 
-        this.authentications.api_key.applyToRequest(requestOptions);
+        this.authentications.api_key.applyToRequest(localVarRequestOptions);
 
-        this.authentications.default.applyToRequest(requestOptions);
+        this.authentications.default.applyToRequest(localVarRequestOptions);
 
-        if (Object.keys(formParams).length) {
-            if (useFormData) {
-                (<any>requestOptions).formData = formParams;
+        if (Object.keys(localVarFormParams).length) {
+            if (localVarUseFormData) {
+                (<any>localVarRequestOptions).formData = localVarFormParams;
             } else {
-                requestOptions.form = formParams;
+                localVarRequestOptions.form = localVarFormParams;
             }
         }
         return new Promise<{ response: http.ClientResponse; body: Pet;  }>((resolve, reject) => {
-            localVarRequest(requestOptions, (error, response, body) => {
+            localVarRequest(localVarRequestOptions, (error, response, body) => {
                 if (error) {
                     reject(error);
                 } else {
@@ -809,9 +809,9 @@ export class PetApi {
      */
     public updatePet (body: Pet) : Promise<{ response: http.ClientResponse; body?: any;  }> {
         const localVarPath = this.basePath + '/pet';
-        let queryParameters: any = {};
-        let headerParams: any = (<any>Object).assign({}, this.defaultHeaders);
-        let formParams: any = {};
+        let localVarQueryParameters: any = {};
+        let localVarHeaderParams: any = (<any>Object).assign({}, this.defaultHeaders);
+        let localVarFormParams: any = {};
 
         // verify required parameter 'body' is not null or undefined
         if (body === null || body === undefined) {
@@ -819,31 +819,31 @@ export class PetApi {
         }
 
 
-        let useFormData = false;
+        let localVarUseFormData = false;
 
-        let requestOptions: localVarRequest.Options = {
+        let localVarRequestOptions: localVarRequest.Options = {
             method: 'PUT',
-            qs: queryParameters,
-            headers: headerParams,
+            qs: localVarQueryParameters,
+            headers: localVarHeaderParams,
             uri: localVarPath,
             useQuerystring: this._useQuerystring,
             json: true,
             body: ObjectSerializer.serialize(body, "Pet")
         };
 
-        this.authentications.petstore_auth.applyToRequest(requestOptions);
+        this.authentications.petstore_auth.applyToRequest(localVarRequestOptions);
 
-        this.authentications.default.applyToRequest(requestOptions);
+        this.authentications.default.applyToRequest(localVarRequestOptions);
 
-        if (Object.keys(formParams).length) {
-            if (useFormData) {
-                (<any>requestOptions).formData = formParams;
+        if (Object.keys(localVarFormParams).length) {
+            if (localVarUseFormData) {
+                (<any>localVarRequestOptions).formData = localVarFormParams;
             } else {
-                requestOptions.form = formParams;
+                localVarRequestOptions.form = localVarFormParams;
             }
         }
         return new Promise<{ response: http.ClientResponse; body?: any;  }>((resolve, reject) => {
-            localVarRequest(requestOptions, (error, response, body) => {
+            localVarRequest(localVarRequestOptions, (error, response, body) => {
                 if (error) {
                     reject(error);
                 } else {
@@ -866,9 +866,9 @@ export class PetApi {
     public updatePetWithForm (petId: number, name?: string, status?: string) : Promise<{ response: http.ClientResponse; body?: any;  }> {
         const localVarPath = this.basePath + '/pet/{petId}'
             .replace('{' + 'petId' + '}', encodeURIComponent(String(petId)));
-        let queryParameters: any = {};
-        let headerParams: any = (<any>Object).assign({}, this.defaultHeaders);
-        let formParams: any = {};
+        let localVarQueryParameters: any = {};
+        let localVarHeaderParams: any = (<any>Object).assign({}, this.defaultHeaders);
+        let localVarFormParams: any = {};
 
         // verify required parameter 'petId' is not null or undefined
         if (petId === null || petId === undefined) {
@@ -876,38 +876,38 @@ export class PetApi {
         }
 
 
-        let useFormData = false;
+        let localVarUseFormData = false;
 
         if (name !== undefined) {
-            formParams['name'] = ObjectSerializer.serialize(name, "string");
+            localVarFormParams['name'] = ObjectSerializer.serialize(name, "string");
         }
 
         if (status !== undefined) {
-            formParams['status'] = ObjectSerializer.serialize(status, "string");
+            localVarFormParams['status'] = ObjectSerializer.serialize(status, "string");
         }
 
-        let requestOptions: localVarRequest.Options = {
+        let localVarRequestOptions: localVarRequest.Options = {
             method: 'POST',
-            qs: queryParameters,
-            headers: headerParams,
+            qs: localVarQueryParameters,
+            headers: localVarHeaderParams,
             uri: localVarPath,
             useQuerystring: this._useQuerystring,
             json: true,
         };
 
-        this.authentications.petstore_auth.applyToRequest(requestOptions);
+        this.authentications.petstore_auth.applyToRequest(localVarRequestOptions);
 
-        this.authentications.default.applyToRequest(requestOptions);
+        this.authentications.default.applyToRequest(localVarRequestOptions);
 
-        if (Object.keys(formParams).length) {
-            if (useFormData) {
-                (<any>requestOptions).formData = formParams;
+        if (Object.keys(localVarFormParams).length) {
+            if (localVarUseFormData) {
+                (<any>localVarRequestOptions).formData = localVarFormParams;
             } else {
-                requestOptions.form = formParams;
+                localVarRequestOptions.form = localVarFormParams;
             }
         }
         return new Promise<{ response: http.ClientResponse; body?: any;  }>((resolve, reject) => {
-            localVarRequest(requestOptions, (error, response, body) => {
+            localVarRequest(localVarRequestOptions, (error, response, body) => {
                 if (error) {
                     reject(error);
                 } else {
@@ -930,9 +930,9 @@ export class PetApi {
     public uploadFile (petId: number, additionalMetadata?: string, file?: Buffer) : Promise<{ response: http.ClientResponse; body: ApiResponse;  }> {
         const localVarPath = this.basePath + '/pet/{petId}/uploadImage'
             .replace('{' + 'petId' + '}', encodeURIComponent(String(petId)));
-        let queryParameters: any = {};
-        let headerParams: any = (<any>Object).assign({}, this.defaultHeaders);
-        let formParams: any = {};
+        let localVarQueryParameters: any = {};
+        let localVarHeaderParams: any = (<any>Object).assign({}, this.defaultHeaders);
+        let localVarFormParams: any = {};
 
         // verify required parameter 'petId' is not null or undefined
         if (petId === null || petId === undefined) {
@@ -940,39 +940,39 @@ export class PetApi {
         }
 
 
-        let useFormData = false;
+        let localVarUseFormData = false;
 
         if (additionalMetadata !== undefined) {
-            formParams['additionalMetadata'] = ObjectSerializer.serialize(additionalMetadata, "string");
+            localVarFormParams['additionalMetadata'] = ObjectSerializer.serialize(additionalMetadata, "string");
         }
 
         if (file !== undefined) {
-            formParams['file'] = file;
+            localVarFormParams['file'] = file;
         }
-        useFormData = true;
+        localVarUseFormData = true;
 
-        let requestOptions: localVarRequest.Options = {
+        let localVarRequestOptions: localVarRequest.Options = {
             method: 'POST',
-            qs: queryParameters,
-            headers: headerParams,
+            qs: localVarQueryParameters,
+            headers: localVarHeaderParams,
             uri: localVarPath,
             useQuerystring: this._useQuerystring,
             json: true,
         };
 
-        this.authentications.petstore_auth.applyToRequest(requestOptions);
+        this.authentications.petstore_auth.applyToRequest(localVarRequestOptions);
 
-        this.authentications.default.applyToRequest(requestOptions);
+        this.authentications.default.applyToRequest(localVarRequestOptions);
 
-        if (Object.keys(formParams).length) {
-            if (useFormData) {
-                (<any>requestOptions).formData = formParams;
+        if (Object.keys(localVarFormParams).length) {
+            if (localVarUseFormData) {
+                (<any>localVarRequestOptions).formData = localVarFormParams;
             } else {
-                requestOptions.form = formParams;
+                localVarRequestOptions.form = localVarFormParams;
             }
         }
         return new Promise<{ response: http.ClientResponse; body: ApiResponse;  }>((resolve, reject) => {
-            localVarRequest(requestOptions, (error, response, body) => {
+            localVarRequest(localVarRequestOptions, (error, response, body) => {
                 if (error) {
                     reject(error);
                 } else {
@@ -1046,9 +1046,9 @@ export class StoreApi {
     public deleteOrder (orderId: string) : Promise<{ response: http.ClientResponse; body?: any;  }> {
         const localVarPath = this.basePath + '/store/order/{orderId}'
             .replace('{' + 'orderId' + '}', encodeURIComponent(String(orderId)));
-        let queryParameters: any = {};
-        let headerParams: any = (<any>Object).assign({}, this.defaultHeaders);
-        let formParams: any = {};
+        let localVarQueryParameters: any = {};
+        let localVarHeaderParams: any = (<any>Object).assign({}, this.defaultHeaders);
+        let localVarFormParams: any = {};
 
         // verify required parameter 'orderId' is not null or undefined
         if (orderId === null || orderId === undefined) {
@@ -1056,28 +1056,28 @@ export class StoreApi {
         }
 
 
-        let useFormData = false;
+        let localVarUseFormData = false;
 
-        let requestOptions: localVarRequest.Options = {
+        let localVarRequestOptions: localVarRequest.Options = {
             method: 'DELETE',
-            qs: queryParameters,
-            headers: headerParams,
+            qs: localVarQueryParameters,
+            headers: localVarHeaderParams,
             uri: localVarPath,
             useQuerystring: this._useQuerystring,
             json: true,
         };
 
-        this.authentications.default.applyToRequest(requestOptions);
+        this.authentications.default.applyToRequest(localVarRequestOptions);
 
-        if (Object.keys(formParams).length) {
-            if (useFormData) {
-                (<any>requestOptions).formData = formParams;
+        if (Object.keys(localVarFormParams).length) {
+            if (localVarUseFormData) {
+                (<any>localVarRequestOptions).formData = localVarFormParams;
             } else {
-                requestOptions.form = formParams;
+                localVarRequestOptions.form = localVarFormParams;
             }
         }
         return new Promise<{ response: http.ClientResponse; body?: any;  }>((resolve, reject) => {
-            localVarRequest(requestOptions, (error, response, body) => {
+            localVarRequest(localVarRequestOptions, (error, response, body) => {
                 if (error) {
                     reject(error);
                 } else {
@@ -1096,35 +1096,35 @@ export class StoreApi {
      */
     public getInventory () : Promise<{ response: http.ClientResponse; body: { [key: string]: number; };  }> {
         const localVarPath = this.basePath + '/store/inventory';
-        let queryParameters: any = {};
-        let headerParams: any = (<any>Object).assign({}, this.defaultHeaders);
-        let formParams: any = {};
+        let localVarQueryParameters: any = {};
+        let localVarHeaderParams: any = (<any>Object).assign({}, this.defaultHeaders);
+        let localVarFormParams: any = {};
 
 
-        let useFormData = false;
+        let localVarUseFormData = false;
 
-        let requestOptions: localVarRequest.Options = {
+        let localVarRequestOptions: localVarRequest.Options = {
             method: 'GET',
-            qs: queryParameters,
-            headers: headerParams,
+            qs: localVarQueryParameters,
+            headers: localVarHeaderParams,
             uri: localVarPath,
             useQuerystring: this._useQuerystring,
             json: true,
         };
 
-        this.authentications.api_key.applyToRequest(requestOptions);
+        this.authentications.api_key.applyToRequest(localVarRequestOptions);
 
-        this.authentications.default.applyToRequest(requestOptions);
+        this.authentications.default.applyToRequest(localVarRequestOptions);
 
-        if (Object.keys(formParams).length) {
-            if (useFormData) {
-                (<any>requestOptions).formData = formParams;
+        if (Object.keys(localVarFormParams).length) {
+            if (localVarUseFormData) {
+                (<any>localVarRequestOptions).formData = localVarFormParams;
             } else {
-                requestOptions.form = formParams;
+                localVarRequestOptions.form = localVarFormParams;
             }
         }
         return new Promise<{ response: http.ClientResponse; body: { [key: string]: number; };  }>((resolve, reject) => {
-            localVarRequest(requestOptions, (error, response, body) => {
+            localVarRequest(localVarRequestOptions, (error, response, body) => {
                 if (error) {
                     reject(error);
                 } else {
@@ -1146,9 +1146,9 @@ export class StoreApi {
     public getOrderById (orderId: number) : Promise<{ response: http.ClientResponse; body: Order;  }> {
         const localVarPath = this.basePath + '/store/order/{orderId}'
             .replace('{' + 'orderId' + '}', encodeURIComponent(String(orderId)));
-        let queryParameters: any = {};
-        let headerParams: any = (<any>Object).assign({}, this.defaultHeaders);
-        let formParams: any = {};
+        let localVarQueryParameters: any = {};
+        let localVarHeaderParams: any = (<any>Object).assign({}, this.defaultHeaders);
+        let localVarFormParams: any = {};
 
         // verify required parameter 'orderId' is not null or undefined
         if (orderId === null || orderId === undefined) {
@@ -1156,28 +1156,28 @@ export class StoreApi {
         }
 
 
-        let useFormData = false;
+        let localVarUseFormData = false;
 
-        let requestOptions: localVarRequest.Options = {
+        let localVarRequestOptions: localVarRequest.Options = {
             method: 'GET',
-            qs: queryParameters,
-            headers: headerParams,
+            qs: localVarQueryParameters,
+            headers: localVarHeaderParams,
             uri: localVarPath,
             useQuerystring: this._useQuerystring,
             json: true,
         };
 
-        this.authentications.default.applyToRequest(requestOptions);
+        this.authentications.default.applyToRequest(localVarRequestOptions);
 
-        if (Object.keys(formParams).length) {
-            if (useFormData) {
-                (<any>requestOptions).formData = formParams;
+        if (Object.keys(localVarFormParams).length) {
+            if (localVarUseFormData) {
+                (<any>localVarRequestOptions).formData = localVarFormParams;
             } else {
-                requestOptions.form = formParams;
+                localVarRequestOptions.form = localVarFormParams;
             }
         }
         return new Promise<{ response: http.ClientResponse; body: Order;  }>((resolve, reject) => {
-            localVarRequest(requestOptions, (error, response, body) => {
+            localVarRequest(localVarRequestOptions, (error, response, body) => {
                 if (error) {
                     reject(error);
                 } else {
@@ -1198,9 +1198,9 @@ export class StoreApi {
      */
     public placeOrder (body: Order) : Promise<{ response: http.ClientResponse; body: Order;  }> {
         const localVarPath = this.basePath + '/store/order';
-        let queryParameters: any = {};
-        let headerParams: any = (<any>Object).assign({}, this.defaultHeaders);
-        let formParams: any = {};
+        let localVarQueryParameters: any = {};
+        let localVarHeaderParams: any = (<any>Object).assign({}, this.defaultHeaders);
+        let localVarFormParams: any = {};
 
         // verify required parameter 'body' is not null or undefined
         if (body === null || body === undefined) {
@@ -1208,29 +1208,29 @@ export class StoreApi {
         }
 
 
-        let useFormData = false;
+        let localVarUseFormData = false;
 
-        let requestOptions: localVarRequest.Options = {
+        let localVarRequestOptions: localVarRequest.Options = {
             method: 'POST',
-            qs: queryParameters,
-            headers: headerParams,
+            qs: localVarQueryParameters,
+            headers: localVarHeaderParams,
             uri: localVarPath,
             useQuerystring: this._useQuerystring,
             json: true,
             body: ObjectSerializer.serialize(body, "Order")
         };
 
-        this.authentications.default.applyToRequest(requestOptions);
+        this.authentications.default.applyToRequest(localVarRequestOptions);
 
-        if (Object.keys(formParams).length) {
-            if (useFormData) {
-                (<any>requestOptions).formData = formParams;
+        if (Object.keys(localVarFormParams).length) {
+            if (localVarUseFormData) {
+                (<any>localVarRequestOptions).formData = localVarFormParams;
             } else {
-                requestOptions.form = formParams;
+                localVarRequestOptions.form = localVarFormParams;
             }
         }
         return new Promise<{ response: http.ClientResponse; body: Order;  }>((resolve, reject) => {
-            localVarRequest(requestOptions, (error, response, body) => {
+            localVarRequest(localVarRequestOptions, (error, response, body) => {
                 if (error) {
                     reject(error);
                 } else {
@@ -1303,9 +1303,9 @@ export class UserApi {
      */
     public createUser (body: User) : Promise<{ response: http.ClientResponse; body?: any;  }> {
         const localVarPath = this.basePath + '/user';
-        let queryParameters: any = {};
-        let headerParams: any = (<any>Object).assign({}, this.defaultHeaders);
-        let formParams: any = {};
+        let localVarQueryParameters: any = {};
+        let localVarHeaderParams: any = (<any>Object).assign({}, this.defaultHeaders);
+        let localVarFormParams: any = {};
 
         // verify required parameter 'body' is not null or undefined
         if (body === null || body === undefined) {
@@ -1313,29 +1313,29 @@ export class UserApi {
         }
 
 
-        let useFormData = false;
+        let localVarUseFormData = false;
 
-        let requestOptions: localVarRequest.Options = {
+        let localVarRequestOptions: localVarRequest.Options = {
             method: 'POST',
-            qs: queryParameters,
-            headers: headerParams,
+            qs: localVarQueryParameters,
+            headers: localVarHeaderParams,
             uri: localVarPath,
             useQuerystring: this._useQuerystring,
             json: true,
             body: ObjectSerializer.serialize(body, "User")
         };
 
-        this.authentications.default.applyToRequest(requestOptions);
+        this.authentications.default.applyToRequest(localVarRequestOptions);
 
-        if (Object.keys(formParams).length) {
-            if (useFormData) {
-                (<any>requestOptions).formData = formParams;
+        if (Object.keys(localVarFormParams).length) {
+            if (localVarUseFormData) {
+                (<any>localVarRequestOptions).formData = localVarFormParams;
             } else {
-                requestOptions.form = formParams;
+                localVarRequestOptions.form = localVarFormParams;
             }
         }
         return new Promise<{ response: http.ClientResponse; body?: any;  }>((resolve, reject) => {
-            localVarRequest(requestOptions, (error, response, body) => {
+            localVarRequest(localVarRequestOptions, (error, response, body) => {
                 if (error) {
                     reject(error);
                 } else {
@@ -1355,9 +1355,9 @@ export class UserApi {
      */
     public createUsersWithArrayInput (body: Array<User>) : Promise<{ response: http.ClientResponse; body?: any;  }> {
         const localVarPath = this.basePath + '/user/createWithArray';
-        let queryParameters: any = {};
-        let headerParams: any = (<any>Object).assign({}, this.defaultHeaders);
-        let formParams: any = {};
+        let localVarQueryParameters: any = {};
+        let localVarHeaderParams: any = (<any>Object).assign({}, this.defaultHeaders);
+        let localVarFormParams: any = {};
 
         // verify required parameter 'body' is not null or undefined
         if (body === null || body === undefined) {
@@ -1365,29 +1365,29 @@ export class UserApi {
         }
 
 
-        let useFormData = false;
+        let localVarUseFormData = false;
 
-        let requestOptions: localVarRequest.Options = {
+        let localVarRequestOptions: localVarRequest.Options = {
             method: 'POST',
-            qs: queryParameters,
-            headers: headerParams,
+            qs: localVarQueryParameters,
+            headers: localVarHeaderParams,
             uri: localVarPath,
             useQuerystring: this._useQuerystring,
             json: true,
             body: ObjectSerializer.serialize(body, "Array<User>")
         };
 
-        this.authentications.default.applyToRequest(requestOptions);
+        this.authentications.default.applyToRequest(localVarRequestOptions);
 
-        if (Object.keys(formParams).length) {
-            if (useFormData) {
-                (<any>requestOptions).formData = formParams;
+        if (Object.keys(localVarFormParams).length) {
+            if (localVarUseFormData) {
+                (<any>localVarRequestOptions).formData = localVarFormParams;
             } else {
-                requestOptions.form = formParams;
+                localVarRequestOptions.form = localVarFormParams;
             }
         }
         return new Promise<{ response: http.ClientResponse; body?: any;  }>((resolve, reject) => {
-            localVarRequest(requestOptions, (error, response, body) => {
+            localVarRequest(localVarRequestOptions, (error, response, body) => {
                 if (error) {
                     reject(error);
                 } else {
@@ -1407,9 +1407,9 @@ export class UserApi {
      */
     public createUsersWithListInput (body: Array<User>) : Promise<{ response: http.ClientResponse; body?: any;  }> {
         const localVarPath = this.basePath + '/user/createWithList';
-        let queryParameters: any = {};
-        let headerParams: any = (<any>Object).assign({}, this.defaultHeaders);
-        let formParams: any = {};
+        let localVarQueryParameters: any = {};
+        let localVarHeaderParams: any = (<any>Object).assign({}, this.defaultHeaders);
+        let localVarFormParams: any = {};
 
         // verify required parameter 'body' is not null or undefined
         if (body === null || body === undefined) {
@@ -1417,29 +1417,29 @@ export class UserApi {
         }
 
 
-        let useFormData = false;
+        let localVarUseFormData = false;
 
-        let requestOptions: localVarRequest.Options = {
+        let localVarRequestOptions: localVarRequest.Options = {
             method: 'POST',
-            qs: queryParameters,
-            headers: headerParams,
+            qs: localVarQueryParameters,
+            headers: localVarHeaderParams,
             uri: localVarPath,
             useQuerystring: this._useQuerystring,
             json: true,
             body: ObjectSerializer.serialize(body, "Array<User>")
         };
 
-        this.authentications.default.applyToRequest(requestOptions);
+        this.authentications.default.applyToRequest(localVarRequestOptions);
 
-        if (Object.keys(formParams).length) {
-            if (useFormData) {
-                (<any>requestOptions).formData = formParams;
+        if (Object.keys(localVarFormParams).length) {
+            if (localVarUseFormData) {
+                (<any>localVarRequestOptions).formData = localVarFormParams;
             } else {
-                requestOptions.form = formParams;
+                localVarRequestOptions.form = localVarFormParams;
             }
         }
         return new Promise<{ response: http.ClientResponse; body?: any;  }>((resolve, reject) => {
-            localVarRequest(requestOptions, (error, response, body) => {
+            localVarRequest(localVarRequestOptions, (error, response, body) => {
                 if (error) {
                     reject(error);
                 } else {
@@ -1460,9 +1460,9 @@ export class UserApi {
     public deleteUser (username: string) : Promise<{ response: http.ClientResponse; body?: any;  }> {
         const localVarPath = this.basePath + '/user/{username}'
             .replace('{' + 'username' + '}', encodeURIComponent(String(username)));
-        let queryParameters: any = {};
-        let headerParams: any = (<any>Object).assign({}, this.defaultHeaders);
-        let formParams: any = {};
+        let localVarQueryParameters: any = {};
+        let localVarHeaderParams: any = (<any>Object).assign({}, this.defaultHeaders);
+        let localVarFormParams: any = {};
 
         // verify required parameter 'username' is not null or undefined
         if (username === null || username === undefined) {
@@ -1470,28 +1470,28 @@ export class UserApi {
         }
 
 
-        let useFormData = false;
+        let localVarUseFormData = false;
 
-        let requestOptions: localVarRequest.Options = {
+        let localVarRequestOptions: localVarRequest.Options = {
             method: 'DELETE',
-            qs: queryParameters,
-            headers: headerParams,
+            qs: localVarQueryParameters,
+            headers: localVarHeaderParams,
             uri: localVarPath,
             useQuerystring: this._useQuerystring,
             json: true,
         };
 
-        this.authentications.default.applyToRequest(requestOptions);
+        this.authentications.default.applyToRequest(localVarRequestOptions);
 
-        if (Object.keys(formParams).length) {
-            if (useFormData) {
-                (<any>requestOptions).formData = formParams;
+        if (Object.keys(localVarFormParams).length) {
+            if (localVarUseFormData) {
+                (<any>localVarRequestOptions).formData = localVarFormParams;
             } else {
-                requestOptions.form = formParams;
+                localVarRequestOptions.form = localVarFormParams;
             }
         }
         return new Promise<{ response: http.ClientResponse; body?: any;  }>((resolve, reject) => {
-            localVarRequest(requestOptions, (error, response, body) => {
+            localVarRequest(localVarRequestOptions, (error, response, body) => {
                 if (error) {
                     reject(error);
                 } else {
@@ -1512,9 +1512,9 @@ export class UserApi {
     public getUserByName (username: string) : Promise<{ response: http.ClientResponse; body: User;  }> {
         const localVarPath = this.basePath + '/user/{username}'
             .replace('{' + 'username' + '}', encodeURIComponent(String(username)));
-        let queryParameters: any = {};
-        let headerParams: any = (<any>Object).assign({}, this.defaultHeaders);
-        let formParams: any = {};
+        let localVarQueryParameters: any = {};
+        let localVarHeaderParams: any = (<any>Object).assign({}, this.defaultHeaders);
+        let localVarFormParams: any = {};
 
         // verify required parameter 'username' is not null or undefined
         if (username === null || username === undefined) {
@@ -1522,28 +1522,28 @@ export class UserApi {
         }
 
 
-        let useFormData = false;
+        let localVarUseFormData = false;
 
-        let requestOptions: localVarRequest.Options = {
+        let localVarRequestOptions: localVarRequest.Options = {
             method: 'GET',
-            qs: queryParameters,
-            headers: headerParams,
+            qs: localVarQueryParameters,
+            headers: localVarHeaderParams,
             uri: localVarPath,
             useQuerystring: this._useQuerystring,
             json: true,
         };
 
-        this.authentications.default.applyToRequest(requestOptions);
+        this.authentications.default.applyToRequest(localVarRequestOptions);
 
-        if (Object.keys(formParams).length) {
-            if (useFormData) {
-                (<any>requestOptions).formData = formParams;
+        if (Object.keys(localVarFormParams).length) {
+            if (localVarUseFormData) {
+                (<any>localVarRequestOptions).formData = localVarFormParams;
             } else {
-                requestOptions.form = formParams;
+                localVarRequestOptions.form = localVarFormParams;
             }
         }
         return new Promise<{ response: http.ClientResponse; body: User;  }>((resolve, reject) => {
-            localVarRequest(requestOptions, (error, response, body) => {
+            localVarRequest(localVarRequestOptions, (error, response, body) => {
                 if (error) {
                     reject(error);
                 } else {
@@ -1565,9 +1565,9 @@ export class UserApi {
      */
     public loginUser (username: string, password: string) : Promise<{ response: http.ClientResponse; body: string;  }> {
         const localVarPath = this.basePath + '/user/login';
-        let queryParameters: any = {};
-        let headerParams: any = (<any>Object).assign({}, this.defaultHeaders);
-        let formParams: any = {};
+        let localVarQueryParameters: any = {};
+        let localVarHeaderParams: any = (<any>Object).assign({}, this.defaultHeaders);
+        let localVarFormParams: any = {};
 
         // verify required parameter 'username' is not null or undefined
         if (username === null || username === undefined) {
@@ -1580,36 +1580,36 @@ export class UserApi {
         }
 
         if (username !== undefined) {
-            queryParameters['username'] = ObjectSerializer.serialize(username, "string");
+            localVarQueryParameters['username'] = ObjectSerializer.serialize(username, "string");
         }
 
         if (password !== undefined) {
-            queryParameters['password'] = ObjectSerializer.serialize(password, "string");
+            localVarQueryParameters['password'] = ObjectSerializer.serialize(password, "string");
         }
 
 
-        let useFormData = false;
+        let localVarUseFormData = false;
 
-        let requestOptions: localVarRequest.Options = {
+        let localVarRequestOptions: localVarRequest.Options = {
             method: 'GET',
-            qs: queryParameters,
-            headers: headerParams,
+            qs: localVarQueryParameters,
+            headers: localVarHeaderParams,
             uri: localVarPath,
             useQuerystring: this._useQuerystring,
             json: true,
         };
 
-        this.authentications.default.applyToRequest(requestOptions);
+        this.authentications.default.applyToRequest(localVarRequestOptions);
 
-        if (Object.keys(formParams).length) {
-            if (useFormData) {
-                (<any>requestOptions).formData = formParams;
+        if (Object.keys(localVarFormParams).length) {
+            if (localVarUseFormData) {
+                (<any>localVarRequestOptions).formData = localVarFormParams;
             } else {
-                requestOptions.form = formParams;
+                localVarRequestOptions.form = localVarFormParams;
             }
         }
         return new Promise<{ response: http.ClientResponse; body: string;  }>((resolve, reject) => {
-            localVarRequest(requestOptions, (error, response, body) => {
+            localVarRequest(localVarRequestOptions, (error, response, body) => {
                 if (error) {
                     reject(error);
                 } else {
@@ -1629,33 +1629,33 @@ export class UserApi {
      */
     public logoutUser () : Promise<{ response: http.ClientResponse; body?: any;  }> {
         const localVarPath = this.basePath + '/user/logout';
-        let queryParameters: any = {};
-        let headerParams: any = (<any>Object).assign({}, this.defaultHeaders);
-        let formParams: any = {};
+        let localVarQueryParameters: any = {};
+        let localVarHeaderParams: any = (<any>Object).assign({}, this.defaultHeaders);
+        let localVarFormParams: any = {};
 
 
-        let useFormData = false;
+        let localVarUseFormData = false;
 
-        let requestOptions: localVarRequest.Options = {
+        let localVarRequestOptions: localVarRequest.Options = {
             method: 'GET',
-            qs: queryParameters,
-            headers: headerParams,
+            qs: localVarQueryParameters,
+            headers: localVarHeaderParams,
             uri: localVarPath,
             useQuerystring: this._useQuerystring,
             json: true,
         };
 
-        this.authentications.default.applyToRequest(requestOptions);
+        this.authentications.default.applyToRequest(localVarRequestOptions);
 
-        if (Object.keys(formParams).length) {
-            if (useFormData) {
-                (<any>requestOptions).formData = formParams;
+        if (Object.keys(localVarFormParams).length) {
+            if (localVarUseFormData) {
+                (<any>localVarRequestOptions).formData = localVarFormParams;
             } else {
-                requestOptions.form = formParams;
+                localVarRequestOptions.form = localVarFormParams;
             }
         }
         return new Promise<{ response: http.ClientResponse; body?: any;  }>((resolve, reject) => {
-            localVarRequest(requestOptions, (error, response, body) => {
+            localVarRequest(localVarRequestOptions, (error, response, body) => {
                 if (error) {
                     reject(error);
                 } else {
@@ -1677,9 +1677,9 @@ export class UserApi {
     public updateUser (username: string, body: User) : Promise<{ response: http.ClientResponse; body?: any;  }> {
         const localVarPath = this.basePath + '/user/{username}'
             .replace('{' + 'username' + '}', encodeURIComponent(String(username)));
-        let queryParameters: any = {};
-        let headerParams: any = (<any>Object).assign({}, this.defaultHeaders);
-        let formParams: any = {};
+        let localVarQueryParameters: any = {};
+        let localVarHeaderParams: any = (<any>Object).assign({}, this.defaultHeaders);
+        let localVarFormParams: any = {};
 
         // verify required parameter 'username' is not null or undefined
         if (username === null || username === undefined) {
@@ -1692,29 +1692,29 @@ export class UserApi {
         }
 
 
-        let useFormData = false;
+        let localVarUseFormData = false;
 
-        let requestOptions: localVarRequest.Options = {
+        let localVarRequestOptions: localVarRequest.Options = {
             method: 'PUT',
-            qs: queryParameters,
-            headers: headerParams,
+            qs: localVarQueryParameters,
+            headers: localVarHeaderParams,
             uri: localVarPath,
             useQuerystring: this._useQuerystring,
             json: true,
             body: ObjectSerializer.serialize(body, "User")
         };
 
-        this.authentications.default.applyToRequest(requestOptions);
+        this.authentications.default.applyToRequest(localVarRequestOptions);
 
-        if (Object.keys(formParams).length) {
-            if (useFormData) {
-                (<any>requestOptions).formData = formParams;
+        if (Object.keys(localVarFormParams).length) {
+            if (localVarUseFormData) {
+                (<any>localVarRequestOptions).formData = localVarFormParams;
             } else {
-                requestOptions.form = formParams;
+                localVarRequestOptions.form = localVarFormParams;
             }
         }
         return new Promise<{ response: http.ClientResponse; body?: any;  }>((resolve, reject) => {
-            localVarRequest(requestOptions, (error, response, body) => {
+            localVarRequest(localVarRequestOptions, (error, response, body) => {
                 if (error) {
                     reject(error);
                 } else {

--- a/samples/client/petstore/typescript-node/npm/api.ts
+++ b/samples/client/petstore/typescript-node/npm/api.ts
@@ -10,7 +10,7 @@
  * Do not edit the class manually.
  */
 
-import $request = require('request');
+import localVarRequest = require('request');
 import http = require('http');
 import Promise = require('bluebird');
 
@@ -424,13 +424,13 @@ export interface Authentication {
     /**
     * Apply authentication settings to header and query params.
     */
-    applyToRequest(requestOptions: $request.Options): void;
+    applyToRequest(requestOptions: localVarRequest.Options): void;
 }
 
 export class HttpBasicAuth implements Authentication {
     public username: string;
     public password: string;
-    applyToRequest(requestOptions: $request.Options): void {
+    applyToRequest(requestOptions: localVarRequest.Options): void {
         requestOptions.auth = {
             username: this.username, password: this.password
         }
@@ -443,7 +443,7 @@ export class ApiKeyAuth implements Authentication {
     constructor(private location: string, private paramName: string) {
     }
 
-    applyToRequest(requestOptions: $request.Options): void {
+    applyToRequest(requestOptions: localVarRequest.Options): void {
         if (this.location == "query") {
             (<any>requestOptions.qs)[this.paramName] = this.apiKey;
         } else if (this.location == "header" && requestOptions && requestOptions.headers) {
@@ -455,7 +455,7 @@ export class ApiKeyAuth implements Authentication {
 export class OAuth implements Authentication {
     public accessToken: string;
 
-    applyToRequest(requestOptions: $request.Options): void {
+    applyToRequest(requestOptions: localVarRequest.Options): void {
         if (requestOptions && requestOptions.headers) {
             requestOptions.headers["Authorization"] = "Bearer " + this.accessToken;
         }
@@ -465,7 +465,7 @@ export class OAuth implements Authentication {
 export class VoidAuth implements Authentication {
     public username: string;
     public password: string;
-    applyToRequest(_: $request.Options): void {
+    applyToRequest(_: localVarRequest.Options): void {
         // Do nothing
     }
 }
@@ -540,7 +540,7 @@ export class PetApi {
 
         let useFormData = false;
 
-        let requestOptions: $request.Options = {
+        let requestOptions: localVarRequest.Options = {
             method: 'POST',
             qs: queryParameters,
             headers: headerParams,
@@ -562,7 +562,7 @@ export class PetApi {
             }
         }
         return new Promise<{ response: http.ClientResponse; body?: any;  }>((resolve, reject) => {
-            $request(requestOptions, (error, response, body) => {
+            localVarRequest(requestOptions, (error, response, body) => {
                 if (error) {
                     reject(error);
                 } else {
@@ -597,7 +597,7 @@ export class PetApi {
 
         let useFormData = false;
 
-        let requestOptions: $request.Options = {
+        let requestOptions: localVarRequest.Options = {
             method: 'DELETE',
             qs: queryParameters,
             headers: headerParams,
@@ -618,7 +618,7 @@ export class PetApi {
             }
         }
         return new Promise<{ response: http.ClientResponse; body?: any;  }>((resolve, reject) => {
-            $request(requestOptions, (error, response, body) => {
+            localVarRequest(requestOptions, (error, response, body) => {
                 if (error) {
                     reject(error);
                 } else {
@@ -654,7 +654,7 @@ export class PetApi {
 
         let useFormData = false;
 
-        let requestOptions: $request.Options = {
+        let requestOptions: localVarRequest.Options = {
             method: 'GET',
             qs: queryParameters,
             headers: headerParams,
@@ -675,7 +675,7 @@ export class PetApi {
             }
         }
         return new Promise<{ response: http.ClientResponse; body: Array<Pet>;  }>((resolve, reject) => {
-            $request(requestOptions, (error, response, body) => {
+            localVarRequest(requestOptions, (error, response, body) => {
                 if (error) {
                     reject(error);
                 } else {
@@ -712,7 +712,7 @@ export class PetApi {
 
         let useFormData = false;
 
-        let requestOptions: $request.Options = {
+        let requestOptions: localVarRequest.Options = {
             method: 'GET',
             qs: queryParameters,
             headers: headerParams,
@@ -733,7 +733,7 @@ export class PetApi {
             }
         }
         return new Promise<{ response: http.ClientResponse; body: Array<Pet>;  }>((resolve, reject) => {
-            $request(requestOptions, (error, response, body) => {
+            localVarRequest(requestOptions, (error, response, body) => {
                 if (error) {
                     reject(error);
                 } else {
@@ -767,7 +767,7 @@ export class PetApi {
 
         let useFormData = false;
 
-        let requestOptions: $request.Options = {
+        let requestOptions: localVarRequest.Options = {
             method: 'GET',
             qs: queryParameters,
             headers: headerParams,
@@ -788,7 +788,7 @@ export class PetApi {
             }
         }
         return new Promise<{ response: http.ClientResponse; body: Pet;  }>((resolve, reject) => {
-            $request(requestOptions, (error, response, body) => {
+            localVarRequest(requestOptions, (error, response, body) => {
                 if (error) {
                     reject(error);
                 } else {
@@ -821,7 +821,7 @@ export class PetApi {
 
         let useFormData = false;
 
-        let requestOptions: $request.Options = {
+        let requestOptions: localVarRequest.Options = {
             method: 'PUT',
             qs: queryParameters,
             headers: headerParams,
@@ -843,7 +843,7 @@ export class PetApi {
             }
         }
         return new Promise<{ response: http.ClientResponse; body?: any;  }>((resolve, reject) => {
-            $request(requestOptions, (error, response, body) => {
+            localVarRequest(requestOptions, (error, response, body) => {
                 if (error) {
                     reject(error);
                 } else {
@@ -886,7 +886,7 @@ export class PetApi {
             formParams['status'] = ObjectSerializer.serialize(status, "string");
         }
 
-        let requestOptions: $request.Options = {
+        let requestOptions: localVarRequest.Options = {
             method: 'POST',
             qs: queryParameters,
             headers: headerParams,
@@ -907,7 +907,7 @@ export class PetApi {
             }
         }
         return new Promise<{ response: http.ClientResponse; body?: any;  }>((resolve, reject) => {
-            $request(requestOptions, (error, response, body) => {
+            localVarRequest(requestOptions, (error, response, body) => {
                 if (error) {
                     reject(error);
                 } else {
@@ -951,7 +951,7 @@ export class PetApi {
         }
         useFormData = true;
 
-        let requestOptions: $request.Options = {
+        let requestOptions: localVarRequest.Options = {
             method: 'POST',
             qs: queryParameters,
             headers: headerParams,
@@ -972,7 +972,7 @@ export class PetApi {
             }
         }
         return new Promise<{ response: http.ClientResponse; body: ApiResponse;  }>((resolve, reject) => {
-            $request(requestOptions, (error, response, body) => {
+            localVarRequest(requestOptions, (error, response, body) => {
                 if (error) {
                     reject(error);
                 } else {
@@ -1058,7 +1058,7 @@ export class StoreApi {
 
         let useFormData = false;
 
-        let requestOptions: $request.Options = {
+        let requestOptions: localVarRequest.Options = {
             method: 'DELETE',
             qs: queryParameters,
             headers: headerParams,
@@ -1077,7 +1077,7 @@ export class StoreApi {
             }
         }
         return new Promise<{ response: http.ClientResponse; body?: any;  }>((resolve, reject) => {
-            $request(requestOptions, (error, response, body) => {
+            localVarRequest(requestOptions, (error, response, body) => {
                 if (error) {
                     reject(error);
                 } else {
@@ -1103,7 +1103,7 @@ export class StoreApi {
 
         let useFormData = false;
 
-        let requestOptions: $request.Options = {
+        let requestOptions: localVarRequest.Options = {
             method: 'GET',
             qs: queryParameters,
             headers: headerParams,
@@ -1124,7 +1124,7 @@ export class StoreApi {
             }
         }
         return new Promise<{ response: http.ClientResponse; body: { [key: string]: number; };  }>((resolve, reject) => {
-            $request(requestOptions, (error, response, body) => {
+            localVarRequest(requestOptions, (error, response, body) => {
                 if (error) {
                     reject(error);
                 } else {
@@ -1158,7 +1158,7 @@ export class StoreApi {
 
         let useFormData = false;
 
-        let requestOptions: $request.Options = {
+        let requestOptions: localVarRequest.Options = {
             method: 'GET',
             qs: queryParameters,
             headers: headerParams,
@@ -1177,7 +1177,7 @@ export class StoreApi {
             }
         }
         return new Promise<{ response: http.ClientResponse; body: Order;  }>((resolve, reject) => {
-            $request(requestOptions, (error, response, body) => {
+            localVarRequest(requestOptions, (error, response, body) => {
                 if (error) {
                     reject(error);
                 } else {
@@ -1210,7 +1210,7 @@ export class StoreApi {
 
         let useFormData = false;
 
-        let requestOptions: $request.Options = {
+        let requestOptions: localVarRequest.Options = {
             method: 'POST',
             qs: queryParameters,
             headers: headerParams,
@@ -1230,7 +1230,7 @@ export class StoreApi {
             }
         }
         return new Promise<{ response: http.ClientResponse; body: Order;  }>((resolve, reject) => {
-            $request(requestOptions, (error, response, body) => {
+            localVarRequest(requestOptions, (error, response, body) => {
                 if (error) {
                     reject(error);
                 } else {
@@ -1315,7 +1315,7 @@ export class UserApi {
 
         let useFormData = false;
 
-        let requestOptions: $request.Options = {
+        let requestOptions: localVarRequest.Options = {
             method: 'POST',
             qs: queryParameters,
             headers: headerParams,
@@ -1335,7 +1335,7 @@ export class UserApi {
             }
         }
         return new Promise<{ response: http.ClientResponse; body?: any;  }>((resolve, reject) => {
-            $request(requestOptions, (error, response, body) => {
+            localVarRequest(requestOptions, (error, response, body) => {
                 if (error) {
                     reject(error);
                 } else {
@@ -1367,7 +1367,7 @@ export class UserApi {
 
         let useFormData = false;
 
-        let requestOptions: $request.Options = {
+        let requestOptions: localVarRequest.Options = {
             method: 'POST',
             qs: queryParameters,
             headers: headerParams,
@@ -1387,7 +1387,7 @@ export class UserApi {
             }
         }
         return new Promise<{ response: http.ClientResponse; body?: any;  }>((resolve, reject) => {
-            $request(requestOptions, (error, response, body) => {
+            localVarRequest(requestOptions, (error, response, body) => {
                 if (error) {
                     reject(error);
                 } else {
@@ -1419,7 +1419,7 @@ export class UserApi {
 
         let useFormData = false;
 
-        let requestOptions: $request.Options = {
+        let requestOptions: localVarRequest.Options = {
             method: 'POST',
             qs: queryParameters,
             headers: headerParams,
@@ -1439,7 +1439,7 @@ export class UserApi {
             }
         }
         return new Promise<{ response: http.ClientResponse; body?: any;  }>((resolve, reject) => {
-            $request(requestOptions, (error, response, body) => {
+            localVarRequest(requestOptions, (error, response, body) => {
                 if (error) {
                     reject(error);
                 } else {
@@ -1472,7 +1472,7 @@ export class UserApi {
 
         let useFormData = false;
 
-        let requestOptions: $request.Options = {
+        let requestOptions: localVarRequest.Options = {
             method: 'DELETE',
             qs: queryParameters,
             headers: headerParams,
@@ -1491,7 +1491,7 @@ export class UserApi {
             }
         }
         return new Promise<{ response: http.ClientResponse; body?: any;  }>((resolve, reject) => {
-            $request(requestOptions, (error, response, body) => {
+            localVarRequest(requestOptions, (error, response, body) => {
                 if (error) {
                     reject(error);
                 } else {
@@ -1524,7 +1524,7 @@ export class UserApi {
 
         let useFormData = false;
 
-        let requestOptions: $request.Options = {
+        let requestOptions: localVarRequest.Options = {
             method: 'GET',
             qs: queryParameters,
             headers: headerParams,
@@ -1543,7 +1543,7 @@ export class UserApi {
             }
         }
         return new Promise<{ response: http.ClientResponse; body: User;  }>((resolve, reject) => {
-            $request(requestOptions, (error, response, body) => {
+            localVarRequest(requestOptions, (error, response, body) => {
                 if (error) {
                     reject(error);
                 } else {
@@ -1590,7 +1590,7 @@ export class UserApi {
 
         let useFormData = false;
 
-        let requestOptions: $request.Options = {
+        let requestOptions: localVarRequest.Options = {
             method: 'GET',
             qs: queryParameters,
             headers: headerParams,
@@ -1609,7 +1609,7 @@ export class UserApi {
             }
         }
         return new Promise<{ response: http.ClientResponse; body: string;  }>((resolve, reject) => {
-            $request(requestOptions, (error, response, body) => {
+            localVarRequest(requestOptions, (error, response, body) => {
                 if (error) {
                     reject(error);
                 } else {
@@ -1636,7 +1636,7 @@ export class UserApi {
 
         let useFormData = false;
 
-        let requestOptions: $request.Options = {
+        let requestOptions: localVarRequest.Options = {
             method: 'GET',
             qs: queryParameters,
             headers: headerParams,
@@ -1655,7 +1655,7 @@ export class UserApi {
             }
         }
         return new Promise<{ response: http.ClientResponse; body?: any;  }>((resolve, reject) => {
-            $request(requestOptions, (error, response, body) => {
+            localVarRequest(requestOptions, (error, response, body) => {
                 if (error) {
                     reject(error);
                 } else {
@@ -1694,7 +1694,7 @@ export class UserApi {
 
         let useFormData = false;
 
-        let requestOptions: $request.Options = {
+        let requestOptions: localVarRequest.Options = {
             method: 'PUT',
             qs: queryParameters,
             headers: headerParams,
@@ -1714,7 +1714,7 @@ export class UserApi {
             }
         }
         return new Promise<{ response: http.ClientResponse; body?: any;  }>((resolve, reject) => {
-            $request(requestOptions, (error, response, body) => {
+            localVarRequest(requestOptions, (error, response, body) => {
                 if (error) {
                     reject(error);
                 } else {


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [x] Filed the PR against the correct branch: `3.0.0` branch for changes related to OpenAPI spec 3.0. Default: `master`.
- [x] Copied the [technical committee](https://github.com/swagger-api/swagger-codegen/#swagger-codegen-technical-committee) to review the pull request if your PR is targeting a particular programming langauge.

### Description of the PR

fixes https://github.com/swagger-api/swagger-codegen/issues/6750

rename `import request = require('request');` to `import $request = require('request');` to fix the clash described in #6750

Could someone of you please have a look @TiFu @taxpon @sebastianhaas @kenisteward @Vrolijkx