### PR TITLE
[TypeScript-Angular] Path URI Encoding Update

### DIFF
--- a/samples/client/petstore/typescript-angular-v4.3/npm/model/apiResponse.ts
+++ b/samples/client/petstore/typescript-angular-v4.3/npm/model/apiResponse.ts
@@ -23,3 +23,5 @@ export interface ApiResponse {
     message?: string;
 
 }
+
+

--- a/samples/client/petstore/typescript-angular-v4.3/npm/model/category.ts
+++ b/samples/client/petstore/typescript-angular-v4.3/npm/model/category.ts
@@ -21,3 +21,5 @@ export interface Category {
     name?: string;
 
 }
+
+

--- a/samples/client/petstore/typescript-angular-v4.3/npm/model/order.ts
+++ b/samples/client/petstore/typescript-angular-v4.3/npm/model/order.ts
@@ -33,9 +33,7 @@ export interface Order {
 
 }
 export namespace Order {
-    export enum StatusEnum {
-        Placed = <any> 'placed',
-        Approved = <any> 'approved',
-        Delivered = <any> 'delivered'
-    }
+    export type StatusEnum = 'placed' | 'approved' | 'delivered';
 }
+
+

--- a/samples/client/petstore/typescript-angular-v4.3/npm/model/pet.ts
+++ b/samples/client/petstore/typescript-angular-v4.3/npm/model/pet.ts
@@ -35,9 +35,7 @@ export interface Pet {
 
 }
 export namespace Pet {
-    export enum StatusEnum {
-        Available = <any> 'available',
-        Pending = <any> 'pending',
-        Sold = <any> 'sold'
-    }
+    export type StatusEnum = 'available' | 'pending' | 'sold';
 }
+
+

--- a/samples/client/petstore/typescript-angular-v4.3/npm/model/tag.ts
+++ b/samples/client/petstore/typescript-angular-v4.3/npm/model/tag.ts
@@ -21,3 +21,5 @@ export interface Tag {
     name?: string;
 
 }
+
+

--- a/samples/client/petstore/typescript-angular-v4.3/npm/model/user.ts
+++ b/samples/client/petstore/typescript-angular-v4.3/npm/model/user.ts
@@ -36,3 +36,5 @@ export interface User {
     userStatus?: number;
 
 }
+
+


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [x] Filed the PR against the correct branch: `3.0.0` branch for changes related to OpenAPI spec 3.0. Default: `master`.
- [x] Copied the [technical committee](https://github.com/swagger-api/swagger-codegen/#swagger-codegen-technical-committee) to review the pull request if your PR is targeting a particular programming langauge.

### Description of the PR

This update replaces the code for updating paths for URI encoding. Previously, this code was not converting from snake_case to camelCase, causing the variables embedded in the path to not match the parameter names they were passed to the function as.

The new method involves finding matches of items in curly-braces and iterating through them. Each match is then searched through for underscores. If one is found, it is removed and the following letter is capitalized.

The more complicated replacement is necessary to guarantee we only change the format of the variables inside the template braces. Otherwise, it might replace parts of the url/path itself, rather than just the variable names.

This should fix #6762.

@TiFu @taxpon @sebastianhaas @kenisteward @Vrolijkx 