### PR TITLE
[JAVA] Use application/octet-stream as the default content type

### DIFF
--- a/modules/swagger-codegen/src/main/resources/Java/ApiClient.mustache
+++ b/modules/swagger-codegen/src/main/resources/Java/ApiClient.mustache
@@ -523,7 +523,7 @@ public class ApiClient {
    */
   public String selectHeaderContentType(String[] contentTypes) {
     if (contentTypes.length == 0 || contentTypes[0].equals("*/*")) {
-      return "application/json";
+      return "application/octet-stream";
     }
     for (String contentType : contentTypes) {
       if (isJsonMime(contentType)) {

--- a/modules/swagger-codegen/src/main/resources/Java/libraries/feign/ApiClient.mustache
+++ b/modules/swagger-codegen/src/main/resources/Java/libraries/feign/ApiClient.mustache
@@ -216,7 +216,7 @@ public class ApiClient {
    *   JSON will be used.
    */
   public String selectHeaderContentType(String[] contentTypes) {
-    if (contentTypes.length == 0) return "application/json";
+    if (contentTypes.length == 0) return "application/octet-stream";
     if (StringUtil.containsIgnoreCase(contentTypes, "application/json")) return "application/json";
     return contentTypes[0];
   }

--- a/modules/swagger-codegen/src/main/resources/Java/libraries/jersey2/ApiClient.mustache
+++ b/modules/swagger-codegen/src/main/resources/Java/libraries/jersey2/ApiClient.mustache
@@ -480,7 +480,7 @@ public class ApiClient {
    */
   public String selectHeaderContentType(String[] contentTypes) {
     if (contentTypes.length == 0) {
-      return "application/json";
+      return "application/octet-stream";
     }
     for (String contentType : contentTypes) {
       if (isJsonMime(contentType)) {

--- a/modules/swagger-codegen/src/main/resources/Java/libraries/okhttp-gson/ApiClient.mustache
+++ b/modules/swagger-codegen/src/main/resources/Java/libraries/okhttp-gson/ApiClient.mustache
@@ -612,7 +612,7 @@ public class ApiClient {
      */
     public String selectHeaderContentType(String[] contentTypes) {
         if (contentTypes.length == 0 || contentTypes[0].equals("*/*")) {
-             return "application/json";
+             return "application/octet-stream";
         }
         for (String contentType : contentTypes) {
             if (isJsonMime(contentType)) {

--- a/modules/swagger-codegen/src/main/resources/Java/libraries/resteasy/ApiClient.mustache
+++ b/modules/swagger-codegen/src/main/resources/Java/libraries/resteasy/ApiClient.mustache
@@ -418,7 +418,7 @@ public class ApiClient {
    */
   public String selectHeaderContentType(String[] contentTypes) {
     if (contentTypes.length == 0) {
-      return "application/json";
+      return "application/octet-stream";
     }
     for (String contentType : contentTypes) {
       if (isJsonMime(contentType)) {

--- a/modules/swagger-codegen/src/main/resources/Java/libraries/resttemplate/ApiClient.mustache
+++ b/modules/swagger-codegen/src/main/resources/Java/libraries/resttemplate/ApiClient.mustache
@@ -480,7 +480,7 @@ public class ApiClient {
      */
     public MediaType selectHeaderContentType(String[] contentTypes) {
         if (contentTypes.length == 0) {
-            return MediaType.APPLICATION_JSON;
+            return MediaType.APPLICATION_OCTET_STREAM;
         }
         for (String contentType : contentTypes) {
             MediaType mediaType = MediaType.parseMediaType(contentType);

--- a/modules/swagger-codegen/src/main/resources/Java/libraries/vertx/ApiClient.mustache
+++ b/modules/swagger-codegen/src/main/resources/Java/libraries/vertx/ApiClient.mustache
@@ -374,7 +374,7 @@ public class ApiClient {
      */
     protected String selectHeaderContentType(String[] contentTypes) {
         if (contentTypes.length == 0) {
-            return "application/json";
+            return "application/octet-stream";
         }
         for (String contentType : contentTypes) {
             if (isJsonMime(contentType)) {

--- a/samples/client/petstore/java/feign/src/main/java/io/swagger/client/ApiClient.java
+++ b/samples/client/petstore/java/feign/src/main/java/io/swagger/client/ApiClient.java
@@ -191,7 +191,7 @@ public class ApiClient {
    *   JSON will be used.
    */
   public String selectHeaderContentType(String[] contentTypes) {
-    if (contentTypes.length == 0) return "application/json";
+    if (contentTypes.length == 0) return "application/octet-stream";
     if (StringUtil.containsIgnoreCase(contentTypes, "application/json")) return "application/json";
     return contentTypes[0];
   }

--- a/samples/client/petstore/java/jersey1/src/main/java/io/swagger/client/ApiClient.java
+++ b/samples/client/petstore/java/jersey1/src/main/java/io/swagger/client/ApiClient.java
@@ -517,7 +517,7 @@ public class ApiClient {
    */
   public String selectHeaderContentType(String[] contentTypes) {
     if (contentTypes.length == 0 || contentTypes[0].equals("*/*")) {
-      return "application/json";
+      return "application/octet-stream";
     }
     for (String contentType : contentTypes) {
       if (isJsonMime(contentType)) {

--- a/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/io/swagger/client/ApiClient.java
+++ b/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/io/swagger/client/ApiClient.java
@@ -594,7 +594,7 @@ public class ApiClient {
      */
     public String selectHeaderContentType(String[] contentTypes) {
         if (contentTypes.length == 0 || contentTypes[0].equals("*/*")) {
-             return "application/json";
+             return "application/octet-stream";
         }
         for (String contentType : contentTypes) {
             if (isJsonMime(contentType)) {

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/io/swagger/client/ApiClient.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/io/swagger/client/ApiClient.java
@@ -594,7 +594,7 @@ public class ApiClient {
      */
     public String selectHeaderContentType(String[] contentTypes) {
         if (contentTypes.length == 0 || contentTypes[0].equals("*/*")) {
-             return "application/json";
+             return "application/octet-stream";
         }
         for (String contentType : contentTypes) {
             if (isJsonMime(contentType)) {


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [x] Filed the PR against the correct branch: `3.0.0` branch for changes related to OpenAPI spec 3.0. Default: `master`.
- [x] Copied the [technical committee](https://github.com/swagger-api/swagger-codegen/#swagger-codegen-technical-committee) to review the pull request if your PR is targeting a particular programming langauge.

### Description of the PR

If no content-type header is specified, use `application/octet-stream` as a sensible "default".
Fixes #6819 

cc @bbdouglas @JFCote @sreeshas @jfiala @lukoyanov @cbornet 

