### PR TITLE
revert changes to fakes yaml

### DIFF
--- a/README.md
+++ b/README.md
@@ -970,6 +970,7 @@ Here is a list of template creators:
    * Groovy: @victorgit
    * Go: @wing328
    * Go (rewritten in 2.3.0): @antihax
+   * Haskell (http-client): @jonschoning
    * Java (Feign): @davidkiss
    * Java (Retrofit): @0legg
    * Java (Retrofit2): @emilianobonassi

--- a/modules/swagger-codegen/src/test/resources/2_0/petstore-with-fake-endpoints-models-for-testing.yaml
+++ b/modules/swagger-codegen/src/test/resources/2_0/petstore-with-fake-endpoints-models-for-testing.yaml
@@ -898,35 +898,6 @@ paths:
       responses:
         '200':
           description: successful operation
-  /fake/xmlFeatures:
-    get:
-      summary: Get some XML
-      operationId: getXmlFeatures
-      produces:
-        - application/xml
-      consumes:
-        - application/xml
-      responses:
-        200:
-          description: Success
-          schema:
-            $ref: '#/definitions/xmlObject'
-    post:
-      parameters:
-        - name: xmlObject
-          in: body
-          required: true
-          schema:
-            $ref: '#/definitions/xmlObject'
-      summary: Post some xml
-      operationId: postXmlFeatures
-      produces:
-        - application/xml
-      consumes:
-        - application/xml
-      responses:
-        200:
-          description: Success
   /fake/inline-additionalProperties:
     post:
       tags:
@@ -971,7 +942,6 @@ paths:
           description: successful operation
           schema:
             $ref: '#/definitions/Client'
-
 securityDefinitions:
   petstore_auth:
     type: oauth2
@@ -987,7 +957,7 @@ securityDefinitions:
   api_key_query:
     type: apiKey
     name: api_key_query
-    in: query
+    in: query 
   http_basic_test:
     type: basic
 definitions:
@@ -1010,7 +980,7 @@ definitions:
         type: string
         description: Order Status
         enum:
-          - placedtest
+          - placed
           - approved
           - delivered
       complete:


### PR DESCRIPTION
* the yaml currently includes invalid definitions that do not exist: `#/definitions/xmlObject`. 
introduced in 1d89ab6e0 

Revert to previous known good yaml state.

* update template creators