### PR TITLE
[Java] Fixed @Deprecated annotations

### DIFF
--- a/modules/swagger-codegen/src/main/resources/Java/api.mustache
+++ b/modules/swagger-codegen/src/main/resources/Java/api.mustache
@@ -53,13 +53,16 @@ public class {{classname}} {
    {{/returnType}}
    * @throws ApiException if fails to make API call
    {{#isDeprecated}}
-   * @Deprecated
+   * @deprecated
    {{/isDeprecated}}
    {{#externalDocs}}
    * {{description}}
    * @see <a href="{{url}}">{{summary}} Documentation</a>
    {{/externalDocs}}
    */
+  {{#isDeprecated}}
+  @Deprecated
+  {{/isDeprecated}}
   public {{#returnType}}{{{returnType}}} {{/returnType}}{{^returnType}}void {{/returnType}}{{operationId}}({{#allParams}}{{{dataType}}} {{paramName}}{{#hasMore}}, {{/hasMore}}{{/allParams}}) throws ApiException {
     Object {{localVariablePrefix}}localVarPostBody = {{#bodyParam}}{{paramName}}{{/bodyParam}}{{^bodyParam}}null{{/bodyParam}};
     {{#allParams}}{{#required}}

--- a/modules/swagger-codegen/src/main/resources/Java/libraries/jersey2/api.mustache
+++ b/modules/swagger-codegen/src/main/resources/Java/libraries/jersey2/api.mustache
@@ -50,13 +50,16 @@ public class {{classname}} {
    {{/returnType}}
    * @throws ApiException if fails to make API call
    {{#isDeprecated}}
-   * @Deprecated
+   * @deprecated
    {{/isDeprecated}}
    {{#externalDocs}}
    * {{description}}
    * @see <a href="{{url}}">{{summary}} Documentation</a>
    {{/externalDocs}}
    */
+  {{#isDeprecated}}
+  @Deprecated
+  {{/isDeprecated}}
   public {{#returnType}}{{{returnType}}} {{/returnType}}{{^returnType}}void {{/returnType}}{{operationId}}({{#allParams}}{{{dataType}}} {{paramName}}{{#hasMore}}, {{/hasMore}}{{/allParams}}) throws ApiException {
     Object {{localVariablePrefix}}localVarPostBody = {{#bodyParam}}{{paramName}}{{/bodyParam}}{{^bodyParam}}null{{/bodyParam}};
     {{#allParams}}{{#required}}

--- a/modules/swagger-codegen/src/main/resources/Java/libraries/okhttp-gson/api.mustache
+++ b/modules/swagger-codegen/src/main/resources/Java/libraries/okhttp-gson/api.mustache
@@ -70,14 +70,20 @@ public class {{classname}} {
      * @param progressRequestListener Progress request listener
      * @return Call to execute
      * @throws ApiException If fail to serialize the request body object
+     {{#isDeprecated}}
+     * @deprecated
+     {{/isDeprecated}}
         {{#externalDocs}}
      * {{description}}
      * @see <a href="{{url}}">{{summary}} Documentation</a>
         {{/externalDocs}}
      */
+    {{#isDeprecated}}
+    @Deprecated
+    {{/isDeprecated}}
     public com.squareup.okhttp.Call {{operationId}}Call({{#allParams}}{{{dataType}}} {{paramName}}, {{/allParams}}final ProgressResponseBody.ProgressListener progressListener, final ProgressRequestBody.ProgressRequestListener progressRequestListener) throws ApiException {
         Object {{localVariablePrefix}}localVarPostBody = {{#bodyParam}}{{paramName}}{{/bodyParam}}{{^bodyParam}}null{{/bodyParam}};
-        
+
         // create path and map variables
         String {{localVariablePrefix}}localVarPath = "{{{path}}}"{{#pathParams}}
             .replaceAll("\\{" + "{{baseName}}" + "\\}", {{localVariablePrefix}}apiClient.escapeString({{{paramName}}}.toString())){{/pathParams}};
@@ -122,7 +128,10 @@ public class {{classname}} {
         String[] {{localVariablePrefix}}localVarAuthNames = new String[] { {{#authMethods}}"{{name}}"{{#hasMore}}, {{/hasMore}}{{/authMethods}} };
         return {{localVariablePrefix}}apiClient.buildCall({{localVariablePrefix}}localVarPath, "{{httpMethod}}", {{localVariablePrefix}}localVarQueryParams, {{localVariablePrefix}}localVarCollectionQueryParams, {{localVariablePrefix}}localVarPostBody, {{localVariablePrefix}}localVarHeaderParams, {{localVariablePrefix}}localVarFormParams, {{localVariablePrefix}}localVarAuthNames, progressRequestListener);
     }
-    
+
+    {{#isDeprecated}}
+    @Deprecated
+    {{/isDeprecated}}
     @SuppressWarnings("rawtypes")
     private com.squareup.okhttp.Call {{operationId}}ValidateBeforeCall({{#allParams}}{{{dataType}}} {{paramName}}, {{/allParams}}final ProgressResponseBody.ProgressListener progressListener, final ProgressRequestBody.ProgressRequestListener progressRequestListener) throws ApiException {
         {{^performBeanValidation}}
@@ -132,7 +141,7 @@ public class {{classname}} {
             throw new ApiException("Missing the required parameter '{{paramName}}' when calling {{operationId}}(Async)");
         }
         {{/required}}{{/allParams}}
-        
+
         com.squareup.okhttp.Call {{localVariablePrefix}}call = {{operationId}}Call({{#allParams}}{{paramName}}, {{/allParams}}progressListener, progressRequestListener);
         return {{localVariablePrefix}}call;
 
@@ -150,7 +159,7 @@ public class {{classname}} {
             if (violations.size() == 0) {
                 com.squareup.okhttp.Call {{localVariablePrefix}}call = {{operationId}}Call({{#allParams}}{{paramName}}, {{/allParams}}progressListener, progressRequestListener);
                 return {{localVariablePrefix}}call;
-            
+
             } else {
                 throw new BeanValidationException((Set) violations);
             }
@@ -161,12 +170,8 @@ public class {{classname}} {
             e.printStackTrace();
             throw new ApiException(e.getMessage());
         }
-            
+
         {{/performBeanValidation}}
-        
-        
-        
-        
     }
 
     /**
@@ -175,11 +180,17 @@ public class {{classname}} {
      * @param {{paramName}} {{description}}{{#required}} (required){{/required}}{{^required}} (optional{{#defaultValue}}, default to {{{.}}}{{/defaultValue}}){{/required}}{{/allParams}}{{#returnType}}
      * @return {{returnType}}{{/returnType}}
      * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
+     {{#isDeprecated}}
+     * @deprecated
+     {{/isDeprecated}}
         {{#externalDocs}}
      * {{description}}
      * @see <a href="{{url}}">{{summary}} Documentation</a>
         {{/externalDocs}}
      */
+    {{#isDeprecated}}
+    @Deprecated
+    {{/isDeprecated}}
     public {{#returnType}}{{{returnType}}} {{/returnType}}{{^returnType}}void {{/returnType}}{{operationId}}({{#allParams}}{{{dataType}}} {{paramName}}{{#hasMore}}, {{/hasMore}}{{/allParams}}) throws ApiException {
         {{#returnType}}ApiResponse<{{{returnType}}}> {{localVariablePrefix}}resp = {{/returnType}}{{operationId}}WithHttpInfo({{#allParams}}{{paramName}}{{#hasMore}}, {{/hasMore}}{{/allParams}});{{#returnType}}
         return {{localVariablePrefix}}resp.getData();{{/returnType}}
@@ -191,11 +202,17 @@ public class {{classname}} {
      * @param {{paramName}} {{description}}{{#required}} (required){{/required}}{{^required}} (optional{{#defaultValue}}, default to {{{.}}}{{/defaultValue}}){{/required}}{{/allParams}}
      * @return ApiResponse&lt;{{#returnType}}{{returnType}}{{/returnType}}{{^returnType}}Void{{/returnType}}&gt;
      * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
+     {{#isDeprecated}}
+     * @deprecated
+     {{/isDeprecated}}
         {{#externalDocs}}
      * {{description}}
      * @see <a href="{{url}}">{{summary}} Documentation</a>
         {{/externalDocs}}
      */
+    {{#isDeprecated}}
+    @Deprecated
+    {{/isDeprecated}}
     public ApiResponse<{{#returnType}}{{{returnType}}}{{/returnType}}{{^returnType}}Void{{/returnType}}> {{operationId}}WithHttpInfo({{#allParams}}{{#useBeanValidation}}{{>beanValidationQueryParams}}{{/useBeanValidation}}{{{dataType}}} {{paramName}}{{#hasMore}}, {{/hasMore}}{{/allParams}}) throws ApiException {
         com.squareup.okhttp.Call {{localVariablePrefix}}call = {{operationId}}ValidateBeforeCall({{#allParams}}{{paramName}}, {{/allParams}}null, null);
         {{#returnType}}Type {{localVariablePrefix}}localVarReturnType = new TypeToken<{{{returnType}}}>(){}.getType();
@@ -209,11 +226,17 @@ public class {{classname}} {
      * @param callback The callback to be executed when the API call finishes
      * @return The request call
      * @throws ApiException If fail to process the API call, e.g. serializing the request body object
+     {{#isDeprecated}}
+     * @deprecated
+     {{/isDeprecated}}
         {{#externalDocs}}
      * {{description}}
      * @see <a href="{{url}}">{{summary}} Documentation</a>
         {{/externalDocs}}
      */
+    {{#isDeprecated}}
+    @Deprecated
+    {{/isDeprecated}}
     public com.squareup.okhttp.Call {{operationId}}Async({{#allParams}}{{{dataType}}} {{paramName}}, {{/allParams}}final ApiCallback<{{#returnType}}{{{returnType}}}{{/returnType}}{{^returnType}}Void{{/returnType}}> {{localVariablePrefix}}callback) throws ApiException {
 
         ProgressResponseBody.ProgressListener progressListener = null;

--- a/modules/swagger-codegen/src/main/resources/Java/libraries/resteasy/api.mustache
+++ b/modules/swagger-codegen/src/main/resources/Java/libraries/resteasy/api.mustache
@@ -46,13 +46,16 @@ public class {{classname}} {
    * @return {{{returnType}}}{{/returnType}}
    * @throws ApiException if fails to make API call
    {{#isDeprecated}}
-   * @Deprecated
+   * @deprecated
    {{/isDeprecated}}
    {{#externalDocs}}
    * {{description}}
    * @see <a href="{{url}}">{{summary}} Documentation</a>
    {{/externalDocs}}
    */
+  {{#isDeprecated}}
+  @Deprecated
+  {{/isDeprecated}}
   public {{#returnType}}{{{returnType}}} {{/returnType}}{{^returnType}}void {{/returnType}}{{operationId}}({{#allParams}}{{{dataType}}} {{paramName}}{{#hasMore}}, {{/hasMore}}{{/allParams}}) throws ApiException {
     Object {{localVariablePrefix}}localVarPostBody = {{#bodyParam}}{{paramName}}{{/bodyParam}}{{^bodyParam}}null{{/bodyParam}};
     {{#allParams}}{{#required}}

--- a/samples/client/petstore/java/feign/src/main/java/io/swagger/client/api/FakeApi.java
+++ b/samples/client/petstore/java/feign/src/main/java/io/swagger/client/api/FakeApi.java
@@ -182,6 +182,18 @@ public interface FakeApi extends ApiClient.Api {
   }
 
   /**
+   * test inline additionalProperties
+   * 
+    * @param param request body (required)
+   */
+  @RequestLine("POST /fake/inline-additionalProperties")
+  @Headers({
+    "Content-Type: application/json",
+    "Accept: application/json",
+  })
+  void testInlineAdditionalProperties(Object param);
+
+  /**
    * test json serialization of form data
    * 
     * @param param field1 (required)

--- a/samples/client/petstore/java/jersey1/docs/FakeApi.md
+++ b/samples/client/petstore/java/jersey1/docs/FakeApi.md
@@ -11,6 +11,7 @@ Method | HTTP request | Description
 [**testClientModel**](FakeApi.md#testClientModel) | **PATCH** /fake | To test \&quot;client\&quot; model
 [**testEndpointParameters**](FakeApi.md#testEndpointParameters) | **POST** /fake | Fake endpoint for testing various parameters 假端點 偽のエンドポイント 가짜 엔드 포인트 
 [**testEnumParameters**](FakeApi.md#testEnumParameters) | **GET** /fake | To test enum parameters
+[**testInlineAdditionalProperties**](FakeApi.md#testInlineAdditionalProperties) | **POST** /fake/inline-additionalProperties | test inline additionalProperties
 [**testJsonFormData**](FakeApi.md#testJsonFormData) | **GET** /fake/jsonFormData | test json serialization of form data
 
 
@@ -375,6 +376,50 @@ No authorization required
 
  - **Content-Type**: */*
  - **Accept**: */*
+
+<a name="testInlineAdditionalProperties"></a>
+# **testInlineAdditionalProperties**
+> testInlineAdditionalProperties(param)
+
+test inline additionalProperties
+
+
+
+### Example
+```java
+// Import classes:
+//import io.swagger.client.ApiException;
+//import io.swagger.client.api.FakeApi;
+
+
+FakeApi apiInstance = new FakeApi();
+Object param = null; // Object | request body
+try {
+    apiInstance.testInlineAdditionalProperties(param);
+} catch (ApiException e) {
+    System.err.println("Exception when calling FakeApi#testInlineAdditionalProperties");
+    e.printStackTrace();
+}
+```
+
+### Parameters
+
+Name | Type | Description  | Notes
+------------- | ------------- | ------------- | -------------
+ **param** | **Object**| request body |
+
+### Return type
+
+null (empty response body)
+
+### Authorization
+
+No authorization required
+
+### HTTP request headers
+
+ - **Content-Type**: application/json
+ - **Accept**: Not defined
 
 <a name="testJsonFormData"></a>
 # **testJsonFormData**

--- a/samples/client/petstore/java/jersey1/src/main/java/io/swagger/client/api/FakeApi.java
+++ b/samples/client/petstore/java/jersey1/src/main/java/io/swagger/client/api/FakeApi.java
@@ -396,6 +396,47 @@ if (enumQueryDouble != null)
     apiClient.invokeAPI(localVarPath, "GET", localVarQueryParams, localVarCollectionQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarAccept, localVarContentType, localVarAuthNames, null);
   }
   /**
+   * test inline additionalProperties
+   * 
+   * @param param request body (required)
+   * @throws ApiException if fails to make API call
+   */
+  public void testInlineAdditionalProperties(Object param) throws ApiException {
+    Object localVarPostBody = param;
+    
+    // verify the required parameter 'param' is set
+    if (param == null) {
+      throw new ApiException(400, "Missing the required parameter 'param' when calling testInlineAdditionalProperties");
+    }
+    
+    // create path and map variables
+    String localVarPath = "/fake/inline-additionalProperties";
+
+    // query params
+    List<Pair> localVarQueryParams = new ArrayList<Pair>();
+    List<Pair> localVarCollectionQueryParams = new ArrayList<Pair>();
+    Map<String, String> localVarHeaderParams = new HashMap<String, String>();
+    Map<String, Object> localVarFormParams = new HashMap<String, Object>();
+
+
+    
+    
+    final String[] localVarAccepts = {
+      
+    };
+    final String localVarAccept = apiClient.selectHeaderAccept(localVarAccepts);
+
+    final String[] localVarContentTypes = {
+      "application/json"
+    };
+    final String localVarContentType = apiClient.selectHeaderContentType(localVarContentTypes);
+
+    String[] localVarAuthNames = new String[] {  };
+
+
+    apiClient.invokeAPI(localVarPath, "POST", localVarQueryParams, localVarCollectionQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarAccept, localVarContentType, localVarAuthNames, null);
+  }
+  /**
    * test json serialization of form data
    * 
    * @param param field1 (required)

--- a/samples/client/petstore/java/jersey1/src/main/java/io/swagger/client/api/PetApi.java
+++ b/samples/client/petstore/java/jersey1/src/main/java/io/swagger/client/api/PetApi.java
@@ -185,8 +185,9 @@ public class PetApi {
    * @param tags Tags to filter by (required)
    * @return List&lt;Pet&gt;
    * @throws ApiException if fails to make API call
-   * @Deprecated
+   * @deprecated
    */
+  @Deprecated
   public List<Pet> findPetsByTags(List<String> tags) throws ApiException {
     Object localVarPostBody = null;
     

--- a/samples/client/petstore/java/jersey2-java6/docs/FakeApi.md
+++ b/samples/client/petstore/java/jersey2-java6/docs/FakeApi.md
@@ -11,6 +11,7 @@ Method | HTTP request | Description
 [**testClientModel**](FakeApi.md#testClientModel) | **PATCH** /fake | To test \&quot;client\&quot; model
 [**testEndpointParameters**](FakeApi.md#testEndpointParameters) | **POST** /fake | Fake endpoint for testing various parameters 假端點 偽のエンドポイント 가짜 엔드 포인트 
 [**testEnumParameters**](FakeApi.md#testEnumParameters) | **GET** /fake | To test enum parameters
+[**testInlineAdditionalProperties**](FakeApi.md#testInlineAdditionalProperties) | **POST** /fake/inline-additionalProperties | test inline additionalProperties
 [**testJsonFormData**](FakeApi.md#testJsonFormData) | **GET** /fake/jsonFormData | test json serialization of form data
 
 
@@ -375,6 +376,50 @@ No authorization required
 
  - **Content-Type**: */*
  - **Accept**: */*
+
+<a name="testInlineAdditionalProperties"></a>
+# **testInlineAdditionalProperties**
+> testInlineAdditionalProperties(param)
+
+test inline additionalProperties
+
+
+
+### Example
+```java
+// Import classes:
+//import io.swagger.client.ApiException;
+//import io.swagger.client.api.FakeApi;
+
+
+FakeApi apiInstance = new FakeApi();
+Object param = null; // Object | request body
+try {
+    apiInstance.testInlineAdditionalProperties(param);
+} catch (ApiException e) {
+    System.err.println("Exception when calling FakeApi#testInlineAdditionalProperties");
+    e.printStackTrace();
+}
+```
+
+### Parameters
+
+Name | Type | Description  | Notes
+------------- | ------------- | ------------- | -------------
+ **param** | **Object**| request body |
+
+### Return type
+
+null (empty response body)
+
+### Authorization
+
+No authorization required
+
+### HTTP request headers
+
+ - **Content-Type**: application/json
+ - **Accept**: Not defined
 
 <a name="testJsonFormData"></a>
 # **testJsonFormData**

--- a/samples/client/petstore/java/jersey2-java6/src/main/java/io/swagger/client/api/FakeApi.java
+++ b/samples/client/petstore/java/jersey2-java6/src/main/java/io/swagger/client/api/FakeApi.java
@@ -375,6 +375,46 @@ if (enumQueryDouble != null)
     apiClient.invokeAPI(localVarPath, "GET", localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarAccept, localVarContentType, localVarAuthNames, null);
   }
   /**
+   * test inline additionalProperties
+   * 
+   * @param param request body (required)
+   * @throws ApiException if fails to make API call
+   */
+  public void testInlineAdditionalProperties(Object param) throws ApiException {
+    Object localVarPostBody = param;
+    
+    // verify the required parameter 'param' is set
+    if (param == null) {
+      throw new ApiException(400, "Missing the required parameter 'param' when calling testInlineAdditionalProperties");
+    }
+    
+    // create path and map variables
+    String localVarPath = "/fake/inline-additionalProperties";
+
+    // query params
+    List<Pair> localVarQueryParams = new ArrayList<Pair>();
+    Map<String, String> localVarHeaderParams = new HashMap<String, String>();
+    Map<String, Object> localVarFormParams = new HashMap<String, Object>();
+
+
+    
+    
+    final String[] localVarAccepts = {
+      
+    };
+    final String localVarAccept = apiClient.selectHeaderAccept(localVarAccepts);
+
+    final String[] localVarContentTypes = {
+      "application/json"
+    };
+    final String localVarContentType = apiClient.selectHeaderContentType(localVarContentTypes);
+
+    String[] localVarAuthNames = new String[] {  };
+
+
+    apiClient.invokeAPI(localVarPath, "POST", localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarAccept, localVarContentType, localVarAuthNames, null);
+  }
+  /**
    * test json serialization of form data
    * 
    * @param param field1 (required)

--- a/samples/client/petstore/java/jersey2-java6/src/main/java/io/swagger/client/api/PetApi.java
+++ b/samples/client/petstore/java/jersey2-java6/src/main/java/io/swagger/client/api/PetApi.java
@@ -168,8 +168,9 @@ public class PetApi {
    * @param tags Tags to filter by (required)
    * @return List&lt;Pet&gt;
    * @throws ApiException if fails to make API call
-   * @Deprecated
+   * @deprecated
    */
+  @Deprecated
   public List<Pet> findPetsByTags(List<String> tags) throws ApiException {
     Object localVarPostBody = null;
     

--- a/samples/client/petstore/java/jersey2-java8/docs/FakeApi.md
+++ b/samples/client/petstore/java/jersey2-java8/docs/FakeApi.md
@@ -11,6 +11,7 @@ Method | HTTP request | Description
 [**testClientModel**](FakeApi.md#testClientModel) | **PATCH** /fake | To test \&quot;client\&quot; model
 [**testEndpointParameters**](FakeApi.md#testEndpointParameters) | **POST** /fake | Fake endpoint for testing various parameters 假端點 偽のエンドポイント 가짜 엔드 포인트 
 [**testEnumParameters**](FakeApi.md#testEnumParameters) | **GET** /fake | To test enum parameters
+[**testInlineAdditionalProperties**](FakeApi.md#testInlineAdditionalProperties) | **POST** /fake/inline-additionalProperties | test inline additionalProperties
 [**testJsonFormData**](FakeApi.md#testJsonFormData) | **GET** /fake/jsonFormData | test json serialization of form data
 
 
@@ -375,6 +376,50 @@ No authorization required
 
  - **Content-Type**: */*
  - **Accept**: */*
+
+<a name="testInlineAdditionalProperties"></a>
+# **testInlineAdditionalProperties**
+> testInlineAdditionalProperties(param)
+
+test inline additionalProperties
+
+
+
+### Example
+```java
+// Import classes:
+//import io.swagger.client.ApiException;
+//import io.swagger.client.api.FakeApi;
+
+
+FakeApi apiInstance = new FakeApi();
+Object param = null; // Object | request body
+try {
+    apiInstance.testInlineAdditionalProperties(param);
+} catch (ApiException e) {
+    System.err.println("Exception when calling FakeApi#testInlineAdditionalProperties");
+    e.printStackTrace();
+}
+```
+
+### Parameters
+
+Name | Type | Description  | Notes
+------------- | ------------- | ------------- | -------------
+ **param** | **Object**| request body |
+
+### Return type
+
+null (empty response body)
+
+### Authorization
+
+No authorization required
+
+### HTTP request headers
+
+ - **Content-Type**: application/json
+ - **Accept**: Not defined
 
 <a name="testJsonFormData"></a>
 # **testJsonFormData**

--- a/samples/client/petstore/java/jersey2-java8/src/main/java/io/swagger/client/api/FakeApi.java
+++ b/samples/client/petstore/java/jersey2-java8/src/main/java/io/swagger/client/api/FakeApi.java
@@ -375,6 +375,46 @@ if (enumQueryDouble != null)
     apiClient.invokeAPI(localVarPath, "GET", localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarAccept, localVarContentType, localVarAuthNames, null);
   }
   /**
+   * test inline additionalProperties
+   * 
+   * @param param request body (required)
+   * @throws ApiException if fails to make API call
+   */
+  public void testInlineAdditionalProperties(Object param) throws ApiException {
+    Object localVarPostBody = param;
+    
+    // verify the required parameter 'param' is set
+    if (param == null) {
+      throw new ApiException(400, "Missing the required parameter 'param' when calling testInlineAdditionalProperties");
+    }
+    
+    // create path and map variables
+    String localVarPath = "/fake/inline-additionalProperties";
+
+    // query params
+    List<Pair> localVarQueryParams = new ArrayList<Pair>();
+    Map<String, String> localVarHeaderParams = new HashMap<String, String>();
+    Map<String, Object> localVarFormParams = new HashMap<String, Object>();
+
+
+    
+    
+    final String[] localVarAccepts = {
+      
+    };
+    final String localVarAccept = apiClient.selectHeaderAccept(localVarAccepts);
+
+    final String[] localVarContentTypes = {
+      "application/json"
+    };
+    final String localVarContentType = apiClient.selectHeaderContentType(localVarContentTypes);
+
+    String[] localVarAuthNames = new String[] {  };
+
+
+    apiClient.invokeAPI(localVarPath, "POST", localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarAccept, localVarContentType, localVarAuthNames, null);
+  }
+  /**
    * test json serialization of form data
    * 
    * @param param field1 (required)

--- a/samples/client/petstore/java/jersey2-java8/src/main/java/io/swagger/client/api/PetApi.java
+++ b/samples/client/petstore/java/jersey2-java8/src/main/java/io/swagger/client/api/PetApi.java
@@ -168,8 +168,9 @@ public class PetApi {
    * @param tags Tags to filter by (required)
    * @return List&lt;Pet&gt;
    * @throws ApiException if fails to make API call
-   * @Deprecated
+   * @deprecated
    */
+  @Deprecated
   public List<Pet> findPetsByTags(List<String> tags) throws ApiException {
     Object localVarPostBody = null;
     

--- a/samples/client/petstore/java/jersey2-java8/src/main/java/io/swagger/client/model/AdditionalPropertiesClass.java
+++ b/samples/client/petstore/java/jersey2-java8/src/main/java/io/swagger/client/model/AdditionalPropertiesClass.java
@@ -41,7 +41,7 @@ public class AdditionalPropertiesClass {
 
   public AdditionalPropertiesClass putMapPropertyItem(String key, String mapPropertyItem) {
     if (this.mapProperty == null) {
-      this.mapProperty = new HashMap<String, String>();
+      this.mapProperty = new HashMap<>();
     }
     this.mapProperty.put(key, mapPropertyItem);
     return this;
@@ -67,7 +67,7 @@ public class AdditionalPropertiesClass {
 
   public AdditionalPropertiesClass putMapOfMapPropertyItem(String key, Map<String, String> mapOfMapPropertyItem) {
     if (this.mapOfMapProperty == null) {
-      this.mapOfMapProperty = new HashMap<String, Map<String, String>>();
+      this.mapOfMapProperty = new HashMap<>();
     }
     this.mapOfMapProperty.put(key, mapOfMapPropertyItem);
     return this;

--- a/samples/client/petstore/java/jersey2-java8/src/main/java/io/swagger/client/model/ArrayOfArrayOfNumberOnly.java
+++ b/samples/client/petstore/java/jersey2-java8/src/main/java/io/swagger/client/model/ArrayOfArrayOfNumberOnly.java
@@ -38,7 +38,7 @@ public class ArrayOfArrayOfNumberOnly {
 
   public ArrayOfArrayOfNumberOnly addArrayArrayNumberItem(List<BigDecimal> arrayArrayNumberItem) {
     if (this.arrayArrayNumber == null) {
-      this.arrayArrayNumber = new ArrayList<List<BigDecimal>>();
+      this.arrayArrayNumber = new ArrayList<>();
     }
     this.arrayArrayNumber.add(arrayArrayNumberItem);
     return this;

--- a/samples/client/petstore/java/jersey2-java8/src/main/java/io/swagger/client/model/ArrayOfNumberOnly.java
+++ b/samples/client/petstore/java/jersey2-java8/src/main/java/io/swagger/client/model/ArrayOfNumberOnly.java
@@ -38,7 +38,7 @@ public class ArrayOfNumberOnly {
 
   public ArrayOfNumberOnly addArrayNumberItem(BigDecimal arrayNumberItem) {
     if (this.arrayNumber == null) {
-      this.arrayNumber = new ArrayList<BigDecimal>();
+      this.arrayNumber = new ArrayList<>();
     }
     this.arrayNumber.add(arrayNumberItem);
     return this;

--- a/samples/client/petstore/java/jersey2-java8/src/main/java/io/swagger/client/model/ArrayTest.java
+++ b/samples/client/petstore/java/jersey2-java8/src/main/java/io/swagger/client/model/ArrayTest.java
@@ -44,7 +44,7 @@ public class ArrayTest {
 
   public ArrayTest addArrayOfStringItem(String arrayOfStringItem) {
     if (this.arrayOfString == null) {
-      this.arrayOfString = new ArrayList<String>();
+      this.arrayOfString = new ArrayList<>();
     }
     this.arrayOfString.add(arrayOfStringItem);
     return this;
@@ -70,7 +70,7 @@ public class ArrayTest {
 
   public ArrayTest addArrayArrayOfIntegerItem(List<Long> arrayArrayOfIntegerItem) {
     if (this.arrayArrayOfInteger == null) {
-      this.arrayArrayOfInteger = new ArrayList<List<Long>>();
+      this.arrayArrayOfInteger = new ArrayList<>();
     }
     this.arrayArrayOfInteger.add(arrayArrayOfIntegerItem);
     return this;
@@ -96,7 +96,7 @@ public class ArrayTest {
 
   public ArrayTest addArrayArrayOfModelItem(List<ReadOnlyFirst> arrayArrayOfModelItem) {
     if (this.arrayArrayOfModel == null) {
-      this.arrayArrayOfModel = new ArrayList<List<ReadOnlyFirst>>();
+      this.arrayArrayOfModel = new ArrayList<>();
     }
     this.arrayArrayOfModel.add(arrayArrayOfModelItem);
     return this;

--- a/samples/client/petstore/java/jersey2-java8/src/main/java/io/swagger/client/model/EnumArrays.java
+++ b/samples/client/petstore/java/jersey2-java8/src/main/java/io/swagger/client/model/EnumArrays.java
@@ -128,7 +128,7 @@ public class EnumArrays {
 
   public EnumArrays addArrayEnumItem(ArrayEnumEnum arrayEnumItem) {
     if (this.arrayEnum == null) {
-      this.arrayEnum = new ArrayList<ArrayEnumEnum>();
+      this.arrayEnum = new ArrayList<>();
     }
     this.arrayEnum.add(arrayEnumItem);
     return this;

--- a/samples/client/petstore/java/jersey2-java8/src/main/java/io/swagger/client/model/MapTest.java
+++ b/samples/client/petstore/java/jersey2-java8/src/main/java/io/swagger/client/model/MapTest.java
@@ -76,7 +76,7 @@ public class MapTest {
 
   public MapTest putMapMapOfStringItem(String key, Map<String, String> mapMapOfStringItem) {
     if (this.mapMapOfString == null) {
-      this.mapMapOfString = new HashMap<String, Map<String, String>>();
+      this.mapMapOfString = new HashMap<>();
     }
     this.mapMapOfString.put(key, mapMapOfStringItem);
     return this;
@@ -102,7 +102,7 @@ public class MapTest {
 
   public MapTest putMapOfEnumStringItem(String key, InnerEnum mapOfEnumStringItem) {
     if (this.mapOfEnumString == null) {
-      this.mapOfEnumString = new HashMap<String, InnerEnum>();
+      this.mapOfEnumString = new HashMap<>();
     }
     this.mapOfEnumString.put(key, mapOfEnumStringItem);
     return this;

--- a/samples/client/petstore/java/jersey2-java8/src/main/java/io/swagger/client/model/MixedPropertiesAndAdditionalPropertiesClass.java
+++ b/samples/client/petstore/java/jersey2-java8/src/main/java/io/swagger/client/model/MixedPropertiesAndAdditionalPropertiesClass.java
@@ -83,7 +83,7 @@ public class MixedPropertiesAndAdditionalPropertiesClass {
 
   public MixedPropertiesAndAdditionalPropertiesClass putMapItem(String key, Animal mapItem) {
     if (this.map == null) {
-      this.map = new HashMap<String, Animal>();
+      this.map = new HashMap<>();
     }
     this.map.put(key, mapItem);
     return this;

--- a/samples/client/petstore/java/jersey2-java8/src/main/java/io/swagger/client/model/Pet.java
+++ b/samples/client/petstore/java/jersey2-java8/src/main/java/io/swagger/client/model/Pet.java
@@ -39,7 +39,7 @@ public class Pet {
   private String name = null;
 
   @JsonProperty("photoUrls")
-  private List<String> photoUrls = new ArrayList<String>();
+  private List<String> photoUrls = new ArrayList<>();
 
   @JsonProperty("tags")
   private List<Tag> tags = null;
@@ -168,7 +168,7 @@ public class Pet {
 
   public Pet addTagsItem(Tag tagsItem) {
     if (this.tags == null) {
-      this.tags = new ArrayList<Tag>();
+      this.tags = new ArrayList<>();
     }
     this.tags.add(tagsItem);
     return this;

--- a/samples/client/petstore/java/jersey2/docs/FakeApi.md
+++ b/samples/client/petstore/java/jersey2/docs/FakeApi.md
@@ -11,6 +11,7 @@ Method | HTTP request | Description
 [**testClientModel**](FakeApi.md#testClientModel) | **PATCH** /fake | To test \&quot;client\&quot; model
 [**testEndpointParameters**](FakeApi.md#testEndpointParameters) | **POST** /fake | Fake endpoint for testing various parameters 假端點 偽のエンドポイント 가짜 엔드 포인트 
 [**testEnumParameters**](FakeApi.md#testEnumParameters) | **GET** /fake | To test enum parameters
+[**testInlineAdditionalProperties**](FakeApi.md#testInlineAdditionalProperties) | **POST** /fake/inline-additionalProperties | test inline additionalProperties
 [**testJsonFormData**](FakeApi.md#testJsonFormData) | **GET** /fake/jsonFormData | test json serialization of form data
 
 
@@ -375,6 +376,50 @@ No authorization required
 
  - **Content-Type**: */*
  - **Accept**: */*
+
+<a name="testInlineAdditionalProperties"></a>
+# **testInlineAdditionalProperties**
+> testInlineAdditionalProperties(param)
+
+test inline additionalProperties
+
+
+
+### Example
+```java
+// Import classes:
+//import io.swagger.client.ApiException;
+//import io.swagger.client.api.FakeApi;
+
+
+FakeApi apiInstance = new FakeApi();
+Object param = null; // Object | request body
+try {
+    apiInstance.testInlineAdditionalProperties(param);
+} catch (ApiException e) {
+    System.err.println("Exception when calling FakeApi#testInlineAdditionalProperties");
+    e.printStackTrace();
+}
+```
+
+### Parameters
+
+Name | Type | Description  | Notes
+------------- | ------------- | ------------- | -------------
+ **param** | **Object**| request body |
+
+### Return type
+
+null (empty response body)
+
+### Authorization
+
+No authorization required
+
+### HTTP request headers
+
+ - **Content-Type**: application/json
+ - **Accept**: Not defined
 
 <a name="testJsonFormData"></a>
 # **testJsonFormData**

--- a/samples/client/petstore/java/jersey2/src/main/java/io/swagger/client/api/FakeApi.java
+++ b/samples/client/petstore/java/jersey2/src/main/java/io/swagger/client/api/FakeApi.java
@@ -375,6 +375,46 @@ if (enumQueryDouble != null)
     apiClient.invokeAPI(localVarPath, "GET", localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarAccept, localVarContentType, localVarAuthNames, null);
   }
   /**
+   * test inline additionalProperties
+   * 
+   * @param param request body (required)
+   * @throws ApiException if fails to make API call
+   */
+  public void testInlineAdditionalProperties(Object param) throws ApiException {
+    Object localVarPostBody = param;
+    
+    // verify the required parameter 'param' is set
+    if (param == null) {
+      throw new ApiException(400, "Missing the required parameter 'param' when calling testInlineAdditionalProperties");
+    }
+    
+    // create path and map variables
+    String localVarPath = "/fake/inline-additionalProperties";
+
+    // query params
+    List<Pair> localVarQueryParams = new ArrayList<Pair>();
+    Map<String, String> localVarHeaderParams = new HashMap<String, String>();
+    Map<String, Object> localVarFormParams = new HashMap<String, Object>();
+
+
+    
+    
+    final String[] localVarAccepts = {
+      
+    };
+    final String localVarAccept = apiClient.selectHeaderAccept(localVarAccepts);
+
+    final String[] localVarContentTypes = {
+      "application/json"
+    };
+    final String localVarContentType = apiClient.selectHeaderContentType(localVarContentTypes);
+
+    String[] localVarAuthNames = new String[] {  };
+
+
+    apiClient.invokeAPI(localVarPath, "POST", localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarAccept, localVarContentType, localVarAuthNames, null);
+  }
+  /**
    * test json serialization of form data
    * 
    * @param param field1 (required)

--- a/samples/client/petstore/java/jersey2/src/main/java/io/swagger/client/api/PetApi.java
+++ b/samples/client/petstore/java/jersey2/src/main/java/io/swagger/client/api/PetApi.java
@@ -168,8 +168,9 @@ public class PetApi {
    * @param tags Tags to filter by (required)
    * @return List&lt;Pet&gt;
    * @throws ApiException if fails to make API call
-   * @Deprecated
+   * @deprecated
    */
+  @Deprecated
   public List<Pet> findPetsByTags(List<String> tags) throws ApiException {
     Object localVarPostBody = null;
     

--- a/samples/client/petstore/java/okhttp-gson-parcelableModel/docs/FakeApi.md
+++ b/samples/client/petstore/java/okhttp-gson-parcelableModel/docs/FakeApi.md
@@ -11,6 +11,7 @@ Method | HTTP request | Description
 [**testClientModel**](FakeApi.md#testClientModel) | **PATCH** /fake | To test \&quot;client\&quot; model
 [**testEndpointParameters**](FakeApi.md#testEndpointParameters) | **POST** /fake | Fake endpoint for testing various parameters 假端點 偽のエンドポイント 가짜 엔드 포인트 
 [**testEnumParameters**](FakeApi.md#testEnumParameters) | **GET** /fake | To test enum parameters
+[**testInlineAdditionalProperties**](FakeApi.md#testInlineAdditionalProperties) | **POST** /fake/inline-additionalProperties | test inline additionalProperties
 [**testJsonFormData**](FakeApi.md#testJsonFormData) | **GET** /fake/jsonFormData | test json serialization of form data
 
 
@@ -375,6 +376,50 @@ No authorization required
 
  - **Content-Type**: */*
  - **Accept**: */*
+
+<a name="testInlineAdditionalProperties"></a>
+# **testInlineAdditionalProperties**
+> testInlineAdditionalProperties(param)
+
+test inline additionalProperties
+
+
+
+### Example
+```java
+// Import classes:
+//import io.swagger.client.ApiException;
+//import io.swagger.client.api.FakeApi;
+
+
+FakeApi apiInstance = new FakeApi();
+Object param = null; // Object | request body
+try {
+    apiInstance.testInlineAdditionalProperties(param);
+} catch (ApiException e) {
+    System.err.println("Exception when calling FakeApi#testInlineAdditionalProperties");
+    e.printStackTrace();
+}
+```
+
+### Parameters
+
+Name | Type | Description  | Notes
+------------- | ------------- | ------------- | -------------
+ **param** | **Object**| request body |
+
+### Return type
+
+null (empty response body)
+
+### Authorization
+
+No authorization required
+
+### HTTP request headers
+
+ - **Content-Type**: application/json
+ - **Accept**: Not defined
 
 <a name="testJsonFormData"></a>
 # **testJsonFormData**

--- a/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/io/swagger/client/api/AnotherFakeApi.java
+++ b/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/io/swagger/client/api/AnotherFakeApi.java
@@ -64,7 +64,7 @@ public class AnotherFakeApi {
      */
     public com.squareup.okhttp.Call testSpecialTagsCall(Client body, final ProgressResponseBody.ProgressListener progressListener, final ProgressRequestBody.ProgressRequestListener progressRequestListener) throws ApiException {
         Object localVarPostBody = body;
-        
+
         // create path and map variables
         String localVarPath = "/another-fake/dummy";
 
@@ -102,7 +102,7 @@ public class AnotherFakeApi {
         String[] localVarAuthNames = new String[] {  };
         return apiClient.buildCall(localVarPath, "PATCH", localVarQueryParams, localVarCollectionQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarAuthNames, progressRequestListener);
     }
-    
+
     @SuppressWarnings("rawtypes")
     private com.squareup.okhttp.Call testSpecialTagsValidateBeforeCall(Client body, final ProgressResponseBody.ProgressListener progressListener, final ProgressRequestBody.ProgressRequestListener progressRequestListener) throws ApiException {
         
@@ -111,14 +111,10 @@ public class AnotherFakeApi {
             throw new ApiException("Missing the required parameter 'body' when calling testSpecialTags(Async)");
         }
         
-        
+
         com.squareup.okhttp.Call call = testSpecialTagsCall(body, progressListener, progressRequestListener);
         return call;
 
-        
-        
-        
-        
     }
 
     /**

--- a/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/io/swagger/client/api/FakeApi.java
+++ b/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/io/swagger/client/api/FakeApi.java
@@ -68,7 +68,7 @@ public class FakeApi {
      */
     public com.squareup.okhttp.Call fakeOuterBooleanSerializeCall(Boolean body, final ProgressResponseBody.ProgressListener progressListener, final ProgressRequestBody.ProgressRequestListener progressRequestListener) throws ApiException {
         Object localVarPostBody = body;
-        
+
         // create path and map variables
         String localVarPath = "/fake/outer/boolean";
 
@@ -106,18 +106,14 @@ public class FakeApi {
         String[] localVarAuthNames = new String[] {  };
         return apiClient.buildCall(localVarPath, "POST", localVarQueryParams, localVarCollectionQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarAuthNames, progressRequestListener);
     }
-    
+
     @SuppressWarnings("rawtypes")
     private com.squareup.okhttp.Call fakeOuterBooleanSerializeValidateBeforeCall(Boolean body, final ProgressResponseBody.ProgressListener progressListener, final ProgressRequestBody.ProgressRequestListener progressRequestListener) throws ApiException {
         
-        
+
         com.squareup.okhttp.Call call = fakeOuterBooleanSerializeCall(body, progressListener, progressRequestListener);
         return call;
 
-        
-        
-        
-        
     }
 
     /**
@@ -189,7 +185,7 @@ public class FakeApi {
      */
     public com.squareup.okhttp.Call fakeOuterCompositeSerializeCall(OuterComposite body, final ProgressResponseBody.ProgressListener progressListener, final ProgressRequestBody.ProgressRequestListener progressRequestListener) throws ApiException {
         Object localVarPostBody = body;
-        
+
         // create path and map variables
         String localVarPath = "/fake/outer/composite";
 
@@ -227,18 +223,14 @@ public class FakeApi {
         String[] localVarAuthNames = new String[] {  };
         return apiClient.buildCall(localVarPath, "POST", localVarQueryParams, localVarCollectionQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarAuthNames, progressRequestListener);
     }
-    
+
     @SuppressWarnings("rawtypes")
     private com.squareup.okhttp.Call fakeOuterCompositeSerializeValidateBeforeCall(OuterComposite body, final ProgressResponseBody.ProgressListener progressListener, final ProgressRequestBody.ProgressRequestListener progressRequestListener) throws ApiException {
         
-        
+
         com.squareup.okhttp.Call call = fakeOuterCompositeSerializeCall(body, progressListener, progressRequestListener);
         return call;
 
-        
-        
-        
-        
     }
 
     /**
@@ -310,7 +302,7 @@ public class FakeApi {
      */
     public com.squareup.okhttp.Call fakeOuterNumberSerializeCall(BigDecimal body, final ProgressResponseBody.ProgressListener progressListener, final ProgressRequestBody.ProgressRequestListener progressRequestListener) throws ApiException {
         Object localVarPostBody = body;
-        
+
         // create path and map variables
         String localVarPath = "/fake/outer/number";
 
@@ -348,18 +340,14 @@ public class FakeApi {
         String[] localVarAuthNames = new String[] {  };
         return apiClient.buildCall(localVarPath, "POST", localVarQueryParams, localVarCollectionQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarAuthNames, progressRequestListener);
     }
-    
+
     @SuppressWarnings("rawtypes")
     private com.squareup.okhttp.Call fakeOuterNumberSerializeValidateBeforeCall(BigDecimal body, final ProgressResponseBody.ProgressListener progressListener, final ProgressRequestBody.ProgressRequestListener progressRequestListener) throws ApiException {
         
-        
+
         com.squareup.okhttp.Call call = fakeOuterNumberSerializeCall(body, progressListener, progressRequestListener);
         return call;
 
-        
-        
-        
-        
     }
 
     /**
@@ -431,7 +419,7 @@ public class FakeApi {
      */
     public com.squareup.okhttp.Call fakeOuterStringSerializeCall(String body, final ProgressResponseBody.ProgressListener progressListener, final ProgressRequestBody.ProgressRequestListener progressRequestListener) throws ApiException {
         Object localVarPostBody = body;
-        
+
         // create path and map variables
         String localVarPath = "/fake/outer/string";
 
@@ -469,18 +457,14 @@ public class FakeApi {
         String[] localVarAuthNames = new String[] {  };
         return apiClient.buildCall(localVarPath, "POST", localVarQueryParams, localVarCollectionQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarAuthNames, progressRequestListener);
     }
-    
+
     @SuppressWarnings("rawtypes")
     private com.squareup.okhttp.Call fakeOuterStringSerializeValidateBeforeCall(String body, final ProgressResponseBody.ProgressListener progressListener, final ProgressRequestBody.ProgressRequestListener progressRequestListener) throws ApiException {
         
-        
+
         com.squareup.okhttp.Call call = fakeOuterStringSerializeCall(body, progressListener, progressRequestListener);
         return call;
 
-        
-        
-        
-        
     }
 
     /**
@@ -552,7 +536,7 @@ public class FakeApi {
      */
     public com.squareup.okhttp.Call testClientModelCall(Client body, final ProgressResponseBody.ProgressListener progressListener, final ProgressRequestBody.ProgressRequestListener progressRequestListener) throws ApiException {
         Object localVarPostBody = body;
-        
+
         // create path and map variables
         String localVarPath = "/fake";
 
@@ -590,7 +574,7 @@ public class FakeApi {
         String[] localVarAuthNames = new String[] {  };
         return apiClient.buildCall(localVarPath, "PATCH", localVarQueryParams, localVarCollectionQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarAuthNames, progressRequestListener);
     }
-    
+
     @SuppressWarnings("rawtypes")
     private com.squareup.okhttp.Call testClientModelValidateBeforeCall(Client body, final ProgressResponseBody.ProgressListener progressListener, final ProgressRequestBody.ProgressRequestListener progressRequestListener) throws ApiException {
         
@@ -599,14 +583,10 @@ public class FakeApi {
             throw new ApiException("Missing the required parameter 'body' when calling testClientModel(Async)");
         }
         
-        
+
         com.squareup.okhttp.Call call = testClientModelCall(body, progressListener, progressRequestListener);
         return call;
 
-        
-        
-        
-        
     }
 
     /**
@@ -691,7 +671,7 @@ public class FakeApi {
      */
     public com.squareup.okhttp.Call testEndpointParametersCall(BigDecimal number, Double _double, String patternWithoutDelimiter, byte[] _byte, Integer integer, Integer int32, Long int64, Float _float, String string, byte[] binary, LocalDate date, OffsetDateTime dateTime, String password, String paramCallback, final ProgressResponseBody.ProgressListener progressListener, final ProgressRequestBody.ProgressRequestListener progressRequestListener) throws ApiException {
         Object localVarPostBody = null;
-        
+
         // create path and map variables
         String localVarPath = "/fake";
 
@@ -757,7 +737,7 @@ public class FakeApi {
         String[] localVarAuthNames = new String[] { "http_basic_test" };
         return apiClient.buildCall(localVarPath, "POST", localVarQueryParams, localVarCollectionQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarAuthNames, progressRequestListener);
     }
-    
+
     @SuppressWarnings("rawtypes")
     private com.squareup.okhttp.Call testEndpointParametersValidateBeforeCall(BigDecimal number, Double _double, String patternWithoutDelimiter, byte[] _byte, Integer integer, Integer int32, Long int64, Float _float, String string, byte[] binary, LocalDate date, OffsetDateTime dateTime, String password, String paramCallback, final ProgressResponseBody.ProgressListener progressListener, final ProgressRequestBody.ProgressRequestListener progressRequestListener) throws ApiException {
         
@@ -781,14 +761,10 @@ public class FakeApi {
             throw new ApiException("Missing the required parameter '_byte' when calling testEndpointParameters(Async)");
         }
         
-        
+
         com.squareup.okhttp.Call call = testEndpointParametersCall(number, _double, patternWithoutDelimiter, _byte, integer, int32, int64, _float, string, binary, date, dateTime, password, paramCallback, progressListener, progressRequestListener);
         return call;
 
-        
-        
-        
-        
     }
 
     /**
@@ -902,7 +878,7 @@ public class FakeApi {
      */
     public com.squareup.okhttp.Call testEnumParametersCall(List<String> enumFormStringArray, String enumFormString, List<String> enumHeaderStringArray, String enumHeaderString, List<String> enumQueryStringArray, String enumQueryString, Integer enumQueryInteger, Double enumQueryDouble, final ProgressResponseBody.ProgressListener progressListener, final ProgressRequestBody.ProgressRequestListener progressRequestListener) throws ApiException {
         Object localVarPostBody = null;
-        
+
         // create path and map variables
         String localVarPath = "/fake";
 
@@ -956,18 +932,14 @@ public class FakeApi {
         String[] localVarAuthNames = new String[] {  };
         return apiClient.buildCall(localVarPath, "GET", localVarQueryParams, localVarCollectionQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarAuthNames, progressRequestListener);
     }
-    
+
     @SuppressWarnings("rawtypes")
     private com.squareup.okhttp.Call testEnumParametersValidateBeforeCall(List<String> enumFormStringArray, String enumFormString, List<String> enumHeaderStringArray, String enumHeaderString, List<String> enumQueryStringArray, String enumQueryString, Integer enumQueryInteger, Double enumQueryDouble, final ProgressResponseBody.ProgressListener progressListener, final ProgressRequestBody.ProgressRequestListener progressRequestListener) throws ApiException {
         
-        
+
         com.squareup.okhttp.Call call = testEnumParametersCall(enumFormStringArray, enumFormString, enumHeaderStringArray, enumHeaderString, enumQueryStringArray, enumQueryString, enumQueryInteger, enumQueryDouble, progressListener, progressRequestListener);
         return call;
 
-        
-        
-        
-        
     }
 
     /**
@@ -1047,6 +1019,124 @@ public class FakeApi {
         return call;
     }
     /**
+     * Build call for testInlineAdditionalProperties
+     * @param param request body (required)
+     * @param progressListener Progress listener
+     * @param progressRequestListener Progress request listener
+     * @return Call to execute
+     * @throws ApiException If fail to serialize the request body object
+     */
+    public com.squareup.okhttp.Call testInlineAdditionalPropertiesCall(Object param, final ProgressResponseBody.ProgressListener progressListener, final ProgressRequestBody.ProgressRequestListener progressRequestListener) throws ApiException {
+        Object localVarPostBody = param;
+
+        // create path and map variables
+        String localVarPath = "/fake/inline-additionalProperties";
+
+        List<Pair> localVarQueryParams = new ArrayList<Pair>();
+        List<Pair> localVarCollectionQueryParams = new ArrayList<Pair>();
+
+        Map<String, String> localVarHeaderParams = new HashMap<String, String>();
+
+        Map<String, Object> localVarFormParams = new HashMap<String, Object>();
+
+        final String[] localVarAccepts = {
+            
+        };
+        final String localVarAccept = apiClient.selectHeaderAccept(localVarAccepts);
+        if (localVarAccept != null) localVarHeaderParams.put("Accept", localVarAccept);
+
+        final String[] localVarContentTypes = {
+            "application/json"
+        };
+        final String localVarContentType = apiClient.selectHeaderContentType(localVarContentTypes);
+        localVarHeaderParams.put("Content-Type", localVarContentType);
+
+        if(progressListener != null) {
+            apiClient.getHttpClient().networkInterceptors().add(new com.squareup.okhttp.Interceptor() {
+                @Override
+                public com.squareup.okhttp.Response intercept(com.squareup.okhttp.Interceptor.Chain chain) throws IOException {
+                    com.squareup.okhttp.Response originalResponse = chain.proceed(chain.request());
+                    return originalResponse.newBuilder()
+                    .body(new ProgressResponseBody(originalResponse.body(), progressListener))
+                    .build();
+                }
+            });
+        }
+
+        String[] localVarAuthNames = new String[] {  };
+        return apiClient.buildCall(localVarPath, "POST", localVarQueryParams, localVarCollectionQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarAuthNames, progressRequestListener);
+    }
+
+    @SuppressWarnings("rawtypes")
+    private com.squareup.okhttp.Call testInlineAdditionalPropertiesValidateBeforeCall(Object param, final ProgressResponseBody.ProgressListener progressListener, final ProgressRequestBody.ProgressRequestListener progressRequestListener) throws ApiException {
+        
+        // verify the required parameter 'param' is set
+        if (param == null) {
+            throw new ApiException("Missing the required parameter 'param' when calling testInlineAdditionalProperties(Async)");
+        }
+        
+
+        com.squareup.okhttp.Call call = testInlineAdditionalPropertiesCall(param, progressListener, progressRequestListener);
+        return call;
+
+    }
+
+    /**
+     * test inline additionalProperties
+     * 
+     * @param param request body (required)
+     * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
+     */
+    public void testInlineAdditionalProperties(Object param) throws ApiException {
+        testInlineAdditionalPropertiesWithHttpInfo(param);
+    }
+
+    /**
+     * test inline additionalProperties
+     * 
+     * @param param request body (required)
+     * @return ApiResponse&lt;Void&gt;
+     * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
+     */
+    public ApiResponse<Void> testInlineAdditionalPropertiesWithHttpInfo(Object param) throws ApiException {
+        com.squareup.okhttp.Call call = testInlineAdditionalPropertiesValidateBeforeCall(param, null, null);
+        return apiClient.execute(call);
+    }
+
+    /**
+     * test inline additionalProperties (asynchronously)
+     * 
+     * @param param request body (required)
+     * @param callback The callback to be executed when the API call finishes
+     * @return The request call
+     * @throws ApiException If fail to process the API call, e.g. serializing the request body object
+     */
+    public com.squareup.okhttp.Call testInlineAdditionalPropertiesAsync(Object param, final ApiCallback<Void> callback) throws ApiException {
+
+        ProgressResponseBody.ProgressListener progressListener = null;
+        ProgressRequestBody.ProgressRequestListener progressRequestListener = null;
+
+        if (callback != null) {
+            progressListener = new ProgressResponseBody.ProgressListener() {
+                @Override
+                public void update(long bytesRead, long contentLength, boolean done) {
+                    callback.onDownloadProgress(bytesRead, contentLength, done);
+                }
+            };
+
+            progressRequestListener = new ProgressRequestBody.ProgressRequestListener() {
+                @Override
+                public void onRequestProgress(long bytesWritten, long contentLength, boolean done) {
+                    callback.onUploadProgress(bytesWritten, contentLength, done);
+                }
+            };
+        }
+
+        com.squareup.okhttp.Call call = testInlineAdditionalPropertiesValidateBeforeCall(param, progressListener, progressRequestListener);
+        apiClient.executeAsync(call, callback);
+        return call;
+    }
+    /**
      * Build call for testJsonFormData
      * @param param field1 (required)
      * @param param2 field2 (required)
@@ -1057,7 +1147,7 @@ public class FakeApi {
      */
     public com.squareup.okhttp.Call testJsonFormDataCall(String param, String param2, final ProgressResponseBody.ProgressListener progressListener, final ProgressRequestBody.ProgressRequestListener progressRequestListener) throws ApiException {
         Object localVarPostBody = null;
-        
+
         // create path and map variables
         String localVarPath = "/fake/jsonFormData";
 
@@ -1099,7 +1189,7 @@ public class FakeApi {
         String[] localVarAuthNames = new String[] {  };
         return apiClient.buildCall(localVarPath, "GET", localVarQueryParams, localVarCollectionQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarAuthNames, progressRequestListener);
     }
-    
+
     @SuppressWarnings("rawtypes")
     private com.squareup.okhttp.Call testJsonFormDataValidateBeforeCall(String param, String param2, final ProgressResponseBody.ProgressListener progressListener, final ProgressRequestBody.ProgressRequestListener progressRequestListener) throws ApiException {
         
@@ -1113,14 +1203,10 @@ public class FakeApi {
             throw new ApiException("Missing the required parameter 'param2' when calling testJsonFormData(Async)");
         }
         
-        
+
         com.squareup.okhttp.Call call = testJsonFormDataCall(param, param2, progressListener, progressRequestListener);
         return call;
 
-        
-        
-        
-        
     }
 
     /**

--- a/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/io/swagger/client/api/FakeClassnameTags123Api.java
+++ b/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/io/swagger/client/api/FakeClassnameTags123Api.java
@@ -64,7 +64,7 @@ public class FakeClassnameTags123Api {
      */
     public com.squareup.okhttp.Call testClassnameCall(Client body, final ProgressResponseBody.ProgressListener progressListener, final ProgressRequestBody.ProgressRequestListener progressRequestListener) throws ApiException {
         Object localVarPostBody = body;
-        
+
         // create path and map variables
         String localVarPath = "/fake_classname_test";
 
@@ -102,7 +102,7 @@ public class FakeClassnameTags123Api {
         String[] localVarAuthNames = new String[] { "api_key_query" };
         return apiClient.buildCall(localVarPath, "PATCH", localVarQueryParams, localVarCollectionQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarAuthNames, progressRequestListener);
     }
-    
+
     @SuppressWarnings("rawtypes")
     private com.squareup.okhttp.Call testClassnameValidateBeforeCall(Client body, final ProgressResponseBody.ProgressListener progressListener, final ProgressRequestBody.ProgressRequestListener progressRequestListener) throws ApiException {
         
@@ -111,14 +111,10 @@ public class FakeClassnameTags123Api {
             throw new ApiException("Missing the required parameter 'body' when calling testClassname(Async)");
         }
         
-        
+
         com.squareup.okhttp.Call call = testClassnameCall(body, progressListener, progressRequestListener);
         return call;
 
-        
-        
-        
-        
     }
 
     /**

--- a/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/io/swagger/client/api/PetApi.java
+++ b/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/io/swagger/client/api/PetApi.java
@@ -66,7 +66,7 @@ public class PetApi {
      */
     public com.squareup.okhttp.Call addPetCall(Pet body, final ProgressResponseBody.ProgressListener progressListener, final ProgressRequestBody.ProgressRequestListener progressRequestListener) throws ApiException {
         Object localVarPostBody = body;
-        
+
         // create path and map variables
         String localVarPath = "/pet";
 
@@ -104,7 +104,7 @@ public class PetApi {
         String[] localVarAuthNames = new String[] { "petstore_auth" };
         return apiClient.buildCall(localVarPath, "POST", localVarQueryParams, localVarCollectionQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarAuthNames, progressRequestListener);
     }
-    
+
     @SuppressWarnings("rawtypes")
     private com.squareup.okhttp.Call addPetValidateBeforeCall(Pet body, final ProgressResponseBody.ProgressListener progressListener, final ProgressRequestBody.ProgressRequestListener progressRequestListener) throws ApiException {
         
@@ -113,14 +113,10 @@ public class PetApi {
             throw new ApiException("Missing the required parameter 'body' when calling addPet(Async)");
         }
         
-        
+
         com.squareup.okhttp.Call call = addPetCall(body, progressListener, progressRequestListener);
         return call;
 
-        
-        
-        
-        
     }
 
     /**
@@ -189,7 +185,7 @@ public class PetApi {
      */
     public com.squareup.okhttp.Call deletePetCall(Long petId, String apiKey, final ProgressResponseBody.ProgressListener progressListener, final ProgressRequestBody.ProgressRequestListener progressRequestListener) throws ApiException {
         Object localVarPostBody = null;
-        
+
         // create path and map variables
         String localVarPath = "/pet/{petId}"
             .replaceAll("\\{" + "petId" + "\\}", apiClient.escapeString(petId.toString()));
@@ -230,7 +226,7 @@ public class PetApi {
         String[] localVarAuthNames = new String[] { "petstore_auth" };
         return apiClient.buildCall(localVarPath, "DELETE", localVarQueryParams, localVarCollectionQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarAuthNames, progressRequestListener);
     }
-    
+
     @SuppressWarnings("rawtypes")
     private com.squareup.okhttp.Call deletePetValidateBeforeCall(Long petId, String apiKey, final ProgressResponseBody.ProgressListener progressListener, final ProgressRequestBody.ProgressRequestListener progressRequestListener) throws ApiException {
         
@@ -239,14 +235,10 @@ public class PetApi {
             throw new ApiException("Missing the required parameter 'petId' when calling deletePet(Async)");
         }
         
-        
+
         com.squareup.okhttp.Call call = deletePetCall(petId, apiKey, progressListener, progressRequestListener);
         return call;
 
-        
-        
-        
-        
     }
 
     /**
@@ -317,7 +309,7 @@ public class PetApi {
      */
     public com.squareup.okhttp.Call findPetsByStatusCall(List<String> status, final ProgressResponseBody.ProgressListener progressListener, final ProgressRequestBody.ProgressRequestListener progressRequestListener) throws ApiException {
         Object localVarPostBody = null;
-        
+
         // create path and map variables
         String localVarPath = "/pet/findByStatus";
 
@@ -357,7 +349,7 @@ public class PetApi {
         String[] localVarAuthNames = new String[] { "petstore_auth" };
         return apiClient.buildCall(localVarPath, "GET", localVarQueryParams, localVarCollectionQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarAuthNames, progressRequestListener);
     }
-    
+
     @SuppressWarnings("rawtypes")
     private com.squareup.okhttp.Call findPetsByStatusValidateBeforeCall(List<String> status, final ProgressResponseBody.ProgressListener progressListener, final ProgressRequestBody.ProgressRequestListener progressRequestListener) throws ApiException {
         
@@ -366,14 +358,10 @@ public class PetApi {
             throw new ApiException("Missing the required parameter 'status' when calling findPetsByStatus(Async)");
         }
         
-        
+
         com.squareup.okhttp.Call call = findPetsByStatusCall(status, progressListener, progressRequestListener);
         return call;
 
-        
-        
-        
-        
     }
 
     /**
@@ -442,10 +430,12 @@ public class PetApi {
      * @param progressRequestListener Progress request listener
      * @return Call to execute
      * @throws ApiException If fail to serialize the request body object
+     * @deprecated
      */
+    @Deprecated
     public com.squareup.okhttp.Call findPetsByTagsCall(List<String> tags, final ProgressResponseBody.ProgressListener progressListener, final ProgressRequestBody.ProgressRequestListener progressRequestListener) throws ApiException {
         Object localVarPostBody = null;
-        
+
         // create path and map variables
         String localVarPath = "/pet/findByTags";
 
@@ -485,7 +475,8 @@ public class PetApi {
         String[] localVarAuthNames = new String[] { "petstore_auth" };
         return apiClient.buildCall(localVarPath, "GET", localVarQueryParams, localVarCollectionQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarAuthNames, progressRequestListener);
     }
-    
+
+    @Deprecated
     @SuppressWarnings("rawtypes")
     private com.squareup.okhttp.Call findPetsByTagsValidateBeforeCall(List<String> tags, final ProgressResponseBody.ProgressListener progressListener, final ProgressRequestBody.ProgressRequestListener progressRequestListener) throws ApiException {
         
@@ -494,14 +485,10 @@ public class PetApi {
             throw new ApiException("Missing the required parameter 'tags' when calling findPetsByTags(Async)");
         }
         
-        
+
         com.squareup.okhttp.Call call = findPetsByTagsCall(tags, progressListener, progressRequestListener);
         return call;
 
-        
-        
-        
-        
     }
 
     /**
@@ -510,7 +497,9 @@ public class PetApi {
      * @param tags Tags to filter by (required)
      * @return List&lt;Pet&gt;
      * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
+     * @deprecated
      */
+    @Deprecated
     public List<Pet> findPetsByTags(List<String> tags) throws ApiException {
         ApiResponse<List<Pet>> resp = findPetsByTagsWithHttpInfo(tags);
         return resp.getData();
@@ -522,7 +511,9 @@ public class PetApi {
      * @param tags Tags to filter by (required)
      * @return ApiResponse&lt;List&lt;Pet&gt;&gt;
      * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
+     * @deprecated
      */
+    @Deprecated
     public ApiResponse<List<Pet>> findPetsByTagsWithHttpInfo(List<String> tags) throws ApiException {
         com.squareup.okhttp.Call call = findPetsByTagsValidateBeforeCall(tags, null, null);
         Type localVarReturnType = new TypeToken<List<Pet>>(){}.getType();
@@ -536,7 +527,9 @@ public class PetApi {
      * @param callback The callback to be executed when the API call finishes
      * @return The request call
      * @throws ApiException If fail to process the API call, e.g. serializing the request body object
+     * @deprecated
      */
+    @Deprecated
     public com.squareup.okhttp.Call findPetsByTagsAsync(List<String> tags, final ApiCallback<List<Pet>> callback) throws ApiException {
 
         ProgressResponseBody.ProgressListener progressListener = null;
@@ -573,7 +566,7 @@ public class PetApi {
      */
     public com.squareup.okhttp.Call getPetByIdCall(Long petId, final ProgressResponseBody.ProgressListener progressListener, final ProgressRequestBody.ProgressRequestListener progressRequestListener) throws ApiException {
         Object localVarPostBody = null;
-        
+
         // create path and map variables
         String localVarPath = "/pet/{petId}"
             .replaceAll("\\{" + "petId" + "\\}", apiClient.escapeString(petId.toString()));
@@ -612,7 +605,7 @@ public class PetApi {
         String[] localVarAuthNames = new String[] { "api_key" };
         return apiClient.buildCall(localVarPath, "GET", localVarQueryParams, localVarCollectionQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarAuthNames, progressRequestListener);
     }
-    
+
     @SuppressWarnings("rawtypes")
     private com.squareup.okhttp.Call getPetByIdValidateBeforeCall(Long petId, final ProgressResponseBody.ProgressListener progressListener, final ProgressRequestBody.ProgressRequestListener progressRequestListener) throws ApiException {
         
@@ -621,14 +614,10 @@ public class PetApi {
             throw new ApiException("Missing the required parameter 'petId' when calling getPetById(Async)");
         }
         
-        
+
         com.squareup.okhttp.Call call = getPetByIdCall(petId, progressListener, progressRequestListener);
         return call;
 
-        
-        
-        
-        
     }
 
     /**
@@ -700,7 +689,7 @@ public class PetApi {
      */
     public com.squareup.okhttp.Call updatePetCall(Pet body, final ProgressResponseBody.ProgressListener progressListener, final ProgressRequestBody.ProgressRequestListener progressRequestListener) throws ApiException {
         Object localVarPostBody = body;
-        
+
         // create path and map variables
         String localVarPath = "/pet";
 
@@ -738,7 +727,7 @@ public class PetApi {
         String[] localVarAuthNames = new String[] { "petstore_auth" };
         return apiClient.buildCall(localVarPath, "PUT", localVarQueryParams, localVarCollectionQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarAuthNames, progressRequestListener);
     }
-    
+
     @SuppressWarnings("rawtypes")
     private com.squareup.okhttp.Call updatePetValidateBeforeCall(Pet body, final ProgressResponseBody.ProgressListener progressListener, final ProgressRequestBody.ProgressRequestListener progressRequestListener) throws ApiException {
         
@@ -747,14 +736,10 @@ public class PetApi {
             throw new ApiException("Missing the required parameter 'body' when calling updatePet(Async)");
         }
         
-        
+
         com.squareup.okhttp.Call call = updatePetCall(body, progressListener, progressRequestListener);
         return call;
 
-        
-        
-        
-        
     }
 
     /**
@@ -824,7 +809,7 @@ public class PetApi {
      */
     public com.squareup.okhttp.Call updatePetWithFormCall(Long petId, String name, String status, final ProgressResponseBody.ProgressListener progressListener, final ProgressRequestBody.ProgressRequestListener progressRequestListener) throws ApiException {
         Object localVarPostBody = null;
-        
+
         // create path and map variables
         String localVarPath = "/pet/{petId}"
             .replaceAll("\\{" + "petId" + "\\}", apiClient.escapeString(petId.toString()));
@@ -867,7 +852,7 @@ public class PetApi {
         String[] localVarAuthNames = new String[] { "petstore_auth" };
         return apiClient.buildCall(localVarPath, "POST", localVarQueryParams, localVarCollectionQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarAuthNames, progressRequestListener);
     }
-    
+
     @SuppressWarnings("rawtypes")
     private com.squareup.okhttp.Call updatePetWithFormValidateBeforeCall(Long petId, String name, String status, final ProgressResponseBody.ProgressListener progressListener, final ProgressRequestBody.ProgressRequestListener progressRequestListener) throws ApiException {
         
@@ -876,14 +861,10 @@ public class PetApi {
             throw new ApiException("Missing the required parameter 'petId' when calling updatePetWithForm(Async)");
         }
         
-        
+
         com.squareup.okhttp.Call call = updatePetWithFormCall(petId, name, status, progressListener, progressRequestListener);
         return call;
 
-        
-        
-        
-        
     }
 
     /**
@@ -959,7 +940,7 @@ public class PetApi {
      */
     public com.squareup.okhttp.Call uploadFileCall(Long petId, String additionalMetadata, File file, final ProgressResponseBody.ProgressListener progressListener, final ProgressRequestBody.ProgressRequestListener progressRequestListener) throws ApiException {
         Object localVarPostBody = null;
-        
+
         // create path and map variables
         String localVarPath = "/pet/{petId}/uploadImage"
             .replaceAll("\\{" + "petId" + "\\}", apiClient.escapeString(petId.toString()));
@@ -1002,7 +983,7 @@ public class PetApi {
         String[] localVarAuthNames = new String[] { "petstore_auth" };
         return apiClient.buildCall(localVarPath, "POST", localVarQueryParams, localVarCollectionQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarAuthNames, progressRequestListener);
     }
-    
+
     @SuppressWarnings("rawtypes")
     private com.squareup.okhttp.Call uploadFileValidateBeforeCall(Long petId, String additionalMetadata, File file, final ProgressResponseBody.ProgressListener progressListener, final ProgressRequestBody.ProgressRequestListener progressRequestListener) throws ApiException {
         
@@ -1011,14 +992,10 @@ public class PetApi {
             throw new ApiException("Missing the required parameter 'petId' when calling uploadFile(Async)");
         }
         
-        
+
         com.squareup.okhttp.Call call = uploadFileCall(petId, additionalMetadata, file, progressListener, progressRequestListener);
         return call;
 
-        
-        
-        
-        
     }
 
     /**

--- a/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/io/swagger/client/api/StoreApi.java
+++ b/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/io/swagger/client/api/StoreApi.java
@@ -64,7 +64,7 @@ public class StoreApi {
      */
     public com.squareup.okhttp.Call deleteOrderCall(String orderId, final ProgressResponseBody.ProgressListener progressListener, final ProgressRequestBody.ProgressRequestListener progressRequestListener) throws ApiException {
         Object localVarPostBody = null;
-        
+
         // create path and map variables
         String localVarPath = "/store/order/{order_id}"
             .replaceAll("\\{" + "order_id" + "\\}", apiClient.escapeString(orderId.toString()));
@@ -103,7 +103,7 @@ public class StoreApi {
         String[] localVarAuthNames = new String[] {  };
         return apiClient.buildCall(localVarPath, "DELETE", localVarQueryParams, localVarCollectionQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarAuthNames, progressRequestListener);
     }
-    
+
     @SuppressWarnings("rawtypes")
     private com.squareup.okhttp.Call deleteOrderValidateBeforeCall(String orderId, final ProgressResponseBody.ProgressListener progressListener, final ProgressRequestBody.ProgressRequestListener progressRequestListener) throws ApiException {
         
@@ -112,14 +112,10 @@ public class StoreApi {
             throw new ApiException("Missing the required parameter 'orderId' when calling deleteOrder(Async)");
         }
         
-        
+
         com.squareup.okhttp.Call call = deleteOrderCall(orderId, progressListener, progressRequestListener);
         return call;
 
-        
-        
-        
-        
     }
 
     /**
@@ -186,7 +182,7 @@ public class StoreApi {
      */
     public com.squareup.okhttp.Call getInventoryCall(final ProgressResponseBody.ProgressListener progressListener, final ProgressRequestBody.ProgressRequestListener progressRequestListener) throws ApiException {
         Object localVarPostBody = null;
-        
+
         // create path and map variables
         String localVarPath = "/store/inventory";
 
@@ -224,18 +220,14 @@ public class StoreApi {
         String[] localVarAuthNames = new String[] { "api_key" };
         return apiClient.buildCall(localVarPath, "GET", localVarQueryParams, localVarCollectionQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarAuthNames, progressRequestListener);
     }
-    
+
     @SuppressWarnings("rawtypes")
     private com.squareup.okhttp.Call getInventoryValidateBeforeCall(final ProgressResponseBody.ProgressListener progressListener, final ProgressRequestBody.ProgressRequestListener progressRequestListener) throws ApiException {
         
-        
+
         com.squareup.okhttp.Call call = getInventoryCall(progressListener, progressRequestListener);
         return call;
 
-        
-        
-        
-        
     }
 
     /**
@@ -304,7 +296,7 @@ public class StoreApi {
      */
     public com.squareup.okhttp.Call getOrderByIdCall(Long orderId, final ProgressResponseBody.ProgressListener progressListener, final ProgressRequestBody.ProgressRequestListener progressRequestListener) throws ApiException {
         Object localVarPostBody = null;
-        
+
         // create path and map variables
         String localVarPath = "/store/order/{order_id}"
             .replaceAll("\\{" + "order_id" + "\\}", apiClient.escapeString(orderId.toString()));
@@ -343,7 +335,7 @@ public class StoreApi {
         String[] localVarAuthNames = new String[] {  };
         return apiClient.buildCall(localVarPath, "GET", localVarQueryParams, localVarCollectionQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarAuthNames, progressRequestListener);
     }
-    
+
     @SuppressWarnings("rawtypes")
     private com.squareup.okhttp.Call getOrderByIdValidateBeforeCall(Long orderId, final ProgressResponseBody.ProgressListener progressListener, final ProgressRequestBody.ProgressRequestListener progressRequestListener) throws ApiException {
         
@@ -352,14 +344,10 @@ public class StoreApi {
             throw new ApiException("Missing the required parameter 'orderId' when calling getOrderById(Async)");
         }
         
-        
+
         com.squareup.okhttp.Call call = getOrderByIdCall(orderId, progressListener, progressRequestListener);
         return call;
 
-        
-        
-        
-        
     }
 
     /**
@@ -431,7 +419,7 @@ public class StoreApi {
      */
     public com.squareup.okhttp.Call placeOrderCall(Order body, final ProgressResponseBody.ProgressListener progressListener, final ProgressRequestBody.ProgressRequestListener progressRequestListener) throws ApiException {
         Object localVarPostBody = body;
-        
+
         // create path and map variables
         String localVarPath = "/store/order";
 
@@ -469,7 +457,7 @@ public class StoreApi {
         String[] localVarAuthNames = new String[] {  };
         return apiClient.buildCall(localVarPath, "POST", localVarQueryParams, localVarCollectionQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarAuthNames, progressRequestListener);
     }
-    
+
     @SuppressWarnings("rawtypes")
     private com.squareup.okhttp.Call placeOrderValidateBeforeCall(Order body, final ProgressResponseBody.ProgressListener progressListener, final ProgressRequestBody.ProgressRequestListener progressRequestListener) throws ApiException {
         
@@ -478,14 +466,10 @@ public class StoreApi {
             throw new ApiException("Missing the required parameter 'body' when calling placeOrder(Async)");
         }
         
-        
+
         com.squareup.okhttp.Call call = placeOrderCall(body, progressListener, progressRequestListener);
         return call;
 
-        
-        
-        
-        
     }
 
     /**

--- a/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/io/swagger/client/api/UserApi.java
+++ b/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/io/swagger/client/api/UserApi.java
@@ -64,7 +64,7 @@ public class UserApi {
      */
     public com.squareup.okhttp.Call createUserCall(User body, final ProgressResponseBody.ProgressListener progressListener, final ProgressRequestBody.ProgressRequestListener progressRequestListener) throws ApiException {
         Object localVarPostBody = body;
-        
+
         // create path and map variables
         String localVarPath = "/user";
 
@@ -102,7 +102,7 @@ public class UserApi {
         String[] localVarAuthNames = new String[] {  };
         return apiClient.buildCall(localVarPath, "POST", localVarQueryParams, localVarCollectionQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarAuthNames, progressRequestListener);
     }
-    
+
     @SuppressWarnings("rawtypes")
     private com.squareup.okhttp.Call createUserValidateBeforeCall(User body, final ProgressResponseBody.ProgressListener progressListener, final ProgressRequestBody.ProgressRequestListener progressRequestListener) throws ApiException {
         
@@ -111,14 +111,10 @@ public class UserApi {
             throw new ApiException("Missing the required parameter 'body' when calling createUser(Async)");
         }
         
-        
+
         com.squareup.okhttp.Call call = createUserCall(body, progressListener, progressRequestListener);
         return call;
 
-        
-        
-        
-        
     }
 
     /**
@@ -186,7 +182,7 @@ public class UserApi {
      */
     public com.squareup.okhttp.Call createUsersWithArrayInputCall(List<User> body, final ProgressResponseBody.ProgressListener progressListener, final ProgressRequestBody.ProgressRequestListener progressRequestListener) throws ApiException {
         Object localVarPostBody = body;
-        
+
         // create path and map variables
         String localVarPath = "/user/createWithArray";
 
@@ -224,7 +220,7 @@ public class UserApi {
         String[] localVarAuthNames = new String[] {  };
         return apiClient.buildCall(localVarPath, "POST", localVarQueryParams, localVarCollectionQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarAuthNames, progressRequestListener);
     }
-    
+
     @SuppressWarnings("rawtypes")
     private com.squareup.okhttp.Call createUsersWithArrayInputValidateBeforeCall(List<User> body, final ProgressResponseBody.ProgressListener progressListener, final ProgressRequestBody.ProgressRequestListener progressRequestListener) throws ApiException {
         
@@ -233,14 +229,10 @@ public class UserApi {
             throw new ApiException("Missing the required parameter 'body' when calling createUsersWithArrayInput(Async)");
         }
         
-        
+
         com.squareup.okhttp.Call call = createUsersWithArrayInputCall(body, progressListener, progressRequestListener);
         return call;
 
-        
-        
-        
-        
     }
 
     /**
@@ -308,7 +300,7 @@ public class UserApi {
      */
     public com.squareup.okhttp.Call createUsersWithListInputCall(List<User> body, final ProgressResponseBody.ProgressListener progressListener, final ProgressRequestBody.ProgressRequestListener progressRequestListener) throws ApiException {
         Object localVarPostBody = body;
-        
+
         // create path and map variables
         String localVarPath = "/user/createWithList";
 
@@ -346,7 +338,7 @@ public class UserApi {
         String[] localVarAuthNames = new String[] {  };
         return apiClient.buildCall(localVarPath, "POST", localVarQueryParams, localVarCollectionQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarAuthNames, progressRequestListener);
     }
-    
+
     @SuppressWarnings("rawtypes")
     private com.squareup.okhttp.Call createUsersWithListInputValidateBeforeCall(List<User> body, final ProgressResponseBody.ProgressListener progressListener, final ProgressRequestBody.ProgressRequestListener progressRequestListener) throws ApiException {
         
@@ -355,14 +347,10 @@ public class UserApi {
             throw new ApiException("Missing the required parameter 'body' when calling createUsersWithListInput(Async)");
         }
         
-        
+
         com.squareup.okhttp.Call call = createUsersWithListInputCall(body, progressListener, progressRequestListener);
         return call;
 
-        
-        
-        
-        
     }
 
     /**
@@ -430,7 +418,7 @@ public class UserApi {
      */
     public com.squareup.okhttp.Call deleteUserCall(String username, final ProgressResponseBody.ProgressListener progressListener, final ProgressRequestBody.ProgressRequestListener progressRequestListener) throws ApiException {
         Object localVarPostBody = null;
-        
+
         // create path and map variables
         String localVarPath = "/user/{username}"
             .replaceAll("\\{" + "username" + "\\}", apiClient.escapeString(username.toString()));
@@ -469,7 +457,7 @@ public class UserApi {
         String[] localVarAuthNames = new String[] {  };
         return apiClient.buildCall(localVarPath, "DELETE", localVarQueryParams, localVarCollectionQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarAuthNames, progressRequestListener);
     }
-    
+
     @SuppressWarnings("rawtypes")
     private com.squareup.okhttp.Call deleteUserValidateBeforeCall(String username, final ProgressResponseBody.ProgressListener progressListener, final ProgressRequestBody.ProgressRequestListener progressRequestListener) throws ApiException {
         
@@ -478,14 +466,10 @@ public class UserApi {
             throw new ApiException("Missing the required parameter 'username' when calling deleteUser(Async)");
         }
         
-        
+
         com.squareup.okhttp.Call call = deleteUserCall(username, progressListener, progressRequestListener);
         return call;
 
-        
-        
-        
-        
     }
 
     /**
@@ -553,7 +537,7 @@ public class UserApi {
      */
     public com.squareup.okhttp.Call getUserByNameCall(String username, final ProgressResponseBody.ProgressListener progressListener, final ProgressRequestBody.ProgressRequestListener progressRequestListener) throws ApiException {
         Object localVarPostBody = null;
-        
+
         // create path and map variables
         String localVarPath = "/user/{username}"
             .replaceAll("\\{" + "username" + "\\}", apiClient.escapeString(username.toString()));
@@ -592,7 +576,7 @@ public class UserApi {
         String[] localVarAuthNames = new String[] {  };
         return apiClient.buildCall(localVarPath, "GET", localVarQueryParams, localVarCollectionQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarAuthNames, progressRequestListener);
     }
-    
+
     @SuppressWarnings("rawtypes")
     private com.squareup.okhttp.Call getUserByNameValidateBeforeCall(String username, final ProgressResponseBody.ProgressListener progressListener, final ProgressRequestBody.ProgressRequestListener progressRequestListener) throws ApiException {
         
@@ -601,14 +585,10 @@ public class UserApi {
             throw new ApiException("Missing the required parameter 'username' when calling getUserByName(Async)");
         }
         
-        
+
         com.squareup.okhttp.Call call = getUserByNameCall(username, progressListener, progressRequestListener);
         return call;
 
-        
-        
-        
-        
     }
 
     /**
@@ -681,7 +661,7 @@ public class UserApi {
      */
     public com.squareup.okhttp.Call loginUserCall(String username, String password, final ProgressResponseBody.ProgressListener progressListener, final ProgressRequestBody.ProgressRequestListener progressRequestListener) throws ApiException {
         Object localVarPostBody = null;
-        
+
         // create path and map variables
         String localVarPath = "/user/login";
 
@@ -723,7 +703,7 @@ public class UserApi {
         String[] localVarAuthNames = new String[] {  };
         return apiClient.buildCall(localVarPath, "GET", localVarQueryParams, localVarCollectionQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarAuthNames, progressRequestListener);
     }
-    
+
     @SuppressWarnings("rawtypes")
     private com.squareup.okhttp.Call loginUserValidateBeforeCall(String username, String password, final ProgressResponseBody.ProgressListener progressListener, final ProgressRequestBody.ProgressRequestListener progressRequestListener) throws ApiException {
         
@@ -737,14 +717,10 @@ public class UserApi {
             throw new ApiException("Missing the required parameter 'password' when calling loginUser(Async)");
         }
         
-        
+
         com.squareup.okhttp.Call call = loginUserCall(username, password, progressListener, progressRequestListener);
         return call;
 
-        
-        
-        
-        
     }
 
     /**
@@ -818,7 +794,7 @@ public class UserApi {
      */
     public com.squareup.okhttp.Call logoutUserCall(final ProgressResponseBody.ProgressListener progressListener, final ProgressRequestBody.ProgressRequestListener progressRequestListener) throws ApiException {
         Object localVarPostBody = null;
-        
+
         // create path and map variables
         String localVarPath = "/user/logout";
 
@@ -856,18 +832,14 @@ public class UserApi {
         String[] localVarAuthNames = new String[] {  };
         return apiClient.buildCall(localVarPath, "GET", localVarQueryParams, localVarCollectionQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarAuthNames, progressRequestListener);
     }
-    
+
     @SuppressWarnings("rawtypes")
     private com.squareup.okhttp.Call logoutUserValidateBeforeCall(final ProgressResponseBody.ProgressListener progressListener, final ProgressRequestBody.ProgressRequestListener progressRequestListener) throws ApiException {
         
-        
+
         com.squareup.okhttp.Call call = logoutUserCall(progressListener, progressRequestListener);
         return call;
 
-        
-        
-        
-        
     }
 
     /**
@@ -933,7 +905,7 @@ public class UserApi {
      */
     public com.squareup.okhttp.Call updateUserCall(String username, User body, final ProgressResponseBody.ProgressListener progressListener, final ProgressRequestBody.ProgressRequestListener progressRequestListener) throws ApiException {
         Object localVarPostBody = body;
-        
+
         // create path and map variables
         String localVarPath = "/user/{username}"
             .replaceAll("\\{" + "username" + "\\}", apiClient.escapeString(username.toString()));
@@ -972,7 +944,7 @@ public class UserApi {
         String[] localVarAuthNames = new String[] {  };
         return apiClient.buildCall(localVarPath, "PUT", localVarQueryParams, localVarCollectionQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarAuthNames, progressRequestListener);
     }
-    
+
     @SuppressWarnings("rawtypes")
     private com.squareup.okhttp.Call updateUserValidateBeforeCall(String username, User body, final ProgressResponseBody.ProgressListener progressListener, final ProgressRequestBody.ProgressRequestListener progressRequestListener) throws ApiException {
         
@@ -986,14 +958,10 @@ public class UserApi {
             throw new ApiException("Missing the required parameter 'body' when calling updateUser(Async)");
         }
         
-        
+
         com.squareup.okhttp.Call call = updateUserCall(username, body, progressListener, progressRequestListener);
         return call;
 
-        
-        
-        
-        
     }
 
     /**

--- a/samples/client/petstore/java/okhttp-gson/docs/FakeApi.md
+++ b/samples/client/petstore/java/okhttp-gson/docs/FakeApi.md
@@ -11,6 +11,7 @@ Method | HTTP request | Description
 [**testClientModel**](FakeApi.md#testClientModel) | **PATCH** /fake | To test \&quot;client\&quot; model
 [**testEndpointParameters**](FakeApi.md#testEndpointParameters) | **POST** /fake | Fake endpoint for testing various parameters 假端點 偽のエンドポイント 가짜 엔드 포인트 
 [**testEnumParameters**](FakeApi.md#testEnumParameters) | **GET** /fake | To test enum parameters
+[**testInlineAdditionalProperties**](FakeApi.md#testInlineAdditionalProperties) | **POST** /fake/inline-additionalProperties | test inline additionalProperties
 [**testJsonFormData**](FakeApi.md#testJsonFormData) | **GET** /fake/jsonFormData | test json serialization of form data
 
 
@@ -375,6 +376,50 @@ No authorization required
 
  - **Content-Type**: */*
  - **Accept**: */*
+
+<a name="testInlineAdditionalProperties"></a>
+# **testInlineAdditionalProperties**
+> testInlineAdditionalProperties(param)
+
+test inline additionalProperties
+
+
+
+### Example
+```java
+// Import classes:
+//import io.swagger.client.ApiException;
+//import io.swagger.client.api.FakeApi;
+
+
+FakeApi apiInstance = new FakeApi();
+Object param = null; // Object | request body
+try {
+    apiInstance.testInlineAdditionalProperties(param);
+} catch (ApiException e) {
+    System.err.println("Exception when calling FakeApi#testInlineAdditionalProperties");
+    e.printStackTrace();
+}
+```
+
+### Parameters
+
+Name | Type | Description  | Notes
+------------- | ------------- | ------------- | -------------
+ **param** | **Object**| request body |
+
+### Return type
+
+null (empty response body)
+
+### Authorization
+
+No authorization required
+
+### HTTP request headers
+
+ - **Content-Type**: application/json
+ - **Accept**: Not defined
 
 <a name="testJsonFormData"></a>
 # **testJsonFormData**

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/io/swagger/client/api/AnotherFakeApi.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/io/swagger/client/api/AnotherFakeApi.java
@@ -64,7 +64,7 @@ public class AnotherFakeApi {
      */
     public com.squareup.okhttp.Call testSpecialTagsCall(Client body, final ProgressResponseBody.ProgressListener progressListener, final ProgressRequestBody.ProgressRequestListener progressRequestListener) throws ApiException {
         Object localVarPostBody = body;
-        
+
         // create path and map variables
         String localVarPath = "/another-fake/dummy";
 
@@ -102,7 +102,7 @@ public class AnotherFakeApi {
         String[] localVarAuthNames = new String[] {  };
         return apiClient.buildCall(localVarPath, "PATCH", localVarQueryParams, localVarCollectionQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarAuthNames, progressRequestListener);
     }
-    
+
     @SuppressWarnings("rawtypes")
     private com.squareup.okhttp.Call testSpecialTagsValidateBeforeCall(Client body, final ProgressResponseBody.ProgressListener progressListener, final ProgressRequestBody.ProgressRequestListener progressRequestListener) throws ApiException {
         
@@ -111,14 +111,10 @@ public class AnotherFakeApi {
             throw new ApiException("Missing the required parameter 'body' when calling testSpecialTags(Async)");
         }
         
-        
+
         com.squareup.okhttp.Call call = testSpecialTagsCall(body, progressListener, progressRequestListener);
         return call;
 
-        
-        
-        
-        
     }
 
     /**

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/io/swagger/client/api/FakeApi.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/io/swagger/client/api/FakeApi.java
@@ -68,7 +68,7 @@ public class FakeApi {
      */
     public com.squareup.okhttp.Call fakeOuterBooleanSerializeCall(Boolean body, final ProgressResponseBody.ProgressListener progressListener, final ProgressRequestBody.ProgressRequestListener progressRequestListener) throws ApiException {
         Object localVarPostBody = body;
-        
+
         // create path and map variables
         String localVarPath = "/fake/outer/boolean";
 
@@ -106,18 +106,14 @@ public class FakeApi {
         String[] localVarAuthNames = new String[] {  };
         return apiClient.buildCall(localVarPath, "POST", localVarQueryParams, localVarCollectionQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarAuthNames, progressRequestListener);
     }
-    
+
     @SuppressWarnings("rawtypes")
     private com.squareup.okhttp.Call fakeOuterBooleanSerializeValidateBeforeCall(Boolean body, final ProgressResponseBody.ProgressListener progressListener, final ProgressRequestBody.ProgressRequestListener progressRequestListener) throws ApiException {
         
-        
+
         com.squareup.okhttp.Call call = fakeOuterBooleanSerializeCall(body, progressListener, progressRequestListener);
         return call;
 
-        
-        
-        
-        
     }
 
     /**
@@ -189,7 +185,7 @@ public class FakeApi {
      */
     public com.squareup.okhttp.Call fakeOuterCompositeSerializeCall(OuterComposite body, final ProgressResponseBody.ProgressListener progressListener, final ProgressRequestBody.ProgressRequestListener progressRequestListener) throws ApiException {
         Object localVarPostBody = body;
-        
+
         // create path and map variables
         String localVarPath = "/fake/outer/composite";
 
@@ -227,18 +223,14 @@ public class FakeApi {
         String[] localVarAuthNames = new String[] {  };
         return apiClient.buildCall(localVarPath, "POST", localVarQueryParams, localVarCollectionQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarAuthNames, progressRequestListener);
     }
-    
+
     @SuppressWarnings("rawtypes")
     private com.squareup.okhttp.Call fakeOuterCompositeSerializeValidateBeforeCall(OuterComposite body, final ProgressResponseBody.ProgressListener progressListener, final ProgressRequestBody.ProgressRequestListener progressRequestListener) throws ApiException {
         
-        
+
         com.squareup.okhttp.Call call = fakeOuterCompositeSerializeCall(body, progressListener, progressRequestListener);
         return call;
 
-        
-        
-        
-        
     }
 
     /**
@@ -310,7 +302,7 @@ public class FakeApi {
      */
     public com.squareup.okhttp.Call fakeOuterNumberSerializeCall(BigDecimal body, final ProgressResponseBody.ProgressListener progressListener, final ProgressRequestBody.ProgressRequestListener progressRequestListener) throws ApiException {
         Object localVarPostBody = body;
-        
+
         // create path and map variables
         String localVarPath = "/fake/outer/number";
 
@@ -348,18 +340,14 @@ public class FakeApi {
         String[] localVarAuthNames = new String[] {  };
         return apiClient.buildCall(localVarPath, "POST", localVarQueryParams, localVarCollectionQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarAuthNames, progressRequestListener);
     }
-    
+
     @SuppressWarnings("rawtypes")
     private com.squareup.okhttp.Call fakeOuterNumberSerializeValidateBeforeCall(BigDecimal body, final ProgressResponseBody.ProgressListener progressListener, final ProgressRequestBody.ProgressRequestListener progressRequestListener) throws ApiException {
         
-        
+
         com.squareup.okhttp.Call call = fakeOuterNumberSerializeCall(body, progressListener, progressRequestListener);
         return call;
 
-        
-        
-        
-        
     }
 
     /**
@@ -431,7 +419,7 @@ public class FakeApi {
      */
     public com.squareup.okhttp.Call fakeOuterStringSerializeCall(String body, final ProgressResponseBody.ProgressListener progressListener, final ProgressRequestBody.ProgressRequestListener progressRequestListener) throws ApiException {
         Object localVarPostBody = body;
-        
+
         // create path and map variables
         String localVarPath = "/fake/outer/string";
 
@@ -469,18 +457,14 @@ public class FakeApi {
         String[] localVarAuthNames = new String[] {  };
         return apiClient.buildCall(localVarPath, "POST", localVarQueryParams, localVarCollectionQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarAuthNames, progressRequestListener);
     }
-    
+
     @SuppressWarnings("rawtypes")
     private com.squareup.okhttp.Call fakeOuterStringSerializeValidateBeforeCall(String body, final ProgressResponseBody.ProgressListener progressListener, final ProgressRequestBody.ProgressRequestListener progressRequestListener) throws ApiException {
         
-        
+
         com.squareup.okhttp.Call call = fakeOuterStringSerializeCall(body, progressListener, progressRequestListener);
         return call;
 
-        
-        
-        
-        
     }
 
     /**
@@ -552,7 +536,7 @@ public class FakeApi {
      */
     public com.squareup.okhttp.Call testClientModelCall(Client body, final ProgressResponseBody.ProgressListener progressListener, final ProgressRequestBody.ProgressRequestListener progressRequestListener) throws ApiException {
         Object localVarPostBody = body;
-        
+
         // create path and map variables
         String localVarPath = "/fake";
 
@@ -590,7 +574,7 @@ public class FakeApi {
         String[] localVarAuthNames = new String[] {  };
         return apiClient.buildCall(localVarPath, "PATCH", localVarQueryParams, localVarCollectionQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarAuthNames, progressRequestListener);
     }
-    
+
     @SuppressWarnings("rawtypes")
     private com.squareup.okhttp.Call testClientModelValidateBeforeCall(Client body, final ProgressResponseBody.ProgressListener progressListener, final ProgressRequestBody.ProgressRequestListener progressRequestListener) throws ApiException {
         
@@ -599,14 +583,10 @@ public class FakeApi {
             throw new ApiException("Missing the required parameter 'body' when calling testClientModel(Async)");
         }
         
-        
+
         com.squareup.okhttp.Call call = testClientModelCall(body, progressListener, progressRequestListener);
         return call;
 
-        
-        
-        
-        
     }
 
     /**
@@ -691,7 +671,7 @@ public class FakeApi {
      */
     public com.squareup.okhttp.Call testEndpointParametersCall(BigDecimal number, Double _double, String patternWithoutDelimiter, byte[] _byte, Integer integer, Integer int32, Long int64, Float _float, String string, byte[] binary, LocalDate date, OffsetDateTime dateTime, String password, String paramCallback, final ProgressResponseBody.ProgressListener progressListener, final ProgressRequestBody.ProgressRequestListener progressRequestListener) throws ApiException {
         Object localVarPostBody = null;
-        
+
         // create path and map variables
         String localVarPath = "/fake";
 
@@ -757,7 +737,7 @@ public class FakeApi {
         String[] localVarAuthNames = new String[] { "http_basic_test" };
         return apiClient.buildCall(localVarPath, "POST", localVarQueryParams, localVarCollectionQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarAuthNames, progressRequestListener);
     }
-    
+
     @SuppressWarnings("rawtypes")
     private com.squareup.okhttp.Call testEndpointParametersValidateBeforeCall(BigDecimal number, Double _double, String patternWithoutDelimiter, byte[] _byte, Integer integer, Integer int32, Long int64, Float _float, String string, byte[] binary, LocalDate date, OffsetDateTime dateTime, String password, String paramCallback, final ProgressResponseBody.ProgressListener progressListener, final ProgressRequestBody.ProgressRequestListener progressRequestListener) throws ApiException {
         
@@ -781,14 +761,10 @@ public class FakeApi {
             throw new ApiException("Missing the required parameter '_byte' when calling testEndpointParameters(Async)");
         }
         
-        
+
         com.squareup.okhttp.Call call = testEndpointParametersCall(number, _double, patternWithoutDelimiter, _byte, integer, int32, int64, _float, string, binary, date, dateTime, password, paramCallback, progressListener, progressRequestListener);
         return call;
 
-        
-        
-        
-        
     }
 
     /**
@@ -902,7 +878,7 @@ public class FakeApi {
      */
     public com.squareup.okhttp.Call testEnumParametersCall(List<String> enumFormStringArray, String enumFormString, List<String> enumHeaderStringArray, String enumHeaderString, List<String> enumQueryStringArray, String enumQueryString, Integer enumQueryInteger, Double enumQueryDouble, final ProgressResponseBody.ProgressListener progressListener, final ProgressRequestBody.ProgressRequestListener progressRequestListener) throws ApiException {
         Object localVarPostBody = null;
-        
+
         // create path and map variables
         String localVarPath = "/fake";
 
@@ -956,18 +932,14 @@ public class FakeApi {
         String[] localVarAuthNames = new String[] {  };
         return apiClient.buildCall(localVarPath, "GET", localVarQueryParams, localVarCollectionQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarAuthNames, progressRequestListener);
     }
-    
+
     @SuppressWarnings("rawtypes")
     private com.squareup.okhttp.Call testEnumParametersValidateBeforeCall(List<String> enumFormStringArray, String enumFormString, List<String> enumHeaderStringArray, String enumHeaderString, List<String> enumQueryStringArray, String enumQueryString, Integer enumQueryInteger, Double enumQueryDouble, final ProgressResponseBody.ProgressListener progressListener, final ProgressRequestBody.ProgressRequestListener progressRequestListener) throws ApiException {
         
-        
+
         com.squareup.okhttp.Call call = testEnumParametersCall(enumFormStringArray, enumFormString, enumHeaderStringArray, enumHeaderString, enumQueryStringArray, enumQueryString, enumQueryInteger, enumQueryDouble, progressListener, progressRequestListener);
         return call;
 
-        
-        
-        
-        
     }
 
     /**
@@ -1047,6 +1019,124 @@ public class FakeApi {
         return call;
     }
     /**
+     * Build call for testInlineAdditionalProperties
+     * @param param request body (required)
+     * @param progressListener Progress listener
+     * @param progressRequestListener Progress request listener
+     * @return Call to execute
+     * @throws ApiException If fail to serialize the request body object
+     */
+    public com.squareup.okhttp.Call testInlineAdditionalPropertiesCall(Object param, final ProgressResponseBody.ProgressListener progressListener, final ProgressRequestBody.ProgressRequestListener progressRequestListener) throws ApiException {
+        Object localVarPostBody = param;
+
+        // create path and map variables
+        String localVarPath = "/fake/inline-additionalProperties";
+
+        List<Pair> localVarQueryParams = new ArrayList<Pair>();
+        List<Pair> localVarCollectionQueryParams = new ArrayList<Pair>();
+
+        Map<String, String> localVarHeaderParams = new HashMap<String, String>();
+
+        Map<String, Object> localVarFormParams = new HashMap<String, Object>();
+
+        final String[] localVarAccepts = {
+            
+        };
+        final String localVarAccept = apiClient.selectHeaderAccept(localVarAccepts);
+        if (localVarAccept != null) localVarHeaderParams.put("Accept", localVarAccept);
+
+        final String[] localVarContentTypes = {
+            "application/json"
+        };
+        final String localVarContentType = apiClient.selectHeaderContentType(localVarContentTypes);
+        localVarHeaderParams.put("Content-Type", localVarContentType);
+
+        if(progressListener != null) {
+            apiClient.getHttpClient().networkInterceptors().add(new com.squareup.okhttp.Interceptor() {
+                @Override
+                public com.squareup.okhttp.Response intercept(com.squareup.okhttp.Interceptor.Chain chain) throws IOException {
+                    com.squareup.okhttp.Response originalResponse = chain.proceed(chain.request());
+                    return originalResponse.newBuilder()
+                    .body(new ProgressResponseBody(originalResponse.body(), progressListener))
+                    .build();
+                }
+            });
+        }
+
+        String[] localVarAuthNames = new String[] {  };
+        return apiClient.buildCall(localVarPath, "POST", localVarQueryParams, localVarCollectionQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarAuthNames, progressRequestListener);
+    }
+
+    @SuppressWarnings("rawtypes")
+    private com.squareup.okhttp.Call testInlineAdditionalPropertiesValidateBeforeCall(Object param, final ProgressResponseBody.ProgressListener progressListener, final ProgressRequestBody.ProgressRequestListener progressRequestListener) throws ApiException {
+        
+        // verify the required parameter 'param' is set
+        if (param == null) {
+            throw new ApiException("Missing the required parameter 'param' when calling testInlineAdditionalProperties(Async)");
+        }
+        
+
+        com.squareup.okhttp.Call call = testInlineAdditionalPropertiesCall(param, progressListener, progressRequestListener);
+        return call;
+
+    }
+
+    /**
+     * test inline additionalProperties
+     * 
+     * @param param request body (required)
+     * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
+     */
+    public void testInlineAdditionalProperties(Object param) throws ApiException {
+        testInlineAdditionalPropertiesWithHttpInfo(param);
+    }
+
+    /**
+     * test inline additionalProperties
+     * 
+     * @param param request body (required)
+     * @return ApiResponse&lt;Void&gt;
+     * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
+     */
+    public ApiResponse<Void> testInlineAdditionalPropertiesWithHttpInfo(Object param) throws ApiException {
+        com.squareup.okhttp.Call call = testInlineAdditionalPropertiesValidateBeforeCall(param, null, null);
+        return apiClient.execute(call);
+    }
+
+    /**
+     * test inline additionalProperties (asynchronously)
+     * 
+     * @param param request body (required)
+     * @param callback The callback to be executed when the API call finishes
+     * @return The request call
+     * @throws ApiException If fail to process the API call, e.g. serializing the request body object
+     */
+    public com.squareup.okhttp.Call testInlineAdditionalPropertiesAsync(Object param, final ApiCallback<Void> callback) throws ApiException {
+
+        ProgressResponseBody.ProgressListener progressListener = null;
+        ProgressRequestBody.ProgressRequestListener progressRequestListener = null;
+
+        if (callback != null) {
+            progressListener = new ProgressResponseBody.ProgressListener() {
+                @Override
+                public void update(long bytesRead, long contentLength, boolean done) {
+                    callback.onDownloadProgress(bytesRead, contentLength, done);
+                }
+            };
+
+            progressRequestListener = new ProgressRequestBody.ProgressRequestListener() {
+                @Override
+                public void onRequestProgress(long bytesWritten, long contentLength, boolean done) {
+                    callback.onUploadProgress(bytesWritten, contentLength, done);
+                }
+            };
+        }
+
+        com.squareup.okhttp.Call call = testInlineAdditionalPropertiesValidateBeforeCall(param, progressListener, progressRequestListener);
+        apiClient.executeAsync(call, callback);
+        return call;
+    }
+    /**
      * Build call for testJsonFormData
      * @param param field1 (required)
      * @param param2 field2 (required)
@@ -1057,7 +1147,7 @@ public class FakeApi {
      */
     public com.squareup.okhttp.Call testJsonFormDataCall(String param, String param2, final ProgressResponseBody.ProgressListener progressListener, final ProgressRequestBody.ProgressRequestListener progressRequestListener) throws ApiException {
         Object localVarPostBody = null;
-        
+
         // create path and map variables
         String localVarPath = "/fake/jsonFormData";
 
@@ -1099,7 +1189,7 @@ public class FakeApi {
         String[] localVarAuthNames = new String[] {  };
         return apiClient.buildCall(localVarPath, "GET", localVarQueryParams, localVarCollectionQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarAuthNames, progressRequestListener);
     }
-    
+
     @SuppressWarnings("rawtypes")
     private com.squareup.okhttp.Call testJsonFormDataValidateBeforeCall(String param, String param2, final ProgressResponseBody.ProgressListener progressListener, final ProgressRequestBody.ProgressRequestListener progressRequestListener) throws ApiException {
         
@@ -1113,14 +1203,10 @@ public class FakeApi {
             throw new ApiException("Missing the required parameter 'param2' when calling testJsonFormData(Async)");
         }
         
-        
+
         com.squareup.okhttp.Call call = testJsonFormDataCall(param, param2, progressListener, progressRequestListener);
         return call;
 
-        
-        
-        
-        
     }
 
     /**

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/io/swagger/client/api/FakeClassnameTags123Api.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/io/swagger/client/api/FakeClassnameTags123Api.java
@@ -64,7 +64,7 @@ public class FakeClassnameTags123Api {
      */
     public com.squareup.okhttp.Call testClassnameCall(Client body, final ProgressResponseBody.ProgressListener progressListener, final ProgressRequestBody.ProgressRequestListener progressRequestListener) throws ApiException {
         Object localVarPostBody = body;
-        
+
         // create path and map variables
         String localVarPath = "/fake_classname_test";
 
@@ -102,7 +102,7 @@ public class FakeClassnameTags123Api {
         String[] localVarAuthNames = new String[] { "api_key_query" };
         return apiClient.buildCall(localVarPath, "PATCH", localVarQueryParams, localVarCollectionQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarAuthNames, progressRequestListener);
     }
-    
+
     @SuppressWarnings("rawtypes")
     private com.squareup.okhttp.Call testClassnameValidateBeforeCall(Client body, final ProgressResponseBody.ProgressListener progressListener, final ProgressRequestBody.ProgressRequestListener progressRequestListener) throws ApiException {
         
@@ -111,14 +111,10 @@ public class FakeClassnameTags123Api {
             throw new ApiException("Missing the required parameter 'body' when calling testClassname(Async)");
         }
         
-        
+
         com.squareup.okhttp.Call call = testClassnameCall(body, progressListener, progressRequestListener);
         return call;
 
-        
-        
-        
-        
     }
 
     /**

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/io/swagger/client/api/PetApi.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/io/swagger/client/api/PetApi.java
@@ -66,7 +66,7 @@ public class PetApi {
      */
     public com.squareup.okhttp.Call addPetCall(Pet body, final ProgressResponseBody.ProgressListener progressListener, final ProgressRequestBody.ProgressRequestListener progressRequestListener) throws ApiException {
         Object localVarPostBody = body;
-        
+
         // create path and map variables
         String localVarPath = "/pet";
 
@@ -104,7 +104,7 @@ public class PetApi {
         String[] localVarAuthNames = new String[] { "petstore_auth" };
         return apiClient.buildCall(localVarPath, "POST", localVarQueryParams, localVarCollectionQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarAuthNames, progressRequestListener);
     }
-    
+
     @SuppressWarnings("rawtypes")
     private com.squareup.okhttp.Call addPetValidateBeforeCall(Pet body, final ProgressResponseBody.ProgressListener progressListener, final ProgressRequestBody.ProgressRequestListener progressRequestListener) throws ApiException {
         
@@ -113,14 +113,10 @@ public class PetApi {
             throw new ApiException("Missing the required parameter 'body' when calling addPet(Async)");
         }
         
-        
+
         com.squareup.okhttp.Call call = addPetCall(body, progressListener, progressRequestListener);
         return call;
 
-        
-        
-        
-        
     }
 
     /**
@@ -189,7 +185,7 @@ public class PetApi {
      */
     public com.squareup.okhttp.Call deletePetCall(Long petId, String apiKey, final ProgressResponseBody.ProgressListener progressListener, final ProgressRequestBody.ProgressRequestListener progressRequestListener) throws ApiException {
         Object localVarPostBody = null;
-        
+
         // create path and map variables
         String localVarPath = "/pet/{petId}"
             .replaceAll("\\{" + "petId" + "\\}", apiClient.escapeString(petId.toString()));
@@ -230,7 +226,7 @@ public class PetApi {
         String[] localVarAuthNames = new String[] { "petstore_auth" };
         return apiClient.buildCall(localVarPath, "DELETE", localVarQueryParams, localVarCollectionQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarAuthNames, progressRequestListener);
     }
-    
+
     @SuppressWarnings("rawtypes")
     private com.squareup.okhttp.Call deletePetValidateBeforeCall(Long petId, String apiKey, final ProgressResponseBody.ProgressListener progressListener, final ProgressRequestBody.ProgressRequestListener progressRequestListener) throws ApiException {
         
@@ -239,14 +235,10 @@ public class PetApi {
             throw new ApiException("Missing the required parameter 'petId' when calling deletePet(Async)");
         }
         
-        
+
         com.squareup.okhttp.Call call = deletePetCall(petId, apiKey, progressListener, progressRequestListener);
         return call;
 
-        
-        
-        
-        
     }
 
     /**
@@ -317,7 +309,7 @@ public class PetApi {
      */
     public com.squareup.okhttp.Call findPetsByStatusCall(List<String> status, final ProgressResponseBody.ProgressListener progressListener, final ProgressRequestBody.ProgressRequestListener progressRequestListener) throws ApiException {
         Object localVarPostBody = null;
-        
+
         // create path and map variables
         String localVarPath = "/pet/findByStatus";
 
@@ -357,7 +349,7 @@ public class PetApi {
         String[] localVarAuthNames = new String[] { "petstore_auth" };
         return apiClient.buildCall(localVarPath, "GET", localVarQueryParams, localVarCollectionQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarAuthNames, progressRequestListener);
     }
-    
+
     @SuppressWarnings("rawtypes")
     private com.squareup.okhttp.Call findPetsByStatusValidateBeforeCall(List<String> status, final ProgressResponseBody.ProgressListener progressListener, final ProgressRequestBody.ProgressRequestListener progressRequestListener) throws ApiException {
         
@@ -366,14 +358,10 @@ public class PetApi {
             throw new ApiException("Missing the required parameter 'status' when calling findPetsByStatus(Async)");
         }
         
-        
+
         com.squareup.okhttp.Call call = findPetsByStatusCall(status, progressListener, progressRequestListener);
         return call;
 
-        
-        
-        
-        
     }
 
     /**
@@ -442,10 +430,12 @@ public class PetApi {
      * @param progressRequestListener Progress request listener
      * @return Call to execute
      * @throws ApiException If fail to serialize the request body object
+     * @deprecated
      */
+    @Deprecated
     public com.squareup.okhttp.Call findPetsByTagsCall(List<String> tags, final ProgressResponseBody.ProgressListener progressListener, final ProgressRequestBody.ProgressRequestListener progressRequestListener) throws ApiException {
         Object localVarPostBody = null;
-        
+
         // create path and map variables
         String localVarPath = "/pet/findByTags";
 
@@ -485,7 +475,8 @@ public class PetApi {
         String[] localVarAuthNames = new String[] { "petstore_auth" };
         return apiClient.buildCall(localVarPath, "GET", localVarQueryParams, localVarCollectionQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarAuthNames, progressRequestListener);
     }
-    
+
+    @Deprecated
     @SuppressWarnings("rawtypes")
     private com.squareup.okhttp.Call findPetsByTagsValidateBeforeCall(List<String> tags, final ProgressResponseBody.ProgressListener progressListener, final ProgressRequestBody.ProgressRequestListener progressRequestListener) throws ApiException {
         
@@ -494,14 +485,10 @@ public class PetApi {
             throw new ApiException("Missing the required parameter 'tags' when calling findPetsByTags(Async)");
         }
         
-        
+
         com.squareup.okhttp.Call call = findPetsByTagsCall(tags, progressListener, progressRequestListener);
         return call;
 
-        
-        
-        
-        
     }
 
     /**
@@ -510,7 +497,9 @@ public class PetApi {
      * @param tags Tags to filter by (required)
      * @return List&lt;Pet&gt;
      * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
+     * @deprecated
      */
+    @Deprecated
     public List<Pet> findPetsByTags(List<String> tags) throws ApiException {
         ApiResponse<List<Pet>> resp = findPetsByTagsWithHttpInfo(tags);
         return resp.getData();
@@ -522,7 +511,9 @@ public class PetApi {
      * @param tags Tags to filter by (required)
      * @return ApiResponse&lt;List&lt;Pet&gt;&gt;
      * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
+     * @deprecated
      */
+    @Deprecated
     public ApiResponse<List<Pet>> findPetsByTagsWithHttpInfo(List<String> tags) throws ApiException {
         com.squareup.okhttp.Call call = findPetsByTagsValidateBeforeCall(tags, null, null);
         Type localVarReturnType = new TypeToken<List<Pet>>(){}.getType();
@@ -536,7 +527,9 @@ public class PetApi {
      * @param callback The callback to be executed when the API call finishes
      * @return The request call
      * @throws ApiException If fail to process the API call, e.g. serializing the request body object
+     * @deprecated
      */
+    @Deprecated
     public com.squareup.okhttp.Call findPetsByTagsAsync(List<String> tags, final ApiCallback<List<Pet>> callback) throws ApiException {
 
         ProgressResponseBody.ProgressListener progressListener = null;
@@ -573,7 +566,7 @@ public class PetApi {
      */
     public com.squareup.okhttp.Call getPetByIdCall(Long petId, final ProgressResponseBody.ProgressListener progressListener, final ProgressRequestBody.ProgressRequestListener progressRequestListener) throws ApiException {
         Object localVarPostBody = null;
-        
+
         // create path and map variables
         String localVarPath = "/pet/{petId}"
             .replaceAll("\\{" + "petId" + "\\}", apiClient.escapeString(petId.toString()));
@@ -612,7 +605,7 @@ public class PetApi {
         String[] localVarAuthNames = new String[] { "api_key" };
         return apiClient.buildCall(localVarPath, "GET", localVarQueryParams, localVarCollectionQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarAuthNames, progressRequestListener);
     }
-    
+
     @SuppressWarnings("rawtypes")
     private com.squareup.okhttp.Call getPetByIdValidateBeforeCall(Long petId, final ProgressResponseBody.ProgressListener progressListener, final ProgressRequestBody.ProgressRequestListener progressRequestListener) throws ApiException {
         
@@ -621,14 +614,10 @@ public class PetApi {
             throw new ApiException("Missing the required parameter 'petId' when calling getPetById(Async)");
         }
         
-        
+
         com.squareup.okhttp.Call call = getPetByIdCall(petId, progressListener, progressRequestListener);
         return call;
 
-        
-        
-        
-        
     }
 
     /**
@@ -700,7 +689,7 @@ public class PetApi {
      */
     public com.squareup.okhttp.Call updatePetCall(Pet body, final ProgressResponseBody.ProgressListener progressListener, final ProgressRequestBody.ProgressRequestListener progressRequestListener) throws ApiException {
         Object localVarPostBody = body;
-        
+
         // create path and map variables
         String localVarPath = "/pet";
 
@@ -738,7 +727,7 @@ public class PetApi {
         String[] localVarAuthNames = new String[] { "petstore_auth" };
         return apiClient.buildCall(localVarPath, "PUT", localVarQueryParams, localVarCollectionQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarAuthNames, progressRequestListener);
     }
-    
+
     @SuppressWarnings("rawtypes")
     private com.squareup.okhttp.Call updatePetValidateBeforeCall(Pet body, final ProgressResponseBody.ProgressListener progressListener, final ProgressRequestBody.ProgressRequestListener progressRequestListener) throws ApiException {
         
@@ -747,14 +736,10 @@ public class PetApi {
             throw new ApiException("Missing the required parameter 'body' when calling updatePet(Async)");
         }
         
-        
+
         com.squareup.okhttp.Call call = updatePetCall(body, progressListener, progressRequestListener);
         return call;
 
-        
-        
-        
-        
     }
 
     /**
@@ -824,7 +809,7 @@ public class PetApi {
      */
     public com.squareup.okhttp.Call updatePetWithFormCall(Long petId, String name, String status, final ProgressResponseBody.ProgressListener progressListener, final ProgressRequestBody.ProgressRequestListener progressRequestListener) throws ApiException {
         Object localVarPostBody = null;
-        
+
         // create path and map variables
         String localVarPath = "/pet/{petId}"
             .replaceAll("\\{" + "petId" + "\\}", apiClient.escapeString(petId.toString()));
@@ -867,7 +852,7 @@ public class PetApi {
         String[] localVarAuthNames = new String[] { "petstore_auth" };
         return apiClient.buildCall(localVarPath, "POST", localVarQueryParams, localVarCollectionQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarAuthNames, progressRequestListener);
     }
-    
+
     @SuppressWarnings("rawtypes")
     private com.squareup.okhttp.Call updatePetWithFormValidateBeforeCall(Long petId, String name, String status, final ProgressResponseBody.ProgressListener progressListener, final ProgressRequestBody.ProgressRequestListener progressRequestListener) throws ApiException {
         
@@ -876,14 +861,10 @@ public class PetApi {
             throw new ApiException("Missing the required parameter 'petId' when calling updatePetWithForm(Async)");
         }
         
-        
+
         com.squareup.okhttp.Call call = updatePetWithFormCall(petId, name, status, progressListener, progressRequestListener);
         return call;
 
-        
-        
-        
-        
     }
 
     /**
@@ -959,7 +940,7 @@ public class PetApi {
      */
     public com.squareup.okhttp.Call uploadFileCall(Long petId, String additionalMetadata, File file, final ProgressResponseBody.ProgressListener progressListener, final ProgressRequestBody.ProgressRequestListener progressRequestListener) throws ApiException {
         Object localVarPostBody = null;
-        
+
         // create path and map variables
         String localVarPath = "/pet/{petId}/uploadImage"
             .replaceAll("\\{" + "petId" + "\\}", apiClient.escapeString(petId.toString()));
@@ -1002,7 +983,7 @@ public class PetApi {
         String[] localVarAuthNames = new String[] { "petstore_auth" };
         return apiClient.buildCall(localVarPath, "POST", localVarQueryParams, localVarCollectionQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarAuthNames, progressRequestListener);
     }
-    
+
     @SuppressWarnings("rawtypes")
     private com.squareup.okhttp.Call uploadFileValidateBeforeCall(Long petId, String additionalMetadata, File file, final ProgressResponseBody.ProgressListener progressListener, final ProgressRequestBody.ProgressRequestListener progressRequestListener) throws ApiException {
         
@@ -1011,14 +992,10 @@ public class PetApi {
             throw new ApiException("Missing the required parameter 'petId' when calling uploadFile(Async)");
         }
         
-        
+
         com.squareup.okhttp.Call call = uploadFileCall(petId, additionalMetadata, file, progressListener, progressRequestListener);
         return call;
 
-        
-        
-        
-        
     }
 
     /**

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/io/swagger/client/api/StoreApi.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/io/swagger/client/api/StoreApi.java
@@ -64,7 +64,7 @@ public class StoreApi {
      */
     public com.squareup.okhttp.Call deleteOrderCall(String orderId, final ProgressResponseBody.ProgressListener progressListener, final ProgressRequestBody.ProgressRequestListener progressRequestListener) throws ApiException {
         Object localVarPostBody = null;
-        
+
         // create path and map variables
         String localVarPath = "/store/order/{order_id}"
             .replaceAll("\\{" + "order_id" + "\\}", apiClient.escapeString(orderId.toString()));
@@ -103,7 +103,7 @@ public class StoreApi {
         String[] localVarAuthNames = new String[] {  };
         return apiClient.buildCall(localVarPath, "DELETE", localVarQueryParams, localVarCollectionQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarAuthNames, progressRequestListener);
     }
-    
+
     @SuppressWarnings("rawtypes")
     private com.squareup.okhttp.Call deleteOrderValidateBeforeCall(String orderId, final ProgressResponseBody.ProgressListener progressListener, final ProgressRequestBody.ProgressRequestListener progressRequestListener) throws ApiException {
         
@@ -112,14 +112,10 @@ public class StoreApi {
             throw new ApiException("Missing the required parameter 'orderId' when calling deleteOrder(Async)");
         }
         
-        
+
         com.squareup.okhttp.Call call = deleteOrderCall(orderId, progressListener, progressRequestListener);
         return call;
 
-        
-        
-        
-        
     }
 
     /**
@@ -186,7 +182,7 @@ public class StoreApi {
      */
     public com.squareup.okhttp.Call getInventoryCall(final ProgressResponseBody.ProgressListener progressListener, final ProgressRequestBody.ProgressRequestListener progressRequestListener) throws ApiException {
         Object localVarPostBody = null;
-        
+
         // create path and map variables
         String localVarPath = "/store/inventory";
 
@@ -224,18 +220,14 @@ public class StoreApi {
         String[] localVarAuthNames = new String[] { "api_key" };
         return apiClient.buildCall(localVarPath, "GET", localVarQueryParams, localVarCollectionQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarAuthNames, progressRequestListener);
     }
-    
+
     @SuppressWarnings("rawtypes")
     private com.squareup.okhttp.Call getInventoryValidateBeforeCall(final ProgressResponseBody.ProgressListener progressListener, final ProgressRequestBody.ProgressRequestListener progressRequestListener) throws ApiException {
         
-        
+
         com.squareup.okhttp.Call call = getInventoryCall(progressListener, progressRequestListener);
         return call;
 
-        
-        
-        
-        
     }
 
     /**
@@ -304,7 +296,7 @@ public class StoreApi {
      */
     public com.squareup.okhttp.Call getOrderByIdCall(Long orderId, final ProgressResponseBody.ProgressListener progressListener, final ProgressRequestBody.ProgressRequestListener progressRequestListener) throws ApiException {
         Object localVarPostBody = null;
-        
+
         // create path and map variables
         String localVarPath = "/store/order/{order_id}"
             .replaceAll("\\{" + "order_id" + "\\}", apiClient.escapeString(orderId.toString()));
@@ -343,7 +335,7 @@ public class StoreApi {
         String[] localVarAuthNames = new String[] {  };
         return apiClient.buildCall(localVarPath, "GET", localVarQueryParams, localVarCollectionQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarAuthNames, progressRequestListener);
     }
-    
+
     @SuppressWarnings("rawtypes")
     private com.squareup.okhttp.Call getOrderByIdValidateBeforeCall(Long orderId, final ProgressResponseBody.ProgressListener progressListener, final ProgressRequestBody.ProgressRequestListener progressRequestListener) throws ApiException {
         
@@ -352,14 +344,10 @@ public class StoreApi {
             throw new ApiException("Missing the required parameter 'orderId' when calling getOrderById(Async)");
         }
         
-        
+
         com.squareup.okhttp.Call call = getOrderByIdCall(orderId, progressListener, progressRequestListener);
         return call;
 
-        
-        
-        
-        
     }
 
     /**
@@ -431,7 +419,7 @@ public class StoreApi {
      */
     public com.squareup.okhttp.Call placeOrderCall(Order body, final ProgressResponseBody.ProgressListener progressListener, final ProgressRequestBody.ProgressRequestListener progressRequestListener) throws ApiException {
         Object localVarPostBody = body;
-        
+
         // create path and map variables
         String localVarPath = "/store/order";
 
@@ -469,7 +457,7 @@ public class StoreApi {
         String[] localVarAuthNames = new String[] {  };
         return apiClient.buildCall(localVarPath, "POST", localVarQueryParams, localVarCollectionQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarAuthNames, progressRequestListener);
     }
-    
+
     @SuppressWarnings("rawtypes")
     private com.squareup.okhttp.Call placeOrderValidateBeforeCall(Order body, final ProgressResponseBody.ProgressListener progressListener, final ProgressRequestBody.ProgressRequestListener progressRequestListener) throws ApiException {
         
@@ -478,14 +466,10 @@ public class StoreApi {
             throw new ApiException("Missing the required parameter 'body' when calling placeOrder(Async)");
         }
         
-        
+
         com.squareup.okhttp.Call call = placeOrderCall(body, progressListener, progressRequestListener);
         return call;
 
-        
-        
-        
-        
     }
 
     /**

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/io/swagger/client/api/UserApi.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/io/swagger/client/api/UserApi.java
@@ -64,7 +64,7 @@ public class UserApi {
      */
     public com.squareup.okhttp.Call createUserCall(User body, final ProgressResponseBody.ProgressListener progressListener, final ProgressRequestBody.ProgressRequestListener progressRequestListener) throws ApiException {
         Object localVarPostBody = body;
-        
+
         // create path and map variables
         String localVarPath = "/user";
 
@@ -102,7 +102,7 @@ public class UserApi {
         String[] localVarAuthNames = new String[] {  };
         return apiClient.buildCall(localVarPath, "POST", localVarQueryParams, localVarCollectionQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarAuthNames, progressRequestListener);
     }
-    
+
     @SuppressWarnings("rawtypes")
     private com.squareup.okhttp.Call createUserValidateBeforeCall(User body, final ProgressResponseBody.ProgressListener progressListener, final ProgressRequestBody.ProgressRequestListener progressRequestListener) throws ApiException {
         
@@ -111,14 +111,10 @@ public class UserApi {
             throw new ApiException("Missing the required parameter 'body' when calling createUser(Async)");
         }
         
-        
+
         com.squareup.okhttp.Call call = createUserCall(body, progressListener, progressRequestListener);
         return call;
 
-        
-        
-        
-        
     }
 
     /**
@@ -186,7 +182,7 @@ public class UserApi {
      */
     public com.squareup.okhttp.Call createUsersWithArrayInputCall(List<User> body, final ProgressResponseBody.ProgressListener progressListener, final ProgressRequestBody.ProgressRequestListener progressRequestListener) throws ApiException {
         Object localVarPostBody = body;
-        
+
         // create path and map variables
         String localVarPath = "/user/createWithArray";
 
@@ -224,7 +220,7 @@ public class UserApi {
         String[] localVarAuthNames = new String[] {  };
         return apiClient.buildCall(localVarPath, "POST", localVarQueryParams, localVarCollectionQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarAuthNames, progressRequestListener);
     }
-    
+
     @SuppressWarnings("rawtypes")
     private com.squareup.okhttp.Call createUsersWithArrayInputValidateBeforeCall(List<User> body, final ProgressResponseBody.ProgressListener progressListener, final ProgressRequestBody.ProgressRequestListener progressRequestListener) throws ApiException {
         
@@ -233,14 +229,10 @@ public class UserApi {
             throw new ApiException("Missing the required parameter 'body' when calling createUsersWithArrayInput(Async)");
         }
         
-        
+
         com.squareup.okhttp.Call call = createUsersWithArrayInputCall(body, progressListener, progressRequestListener);
         return call;
 
-        
-        
-        
-        
     }
 
     /**
@@ -308,7 +300,7 @@ public class UserApi {
      */
     public com.squareup.okhttp.Call createUsersWithListInputCall(List<User> body, final ProgressResponseBody.ProgressListener progressListener, final ProgressRequestBody.ProgressRequestListener progressRequestListener) throws ApiException {
         Object localVarPostBody = body;
-        
+
         // create path and map variables
         String localVarPath = "/user/createWithList";
 
@@ -346,7 +338,7 @@ public class UserApi {
         String[] localVarAuthNames = new String[] {  };
         return apiClient.buildCall(localVarPath, "POST", localVarQueryParams, localVarCollectionQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarAuthNames, progressRequestListener);
     }
-    
+
     @SuppressWarnings("rawtypes")
     private com.squareup.okhttp.Call createUsersWithListInputValidateBeforeCall(List<User> body, final ProgressResponseBody.ProgressListener progressListener, final ProgressRequestBody.ProgressRequestListener progressRequestListener) throws ApiException {
         
@@ -355,14 +347,10 @@ public class UserApi {
             throw new ApiException("Missing the required parameter 'body' when calling createUsersWithListInput(Async)");
         }
         
-        
+
         com.squareup.okhttp.Call call = createUsersWithListInputCall(body, progressListener, progressRequestListener);
         return call;
 
-        
-        
-        
-        
     }
 
     /**
@@ -430,7 +418,7 @@ public class UserApi {
      */
     public com.squareup.okhttp.Call deleteUserCall(String username, final ProgressResponseBody.ProgressListener progressListener, final ProgressRequestBody.ProgressRequestListener progressRequestListener) throws ApiException {
         Object localVarPostBody = null;
-        
+
         // create path and map variables
         String localVarPath = "/user/{username}"
             .replaceAll("\\{" + "username" + "\\}", apiClient.escapeString(username.toString()));
@@ -469,7 +457,7 @@ public class UserApi {
         String[] localVarAuthNames = new String[] {  };
         return apiClient.buildCall(localVarPath, "DELETE", localVarQueryParams, localVarCollectionQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarAuthNames, progressRequestListener);
     }
-    
+
     @SuppressWarnings("rawtypes")
     private com.squareup.okhttp.Call deleteUserValidateBeforeCall(String username, final ProgressResponseBody.ProgressListener progressListener, final ProgressRequestBody.ProgressRequestListener progressRequestListener) throws ApiException {
         
@@ -478,14 +466,10 @@ public class UserApi {
             throw new ApiException("Missing the required parameter 'username' when calling deleteUser(Async)");
         }
         
-        
+
         com.squareup.okhttp.Call call = deleteUserCall(username, progressListener, progressRequestListener);
         return call;
 
-        
-        
-        
-        
     }
 
     /**
@@ -553,7 +537,7 @@ public class UserApi {
      */
     public com.squareup.okhttp.Call getUserByNameCall(String username, final ProgressResponseBody.ProgressListener progressListener, final ProgressRequestBody.ProgressRequestListener progressRequestListener) throws ApiException {
         Object localVarPostBody = null;
-        
+
         // create path and map variables
         String localVarPath = "/user/{username}"
             .replaceAll("\\{" + "username" + "\\}", apiClient.escapeString(username.toString()));
@@ -592,7 +576,7 @@ public class UserApi {
         String[] localVarAuthNames = new String[] {  };
         return apiClient.buildCall(localVarPath, "GET", localVarQueryParams, localVarCollectionQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarAuthNames, progressRequestListener);
     }
-    
+
     @SuppressWarnings("rawtypes")
     private com.squareup.okhttp.Call getUserByNameValidateBeforeCall(String username, final ProgressResponseBody.ProgressListener progressListener, final ProgressRequestBody.ProgressRequestListener progressRequestListener) throws ApiException {
         
@@ -601,14 +585,10 @@ public class UserApi {
             throw new ApiException("Missing the required parameter 'username' when calling getUserByName(Async)");
         }
         
-        
+
         com.squareup.okhttp.Call call = getUserByNameCall(username, progressListener, progressRequestListener);
         return call;
 
-        
-        
-        
-        
     }
 
     /**
@@ -681,7 +661,7 @@ public class UserApi {
      */
     public com.squareup.okhttp.Call loginUserCall(String username, String password, final ProgressResponseBody.ProgressListener progressListener, final ProgressRequestBody.ProgressRequestListener progressRequestListener) throws ApiException {
         Object localVarPostBody = null;
-        
+
         // create path and map variables
         String localVarPath = "/user/login";
 
@@ -723,7 +703,7 @@ public class UserApi {
         String[] localVarAuthNames = new String[] {  };
         return apiClient.buildCall(localVarPath, "GET", localVarQueryParams, localVarCollectionQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarAuthNames, progressRequestListener);
     }
-    
+
     @SuppressWarnings("rawtypes")
     private com.squareup.okhttp.Call loginUserValidateBeforeCall(String username, String password, final ProgressResponseBody.ProgressListener progressListener, final ProgressRequestBody.ProgressRequestListener progressRequestListener) throws ApiException {
         
@@ -737,14 +717,10 @@ public class UserApi {
             throw new ApiException("Missing the required parameter 'password' when calling loginUser(Async)");
         }
         
-        
+
         com.squareup.okhttp.Call call = loginUserCall(username, password, progressListener, progressRequestListener);
         return call;
 
-        
-        
-        
-        
     }
 
     /**
@@ -818,7 +794,7 @@ public class UserApi {
      */
     public com.squareup.okhttp.Call logoutUserCall(final ProgressResponseBody.ProgressListener progressListener, final ProgressRequestBody.ProgressRequestListener progressRequestListener) throws ApiException {
         Object localVarPostBody = null;
-        
+
         // create path and map variables
         String localVarPath = "/user/logout";
 
@@ -856,18 +832,14 @@ public class UserApi {
         String[] localVarAuthNames = new String[] {  };
         return apiClient.buildCall(localVarPath, "GET", localVarQueryParams, localVarCollectionQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarAuthNames, progressRequestListener);
     }
-    
+
     @SuppressWarnings("rawtypes")
     private com.squareup.okhttp.Call logoutUserValidateBeforeCall(final ProgressResponseBody.ProgressListener progressListener, final ProgressRequestBody.ProgressRequestListener progressRequestListener) throws ApiException {
         
-        
+
         com.squareup.okhttp.Call call = logoutUserCall(progressListener, progressRequestListener);
         return call;
 
-        
-        
-        
-        
     }
 
     /**
@@ -933,7 +905,7 @@ public class UserApi {
      */
     public com.squareup.okhttp.Call updateUserCall(String username, User body, final ProgressResponseBody.ProgressListener progressListener, final ProgressRequestBody.ProgressRequestListener progressRequestListener) throws ApiException {
         Object localVarPostBody = body;
-        
+
         // create path and map variables
         String localVarPath = "/user/{username}"
             .replaceAll("\\{" + "username" + "\\}", apiClient.escapeString(username.toString()));
@@ -972,7 +944,7 @@ public class UserApi {
         String[] localVarAuthNames = new String[] {  };
         return apiClient.buildCall(localVarPath, "PUT", localVarQueryParams, localVarCollectionQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarAuthNames, progressRequestListener);
     }
-    
+
     @SuppressWarnings("rawtypes")
     private com.squareup.okhttp.Call updateUserValidateBeforeCall(String username, User body, final ProgressResponseBody.ProgressListener progressListener, final ProgressRequestBody.ProgressRequestListener progressRequestListener) throws ApiException {
         
@@ -986,14 +958,10 @@ public class UserApi {
             throw new ApiException("Missing the required parameter 'body' when calling updateUser(Async)");
         }
         
-        
+
         com.squareup.okhttp.Call call = updateUserCall(username, body, progressListener, progressRequestListener);
         return call;
 
-        
-        
-        
-        
     }
 
     /**

--- a/samples/client/petstore/java/resteasy/docs/FakeApi.md
+++ b/samples/client/petstore/java/resteasy/docs/FakeApi.md
@@ -11,6 +11,7 @@ Method | HTTP request | Description
 [**testClientModel**](FakeApi.md#testClientModel) | **PATCH** /fake | To test \&quot;client\&quot; model
 [**testEndpointParameters**](FakeApi.md#testEndpointParameters) | **POST** /fake | Fake endpoint for testing various parameters 假端點 偽のエンドポイント 가짜 엔드 포인트 
 [**testEnumParameters**](FakeApi.md#testEnumParameters) | **GET** /fake | To test enum parameters
+[**testInlineAdditionalProperties**](FakeApi.md#testInlineAdditionalProperties) | **POST** /fake/inline-additionalProperties | test inline additionalProperties
 [**testJsonFormData**](FakeApi.md#testJsonFormData) | **GET** /fake/jsonFormData | test json serialization of form data
 
 
@@ -375,6 +376,50 @@ No authorization required
 
  - **Content-Type**: */*
  - **Accept**: */*
+
+<a name="testInlineAdditionalProperties"></a>
+# **testInlineAdditionalProperties**
+> testInlineAdditionalProperties(param)
+
+test inline additionalProperties
+
+
+
+### Example
+```java
+// Import classes:
+//import io.swagger.client.ApiException;
+//import io.swagger.client.api.FakeApi;
+
+
+FakeApi apiInstance = new FakeApi();
+Object param = null; // Object | request body
+try {
+    apiInstance.testInlineAdditionalProperties(param);
+} catch (ApiException e) {
+    System.err.println("Exception when calling FakeApi#testInlineAdditionalProperties");
+    e.printStackTrace();
+}
+```
+
+### Parameters
+
+Name | Type | Description  | Notes
+------------- | ------------- | ------------- | -------------
+ **param** | **Object**| request body |
+
+### Return type
+
+null (empty response body)
+
+### Authorization
+
+No authorization required
+
+### HTTP request headers
+
+ - **Content-Type**: application/json
+ - **Accept**: Not defined
 
 <a name="testJsonFormData"></a>
 # **testJsonFormData**

--- a/samples/client/petstore/java/resteasy/src/main/java/io/swagger/client/api/FakeApi.java
+++ b/samples/client/petstore/java/resteasy/src/main/java/io/swagger/client/api/FakeApi.java
@@ -375,6 +375,46 @@ if (enumQueryDouble != null)
     apiClient.invokeAPI(localVarPath, "GET", localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarAccept, localVarContentType, localVarAuthNames, null);
   }
   /**
+   * test inline additionalProperties
+   * 
+   * @param param request body (required)
+   * @throws ApiException if fails to make API call
+   */
+  public void testInlineAdditionalProperties(Object param) throws ApiException {
+    Object localVarPostBody = param;
+    
+    // verify the required parameter 'param' is set
+    if (param == null) {
+      throw new ApiException(400, "Missing the required parameter 'param' when calling testInlineAdditionalProperties");
+    }
+    
+    // create path and map variables
+    String localVarPath = "/fake/inline-additionalProperties".replaceAll("\\{format\\}","json");
+
+    // query params
+    List<Pair> localVarQueryParams = new ArrayList<Pair>();
+    Map<String, String> localVarHeaderParams = new HashMap<String, String>();
+    Map<String, Object> localVarFormParams = new HashMap<String, Object>();
+
+
+    
+    
+    final String[] localVarAccepts = {
+      
+    };
+    final String localVarAccept = apiClient.selectHeaderAccept(localVarAccepts);
+
+    final String[] localVarContentTypes = {
+      "application/json"
+    };
+    final String localVarContentType = apiClient.selectHeaderContentType(localVarContentTypes);
+
+    String[] localVarAuthNames = new String[] {  };
+
+
+    apiClient.invokeAPI(localVarPath, "POST", localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarAccept, localVarContentType, localVarAuthNames, null);
+  }
+  /**
    * test json serialization of form data
    * 
    * @param param field1 (required)

--- a/samples/client/petstore/java/resteasy/src/main/java/io/swagger/client/api/PetApi.java
+++ b/samples/client/petstore/java/resteasy/src/main/java/io/swagger/client/api/PetApi.java
@@ -168,8 +168,9 @@ public class PetApi {
    * @param tags Tags to filter by (required)
    * @return List<Pet>
    * @throws ApiException if fails to make API call
-   * @Deprecated
+   * @deprecated
    */
+  @Deprecated
   public List<Pet> findPetsByTags(List<String> tags) throws ApiException {
     Object localVarPostBody = null;
     

--- a/samples/client/petstore/java/resttemplate-withXml/docs/FakeApi.md
+++ b/samples/client/petstore/java/resttemplate-withXml/docs/FakeApi.md
@@ -11,6 +11,7 @@ Method | HTTP request | Description
 [**testClientModel**](FakeApi.md#testClientModel) | **PATCH** /fake | To test \&quot;client\&quot; model
 [**testEndpointParameters**](FakeApi.md#testEndpointParameters) | **POST** /fake | Fake endpoint for testing various parameters 假端點 偽のエンドポイント 가짜 엔드 포인트 
 [**testEnumParameters**](FakeApi.md#testEnumParameters) | **GET** /fake | To test enum parameters
+[**testInlineAdditionalProperties**](FakeApi.md#testInlineAdditionalProperties) | **POST** /fake/inline-additionalProperties | test inline additionalProperties
 [**testJsonFormData**](FakeApi.md#testJsonFormData) | **GET** /fake/jsonFormData | test json serialization of form data
 
 
@@ -375,6 +376,50 @@ No authorization required
 
  - **Content-Type**: */*
  - **Accept**: */*
+
+<a name="testInlineAdditionalProperties"></a>
+# **testInlineAdditionalProperties**
+> testInlineAdditionalProperties(param)
+
+test inline additionalProperties
+
+
+
+### Example
+```java
+// Import classes:
+//import io.swagger.client.ApiException;
+//import io.swagger.client.api.FakeApi;
+
+
+FakeApi apiInstance = new FakeApi();
+Object param = null; // Object | request body
+try {
+    apiInstance.testInlineAdditionalProperties(param);
+} catch (ApiException e) {
+    System.err.println("Exception when calling FakeApi#testInlineAdditionalProperties");
+    e.printStackTrace();
+}
+```
+
+### Parameters
+
+Name | Type | Description  | Notes
+------------- | ------------- | ------------- | -------------
+ **param** | **Object**| request body |
+
+### Return type
+
+null (empty response body)
+
+### Authorization
+
+No authorization required
+
+### HTTP request headers
+
+ - **Content-Type**: application/json
+ - **Accept**: Not defined
 
 <a name="testJsonFormData"></a>
 # **testJsonFormData**

--- a/samples/client/petstore/java/resttemplate-withXml/src/main/java/io/swagger/client/api/FakeApi.java
+++ b/samples/client/petstore/java/resttemplate-withXml/src/main/java/io/swagger/client/api/FakeApi.java
@@ -341,6 +341,39 @@ public class FakeApi {
         apiClient.invokeAPI(path, HttpMethod.GET, queryParams, postBody, headerParams, formParams, accept, contentType, authNames, returnType);
     }
     /**
+     * test inline additionalProperties
+     * 
+     * <p><b>200</b> - successful operation
+     * @param param request body
+     * @throws RestClientException if an error occurs while attempting to invoke the API
+     */
+    public void testInlineAdditionalProperties(Object param) throws RestClientException {
+        Object postBody = param;
+        
+        // verify the required parameter 'param' is set
+        if (param == null) {
+            throw new HttpClientErrorException(HttpStatus.BAD_REQUEST, "Missing the required parameter 'param' when calling testInlineAdditionalProperties");
+        }
+        
+        String path = UriComponentsBuilder.fromPath("/fake/inline-additionalProperties").build().toUriString();
+        
+        final MultiValueMap<String, String> queryParams = new LinkedMultiValueMap<String, String>();
+        final HttpHeaders headerParams = new HttpHeaders();
+        final MultiValueMap<String, Object> formParams = new LinkedMultiValueMap<String, Object>();
+
+        final String[] accepts = { };
+        final List<MediaType> accept = apiClient.selectHeaderAccept(accepts);
+        final String[] contentTypes = { 
+            "application/json"
+        };
+        final MediaType contentType = apiClient.selectHeaderContentType(contentTypes);
+
+        String[] authNames = new String[] {  };
+
+        ParameterizedTypeReference<Void> returnType = new ParameterizedTypeReference<Void>() {};
+        apiClient.invokeAPI(path, HttpMethod.POST, queryParams, postBody, headerParams, formParams, accept, contentType, authNames, returnType);
+    }
+    /**
      * test json serialization of form data
      * 
      * <p><b>200</b> - successful operation

--- a/samples/client/petstore/java/resttemplate/docs/FakeApi.md
+++ b/samples/client/petstore/java/resttemplate/docs/FakeApi.md
@@ -11,6 +11,7 @@ Method | HTTP request | Description
 [**testClientModel**](FakeApi.md#testClientModel) | **PATCH** /fake | To test \&quot;client\&quot; model
 [**testEndpointParameters**](FakeApi.md#testEndpointParameters) | **POST** /fake | Fake endpoint for testing various parameters 假端點 偽のエンドポイント 가짜 엔드 포인트 
 [**testEnumParameters**](FakeApi.md#testEnumParameters) | **GET** /fake | To test enum parameters
+[**testInlineAdditionalProperties**](FakeApi.md#testInlineAdditionalProperties) | **POST** /fake/inline-additionalProperties | test inline additionalProperties
 [**testJsonFormData**](FakeApi.md#testJsonFormData) | **GET** /fake/jsonFormData | test json serialization of form data
 
 
@@ -375,6 +376,50 @@ No authorization required
 
  - **Content-Type**: */*
  - **Accept**: */*
+
+<a name="testInlineAdditionalProperties"></a>
+# **testInlineAdditionalProperties**
+> testInlineAdditionalProperties(param)
+
+test inline additionalProperties
+
+
+
+### Example
+```java
+// Import classes:
+//import io.swagger.client.ApiException;
+//import io.swagger.client.api.FakeApi;
+
+
+FakeApi apiInstance = new FakeApi();
+Object param = null; // Object | request body
+try {
+    apiInstance.testInlineAdditionalProperties(param);
+} catch (ApiException e) {
+    System.err.println("Exception when calling FakeApi#testInlineAdditionalProperties");
+    e.printStackTrace();
+}
+```
+
+### Parameters
+
+Name | Type | Description  | Notes
+------------- | ------------- | ------------- | -------------
+ **param** | **Object**| request body |
+
+### Return type
+
+null (empty response body)
+
+### Authorization
+
+No authorization required
+
+### HTTP request headers
+
+ - **Content-Type**: application/json
+ - **Accept**: Not defined
 
 <a name="testJsonFormData"></a>
 # **testJsonFormData**

--- a/samples/client/petstore/java/resttemplate/src/main/java/io/swagger/client/api/FakeApi.java
+++ b/samples/client/petstore/java/resttemplate/src/main/java/io/swagger/client/api/FakeApi.java
@@ -341,6 +341,39 @@ public class FakeApi {
         apiClient.invokeAPI(path, HttpMethod.GET, queryParams, postBody, headerParams, formParams, accept, contentType, authNames, returnType);
     }
     /**
+     * test inline additionalProperties
+     * 
+     * <p><b>200</b> - successful operation
+     * @param param request body
+     * @throws RestClientException if an error occurs while attempting to invoke the API
+     */
+    public void testInlineAdditionalProperties(Object param) throws RestClientException {
+        Object postBody = param;
+        
+        // verify the required parameter 'param' is set
+        if (param == null) {
+            throw new HttpClientErrorException(HttpStatus.BAD_REQUEST, "Missing the required parameter 'param' when calling testInlineAdditionalProperties");
+        }
+        
+        String path = UriComponentsBuilder.fromPath("/fake/inline-additionalProperties").build().toUriString();
+        
+        final MultiValueMap<String, String> queryParams = new LinkedMultiValueMap<String, String>();
+        final HttpHeaders headerParams = new HttpHeaders();
+        final MultiValueMap<String, Object> formParams = new LinkedMultiValueMap<String, Object>();
+
+        final String[] accepts = { };
+        final List<MediaType> accept = apiClient.selectHeaderAccept(accepts);
+        final String[] contentTypes = { 
+            "application/json"
+        };
+        final MediaType contentType = apiClient.selectHeaderContentType(contentTypes);
+
+        String[] authNames = new String[] {  };
+
+        ParameterizedTypeReference<Void> returnType = new ParameterizedTypeReference<Void>() {};
+        apiClient.invokeAPI(path, HttpMethod.POST, queryParams, postBody, headerParams, formParams, accept, contentType, authNames, returnType);
+    }
+    /**
      * test json serialization of form data
      * 
      * <p><b>200</b> - successful operation

--- a/samples/client/petstore/java/retrofit/src/main/java/io/swagger/client/api/FakeApi.java
+++ b/samples/client/petstore/java/retrofit/src/main/java/io/swagger/client/api/FakeApi.java
@@ -231,6 +231,30 @@ public interface FakeApi {
     @retrofit.http.Field("enum_form_string_array") List<String> enumFormStringArray, @retrofit.http.Field("enum_form_string") String enumFormString, @retrofit.http.Header("enum_header_string_array") List<String> enumHeaderStringArray, @retrofit.http.Header("enum_header_string") String enumHeaderString, @retrofit.http.Query("enum_query_string_array") CSVParams enumQueryStringArray, @retrofit.http.Query("enum_query_string") String enumQueryString, @retrofit.http.Query("enum_query_integer") Integer enumQueryInteger, @retrofit.http.Field("enum_query_double") Double enumQueryDouble, Callback<Void> cb
   );
   /**
+   * test inline additionalProperties
+   * Sync method
+   * 
+   * @param param request body (required)
+   * @return Void
+   */
+  
+  @POST("/fake/inline-additionalProperties")
+  Void testInlineAdditionalProperties(
+    @retrofit.http.Body Object param
+  );
+
+  /**
+   * test inline additionalProperties
+   * Async method
+   * @param param request body (required)
+   * @param cb callback method
+   */
+  
+  @POST("/fake/inline-additionalProperties")
+  void testInlineAdditionalProperties(
+    @retrofit.http.Body Object param, Callback<Void> cb
+  );
+  /**
    * test json serialization of form data
    * Sync method
    * 

--- a/samples/client/petstore/java/retrofit2-play24/build.gradle
+++ b/samples/client/petstore/java/retrofit2-play24/build.gradle
@@ -100,6 +100,7 @@ ext {
     play_version = "2.4.11"
     swagger_annotations_version = "1.5.15"
     junit_version = "4.12"
+    json_fire_version = "1.8.0"
 }
 
 dependencies {
@@ -108,6 +109,7 @@ dependencies {
     compile "com.squareup.retrofit2:converter-gson:$retrofit_version"
     compile "io.swagger:swagger-annotations:$swagger_annotations_version"
     compile "org.apache.oltu.oauth2:org.apache.oltu.oauth2.client:$oltu_version"
+    compile "io.gsonfire:gson-fire:$json_fire_version"
     compile "com.typesafe.play:play-java-ws_2.11:$play_version"
     compile "com.squareup.retrofit2:converter-jackson:$retrofit_version"
     compile "com.fasterxml.jackson.core:jackson-core:$jackson_version"

--- a/samples/client/petstore/java/retrofit2-play24/build.sbt
+++ b/samples/client/petstore/java/retrofit2-play24/build.sbt
@@ -18,6 +18,7 @@ lazy val root = (project in file(".")).
       "com.squareup.retrofit2" % "converter-jackson" % "2.3.0" % "compile",
       "io.swagger" % "swagger-annotations" % "1.5.15" % "compile",
       "org.apache.oltu.oauth2" % "org.apache.oltu.oauth2.client" % "1.0.1" % "compile",
+      "io.gsonfire" % "gson-fire" % "1.8.0" % "compile",
       "junit" % "junit" % "4.12" % "test",
       "com.novocode" % "junit-interface" % "0.11" % "test"
     )

--- a/samples/client/petstore/java/retrofit2-play24/docs/FakeApi.md
+++ b/samples/client/petstore/java/retrofit2-play24/docs/FakeApi.md
@@ -11,6 +11,7 @@ Method | HTTP request | Description
 [**testClientModel**](FakeApi.md#testClientModel) | **PATCH** fake | To test \&quot;client\&quot; model
 [**testEndpointParameters**](FakeApi.md#testEndpointParameters) | **POST** fake | Fake endpoint for testing various parameters 假端點 偽のエンドポイント 가짜 엔드 포인트 
 [**testEnumParameters**](FakeApi.md#testEnumParameters) | **GET** fake | To test enum parameters
+[**testInlineAdditionalProperties**](FakeApi.md#testInlineAdditionalProperties) | **POST** fake/inline-additionalProperties | test inline additionalProperties
 [**testJsonFormData**](FakeApi.md#testJsonFormData) | **GET** fake/jsonFormData | test json serialization of form data
 
 
@@ -377,6 +378,51 @@ No authorization required
 
  - **Content-Type**: */*
  - **Accept**: */*
+
+<a name="testInlineAdditionalProperties"></a>
+# **testInlineAdditionalProperties**
+> Void testInlineAdditionalProperties(param)
+
+test inline additionalProperties
+
+
+
+### Example
+```java
+// Import classes:
+//import io.swagger.client.ApiException;
+//import io.swagger.client.api.FakeApi;
+
+
+FakeApi apiInstance = new FakeApi();
+Object param = null; // Object | request body
+try {
+    Void result = apiInstance.testInlineAdditionalProperties(param);
+    System.out.println(result);
+} catch (ApiException e) {
+    System.err.println("Exception when calling FakeApi#testInlineAdditionalProperties");
+    e.printStackTrace();
+}
+```
+
+### Parameters
+
+Name | Type | Description  | Notes
+------------- | ------------- | ------------- | -------------
+ **param** | **Object**| request body |
+
+### Return type
+
+[**Void**](.md)
+
+### Authorization
+
+No authorization required
+
+### HTTP request headers
+
+ - **Content-Type**: application/json
+ - **Accept**: Not defined
 
 <a name="testJsonFormData"></a>
 # **testJsonFormData**

--- a/samples/client/petstore/java/retrofit2-play24/pom.xml
+++ b/samples/client/petstore/java/retrofit2-play24/pom.xml
@@ -194,6 +194,11 @@
       <artifactId>org.apache.oltu.oauth2.client</artifactId>
       <version>${oltu-version}</version>
     </dependency>
+    <dependency>
+      <groupId>io.gsonfire</groupId>
+      <artifactId>gson-fire</artifactId>
+      <version>${gson-fire-version}</version>
+    </dependency>
 
     <!-- JSON processing: jackson -->
     <dependency>
@@ -241,6 +246,7 @@
     <java.version>1.8</java.version>
     <maven.compiler.source>${java.version}</maven.compiler.source>
     <maven.compiler.target>${java.version}</maven.compiler.target>
+    <gson-fire-version>1.8.0</gson-fire-version>
     <swagger-core-version>1.5.15</swagger-core-version>
     <jackson-version>2.6.6</jackson-version>
     <play-version>2.4.11</play-version>

--- a/samples/client/petstore/java/retrofit2-play24/src/main/java/io/swagger/client/api/FakeApi.java
+++ b/samples/client/petstore/java/retrofit2-play24/src/main/java/io/swagger/client/api/FakeApi.java
@@ -127,6 +127,20 @@ public interface FakeApi {
   );
 
   /**
+   * test inline additionalProperties
+   * 
+   * @param param request body (required)
+   * @return Call&lt;Void&gt;
+   */
+  @Headers({
+    "Content-Type:application/json"
+  })
+  @POST("fake/inline-additionalProperties")
+  F.Promise<Response<Void>> testInlineAdditionalProperties(
+    @retrofit2.http.Body Object param
+  );
+
+  /**
    * test json serialization of form data
    * 
    * @param param field1 (required)

--- a/samples/client/petstore/java/retrofit2-play24/src/main/java/io/swagger/client/model/AdditionalPropertiesClass.java
+++ b/samples/client/petstore/java/retrofit2-play24/src/main/java/io/swagger/client/model/AdditionalPropertiesClass.java
@@ -43,7 +43,7 @@ public class AdditionalPropertiesClass {
 
   public AdditionalPropertiesClass putMapPropertyItem(String key, String mapPropertyItem) {
     if (this.mapProperty == null) {
-      this.mapProperty = new HashMap<String, String>();
+      this.mapProperty = new HashMap<>();
     }
     this.mapProperty.put(key, mapPropertyItem);
     return this;
@@ -69,7 +69,7 @@ public class AdditionalPropertiesClass {
 
   public AdditionalPropertiesClass putMapOfMapPropertyItem(String key, Map<String, String> mapOfMapPropertyItem) {
     if (this.mapOfMapProperty == null) {
-      this.mapOfMapProperty = new HashMap<String, Map<String, String>>();
+      this.mapOfMapProperty = new HashMap<>();
     }
     this.mapOfMapProperty.put(key, mapOfMapPropertyItem);
     return this;

--- a/samples/client/petstore/java/retrofit2-play24/src/main/java/io/swagger/client/model/ArrayOfArrayOfNumberOnly.java
+++ b/samples/client/petstore/java/retrofit2-play24/src/main/java/io/swagger/client/model/ArrayOfArrayOfNumberOnly.java
@@ -40,7 +40,7 @@ public class ArrayOfArrayOfNumberOnly {
 
   public ArrayOfArrayOfNumberOnly addArrayArrayNumberItem(List<BigDecimal> arrayArrayNumberItem) {
     if (this.arrayArrayNumber == null) {
-      this.arrayArrayNumber = new ArrayList<List<BigDecimal>>();
+      this.arrayArrayNumber = new ArrayList<>();
     }
     this.arrayArrayNumber.add(arrayArrayNumberItem);
     return this;

--- a/samples/client/petstore/java/retrofit2-play24/src/main/java/io/swagger/client/model/ArrayOfNumberOnly.java
+++ b/samples/client/petstore/java/retrofit2-play24/src/main/java/io/swagger/client/model/ArrayOfNumberOnly.java
@@ -40,7 +40,7 @@ public class ArrayOfNumberOnly {
 
   public ArrayOfNumberOnly addArrayNumberItem(BigDecimal arrayNumberItem) {
     if (this.arrayNumber == null) {
-      this.arrayNumber = new ArrayList<BigDecimal>();
+      this.arrayNumber = new ArrayList<>();
     }
     this.arrayNumber.add(arrayNumberItem);
     return this;

--- a/samples/client/petstore/java/retrofit2-play24/src/main/java/io/swagger/client/model/ArrayTest.java
+++ b/samples/client/petstore/java/retrofit2-play24/src/main/java/io/swagger/client/model/ArrayTest.java
@@ -46,7 +46,7 @@ public class ArrayTest {
 
   public ArrayTest addArrayOfStringItem(String arrayOfStringItem) {
     if (this.arrayOfString == null) {
-      this.arrayOfString = new ArrayList<String>();
+      this.arrayOfString = new ArrayList<>();
     }
     this.arrayOfString.add(arrayOfStringItem);
     return this;
@@ -72,7 +72,7 @@ public class ArrayTest {
 
   public ArrayTest addArrayArrayOfIntegerItem(List<Long> arrayArrayOfIntegerItem) {
     if (this.arrayArrayOfInteger == null) {
-      this.arrayArrayOfInteger = new ArrayList<List<Long>>();
+      this.arrayArrayOfInteger = new ArrayList<>();
     }
     this.arrayArrayOfInteger.add(arrayArrayOfIntegerItem);
     return this;
@@ -99,7 +99,7 @@ public class ArrayTest {
 
   public ArrayTest addArrayArrayOfModelItem(List<ReadOnlyFirst> arrayArrayOfModelItem) {
     if (this.arrayArrayOfModel == null) {
-      this.arrayArrayOfModel = new ArrayList<List<ReadOnlyFirst>>();
+      this.arrayArrayOfModel = new ArrayList<>();
     }
     this.arrayArrayOfModel.add(arrayArrayOfModelItem);
     return this;

--- a/samples/client/petstore/java/retrofit2-play24/src/main/java/io/swagger/client/model/EnumArrays.java
+++ b/samples/client/petstore/java/retrofit2-play24/src/main/java/io/swagger/client/model/EnumArrays.java
@@ -130,7 +130,7 @@ public class EnumArrays {
 
   public EnumArrays addArrayEnumItem(ArrayEnumEnum arrayEnumItem) {
     if (this.arrayEnum == null) {
-      this.arrayEnum = new ArrayList<ArrayEnumEnum>();
+      this.arrayEnum = new ArrayList<>();
     }
     this.arrayEnum.add(arrayEnumItem);
     return this;

--- a/samples/client/petstore/java/retrofit2-play24/src/main/java/io/swagger/client/model/MapTest.java
+++ b/samples/client/petstore/java/retrofit2-play24/src/main/java/io/swagger/client/model/MapTest.java
@@ -78,7 +78,7 @@ public class MapTest {
 
   public MapTest putMapMapOfStringItem(String key, Map<String, String> mapMapOfStringItem) {
     if (this.mapMapOfString == null) {
-      this.mapMapOfString = new HashMap<String, Map<String, String>>();
+      this.mapMapOfString = new HashMap<>();
     }
     this.mapMapOfString.put(key, mapMapOfStringItem);
     return this;
@@ -105,7 +105,7 @@ public class MapTest {
 
   public MapTest putMapOfEnumStringItem(String key, InnerEnum mapOfEnumStringItem) {
     if (this.mapOfEnumString == null) {
-      this.mapOfEnumString = new HashMap<String, InnerEnum>();
+      this.mapOfEnumString = new HashMap<>();
     }
     this.mapOfEnumString.put(key, mapOfEnumStringItem);
     return this;

--- a/samples/client/petstore/java/retrofit2-play24/src/main/java/io/swagger/client/model/MixedPropertiesAndAdditionalPropertiesClass.java
+++ b/samples/client/petstore/java/retrofit2-play24/src/main/java/io/swagger/client/model/MixedPropertiesAndAdditionalPropertiesClass.java
@@ -87,7 +87,7 @@ public class MixedPropertiesAndAdditionalPropertiesClass {
 
   public MixedPropertiesAndAdditionalPropertiesClass putMapItem(String key, Animal mapItem) {
     if (this.map == null) {
-      this.map = new HashMap<String, Animal>();
+      this.map = new HashMap<>();
     }
     this.map.put(key, mapItem);
     return this;

--- a/samples/client/petstore/java/retrofit2-play24/src/main/java/io/swagger/client/model/Pet.java
+++ b/samples/client/petstore/java/retrofit2-play24/src/main/java/io/swagger/client/model/Pet.java
@@ -41,7 +41,7 @@ public class Pet {
   private String name = null;
 
   @JsonProperty("photoUrls")
-  private List<String> photoUrls = new ArrayList<String>();
+  private List<String> photoUrls = new ArrayList<>();
 
   @JsonProperty("tags")
   private List<Tag> tags = null;
@@ -173,7 +173,7 @@ public class Pet {
 
   public Pet addTagsItem(Tag tagsItem) {
     if (this.tags == null) {
-      this.tags = new ArrayList<Tag>();
+      this.tags = new ArrayList<>();
     }
     this.tags.add(tagsItem);
     return this;

--- a/samples/client/petstore/java/retrofit2/docs/FakeApi.md
+++ b/samples/client/petstore/java/retrofit2/docs/FakeApi.md
@@ -11,6 +11,7 @@ Method | HTTP request | Description
 [**testClientModel**](FakeApi.md#testClientModel) | **PATCH** fake | To test \&quot;client\&quot; model
 [**testEndpointParameters**](FakeApi.md#testEndpointParameters) | **POST** fake | Fake endpoint for testing various parameters 假端點 偽のエンドポイント 가짜 엔드 포인트 
 [**testEnumParameters**](FakeApi.md#testEnumParameters) | **GET** fake | To test enum parameters
+[**testInlineAdditionalProperties**](FakeApi.md#testInlineAdditionalProperties) | **POST** fake/inline-additionalProperties | test inline additionalProperties
 [**testJsonFormData**](FakeApi.md#testJsonFormData) | **GET** fake/jsonFormData | test json serialization of form data
 
 
@@ -377,6 +378,51 @@ No authorization required
 
  - **Content-Type**: */*
  - **Accept**: */*
+
+<a name="testInlineAdditionalProperties"></a>
+# **testInlineAdditionalProperties**
+> Void testInlineAdditionalProperties(param)
+
+test inline additionalProperties
+
+
+
+### Example
+```java
+// Import classes:
+//import io.swagger.client.ApiException;
+//import io.swagger.client.api.FakeApi;
+
+
+FakeApi apiInstance = new FakeApi();
+Object param = null; // Object | request body
+try {
+    Void result = apiInstance.testInlineAdditionalProperties(param);
+    System.out.println(result);
+} catch (ApiException e) {
+    System.err.println("Exception when calling FakeApi#testInlineAdditionalProperties");
+    e.printStackTrace();
+}
+```
+
+### Parameters
+
+Name | Type | Description  | Notes
+------------- | ------------- | ------------- | -------------
+ **param** | **Object**| request body |
+
+### Return type
+
+[**Void**](.md)
+
+### Authorization
+
+No authorization required
+
+### HTTP request headers
+
+ - **Content-Type**: application/json
+ - **Accept**: Not defined
 
 <a name="testJsonFormData"></a>
 # **testJsonFormData**

--- a/samples/client/petstore/java/retrofit2/src/main/java/io/swagger/client/api/FakeApi.java
+++ b/samples/client/petstore/java/retrofit2/src/main/java/io/swagger/client/api/FakeApi.java
@@ -123,6 +123,20 @@ public interface FakeApi {
   );
 
   /**
+   * test inline additionalProperties
+   * 
+   * @param param request body (required)
+   * @return Call&lt;Void&gt;
+   */
+  @Headers({
+    "Content-Type:application/json"
+  })
+  @POST("fake/inline-additionalProperties")
+  Call<Void> testInlineAdditionalProperties(
+    @retrofit2.http.Body Object param
+  );
+
+  /**
    * test json serialization of form data
    * 
    * @param param field1 (required)

--- a/samples/client/petstore/java/retrofit2rx/build.gradle
+++ b/samples/client/petstore/java/retrofit2rx/build.gradle
@@ -100,6 +100,7 @@ ext {
     junit_version = "4.12"
     rx_java_version = "1.3.0"
     threetenbp_version = "1.3.5"
+    json_fire_version = "1.8.0"
 }
 
 dependencies {
@@ -110,6 +111,7 @@ dependencies {
     compile "io.reactivex:rxjava:$rx_java_version"
     compile "io.swagger:swagger-annotations:$swagger_annotations_version"
     compile "org.apache.oltu.oauth2:org.apache.oltu.oauth2.client:$oltu_version"
+    compile "io.gsonfire:gson-fire:$json_fire_version"
     compile "org.threeten:threetenbp:$threetenbp_version"
 
     testCompile "junit:junit:$junit_version"

--- a/samples/client/petstore/java/retrofit2rx/build.sbt
+++ b/samples/client/petstore/java/retrofit2rx/build.sbt
@@ -17,6 +17,7 @@ lazy val root = (project in file(".")).
       "io.swagger" % "swagger-annotations" % "1.5.15" % "compile",
       "org.apache.oltu.oauth2" % "org.apache.oltu.oauth2.client" % "1.0.1" % "compile",
       "org.threeten" % "threetenbp" % "1.3.5" % "compile",
+      "io.gsonfire" % "gson-fire" % "1.8.0" % "compile",
       "junit" % "junit" % "4.12" % "test",
       "com.novocode" % "junit-interface" % "0.11" % "test"
     )

--- a/samples/client/petstore/java/retrofit2rx/docs/FakeApi.md
+++ b/samples/client/petstore/java/retrofit2rx/docs/FakeApi.md
@@ -11,6 +11,7 @@ Method | HTTP request | Description
 [**testClientModel**](FakeApi.md#testClientModel) | **PATCH** fake | To test \&quot;client\&quot; model
 [**testEndpointParameters**](FakeApi.md#testEndpointParameters) | **POST** fake | Fake endpoint for testing various parameters 假端點 偽のエンドポイント 가짜 엔드 포인트 
 [**testEnumParameters**](FakeApi.md#testEnumParameters) | **GET** fake | To test enum parameters
+[**testInlineAdditionalProperties**](FakeApi.md#testInlineAdditionalProperties) | **POST** fake/inline-additionalProperties | test inline additionalProperties
 [**testJsonFormData**](FakeApi.md#testJsonFormData) | **GET** fake/jsonFormData | test json serialization of form data
 
 
@@ -377,6 +378,51 @@ No authorization required
 
  - **Content-Type**: */*
  - **Accept**: */*
+
+<a name="testInlineAdditionalProperties"></a>
+# **testInlineAdditionalProperties**
+> Void testInlineAdditionalProperties(param)
+
+test inline additionalProperties
+
+
+
+### Example
+```java
+// Import classes:
+//import io.swagger.client.ApiException;
+//import io.swagger.client.api.FakeApi;
+
+
+FakeApi apiInstance = new FakeApi();
+Object param = null; // Object | request body
+try {
+    Void result = apiInstance.testInlineAdditionalProperties(param);
+    System.out.println(result);
+} catch (ApiException e) {
+    System.err.println("Exception when calling FakeApi#testInlineAdditionalProperties");
+    e.printStackTrace();
+}
+```
+
+### Parameters
+
+Name | Type | Description  | Notes
+------------- | ------------- | ------------- | -------------
+ **param** | **Object**| request body |
+
+### Return type
+
+[**Void**](.md)
+
+### Authorization
+
+No authorization required
+
+### HTTP request headers
+
+ - **Content-Type**: application/json
+ - **Accept**: Not defined
 
 <a name="testJsonFormData"></a>
 # **testJsonFormData**

--- a/samples/client/petstore/java/retrofit2rx/pom.xml
+++ b/samples/client/petstore/java/retrofit2rx/pom.xml
@@ -195,6 +195,11 @@
       <version>${oltu-version}</version>
     </dependency>
     <dependency>
+      <groupId>io.gsonfire</groupId>
+      <artifactId>gson-fire</artifactId>
+      <version>${gson-fire-version}</version>
+    </dependency>
+    <dependency>
       <groupId>org.threeten</groupId>
       <artifactId>threetenbp</artifactId>
       <version>${threetenbp-version}</version>
@@ -225,6 +230,7 @@
     <java.version>1.7</java.version>
     <maven.compiler.source>${java.version}</maven.compiler.source>
     <maven.compiler.target>${java.version}</maven.compiler.target>
+    <gson-fire-version>1.8.0</gson-fire-version>
     <swagger-core-version>1.5.15</swagger-core-version>
     <retrofit-version>2.3.0</retrofit-version>
     <rxjava-version>1.3.0</rxjava-version>

--- a/samples/client/petstore/java/retrofit2rx/src/main/java/io/swagger/client/ApiClient.java
+++ b/samples/client/petstore/java/retrofit2rx/src/main/java/io/swagger/client/ApiClient.java
@@ -2,6 +2,7 @@ package io.swagger.client;
 
 import com.google.gson.Gson;
 import com.google.gson.JsonParseException;
+import com.google.gson.JsonElement;
 import okhttp3.Interceptor;
 import okhttp3.OkHttpClient;
 import okhttp3.RequestBody;
@@ -26,6 +27,7 @@ import java.lang.reflect.Type;
 import java.text.DateFormat;
 import java.util.LinkedHashMap;
 import java.util.Map;
+import java.util.HashMap;
 
 public class ApiClient {
 

--- a/samples/client/petstore/java/retrofit2rx/src/main/java/io/swagger/client/api/FakeApi.java
+++ b/samples/client/petstore/java/retrofit2rx/src/main/java/io/swagger/client/api/FakeApi.java
@@ -123,6 +123,20 @@ public interface FakeApi {
   );
 
   /**
+   * test inline additionalProperties
+   * 
+   * @param param request body (required)
+   * @return Call&lt;Void&gt;
+   */
+  @Headers({
+    "Content-Type:application/json"
+  })
+  @POST("fake/inline-additionalProperties")
+  Observable<Void> testInlineAdditionalProperties(
+    @retrofit2.http.Body Object param
+  );
+
+  /**
    * test json serialization of form data
    * 
    * @param param field1 (required)

--- a/samples/client/petstore/java/retrofit2rx2/build.gradle
+++ b/samples/client/petstore/java/retrofit2rx2/build.gradle
@@ -100,6 +100,7 @@ ext {
     junit_version = "4.12"
     rx_java_version = "2.1.1"
     threetenbp_version = "1.3.5"
+    json_fire_version = "1.8.0"
 }
 
 dependencies {
@@ -110,6 +111,7 @@ dependencies {
     compile "io.reactivex.rxjava2:rxjava:$rx_java_version"
     compile "io.swagger:swagger-annotations:$swagger_annotations_version"
     compile "org.apache.oltu.oauth2:org.apache.oltu.oauth2.client:$oltu_version"
+    compile "io.gsonfire:gson-fire:$json_fire_version"
     compile "org.threeten:threetenbp:$threetenbp_version"
 
     testCompile "junit:junit:$junit_version"

--- a/samples/client/petstore/java/retrofit2rx2/build.sbt
+++ b/samples/client/petstore/java/retrofit2rx2/build.sbt
@@ -17,6 +17,7 @@ lazy val root = (project in file(".")).
       "io.swagger" % "swagger-annotations" % "1.5.15" % "compile",
       "org.apache.oltu.oauth2" % "org.apache.oltu.oauth2.client" % "1.0.1" % "compile",
       "org.threeten" % "threetenbp" % "1.3.5" % "compile",
+      "io.gsonfire" % "gson-fire" % "1.8.0" % "compile",
       "junit" % "junit" % "4.12" % "test",
       "com.novocode" % "junit-interface" % "0.11" % "test"
     )

--- a/samples/client/petstore/java/retrofit2rx2/docs/FakeApi.md
+++ b/samples/client/petstore/java/retrofit2rx2/docs/FakeApi.md
@@ -11,6 +11,7 @@ Method | HTTP request | Description
 [**testClientModel**](FakeApi.md#testClientModel) | **PATCH** fake | To test \&quot;client\&quot; model
 [**testEndpointParameters**](FakeApi.md#testEndpointParameters) | **POST** fake | Fake endpoint for testing various parameters 假端點 偽のエンドポイント 가짜 엔드 포인트 
 [**testEnumParameters**](FakeApi.md#testEnumParameters) | **GET** fake | To test enum parameters
+[**testInlineAdditionalProperties**](FakeApi.md#testInlineAdditionalProperties) | **POST** fake/inline-additionalProperties | test inline additionalProperties
 [**testJsonFormData**](FakeApi.md#testJsonFormData) | **GET** fake/jsonFormData | test json serialization of form data
 
 
@@ -377,6 +378,51 @@ No authorization required
 
  - **Content-Type**: */*
  - **Accept**: */*
+
+<a name="testInlineAdditionalProperties"></a>
+# **testInlineAdditionalProperties**
+> Void testInlineAdditionalProperties(param)
+
+test inline additionalProperties
+
+
+
+### Example
+```java
+// Import classes:
+//import io.swagger.client.ApiException;
+//import io.swagger.client.api.FakeApi;
+
+
+FakeApi apiInstance = new FakeApi();
+Object param = null; // Object | request body
+try {
+    Void result = apiInstance.testInlineAdditionalProperties(param);
+    System.out.println(result);
+} catch (ApiException e) {
+    System.err.println("Exception when calling FakeApi#testInlineAdditionalProperties");
+    e.printStackTrace();
+}
+```
+
+### Parameters
+
+Name | Type | Description  | Notes
+------------- | ------------- | ------------- | -------------
+ **param** | **Object**| request body |
+
+### Return type
+
+[**Void**](.md)
+
+### Authorization
+
+No authorization required
+
+### HTTP request headers
+
+ - **Content-Type**: application/json
+ - **Accept**: Not defined
 
 <a name="testJsonFormData"></a>
 # **testJsonFormData**

--- a/samples/client/petstore/java/retrofit2rx2/pom.xml
+++ b/samples/client/petstore/java/retrofit2rx2/pom.xml
@@ -195,6 +195,11 @@
       <version>${oltu-version}</version>
     </dependency>
     <dependency>
+      <groupId>io.gsonfire</groupId>
+      <artifactId>gson-fire</artifactId>
+      <version>${gson-fire-version}</version>
+    </dependency>
+    <dependency>
       <groupId>org.threeten</groupId>
       <artifactId>threetenbp</artifactId>
       <version>${threetenbp-version}</version>
@@ -225,6 +230,7 @@
     <java.version>1.7</java.version>
     <maven.compiler.source>${java.version}</maven.compiler.source>
     <maven.compiler.target>${java.version}</maven.compiler.target>
+    <gson-fire-version>1.8.0</gson-fire-version>
     <swagger-core-version>1.5.15</swagger-core-version>
     <retrofit-version>2.3.0</retrofit-version>
     <rxjava-version>2.1.1</rxjava-version>

--- a/samples/client/petstore/java/retrofit2rx2/src/main/java/io/swagger/client/ApiClient.java
+++ b/samples/client/petstore/java/retrofit2rx2/src/main/java/io/swagger/client/ApiClient.java
@@ -2,6 +2,7 @@ package io.swagger.client;
 
 import com.google.gson.Gson;
 import com.google.gson.JsonParseException;
+import com.google.gson.JsonElement;
 import okhttp3.Interceptor;
 import okhttp3.OkHttpClient;
 import okhttp3.RequestBody;
@@ -26,6 +27,7 @@ import java.lang.reflect.Type;
 import java.text.DateFormat;
 import java.util.LinkedHashMap;
 import java.util.Map;
+import java.util.HashMap;
 
 public class ApiClient {
 

--- a/samples/client/petstore/java/retrofit2rx2/src/main/java/io/swagger/client/api/FakeApi.java
+++ b/samples/client/petstore/java/retrofit2rx2/src/main/java/io/swagger/client/api/FakeApi.java
@@ -123,6 +123,20 @@ public interface FakeApi {
   );
 
   /**
+   * test inline additionalProperties
+   * 
+   * @param param request body (required)
+   * @return Call&lt;Void&gt;
+   */
+  @Headers({
+    "Content-Type:application/json"
+  })
+  @POST("fake/inline-additionalProperties")
+  Observable<Void> testInlineAdditionalProperties(
+    @retrofit2.http.Body Object param
+  );
+
+  /**
    * test json serialization of form data
    * 
    * @param param field1 (required)


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [x] Filed the PR against the correct branch: `3.0.0` branch for changes related to OpenAPI spec 3.0. Default: `master`.
- [x] Copied the [technical committee](https://github.com/swagger-api/swagger-codegen/#swagger-codegen-technical-committee) to review the pull request if your PR is targeting a particular programming langauge.

### Description of the PR
Fixed a previous PR (#6166) by adding the `@Deprecated` annotation to appropriate methods in the jersey2, okhttp-gson, resteasy libraries. 


@bbdouglas @JFCote @sreeshas @jfiala @lukoyanov @cbornet