### PR TITLE
[Ruby] Fix "build_from_hash" function for Ruby enums

### DIFF
--- a/modules/swagger-codegen/src/main/resources/ruby/partial_model_enum_class.mustache
+++ b/modules/swagger-codegen/src/main/resources/ruby/partial_model_enum_class.mustache
@@ -6,8 +6,8 @@
     # @param [String] The enum value in the form of the string
     # @return [String] The enum value
     def build_from_hash(value)
-      consantValues = {{classname}}.constants.select{|c| c.to_s == value}
-      raise "Invalid ENUM value #{value} for class #{{{classname}}}" if consantValues.empty?
+      constantValues = {{classname}}.constants.select{|c| {{classname}}::const_get(c) == value}
+      raise "Invalid ENUM value #{value} for class #{{{classname}}}" if constantValues.empty?
       value
     end
   end

--- a/samples/client/petstore/ruby/lib/petstore/models/enum_class.rb
+++ b/samples/client/petstore/ruby/lib/petstore/models/enum_class.rb
@@ -23,8 +23,8 @@ module Petstore
     # @param [String] The enum value in the form of the string
     # @return [String] The enum value
     def build_from_hash(value)
-      consantValues = EnumClass.constants.select{|c| c.to_s == value}
-      raise "Invalid ENUM value #{value} for class #EnumClass" if consantValues.empty?
+      constantValues = EnumClass.constants.select{|c| EnumClass::const_get(c) == value}
+      raise "Invalid ENUM value #{value} for class #EnumClass" if constantValues.empty?
       value
     end
   end

--- a/samples/client/petstore/ruby/lib/petstore/models/outer_enum.rb
+++ b/samples/client/petstore/ruby/lib/petstore/models/outer_enum.rb
@@ -23,8 +23,8 @@ module Petstore
     # @param [String] The enum value in the form of the string
     # @return [String] The enum value
     def build_from_hash(value)
-      consantValues = OuterEnum.constants.select{|c| c.to_s == value}
-      raise "Invalid ENUM value #{value} for class #OuterEnum" if consantValues.empty?
+      constantValues = OuterEnum.constants.select{|c| OuterEnum::const_get(c) == value}
+      raise "Invalid ENUM value #{value} for class #OuterEnum" if constantValues.empty?
       value
     end
   end


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [x] Filed the PR against the correct branch: `3.0.0` branch for changes related to OpenAPI spec 3.0. Default: `master`.
- [ ] Copied the [technical committee](https://github.com/swagger-api/swagger-codegen/#swagger-codegen-technical-committee) to review the pull request if your PR is targeting a particular programming langauge.

### Description of the PR

Modify build_from_hash to compare the given value against the enum's value rather than the enum's constant name.
Unless I'm missing something, it seems to me that this should be the desired behavior for build_from_hash.

For instance, consider the following Ruby enum class:

```
class Enum
  ENUM1 = "enum 1"
  ENUM2 = "enum 2"
  ENUM3 = "enum 3"
  def build_from_hash(value)
    ...
  end
end
```

If we run the following:
```
Enum.new.build_from_hash("enum 2")
```
It'll return "enum 2".
Before this fix, it would return an error since we were comparing "enum 2" against the constant names "ENUM1", "ENUM2" and "ENUM3".

Hope this makes sense!




