### PR TITLE
[JavaScript] Use babel-preset-env instead of es2015

### DIFF
--- a/modules/swagger-codegen/src/main/resources/Javascript/es6/.babelrc.mustache
+++ b/modules/swagger-codegen/src/main/resources/Javascript/es6/.babelrc.mustache
@@ -1,3 +1,3 @@
 {
-  "presets": ["es2015", "stage-0"]
+  "presets": ["env", "stage-0"]
 }

--- a/modules/swagger-codegen/src/main/resources/Javascript/es6/package.mustache
+++ b/modules/swagger-codegen/src/main/resources/Javascript/es6/package.mustache
@@ -12,12 +12,12 @@
   },
   "dependencies": {
     "babel": "^6.23.0",
-    "babel-cli": "^6.24.1",
+    "babel-cli": "^6.26.0",
     "superagent": "3.5.2"
   },
   "devDependencies": {
-    "babel-core": "6.18.0",
-    "babel-preset-es2015": "^6.24.1",
+    "babel-core": "6.26.0",
+    "babel-preset-env": "^1.6.1",
     "babel-preset-stage-0": "^6.24.1",
     "expect.js": "~0.3.1",
     "mocha": "~2.3.4",

--- a/samples/client/petstore/javascript-es6/.babelrc
+++ b/samples/client/petstore/javascript-es6/.babelrc
@@ -1,3 +1,3 @@
 {
-  "presets": ["es2015", "stage-0"]
+  "presets": ["env", "stage-0"]
 }

--- a/samples/client/petstore/javascript-es6/package.json
+++ b/samples/client/petstore/javascript-es6/package.json
@@ -12,12 +12,12 @@
   },
   "dependencies": {
     "babel": "^6.23.0",
-    "babel-cli": "^6.24.1",
+    "babel-cli": "^6.26.0",
     "superagent": "3.5.2"
   },
   "devDependencies": {
-    "babel-core": "6.18.0",
-    "babel-preset-es2015": "^6.24.1",
+    "babel-core": "6.26.0",
+    "babel-preset-env": "^1.6.1",
     "babel-preset-stage-0": "^6.24.1",
     "expect.js": "~0.3.1",
     "mocha": "~2.3.4",

--- a/samples/client/petstore/javascript-promise-es6/.babelrc
+++ b/samples/client/petstore/javascript-promise-es6/.babelrc
@@ -1,3 +1,3 @@
 {
-  "presets": ["es2015", "stage-0"]
+  "presets": ["env", "stage-0"]
 }

--- a/samples/client/petstore/javascript-promise-es6/package.json
+++ b/samples/client/petstore/javascript-promise-es6/package.json
@@ -12,12 +12,12 @@
   },
   "dependencies": {
     "babel": "^6.23.0",
-    "babel-cli": "^6.24.1",
+    "babel-cli": "^6.26.0",
     "superagent": "3.5.2"
   },
   "devDependencies": {
-    "babel-core": "6.18.0",
-    "babel-preset-es2015": "^6.24.1",
+    "babel-core": "6.26.0",
+    "babel-preset-env": "^1.6.1",
     "babel-preset-stage-0": "^6.24.1",
     "expect.js": "~0.3.1",
     "mocha": "~2.3.4",


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [x] Filed the PR against the correct branch: `3.0.0` branch for changes related to OpenAPI spec 3.0. Default: `master`.
- [x] Copied the [technical committee](https://github.com/swagger-api/swagger-codegen/#swagger-codegen-technical-committee) to review the pull request if your PR is targeting a particular programming langauge.

### Description of the PR

Related issue #6719

* Use babel-preset-env instead of es2015 
* Upgrade babel-cli and babel-core

@CodeNinjai @frol @cliffano
