### PR TITLE
[PHP] Fix #6770: Debug flag is not passed

### DIFF
--- a/modules/swagger-codegen/src/main/resources/php/api.mustache
+++ b/modules/swagger-codegen/src/main/resources/php/api.mustache
@@ -128,6 +128,9 @@ use {{invokerPackage}}\ObjectSerializer;
                 $options = [];
                 if ($this->config->getDebug()) {
                     $options[RequestOptions::DEBUG] = fopen($this->config->getDebugFile(), 'a');
+                    if (!$options[RequestOptions::DEBUG]) {
+                        throw new \RuntimeException('Failed to open the debug file: ' . $this->config->getDebugFile());
+                    }
                 }
                 $response = $this->client->send($request, $options);
             } catch (RequestException $e) {

--- a/modules/swagger-codegen/src/main/resources/php/api.mustache
+++ b/modules/swagger-codegen/src/main/resources/php/api.mustache
@@ -23,6 +23,7 @@ use GuzzleHttp\ClientInterface;
 use GuzzleHttp\Exception\RequestException;
 use GuzzleHttp\Psr7\MultipartStream;
 use GuzzleHttp\Psr7\Request;
+use GuzzleHttp\RequestOptions;
 use {{invokerPackage}}\ApiException;
 use {{invokerPackage}}\Configuration;
 use {{invokerPackage}}\HeaderSelector;
@@ -124,7 +125,11 @@ use {{invokerPackage}}\ObjectSerializer;
         try {
 
             try {
-                $response = $this->client->send($request);
+                $options = [];
+                if ($this->config->getDebug()) {
+                    $options[RequestOptions::DEBUG] = fopen($this->config->getDebugFile(), 'a');
+                }
+                $response = $this->client->send($request, $options);
             } catch (RequestException $e) {
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",

--- a/modules/swagger-codegen/src/main/resources/php/api.mustache
+++ b/modules/swagger-codegen/src/main/resources/php/api.mustache
@@ -243,8 +243,16 @@ use {{invokerPackage}}\ObjectSerializer;
         $returnType = '{{returnType}}';
         $request = $this->{{operationId}}Request({{#allParams}}${{paramName}}{{#hasMore}}, {{/hasMore}}{{/allParams}});
 
+        $options = [];
+        if ($this->config->getDebug()) {
+            $options[RequestOptions::DEBUG] = fopen($this->config->getDebugFile(), 'a');
+            if (!$options[RequestOptions::DEBUG]) {
+                throw new \RuntimeException('Failed to open the debug file: ' . $this->config->getDebugFile());
+            }
+        }
+
         return $this->client
-            ->sendAsync($request)
+            ->sendAsync($request, $options)
             ->then(
                 function ($response) use ($returnType) {
                     {{#returnType}}

--- a/modules/swagger-codegen/src/main/resources/php/api.mustache
+++ b/modules/swagger-codegen/src/main/resources/php/api.mustache
@@ -123,15 +123,8 @@ use {{invokerPackage}}\ObjectSerializer;
         $request = $this->{{operationId}}Request({{#allParams}}${{paramName}}{{#hasMore}}, {{/hasMore}}{{/allParams}});
 
         try {
-
+            $options = $this->createHttpClientOption();
             try {
-                $options = [];
-                if ($this->config->getDebug()) {
-                    $options[RequestOptions::DEBUG] = fopen($this->config->getDebugFile(), 'a');
-                    if (!$options[RequestOptions::DEBUG]) {
-                        throw new \RuntimeException('Failed to open the debug file: ' . $this->config->getDebugFile());
-                    }
-                }
                 $response = $this->client->send($request, $options);
             } catch (RequestException $e) {
                 throw new ApiException(
@@ -243,16 +236,8 @@ use {{invokerPackage}}\ObjectSerializer;
         $returnType = '{{returnType}}';
         $request = $this->{{operationId}}Request({{#allParams}}${{paramName}}{{#hasMore}}, {{/hasMore}}{{/allParams}});
 
-        $options = [];
-        if ($this->config->getDebug()) {
-            $options[RequestOptions::DEBUG] = fopen($this->config->getDebugFile(), 'a');
-            if (!$options[RequestOptions::DEBUG]) {
-                throw new \RuntimeException('Failed to open the debug file: ' . $this->config->getDebugFile());
-            }
-        }
-
         return $this->client
-            ->sendAsync($request, $options)
+            ->sendAsync($request, $this->createHttpClientOption())
             ->then(
                 function ($response) use ($returnType) {
                     {{#returnType}}
@@ -503,5 +488,23 @@ use {{invokerPackage}}\ObjectSerializer;
     }
 
     {{/operation}}
+    /**
+     * Create http client option
+     *
+     * @throws \RuntimeException on file opening failure
+     * @return array of http client options
+     */
+    protected function createHttpClientOption()
+    {
+        $options = [];
+        if ($this->config->getDebug()) {
+            $options[RequestOptions::DEBUG] = fopen($this->config->getDebugFile(), 'a');
+            if (!$options[RequestOptions::DEBUG]) {
+                throw new \RuntimeException('Failed to open the debug file: ' . $this->config->getDebugFile());
+            }
+        }
+
+        return $options;
+    }
 }
 {{/operations}}

--- a/samples/client/petstore-security-test/php/SwaggerClient-php/lib/Api/FakeApi.php
+++ b/samples/client/petstore-security-test/php/SwaggerClient-php/lib/Api/FakeApi.php
@@ -32,6 +32,7 @@ use GuzzleHttp\ClientInterface;
 use GuzzleHttp\Exception\RequestException;
 use GuzzleHttp\Psr7\MultipartStream;
 use GuzzleHttp\Psr7\Request;
+use GuzzleHttp\RequestOptions;
 use Swagger\Client\ApiException;
 use Swagger\Client\Configuration;
 use Swagger\Client\HeaderSelector;
@@ -115,7 +116,11 @@ class FakeApi
         try {
 
             try {
-                $response = $this->client->send($request);
+                $options = [];
+                if ($this->config->getDebug()) {
+                    $options[RequestOptions::DEBUG] = fopen($this->config->getDebugFile(), 'a');
+                }
+                $response = $this->client->send($request, $options);
             } catch (RequestException $e) {
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",

--- a/samples/client/petstore-security-test/php/SwaggerClient-php/lib/Api/FakeApi.php
+++ b/samples/client/petstore-security-test/php/SwaggerClient-php/lib/Api/FakeApi.php
@@ -114,12 +114,8 @@ class FakeApi
         $request = $this->testCodeInjectEndRnNRRequest($test_code_inject____end____rn_n_r);
 
         try {
-
+            $options = $this->createHttpClientOption();
             try {
-                $options = [];
-                if ($this->config->getDebug()) {
-                    $options[RequestOptions::DEBUG] = fopen($this->config->getDebugFile(), 'a');
-                }
                 $response = $this->client->send($request, $options);
             } catch (RequestException $e) {
                 throw new ApiException(
@@ -189,7 +185,7 @@ class FakeApi
         $request = $this->testCodeInjectEndRnNRRequest($test_code_inject____end____rn_n_r);
 
         return $this->client
-            ->sendAsync($request)
+            ->sendAsync($request, $this->createHttpClientOption())
             ->then(
                 function ($response) use ($returnType) {
                     return [null, $response->getStatusCode(), $response->getHeaders()];
@@ -299,4 +295,22 @@ class FakeApi
         );
     }
 
+    /**
+     * Create http client option
+     *
+     * @throws \RuntimeException on file opening failure
+     * @return array of http client options
+     */
+    protected function createHttpClientOption()
+    {
+        $options = [];
+        if ($this->config->getDebug()) {
+            $options[RequestOptions::DEBUG] = fopen($this->config->getDebugFile(), 'a');
+            if (!$options[RequestOptions::DEBUG]) {
+                throw new \RuntimeException('Failed to open the debug file: ' . $this->config->getDebugFile());
+            }
+        }
+
+        return $options;
+    }
 }

--- a/samples/client/petstore/php/SwaggerClient-php/lib/Api/AnotherFakeApi.php
+++ b/samples/client/petstore/php/SwaggerClient-php/lib/Api/AnotherFakeApi.php
@@ -32,6 +32,7 @@ use GuzzleHttp\ClientInterface;
 use GuzzleHttp\Exception\RequestException;
 use GuzzleHttp\Psr7\MultipartStream;
 use GuzzleHttp\Psr7\Request;
+use GuzzleHttp\RequestOptions;
 use Swagger\Client\ApiException;
 use Swagger\Client\Configuration;
 use Swagger\Client\HeaderSelector;
@@ -116,7 +117,11 @@ class AnotherFakeApi
         try {
 
             try {
-                $response = $this->client->send($request);
+                $options = [];
+                if ($this->config->getDebug()) {
+                    $options[RequestOptions::DEBUG] = fopen($this->config->getDebugFile(), 'a');
+                }
+                $response = $this->client->send($request, $options);
             } catch (RequestException $e) {
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",

--- a/samples/client/petstore/php/SwaggerClient-php/lib/Api/AnotherFakeApi.php
+++ b/samples/client/petstore/php/SwaggerClient-php/lib/Api/AnotherFakeApi.php
@@ -115,12 +115,8 @@ class AnotherFakeApi
         $request = $this->testSpecialTagsRequest($body);
 
         try {
-
+            $options = $this->createHttpClientOption();
             try {
-                $options = [];
-                if ($this->config->getDebug()) {
-                    $options[RequestOptions::DEBUG] = fopen($this->config->getDebugFile(), 'a');
-                }
                 $response = $this->client->send($request, $options);
             } catch (RequestException $e) {
                 throw new ApiException(
@@ -212,7 +208,7 @@ class AnotherFakeApi
         $request = $this->testSpecialTagsRequest($body);
 
         return $this->client
-            ->sendAsync($request)
+            ->sendAsync($request, $this->createHttpClientOption())
             ->then(
                 function ($response) use ($returnType) {
                     $responseBody = $response->getBody();
@@ -341,4 +337,22 @@ class AnotherFakeApi
         );
     }
 
+    /**
+     * Create http client option
+     *
+     * @throws \RuntimeException on file opening failure
+     * @return array of http client options
+     */
+    protected function createHttpClientOption()
+    {
+        $options = [];
+        if ($this->config->getDebug()) {
+            $options[RequestOptions::DEBUG] = fopen($this->config->getDebugFile(), 'a');
+            if (!$options[RequestOptions::DEBUG]) {
+                throw new \RuntimeException('Failed to open the debug file: ' . $this->config->getDebugFile());
+            }
+        }
+
+        return $options;
+    }
 }

--- a/samples/client/petstore/php/SwaggerClient-php/lib/Api/FakeApi.php
+++ b/samples/client/petstore/php/SwaggerClient-php/lib/Api/FakeApi.php
@@ -32,6 +32,7 @@ use GuzzleHttp\ClientInterface;
 use GuzzleHttp\Exception\RequestException;
 use GuzzleHttp\Psr7\MultipartStream;
 use GuzzleHttp\Psr7\Request;
+use GuzzleHttp\RequestOptions;
 use Swagger\Client\ApiException;
 use Swagger\Client\Configuration;
 use Swagger\Client\HeaderSelector;
@@ -112,7 +113,11 @@ class FakeApi
         try {
 
             try {
-                $response = $this->client->send($request);
+                $options = [];
+                if ($this->config->getDebug()) {
+                    $options[RequestOptions::DEBUG] = fopen($this->config->getDebugFile(), 'a');
+                }
+                $response = $this->client->send($request, $options);
             } catch (RequestException $e) {
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
@@ -358,7 +363,11 @@ class FakeApi
         try {
 
             try {
-                $response = $this->client->send($request);
+                $options = [];
+                if ($this->config->getDebug()) {
+                    $options[RequestOptions::DEBUG] = fopen($this->config->getDebugFile(), 'a');
+                }
+                $response = $this->client->send($request, $options);
             } catch (RequestException $e) {
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
@@ -604,7 +613,11 @@ class FakeApi
         try {
 
             try {
-                $response = $this->client->send($request);
+                $options = [];
+                if ($this->config->getDebug()) {
+                    $options[RequestOptions::DEBUG] = fopen($this->config->getDebugFile(), 'a');
+                }
+                $response = $this->client->send($request, $options);
             } catch (RequestException $e) {
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
@@ -850,7 +863,11 @@ class FakeApi
         try {
 
             try {
-                $response = $this->client->send($request);
+                $options = [];
+                if ($this->config->getDebug()) {
+                    $options[RequestOptions::DEBUG] = fopen($this->config->getDebugFile(), 'a');
+                }
+                $response = $this->client->send($request, $options);
             } catch (RequestException $e) {
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
@@ -1100,7 +1117,11 @@ class FakeApi
         try {
 
             try {
-                $response = $this->client->send($request);
+                $options = [];
+                if ($this->config->getDebug()) {
+                    $options[RequestOptions::DEBUG] = fopen($this->config->getDebugFile(), 'a');
+                }
+                $response = $this->client->send($request, $options);
             } catch (RequestException $e) {
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
@@ -1381,7 +1402,11 @@ class FakeApi
         try {
 
             try {
-                $response = $this->client->send($request);
+                $options = [];
+                if ($this->config->getDebug()) {
+                    $options[RequestOptions::DEBUG] = fopen($this->config->getDebugFile(), 'a');
+                }
+                $response = $this->client->send($request, $options);
             } catch (RequestException $e) {
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
@@ -1775,7 +1800,11 @@ class FakeApi
         try {
 
             try {
-                $response = $this->client->send($request);
+                $options = [];
+                if ($this->config->getDebug()) {
+                    $options[RequestOptions::DEBUG] = fopen($this->config->getDebugFile(), 'a');
+                }
+                $response = $this->client->send($request, $options);
             } catch (RequestException $e) {
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
@@ -2044,7 +2073,11 @@ class FakeApi
         try {
 
             try {
-                $response = $this->client->send($request);
+                $options = [];
+                if ($this->config->getDebug()) {
+                    $options[RequestOptions::DEBUG] = fopen($this->config->getDebugFile(), 'a');
+                }
+                $response = $this->client->send($request, $options);
             } catch (RequestException $e) {
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
@@ -2265,7 +2298,11 @@ class FakeApi
         try {
 
             try {
-                $response = $this->client->send($request);
+                $options = [];
+                if ($this->config->getDebug()) {
+                    $options[RequestOptions::DEBUG] = fopen($this->config->getDebugFile(), 'a');
+                }
+                $response = $this->client->send($request, $options);
             } catch (RequestException $e) {
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",

--- a/samples/client/petstore/php/SwaggerClient-php/lib/Api/FakeApi.php
+++ b/samples/client/petstore/php/SwaggerClient-php/lib/Api/FakeApi.php
@@ -111,12 +111,8 @@ class FakeApi
         $request = $this->fakeOuterBooleanSerializeRequest($body);
 
         try {
-
+            $options = $this->createHttpClientOption();
             try {
-                $options = [];
-                if ($this->config->getDebug()) {
-                    $options[RequestOptions::DEBUG] = fopen($this->config->getDebugFile(), 'a');
-                }
                 $response = $this->client->send($request, $options);
             } catch (RequestException $e) {
                 throw new ApiException(
@@ -208,7 +204,7 @@ class FakeApi
         $request = $this->fakeOuterBooleanSerializeRequest($body);
 
         return $this->client
-            ->sendAsync($request)
+            ->sendAsync($request, $this->createHttpClientOption())
             ->then(
                 function ($response) use ($returnType) {
                     $responseBody = $response->getBody();
@@ -361,12 +357,8 @@ class FakeApi
         $request = $this->fakeOuterCompositeSerializeRequest($body);
 
         try {
-
+            $options = $this->createHttpClientOption();
             try {
-                $options = [];
-                if ($this->config->getDebug()) {
-                    $options[RequestOptions::DEBUG] = fopen($this->config->getDebugFile(), 'a');
-                }
                 $response = $this->client->send($request, $options);
             } catch (RequestException $e) {
                 throw new ApiException(
@@ -458,7 +450,7 @@ class FakeApi
         $request = $this->fakeOuterCompositeSerializeRequest($body);
 
         return $this->client
-            ->sendAsync($request)
+            ->sendAsync($request, $this->createHttpClientOption())
             ->then(
                 function ($response) use ($returnType) {
                     $responseBody = $response->getBody();
@@ -611,12 +603,8 @@ class FakeApi
         $request = $this->fakeOuterNumberSerializeRequest($body);
 
         try {
-
+            $options = $this->createHttpClientOption();
             try {
-                $options = [];
-                if ($this->config->getDebug()) {
-                    $options[RequestOptions::DEBUG] = fopen($this->config->getDebugFile(), 'a');
-                }
                 $response = $this->client->send($request, $options);
             } catch (RequestException $e) {
                 throw new ApiException(
@@ -708,7 +696,7 @@ class FakeApi
         $request = $this->fakeOuterNumberSerializeRequest($body);
 
         return $this->client
-            ->sendAsync($request)
+            ->sendAsync($request, $this->createHttpClientOption())
             ->then(
                 function ($response) use ($returnType) {
                     $responseBody = $response->getBody();
@@ -861,12 +849,8 @@ class FakeApi
         $request = $this->fakeOuterStringSerializeRequest($body);
 
         try {
-
+            $options = $this->createHttpClientOption();
             try {
-                $options = [];
-                if ($this->config->getDebug()) {
-                    $options[RequestOptions::DEBUG] = fopen($this->config->getDebugFile(), 'a');
-                }
                 $response = $this->client->send($request, $options);
             } catch (RequestException $e) {
                 throw new ApiException(
@@ -958,7 +942,7 @@ class FakeApi
         $request = $this->fakeOuterStringSerializeRequest($body);
 
         return $this->client
-            ->sendAsync($request)
+            ->sendAsync($request, $this->createHttpClientOption())
             ->then(
                 function ($response) use ($returnType) {
                     $responseBody = $response->getBody();
@@ -1115,12 +1099,8 @@ class FakeApi
         $request = $this->testClientModelRequest($body);
 
         try {
-
+            $options = $this->createHttpClientOption();
             try {
-                $options = [];
-                if ($this->config->getDebug()) {
-                    $options[RequestOptions::DEBUG] = fopen($this->config->getDebugFile(), 'a');
-                }
                 $response = $this->client->send($request, $options);
             } catch (RequestException $e) {
                 throw new ApiException(
@@ -1212,7 +1192,7 @@ class FakeApi
         $request = $this->testClientModelRequest($body);
 
         return $this->client
-            ->sendAsync($request)
+            ->sendAsync($request, $this->createHttpClientOption())
             ->then(
                 function ($response) use ($returnType) {
                     $responseBody = $response->getBody();
@@ -1400,12 +1380,8 @@ class FakeApi
         $request = $this->testEndpointParametersRequest($number, $double, $pattern_without_delimiter, $byte, $integer, $int32, $int64, $float, $string, $binary, $date, $date_time, $password, $callback);
 
         try {
-
+            $options = $this->createHttpClientOption();
             try {
-                $options = [];
-                if ($this->config->getDebug()) {
-                    $options[RequestOptions::DEBUG] = fopen($this->config->getDebugFile(), 'a');
-                }
                 $response = $this->client->send($request, $options);
             } catch (RequestException $e) {
                 throw new ApiException(
@@ -1501,7 +1477,7 @@ class FakeApi
         $request = $this->testEndpointParametersRequest($number, $double, $pattern_without_delimiter, $byte, $integer, $int32, $int64, $float, $string, $binary, $date, $date_time, $password, $callback);
 
         return $this->client
-            ->sendAsync($request)
+            ->sendAsync($request, $this->createHttpClientOption())
             ->then(
                 function ($response) use ($returnType) {
                     return [null, $response->getStatusCode(), $response->getHeaders()];
@@ -1798,12 +1774,8 @@ class FakeApi
         $request = $this->testEnumParametersRequest($enum_form_string_array, $enum_form_string, $enum_header_string_array, $enum_header_string, $enum_query_string_array, $enum_query_string, $enum_query_integer, $enum_query_double);
 
         try {
-
+            $options = $this->createHttpClientOption();
             try {
-                $options = [];
-                if ($this->config->getDebug()) {
-                    $options[RequestOptions::DEBUG] = fopen($this->config->getDebugFile(), 'a');
-                }
                 $response = $this->client->send($request, $options);
             } catch (RequestException $e) {
                 throw new ApiException(
@@ -1887,7 +1859,7 @@ class FakeApi
         $request = $this->testEnumParametersRequest($enum_form_string_array, $enum_form_string, $enum_header_string_array, $enum_header_string, $enum_query_string_array, $enum_query_string, $enum_query_integer, $enum_query_double);
 
         return $this->client
-            ->sendAsync($request)
+            ->sendAsync($request, $this->createHttpClientOption())
             ->then(
                 function ($response) use ($returnType) {
                     return [null, $response->getStatusCode(), $response->getHeaders()];
@@ -2071,12 +2043,8 @@ class FakeApi
         $request = $this->testInlineAdditionalPropertiesRequest($param);
 
         try {
-
+            $options = $this->createHttpClientOption();
             try {
-                $options = [];
-                if ($this->config->getDebug()) {
-                    $options[RequestOptions::DEBUG] = fopen($this->config->getDebugFile(), 'a');
-                }
                 $response = $this->client->send($request, $options);
             } catch (RequestException $e) {
                 throw new ApiException(
@@ -2146,7 +2114,7 @@ class FakeApi
         $request = $this->testInlineAdditionalPropertiesRequest($param);
 
         return $this->client
-            ->sendAsync($request)
+            ->sendAsync($request, $this->createHttpClientOption())
             ->then(
                 function ($response) use ($returnType) {
                     return [null, $response->getStatusCode(), $response->getHeaders()];
@@ -2296,12 +2264,8 @@ class FakeApi
         $request = $this->testJsonFormDataRequest($param, $param2);
 
         try {
-
+            $options = $this->createHttpClientOption();
             try {
-                $options = [];
-                if ($this->config->getDebug()) {
-                    $options[RequestOptions::DEBUG] = fopen($this->config->getDebugFile(), 'a');
-                }
                 $response = $this->client->send($request, $options);
             } catch (RequestException $e) {
                 throw new ApiException(
@@ -2373,7 +2337,7 @@ class FakeApi
         $request = $this->testJsonFormDataRequest($param, $param2);
 
         return $this->client
-            ->sendAsync($request)
+            ->sendAsync($request, $this->createHttpClientOption())
             ->then(
                 function ($response) use ($returnType) {
                     return [null, $response->getStatusCode(), $response->getHeaders()];
@@ -2500,4 +2464,22 @@ class FakeApi
         );
     }
 
+    /**
+     * Create http client option
+     *
+     * @throws \RuntimeException on file opening failure
+     * @return array of http client options
+     */
+    protected function createHttpClientOption()
+    {
+        $options = [];
+        if ($this->config->getDebug()) {
+            $options[RequestOptions::DEBUG] = fopen($this->config->getDebugFile(), 'a');
+            if (!$options[RequestOptions::DEBUG]) {
+                throw new \RuntimeException('Failed to open the debug file: ' . $this->config->getDebugFile());
+            }
+        }
+
+        return $options;
+    }
 }

--- a/samples/client/petstore/php/SwaggerClient-php/lib/Api/FakeClassnameTags123Api.php
+++ b/samples/client/petstore/php/SwaggerClient-php/lib/Api/FakeClassnameTags123Api.php
@@ -32,6 +32,7 @@ use GuzzleHttp\ClientInterface;
 use GuzzleHttp\Exception\RequestException;
 use GuzzleHttp\Psr7\MultipartStream;
 use GuzzleHttp\Psr7\Request;
+use GuzzleHttp\RequestOptions;
 use Swagger\Client\ApiException;
 use Swagger\Client\Configuration;
 use Swagger\Client\HeaderSelector;
@@ -116,7 +117,11 @@ class FakeClassnameTags123Api
         try {
 
             try {
-                $response = $this->client->send($request);
+                $options = [];
+                if ($this->config->getDebug()) {
+                    $options[RequestOptions::DEBUG] = fopen($this->config->getDebugFile(), 'a');
+                }
+                $response = $this->client->send($request, $options);
             } catch (RequestException $e) {
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",

--- a/samples/client/petstore/php/SwaggerClient-php/lib/Api/FakeClassnameTags123Api.php
+++ b/samples/client/petstore/php/SwaggerClient-php/lib/Api/FakeClassnameTags123Api.php
@@ -115,12 +115,8 @@ class FakeClassnameTags123Api
         $request = $this->testClassnameRequest($body);
 
         try {
-
+            $options = $this->createHttpClientOption();
             try {
-                $options = [];
-                if ($this->config->getDebug()) {
-                    $options[RequestOptions::DEBUG] = fopen($this->config->getDebugFile(), 'a');
-                }
                 $response = $this->client->send($request, $options);
             } catch (RequestException $e) {
                 throw new ApiException(
@@ -212,7 +208,7 @@ class FakeClassnameTags123Api
         $request = $this->testClassnameRequest($body);
 
         return $this->client
-            ->sendAsync($request)
+            ->sendAsync($request, $this->createHttpClientOption())
             ->then(
                 function ($response) use ($returnType) {
                     $responseBody = $response->getBody();
@@ -346,4 +342,22 @@ class FakeClassnameTags123Api
         );
     }
 
+    /**
+     * Create http client option
+     *
+     * @throws \RuntimeException on file opening failure
+     * @return array of http client options
+     */
+    protected function createHttpClientOption()
+    {
+        $options = [];
+        if ($this->config->getDebug()) {
+            $options[RequestOptions::DEBUG] = fopen($this->config->getDebugFile(), 'a');
+            if (!$options[RequestOptions::DEBUG]) {
+                throw new \RuntimeException('Failed to open the debug file: ' . $this->config->getDebugFile());
+            }
+        }
+
+        return $options;
+    }
 }

--- a/samples/client/petstore/php/SwaggerClient-php/lib/Api/PetApi.php
+++ b/samples/client/petstore/php/SwaggerClient-php/lib/Api/PetApi.php
@@ -32,6 +32,7 @@ use GuzzleHttp\ClientInterface;
 use GuzzleHttp\Exception\RequestException;
 use GuzzleHttp\Psr7\MultipartStream;
 use GuzzleHttp\Psr7\Request;
+use GuzzleHttp\RequestOptions;
 use Swagger\Client\ApiException;
 use Swagger\Client\Configuration;
 use Swagger\Client\HeaderSelector;
@@ -115,7 +116,11 @@ class PetApi
         try {
 
             try {
-                $response = $this->client->send($request);
+                $options = [];
+                if ($this->config->getDebug()) {
+                    $options[RequestOptions::DEBUG] = fopen($this->config->getDebugFile(), 'a');
+                }
+                $response = $this->client->send($request, $options);
             } catch (RequestException $e) {
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
@@ -340,7 +345,11 @@ class PetApi
         try {
 
             try {
-                $response = $this->client->send($request);
+                $options = [];
+                if ($this->config->getDebug()) {
+                    $options[RequestOptions::DEBUG] = fopen($this->config->getDebugFile(), 'a');
+                }
+                $response = $this->client->send($request, $options);
             } catch (RequestException $e) {
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
@@ -576,7 +585,11 @@ class PetApi
         try {
 
             try {
-                $response = $this->client->send($request);
+                $options = [];
+                if ($this->config->getDebug()) {
+                    $options[RequestOptions::DEBUG] = fopen($this->config->getDebugFile(), 'a');
+                }
+                $response = $this->client->send($request, $options);
             } catch (RequestException $e) {
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
@@ -840,7 +853,11 @@ class PetApi
         try {
 
             try {
-                $response = $this->client->send($request);
+                $options = [];
+                if ($this->config->getDebug()) {
+                    $options[RequestOptions::DEBUG] = fopen($this->config->getDebugFile(), 'a');
+                }
+                $response = $this->client->send($request, $options);
             } catch (RequestException $e) {
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
@@ -1104,7 +1121,11 @@ class PetApi
         try {
 
             try {
-                $response = $this->client->send($request);
+                $options = [];
+                if ($this->config->getDebug()) {
+                    $options[RequestOptions::DEBUG] = fopen($this->config->getDebugFile(), 'a');
+                }
+                $response = $this->client->send($request, $options);
             } catch (RequestException $e) {
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
@@ -1369,7 +1390,11 @@ class PetApi
         try {
 
             try {
-                $response = $this->client->send($request);
+                $options = [];
+                if ($this->config->getDebug()) {
+                    $options[RequestOptions::DEBUG] = fopen($this->config->getDebugFile(), 'a');
+                }
+                $response = $this->client->send($request, $options);
             } catch (RequestException $e) {
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
@@ -1596,7 +1621,11 @@ class PetApi
         try {
 
             try {
-                $response = $this->client->send($request);
+                $options = [];
+                if ($this->config->getDebug()) {
+                    $options[RequestOptions::DEBUG] = fopen($this->config->getDebugFile(), 'a');
+                }
+                $response = $this->client->send($request, $options);
             } catch (RequestException $e) {
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
@@ -1843,7 +1872,11 @@ class PetApi
         try {
 
             try {
-                $response = $this->client->send($request);
+                $options = [];
+                if ($this->config->getDebug()) {
+                    $options[RequestOptions::DEBUG] = fopen($this->config->getDebugFile(), 'a');
+                }
+                $response = $this->client->send($request, $options);
             } catch (RequestException $e) {
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",

--- a/samples/client/petstore/php/SwaggerClient-php/lib/Api/PetApi.php
+++ b/samples/client/petstore/php/SwaggerClient-php/lib/Api/PetApi.php
@@ -114,12 +114,8 @@ class PetApi
         $request = $this->addPetRequest($body);
 
         try {
-
+            $options = $this->createHttpClientOption();
             try {
-                $options = [];
-                if ($this->config->getDebug()) {
-                    $options[RequestOptions::DEBUG] = fopen($this->config->getDebugFile(), 'a');
-                }
                 $response = $this->client->send($request, $options);
             } catch (RequestException $e) {
                 throw new ApiException(
@@ -189,7 +185,7 @@ class PetApi
         $request = $this->addPetRequest($body);
 
         return $this->client
-            ->sendAsync($request)
+            ->sendAsync($request, $this->createHttpClientOption())
             ->then(
                 function ($response) use ($returnType) {
                     return [null, $response->getStatusCode(), $response->getHeaders()];
@@ -343,12 +339,8 @@ class PetApi
         $request = $this->deletePetRequest($pet_id, $api_key);
 
         try {
-
+            $options = $this->createHttpClientOption();
             try {
-                $options = [];
-                if ($this->config->getDebug()) {
-                    $options[RequestOptions::DEBUG] = fopen($this->config->getDebugFile(), 'a');
-                }
                 $response = $this->client->send($request, $options);
             } catch (RequestException $e) {
                 throw new ApiException(
@@ -420,7 +412,7 @@ class PetApi
         $request = $this->deletePetRequest($pet_id, $api_key);
 
         return $this->client
-            ->sendAsync($request)
+            ->sendAsync($request, $this->createHttpClientOption())
             ->then(
                 function ($response) use ($returnType) {
                     return [null, $response->getStatusCode(), $response->getHeaders()];
@@ -583,12 +575,8 @@ class PetApi
         $request = $this->findPetsByStatusRequest($status);
 
         try {
-
+            $options = $this->createHttpClientOption();
             try {
-                $options = [];
-                if ($this->config->getDebug()) {
-                    $options[RequestOptions::DEBUG] = fopen($this->config->getDebugFile(), 'a');
-                }
                 $response = $this->client->send($request, $options);
             } catch (RequestException $e) {
                 throw new ApiException(
@@ -680,7 +668,7 @@ class PetApi
         $request = $this->findPetsByStatusRequest($status);
 
         return $this->client
-            ->sendAsync($request)
+            ->sendAsync($request, $this->createHttpClientOption())
             ->then(
                 function ($response) use ($returnType) {
                     $responseBody = $response->getBody();
@@ -851,12 +839,8 @@ class PetApi
         $request = $this->findPetsByTagsRequest($tags);
 
         try {
-
+            $options = $this->createHttpClientOption();
             try {
-                $options = [];
-                if ($this->config->getDebug()) {
-                    $options[RequestOptions::DEBUG] = fopen($this->config->getDebugFile(), 'a');
-                }
                 $response = $this->client->send($request, $options);
             } catch (RequestException $e) {
                 throw new ApiException(
@@ -948,7 +932,7 @@ class PetApi
         $request = $this->findPetsByTagsRequest($tags);
 
         return $this->client
-            ->sendAsync($request)
+            ->sendAsync($request, $this->createHttpClientOption())
             ->then(
                 function ($response) use ($returnType) {
                     $responseBody = $response->getBody();
@@ -1119,12 +1103,8 @@ class PetApi
         $request = $this->getPetByIdRequest($pet_id);
 
         try {
-
+            $options = $this->createHttpClientOption();
             try {
-                $options = [];
-                if ($this->config->getDebug()) {
-                    $options[RequestOptions::DEBUG] = fopen($this->config->getDebugFile(), 'a');
-                }
                 $response = $this->client->send($request, $options);
             } catch (RequestException $e) {
                 throw new ApiException(
@@ -1216,7 +1196,7 @@ class PetApi
         $request = $this->getPetByIdRequest($pet_id);
 
         return $this->client
-            ->sendAsync($request)
+            ->sendAsync($request, $this->createHttpClientOption())
             ->then(
                 function ($response) use ($returnType) {
                     $responseBody = $response->getBody();
@@ -1388,12 +1368,8 @@ class PetApi
         $request = $this->updatePetRequest($body);
 
         try {
-
+            $options = $this->createHttpClientOption();
             try {
-                $options = [];
-                if ($this->config->getDebug()) {
-                    $options[RequestOptions::DEBUG] = fopen($this->config->getDebugFile(), 'a');
-                }
                 $response = $this->client->send($request, $options);
             } catch (RequestException $e) {
                 throw new ApiException(
@@ -1463,7 +1439,7 @@ class PetApi
         $request = $this->updatePetRequest($body);
 
         return $this->client
-            ->sendAsync($request)
+            ->sendAsync($request, $this->createHttpClientOption())
             ->then(
                 function ($response) use ($returnType) {
                     return [null, $response->getStatusCode(), $response->getHeaders()];
@@ -1619,12 +1595,8 @@ class PetApi
         $request = $this->updatePetWithFormRequest($pet_id, $name, $status);
 
         try {
-
+            $options = $this->createHttpClientOption();
             try {
-                $options = [];
-                if ($this->config->getDebug()) {
-                    $options[RequestOptions::DEBUG] = fopen($this->config->getDebugFile(), 'a');
-                }
                 $response = $this->client->send($request, $options);
             } catch (RequestException $e) {
                 throw new ApiException(
@@ -1698,7 +1670,7 @@ class PetApi
         $request = $this->updatePetWithFormRequest($pet_id, $name, $status);
 
         return $this->client
-            ->sendAsync($request)
+            ->sendAsync($request, $this->createHttpClientOption())
             ->then(
                 function ($response) use ($returnType) {
                     return [null, $response->getStatusCode(), $response->getHeaders()];
@@ -1870,12 +1842,8 @@ class PetApi
         $request = $this->uploadFileRequest($pet_id, $additional_metadata, $file);
 
         try {
-
+            $options = $this->createHttpClientOption();
             try {
-                $options = [];
-                if ($this->config->getDebug()) {
-                    $options[RequestOptions::DEBUG] = fopen($this->config->getDebugFile(), 'a');
-                }
                 $response = $this->client->send($request, $options);
             } catch (RequestException $e) {
                 throw new ApiException(
@@ -1971,7 +1939,7 @@ class PetApi
         $request = $this->uploadFileRequest($pet_id, $additional_metadata, $file);
 
         return $this->client
-            ->sendAsync($request)
+            ->sendAsync($request, $this->createHttpClientOption())
             ->then(
                 function ($response) use ($returnType) {
                     $responseBody = $response->getBody();
@@ -2120,4 +2088,22 @@ class PetApi
         );
     }
 
+    /**
+     * Create http client option
+     *
+     * @throws \RuntimeException on file opening failure
+     * @return array of http client options
+     */
+    protected function createHttpClientOption()
+    {
+        $options = [];
+        if ($this->config->getDebug()) {
+            $options[RequestOptions::DEBUG] = fopen($this->config->getDebugFile(), 'a');
+            if (!$options[RequestOptions::DEBUG]) {
+                throw new \RuntimeException('Failed to open the debug file: ' . $this->config->getDebugFile());
+            }
+        }
+
+        return $options;
+    }
 }

--- a/samples/client/petstore/php/SwaggerClient-php/lib/Api/StoreApi.php
+++ b/samples/client/petstore/php/SwaggerClient-php/lib/Api/StoreApi.php
@@ -114,12 +114,8 @@ class StoreApi
         $request = $this->deleteOrderRequest($order_id);
 
         try {
-
+            $options = $this->createHttpClientOption();
             try {
-                $options = [];
-                if ($this->config->getDebug()) {
-                    $options[RequestOptions::DEBUG] = fopen($this->config->getDebugFile(), 'a');
-                }
                 $response = $this->client->send($request, $options);
             } catch (RequestException $e) {
                 throw new ApiException(
@@ -189,7 +185,7 @@ class StoreApi
         $request = $this->deleteOrderRequest($order_id);
 
         return $this->client
-            ->sendAsync($request)
+            ->sendAsync($request, $this->createHttpClientOption())
             ->then(
                 function ($response) use ($returnType) {
                     return [null, $response->getStatusCode(), $response->getHeaders()];
@@ -341,12 +337,8 @@ class StoreApi
         $request = $this->getInventoryRequest();
 
         try {
-
+            $options = $this->createHttpClientOption();
             try {
-                $options = [];
-                if ($this->config->getDebug()) {
-                    $options[RequestOptions::DEBUG] = fopen($this->config->getDebugFile(), 'a');
-                }
                 $response = $this->client->send($request, $options);
             } catch (RequestException $e) {
                 throw new ApiException(
@@ -436,7 +428,7 @@ class StoreApi
         $request = $this->getInventoryRequest();
 
         return $this->client
-            ->sendAsync($request)
+            ->sendAsync($request, $this->createHttpClientOption())
             ->then(
                 function ($response) use ($returnType) {
                     $responseBody = $response->getBody();
@@ -594,12 +586,8 @@ class StoreApi
         $request = $this->getOrderByIdRequest($order_id);
 
         try {
-
+            $options = $this->createHttpClientOption();
             try {
-                $options = [];
-                if ($this->config->getDebug()) {
-                    $options[RequestOptions::DEBUG] = fopen($this->config->getDebugFile(), 'a');
-                }
                 $response = $this->client->send($request, $options);
             } catch (RequestException $e) {
                 throw new ApiException(
@@ -691,7 +679,7 @@ class StoreApi
         $request = $this->getOrderByIdRequest($order_id);
 
         return $this->client
-            ->sendAsync($request)
+            ->sendAsync($request, $this->createHttpClientOption())
             ->then(
                 function ($response) use ($returnType) {
                     $responseBody = $response->getBody();
@@ -866,12 +854,8 @@ class StoreApi
         $request = $this->placeOrderRequest($body);
 
         try {
-
+            $options = $this->createHttpClientOption();
             try {
-                $options = [];
-                if ($this->config->getDebug()) {
-                    $options[RequestOptions::DEBUG] = fopen($this->config->getDebugFile(), 'a');
-                }
                 $response = $this->client->send($request, $options);
             } catch (RequestException $e) {
                 throw new ApiException(
@@ -963,7 +947,7 @@ class StoreApi
         $request = $this->placeOrderRequest($body);
 
         return $this->client
-            ->sendAsync($request)
+            ->sendAsync($request, $this->createHttpClientOption())
             ->then(
                 function ($response) use ($returnType) {
                     $responseBody = $response->getBody();
@@ -1092,4 +1076,22 @@ class StoreApi
         );
     }
 
+    /**
+     * Create http client option
+     *
+     * @throws \RuntimeException on file opening failure
+     * @return array of http client options
+     */
+    protected function createHttpClientOption()
+    {
+        $options = [];
+        if ($this->config->getDebug()) {
+            $options[RequestOptions::DEBUG] = fopen($this->config->getDebugFile(), 'a');
+            if (!$options[RequestOptions::DEBUG]) {
+                throw new \RuntimeException('Failed to open the debug file: ' . $this->config->getDebugFile());
+            }
+        }
+
+        return $options;
+    }
 }

--- a/samples/client/petstore/php/SwaggerClient-php/lib/Api/StoreApi.php
+++ b/samples/client/petstore/php/SwaggerClient-php/lib/Api/StoreApi.php
@@ -32,6 +32,7 @@ use GuzzleHttp\ClientInterface;
 use GuzzleHttp\Exception\RequestException;
 use GuzzleHttp\Psr7\MultipartStream;
 use GuzzleHttp\Psr7\Request;
+use GuzzleHttp\RequestOptions;
 use Swagger\Client\ApiException;
 use Swagger\Client\Configuration;
 use Swagger\Client\HeaderSelector;
@@ -115,7 +116,11 @@ class StoreApi
         try {
 
             try {
-                $response = $this->client->send($request);
+                $options = [];
+                if ($this->config->getDebug()) {
+                    $options[RequestOptions::DEBUG] = fopen($this->config->getDebugFile(), 'a');
+                }
+                $response = $this->client->send($request, $options);
             } catch (RequestException $e) {
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
@@ -338,7 +343,11 @@ class StoreApi
         try {
 
             try {
-                $response = $this->client->send($request);
+                $options = [];
+                if ($this->config->getDebug()) {
+                    $options[RequestOptions::DEBUG] = fopen($this->config->getDebugFile(), 'a');
+                }
+                $response = $this->client->send($request, $options);
             } catch (RequestException $e) {
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
@@ -587,7 +596,11 @@ class StoreApi
         try {
 
             try {
-                $response = $this->client->send($request);
+                $options = [];
+                if ($this->config->getDebug()) {
+                    $options[RequestOptions::DEBUG] = fopen($this->config->getDebugFile(), 'a');
+                }
+                $response = $this->client->send($request, $options);
             } catch (RequestException $e) {
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
@@ -855,7 +868,11 @@ class StoreApi
         try {
 
             try {
-                $response = $this->client->send($request);
+                $options = [];
+                if ($this->config->getDebug()) {
+                    $options[RequestOptions::DEBUG] = fopen($this->config->getDebugFile(), 'a');
+                }
+                $response = $this->client->send($request, $options);
             } catch (RequestException $e) {
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",

--- a/samples/client/petstore/php/SwaggerClient-php/lib/Api/UserApi.php
+++ b/samples/client/petstore/php/SwaggerClient-php/lib/Api/UserApi.php
@@ -114,12 +114,8 @@ class UserApi
         $request = $this->createUserRequest($body);
 
         try {
-
+            $options = $this->createHttpClientOption();
             try {
-                $options = [];
-                if ($this->config->getDebug()) {
-                    $options[RequestOptions::DEBUG] = fopen($this->config->getDebugFile(), 'a');
-                }
                 $response = $this->client->send($request, $options);
             } catch (RequestException $e) {
                 throw new ApiException(
@@ -189,7 +185,7 @@ class UserApi
         $request = $this->createUserRequest($body);
 
         return $this->client
-            ->sendAsync($request)
+            ->sendAsync($request, $this->createHttpClientOption())
             ->then(
                 function ($response) use ($returnType) {
                     return [null, $response->getStatusCode(), $response->getHeaders()];
@@ -337,12 +333,8 @@ class UserApi
         $request = $this->createUsersWithArrayInputRequest($body);
 
         try {
-
+            $options = $this->createHttpClientOption();
             try {
-                $options = [];
-                if ($this->config->getDebug()) {
-                    $options[RequestOptions::DEBUG] = fopen($this->config->getDebugFile(), 'a');
-                }
                 $response = $this->client->send($request, $options);
             } catch (RequestException $e) {
                 throw new ApiException(
@@ -412,7 +404,7 @@ class UserApi
         $request = $this->createUsersWithArrayInputRequest($body);
 
         return $this->client
-            ->sendAsync($request)
+            ->sendAsync($request, $this->createHttpClientOption())
             ->then(
                 function ($response) use ($returnType) {
                     return [null, $response->getStatusCode(), $response->getHeaders()];
@@ -560,12 +552,8 @@ class UserApi
         $request = $this->createUsersWithListInputRequest($body);
 
         try {
-
+            $options = $this->createHttpClientOption();
             try {
-                $options = [];
-                if ($this->config->getDebug()) {
-                    $options[RequestOptions::DEBUG] = fopen($this->config->getDebugFile(), 'a');
-                }
                 $response = $this->client->send($request, $options);
             } catch (RequestException $e) {
                 throw new ApiException(
@@ -635,7 +623,7 @@ class UserApi
         $request = $this->createUsersWithListInputRequest($body);
 
         return $this->client
-            ->sendAsync($request)
+            ->sendAsync($request, $this->createHttpClientOption())
             ->then(
                 function ($response) use ($returnType) {
                     return [null, $response->getStatusCode(), $response->getHeaders()];
@@ -783,12 +771,8 @@ class UserApi
         $request = $this->deleteUserRequest($username);
 
         try {
-
+            $options = $this->createHttpClientOption();
             try {
-                $options = [];
-                if ($this->config->getDebug()) {
-                    $options[RequestOptions::DEBUG] = fopen($this->config->getDebugFile(), 'a');
-                }
                 $response = $this->client->send($request, $options);
             } catch (RequestException $e) {
                 throw new ApiException(
@@ -858,7 +842,7 @@ class UserApi
         $request = $this->deleteUserRequest($username);
 
         return $this->client
-            ->sendAsync($request)
+            ->sendAsync($request, $this->createHttpClientOption())
             ->then(
                 function ($response) use ($returnType) {
                     return [null, $response->getStatusCode(), $response->getHeaders()];
@@ -1012,12 +996,8 @@ class UserApi
         $request = $this->getUserByNameRequest($username);
 
         try {
-
+            $options = $this->createHttpClientOption();
             try {
-                $options = [];
-                if ($this->config->getDebug()) {
-                    $options[RequestOptions::DEBUG] = fopen($this->config->getDebugFile(), 'a');
-                }
                 $response = $this->client->send($request, $options);
             } catch (RequestException $e) {
                 throw new ApiException(
@@ -1109,7 +1089,7 @@ class UserApi
         $request = $this->getUserByNameRequest($username);
 
         return $this->client
-            ->sendAsync($request)
+            ->sendAsync($request, $this->createHttpClientOption())
             ->then(
                 function ($response) use ($returnType) {
                     $responseBody = $response->getBody();
@@ -1279,12 +1259,8 @@ class UserApi
         $request = $this->loginUserRequest($username, $password);
 
         try {
-
+            $options = $this->createHttpClientOption();
             try {
-                $options = [];
-                if ($this->config->getDebug()) {
-                    $options[RequestOptions::DEBUG] = fopen($this->config->getDebugFile(), 'a');
-                }
                 $response = $this->client->send($request, $options);
             } catch (RequestException $e) {
                 throw new ApiException(
@@ -1378,7 +1354,7 @@ class UserApi
         $request = $this->loginUserRequest($username, $password);
 
         return $this->client
-            ->sendAsync($request)
+            ->sendAsync($request, $this->createHttpClientOption())
             ->then(
                 function ($response) use ($returnType) {
                     $responseBody = $response->getBody();
@@ -1550,12 +1526,8 @@ class UserApi
         $request = $this->logoutUserRequest();
 
         try {
-
+            $options = $this->createHttpClientOption();
             try {
-                $options = [];
-                if ($this->config->getDebug()) {
-                    $options[RequestOptions::DEBUG] = fopen($this->config->getDebugFile(), 'a');
-                }
                 $response = $this->client->send($request, $options);
             } catch (RequestException $e) {
                 throw new ApiException(
@@ -1623,7 +1595,7 @@ class UserApi
         $request = $this->logoutUserRequest();
 
         return $this->client
-            ->sendAsync($request)
+            ->sendAsync($request, $this->createHttpClientOption())
             ->then(
                 function ($response) use ($returnType) {
                     return [null, $response->getStatusCode(), $response->getHeaders()];
@@ -1763,12 +1735,8 @@ class UserApi
         $request = $this->updateUserRequest($username, $body);
 
         try {
-
+            $options = $this->createHttpClientOption();
             try {
-                $options = [];
-                if ($this->config->getDebug()) {
-                    $options[RequestOptions::DEBUG] = fopen($this->config->getDebugFile(), 'a');
-                }
                 $response = $this->client->send($request, $options);
             } catch (RequestException $e) {
                 throw new ApiException(
@@ -1840,7 +1808,7 @@ class UserApi
         $request = $this->updateUserRequest($username, $body);
 
         return $this->client
-            ->sendAsync($request)
+            ->sendAsync($request, $this->createHttpClientOption())
             ->then(
                 function ($response) use ($returnType) {
                     return [null, $response->getStatusCode(), $response->getHeaders()];
@@ -1970,4 +1938,22 @@ class UserApi
         );
     }
 
+    /**
+     * Create http client option
+     *
+     * @throws \RuntimeException on file opening failure
+     * @return array of http client options
+     */
+    protected function createHttpClientOption()
+    {
+        $options = [];
+        if ($this->config->getDebug()) {
+            $options[RequestOptions::DEBUG] = fopen($this->config->getDebugFile(), 'a');
+            if (!$options[RequestOptions::DEBUG]) {
+                throw new \RuntimeException('Failed to open the debug file: ' . $this->config->getDebugFile());
+            }
+        }
+
+        return $options;
+    }
 }

--- a/samples/client/petstore/php/SwaggerClient-php/lib/Api/UserApi.php
+++ b/samples/client/petstore/php/SwaggerClient-php/lib/Api/UserApi.php
@@ -32,6 +32,7 @@ use GuzzleHttp\ClientInterface;
 use GuzzleHttp\Exception\RequestException;
 use GuzzleHttp\Psr7\MultipartStream;
 use GuzzleHttp\Psr7\Request;
+use GuzzleHttp\RequestOptions;
 use Swagger\Client\ApiException;
 use Swagger\Client\Configuration;
 use Swagger\Client\HeaderSelector;
@@ -115,7 +116,11 @@ class UserApi
         try {
 
             try {
-                $response = $this->client->send($request);
+                $options = [];
+                if ($this->config->getDebug()) {
+                    $options[RequestOptions::DEBUG] = fopen($this->config->getDebugFile(), 'a');
+                }
+                $response = $this->client->send($request, $options);
             } catch (RequestException $e) {
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
@@ -334,7 +339,11 @@ class UserApi
         try {
 
             try {
-                $response = $this->client->send($request);
+                $options = [];
+                if ($this->config->getDebug()) {
+                    $options[RequestOptions::DEBUG] = fopen($this->config->getDebugFile(), 'a');
+                }
+                $response = $this->client->send($request, $options);
             } catch (RequestException $e) {
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
@@ -553,7 +562,11 @@ class UserApi
         try {
 
             try {
-                $response = $this->client->send($request);
+                $options = [];
+                if ($this->config->getDebug()) {
+                    $options[RequestOptions::DEBUG] = fopen($this->config->getDebugFile(), 'a');
+                }
+                $response = $this->client->send($request, $options);
             } catch (RequestException $e) {
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
@@ -772,7 +785,11 @@ class UserApi
         try {
 
             try {
-                $response = $this->client->send($request);
+                $options = [];
+                if ($this->config->getDebug()) {
+                    $options[RequestOptions::DEBUG] = fopen($this->config->getDebugFile(), 'a');
+                }
+                $response = $this->client->send($request, $options);
             } catch (RequestException $e) {
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
@@ -997,7 +1014,11 @@ class UserApi
         try {
 
             try {
-                $response = $this->client->send($request);
+                $options = [];
+                if ($this->config->getDebug()) {
+                    $options[RequestOptions::DEBUG] = fopen($this->config->getDebugFile(), 'a');
+                }
+                $response = $this->client->send($request, $options);
             } catch (RequestException $e) {
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
@@ -1260,7 +1281,11 @@ class UserApi
         try {
 
             try {
-                $response = $this->client->send($request);
+                $options = [];
+                if ($this->config->getDebug()) {
+                    $options[RequestOptions::DEBUG] = fopen($this->config->getDebugFile(), 'a');
+                }
+                $response = $this->client->send($request, $options);
             } catch (RequestException $e) {
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
@@ -1527,7 +1552,11 @@ class UserApi
         try {
 
             try {
-                $response = $this->client->send($request);
+                $options = [];
+                if ($this->config->getDebug()) {
+                    $options[RequestOptions::DEBUG] = fopen($this->config->getDebugFile(), 'a');
+                }
+                $response = $this->client->send($request, $options);
             } catch (RequestException $e) {
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
@@ -1736,7 +1765,11 @@ class UserApi
         try {
 
             try {
-                $response = $this->client->send($request);
+                $options = [];
+                if ($this->config->getDebug()) {
+                    $options[RequestOptions::DEBUG] = fopen($this->config->getDebugFile(), 'a');
+                }
+                $response = $this->client->send($request, $options);
             } catch (RequestException $e) {
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",

--- a/samples/client/petstore/php/SwaggerClient-php/tests/DebugTest.php
+++ b/samples/client/petstore/php/SwaggerClient-php/tests/DebugTest.php
@@ -1,0 +1,26 @@
+<?php
+namespace Swagger\Client;
+
+class DebugTest extends \PHPUnit_Framework_TestCase
+{
+    public function testEnableDebugOutput()
+    {
+        $this->expectOutputRegex('#GET /v2/pet/1 HTTP/1.1#');
+
+        $config = new Configuration();
+        $config->setDebug(true);
+        $api = new Api\PetApi(null, $config);
+        $api->getPetById(1);
+    }
+
+    public function testEnableDebugOutputAsync()
+    {
+        $this->expectOutputRegex('#GET /v2/pet/1 HTTP/1.1#');
+
+        $config = new Configuration();
+        $config->setDebug(true);
+        $api = new Api\PetApi(null, $config);
+        $promise = $api->getPetByIdAsync(1);
+        $promise->wait();
+    }
+}


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [x] Filed the PR against the correct branch: `3.0.0` branch for changes related to OpenAPI spec 3.0. Default: `master`.
- [x] Copied the [technical committee](https://github.com/swagger-api/swagger-codegen/#swagger-codegen-technical-committee) to review the pull request if your PR is targeting a particular programming langauge.

### Description of the PR

Fixes issue #6770

