### PR TITLE
[Elixir Client]Improve elixir client typings

### DIFF
--- a/modules/swagger-codegen/src/main/resources/elixir/request_builder.ex.mustache
+++ b/modules/swagger-codegen/src/main/resources/elixir/request_builder.ex.mustache
@@ -10,13 +10,13 @@ defmodule {{moduleName}}.RequestBuilder do
   ## Parameters
 
   - request (Map) - Collected request options
-  - m (String) - Request method
+  - m (atom) - Request method
 
   ## Returns
 
   Map
   """
-  @spec method(map(), String.t) :: map()
+  @spec method(map(), atom) :: map()
   def method(request, m) do
     Map.put_new(request, :method, m)
   end
@@ -51,7 +51,7 @@ defmodule {{moduleName}}.RequestBuilder do
 
   Map
   """
-  @spec add_optional_params(map(), %{optional(:atom) => :atom}, keyword()) :: map()
+  @spec add_optional_params(map(), %{optional(atom) => atom}, keyword()) :: map()
   def add_optional_params(request, _, []), do: request
   def add_optional_params(request, definitions, [{key, value} | tail]) do
     case definitions do
@@ -78,7 +78,7 @@ defmodule {{moduleName}}.RequestBuilder do
 
   Map
   """
-  @spec add_param(map(), :atom, :atom, any()) :: map()
+  @spec add_param(map(), atom, atom, any()) :: map()
   def add_param(request, :body, :body, value), do: Map.put(request, :body, value)
   def add_param(request, :body, key, value) do
     request
@@ -103,25 +103,20 @@ defmodule {{moduleName}}.RequestBuilder do
 
   ## Parameters
 
-  - env (Tesla.Env) - The response object
-  - struct - The shape of the struct to deserialize into
+  - arg1 (Tesla.Env.t | term) - The response object
+  - arg2 (:false | struct | [struct]) - The shape of the struct to deserialize into
 
   ## Returns
 
   {:ok, struct} on success
-  {:error, info} on failure
+  {:error, term} on failure
   """
-  @spec decode(Tesla.Env.t) :: {:ok, struct()} | {:error, Tesla.Env.t}
+  @spec decode(Tesla.Env.t | term()) :: {:ok, struct()} | {:error, Tesla.Env.t} | {:error, term()}
   def decode(%Tesla.Env{status: 200, body: body}), do: Poison.decode(body)
-  def decode(response) do
-    {:error, response}
-  end
-  @spec decode(Tesla.Env.t, struct()) :: {:ok, struct()} | {:error, Tesla.Env.t}
+  def decode(response), do: {:error, response}
+
+  @spec decode(Tesla.Env.t | term(), :false | struct() | [struct()]) :: {:ok, struct()} | {:error, Tesla.Env.t} | {:error, term()}
   def decode(%Tesla.Env{status: 200} = env, false), do: {:ok, env}
-  def decode(%Tesla.Env{status: 200, body: body}, struct) do
-    Poison.decode(body, as: struct)
-  end
-  def decode(response, _struct) do
-    {:error, response}
-  end
+  def decode(%Tesla.Env{status: 200, body: body}, struct), do: Poison.decode(body, as: struct)
+  def decode(response, _struct), do: {:error, response}
 end

--- a/samples/client/petstore/elixir/lib/swagger_petstore/api/fake.ex
+++ b/samples/client/petstore/elixir/lib/swagger_petstore/api/fake.ex
@@ -248,6 +248,32 @@ defmodule SwaggerPetstore.Api.Fake do
   end
 
   @doc """
+  test inline additionalProperties
+  
+
+  ## Parameters
+
+  - connection (SwaggerPetstore.Connection): Connection to server
+  - param (Object): request body
+  - opts (KeywordList): [optional] Optional parameters
+
+  ## Returns
+
+  {:ok, %{}} on success
+  {:error, info} on failure
+  """
+  @spec test_inline_additional_properties(Tesla.Env.client, SwaggerPetstore.Model.Object.t, keyword()) :: {:ok, nil} | {:error, Tesla.Env.t}
+  def test_inline_additional_properties(connection, param, _opts \\ []) do
+    %{}
+    |> method(:post)
+    |> url("/fake/inline-additionalProperties")
+    |> add_param(:body, :"param", param)
+    |> Enum.into([])
+    |> (&Connection.request(connection, &1)).()
+    |> decode(false)
+  end
+
+  @doc """
   test json serialization of form data
   
 

--- a/samples/client/petstore/elixir/lib/swagger_petstore/request_builder.ex
+++ b/samples/client/petstore/elixir/lib/swagger_petstore/request_builder.ex
@@ -13,13 +13,13 @@ defmodule SwaggerPetstore.RequestBuilder do
   ## Parameters
 
   - request (Map) - Collected request options
-  - m (String) - Request method
+  - m (atom) - Request method
 
   ## Returns
 
   Map
   """
-  @spec method(map(), String.t) :: map()
+  @spec method(map(), atom) :: map()
   def method(request, m) do
     Map.put_new(request, :method, m)
   end
@@ -54,7 +54,7 @@ defmodule SwaggerPetstore.RequestBuilder do
 
   Map
   """
-  @spec add_optional_params(map(), %{optional(:atom) => :atom}, keyword()) :: map()
+  @spec add_optional_params(map(), %{optional(atom) => atom}, keyword()) :: map()
   def add_optional_params(request, _, []), do: request
   def add_optional_params(request, definitions, [{key, value} | tail]) do
     case definitions do
@@ -81,7 +81,7 @@ defmodule SwaggerPetstore.RequestBuilder do
 
   Map
   """
-  @spec add_param(map(), :atom, :atom, any()) :: map()
+  @spec add_param(map(), atom, atom, any()) :: map()
   def add_param(request, :body, :body, value), do: Map.put(request, :body, value)
   def add_param(request, :body, key, value) do
     request
@@ -106,25 +106,20 @@ defmodule SwaggerPetstore.RequestBuilder do
 
   ## Parameters
 
-  - env (Tesla.Env) - The response object
-  - struct - The shape of the struct to deserialize into
+  - arg1 (Tesla.Env.t | term) - The response object
+  - arg2 (:false | struct | [struct]) - The shape of the struct to deserialize into
 
   ## Returns
 
   {:ok, struct} on success
-  {:error, info} on failure
+  {:error, term} on failure
   """
-  @spec decode(Tesla.Env.t) :: {:ok, struct()} | {:error, Tesla.Env.t}
+  @spec decode(Tesla.Env.t | term()) :: {:ok, struct()} | {:error, Tesla.Env.t} | {:error, term()}
   def decode(%Tesla.Env{status: 200, body: body}), do: Poison.decode(body)
-  def decode(response) do
-    {:error, response}
-  end
-  @spec decode(Tesla.Env.t, struct()) :: {:ok, struct()} | {:error, Tesla.Env.t}
+  def decode(response), do: {:error, response}
+
+  @spec decode(Tesla.Env.t | term(), :false | struct() | [struct()]) :: {:ok, struct()} | {:error, Tesla.Env.t} | {:error, term()}
   def decode(%Tesla.Env{status: 200} = env, false), do: {:ok, env}
-  def decode(%Tesla.Env{status: 200, body: body}, struct) do
-    Poison.decode(body, as: struct)
-  end
-  def decode(response, _struct) do
-    {:error, response}
-  end
+  def decode(%Tesla.Env{status: 200, body: body}, struct), do: Poison.decode(body, as: struct)
+  def decode(response, _struct), do: {:error, response}
 end


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [x] Filed the PR against the correct branch: `3.0.0` branch for changes related to OpenAPI spec 3.0. Default: `master`.
- [x] Copied the [technical committee](https://github.com/swagger-api/swagger-codegen/#swagger-codegen-technical-committee) to review the pull request if your PR is targeting a particular programming langauge.

### Description of the PR

Fix following dialyzer warnings in the sample:

<details>

```
lib/swagger_petstore/api/another_fake.ex:30: Function test_special_tags/2 has no local return
lib/swagger_petstore/api/another_fake.ex:30: Function test_special_tags/3 has no local return
lib/swagger_petstore/api/another_fake.ex:32: The call 'Elixir.SwaggerPetstore.RequestBuilder':method(#{},'patch') breaks the contract (map(),'Elixir.String':t()) -> map()
lib/swagger_petstore/api/fake.ex:29: Function fake_outer_boolean_serialize/1 has no local return
lib/swagger_petstore/api/fake.ex:29: Function fake_outer_boolean_serialize/2 has no local return
lib/swagger_petstore/api/fake.ex:34: The call 'Elixir.SwaggerPetstore.RequestBuilder':method(#{},'post') breaks the contract (map(),'Elixir.String':t()) -> map()
lib/swagger_petstore/api/fake.ex:57: Function fake_outer_composite_serialize/1 has no local return
lib/swagger_petstore/api/fake.ex:57: Function fake_outer_composite_serialize/2 has no local return
lib/swagger_petstore/api/fake.ex:62: The call 'Elixir.SwaggerPetstore.RequestBuilder':method(#{},'post') breaks the contract (map(),'Elixir.String':t()) -> map()
lib/swagger_petstore/api/fake.ex:85: Function fake_outer_number_serialize/1 has no local return
lib/swagger_petstore/api/fake.ex:85: Function fake_outer_number_serialize/2 has no local return
lib/swagger_petstore/api/fake.ex:90: The call 'Elixir.SwaggerPetstore.RequestBuilder':method(#{},'post') breaks the contract (map(),'Elixir.String':t()) -> map()
lib/swagger_petstore/api/fake.ex:113: Function fake_outer_string_serialize/1 has no local return
lib/swagger_petstore/api/fake.ex:113: Function fake_outer_string_serialize/2 has no local return
lib/swagger_petstore/api/fake.ex:118: The call 'Elixir.SwaggerPetstore.RequestBuilder':method(#{},'post') breaks the contract (map(),'Elixir.String':t()) -> map()
lib/swagger_petstore/api/fake.ex:142: Function test_client_model/2 has no local return
lib/swagger_petstore/api/fake.ex:142: Function test_client_model/3 has no local return
lib/swagger_petstore/api/fake.ex:144: The call 'Elixir.SwaggerPetstore.RequestBuilder':method(#{},'patch') breaks the contract (map(),'Elixir.String':t()) -> map()
lib/swagger_petstore/api/fake.ex:181: Function test_endpoint_parameters/5 has no local return
lib/swagger_petstore/api/fake.ex:181: Function test_endpoint_parameters/6 has no local return
lib/swagger_petstore/api/fake.ex:195: The call 'Elixir.SwaggerPetstore.RequestBuilder':method(#{},'post') breaks the contract (map(),'Elixir.String':t()) -> map()
lib/swagger_petstore/api/fake.ex:230: Function test_enum_parameters/1 has no local return
lib/swagger_petstore/api/fake.ex:230: Function test_enum_parameters/2 has no local return
lib/swagger_petstore/api/fake.ex:242: The call 'Elixir.SwaggerPetstore.RequestBuilder':method(#{},'get') breaks the contract (map(),'Elixir.String':t()) -> map()
lib/swagger_petstore/api/fake.ex:266: Function test_inline_additional_properties/2 has no local return
lib/swagger_petstore/api/fake.ex:266: Function test_inline_additional_properties/3 has no local return
lib/swagger_petstore/api/fake.ex:268: The call 'Elixir.SwaggerPetstore.RequestBuilder':method(#{},'post') breaks the contract (map(),'Elixir.String':t()) -> map()
lib/swagger_petstore/api/fake.ex:293: Function test_json_form_data/3 has no local return
lib/swagger_petstore/api/fake.ex:293: Function test_json_form_data/4 has no local return
lib/swagger_petstore/api/fake.ex:295: The call 'Elixir.SwaggerPetstore.RequestBuilder':method(#{},'get') breaks the contract (map(),'Elixir.String':t()) -> map()
lib/swagger_petstore/api/fake_classname_tags123.ex:29: Function test_classname/2 has no local return
lib/swagger_petstore/api/fake_classname_tags123.ex:29: Function test_classname/3 has no local return
lib/swagger_petstore/api/fake_classname_tags123.ex:31: The call 'Elixir.SwaggerPetstore.RequestBuilder':method(#{},'patch') breaks the contract (map(),'Elixir.String':t()) -> map()
lib/swagger_petstore/api/pet.ex:30: Function add_pet/2 has no local return
lib/swagger_petstore/api/pet.ex:30: Function add_pet/3 has no local return
lib/swagger_petstore/api/pet.ex:32: The call 'Elixir.SwaggerPetstore.RequestBuilder':method(#{},'post') breaks the contract (map(),'Elixir.String':t()) -> map()
lib/swagger_petstore/api/pet.ex:57: Function delete_pet/2 has no local return
lib/swagger_petstore/api/pet.ex:57: Function delete_pet/3 has no local return
lib/swagger_petstore/api/pet.ex:62: The call 'Elixir.SwaggerPetstore.RequestBuilder':method(#{},'delete') breaks the contract (map(),'Elixir.String':t()) -> map()
lib/swagger_petstore/api/pet.ex:86: Function find_pets_by_status/2 has no local return
lib/swagger_petstore/api/pet.ex:86: Function find_pets_by_status/3 has no local return
lib/swagger_petstore/api/pet.ex:88: The call 'Elixir.SwaggerPetstore.RequestBuilder':method(#{},'get') breaks the contract (map(),'Elixir.String':t()) -> map()
lib/swagger_petstore/api/pet.ex:112: Function find_pets_by_tags/2 has no local return
lib/swagger_petstore/api/pet.ex:112: Function find_pets_by_tags/3 has no local return
lib/swagger_petstore/api/pet.ex:114: The call 'Elixir.SwaggerPetstore.RequestBuilder':method(#{},'get') breaks the contract (map(),'Elixir.String':t()) -> map()
lib/swagger_petstore/api/pet.ex:138: Function get_pet_by_id/2 has no local return
lib/swagger_petstore/api/pet.ex:138: Function get_pet_by_id/3 has no local return
lib/swagger_petstore/api/pet.ex:140: The call 'Elixir.SwaggerPetstore.RequestBuilder':method(#{},'get') breaks the contract (map(),'Elixir.String':t()) -> map()
lib/swagger_petstore/api/pet.ex:163: Function update_pet/2 has no local return
lib/swagger_petstore/api/pet.ex:163: Function update_pet/3 has no local return
lib/swagger_petstore/api/pet.ex:165: The call 'Elixir.SwaggerPetstore.RequestBuilder':method(#{},'put') breaks the contract (map(),'Elixir.String':t()) -> map()
lib/swagger_petstore/api/pet.ex:191: Function update_pet_with_form/2 has no local return
lib/swagger_petstore/api/pet.ex:191: Function update_pet_with_form/3 has no local return
lib/swagger_petstore/api/pet.ex:197: The call 'Elixir.SwaggerPetstore.RequestBuilder':method(#{},'post') breaks the contract (map(),'Elixir.String':t()) -> map()
lib/swagger_petstore/api/pet.ex:223: Function upload_file/2 has no local return
lib/swagger_petstore/api/pet.ex:223: Function upload_file/3 has no local return
lib/swagger_petstore/api/pet.ex:229: The call 'Elixir.SwaggerPetstore.RequestBuilder':method(#{},'post') breaks the contract (map(),'Elixir.String':t()) -> map()
lib/swagger_petstore/api/store.ex:30: Function delete_order/2 has no local return
lib/swagger_petstore/api/store.ex:30: Function delete_order/3 has no local return
lib/swagger_petstore/api/store.ex:32: The call 'Elixir.SwaggerPetstore.RequestBuilder':method(#{},'delete') breaks the contract (map(),'Elixir.String':t()) -> map()
lib/swagger_petstore/api/store.ex:54: Function get_inventory/1 has no local return
lib/swagger_petstore/api/store.ex:54: Function get_inventory/2 has no local return
lib/swagger_petstore/api/store.ex:56: The call 'Elixir.SwaggerPetstore.RequestBuilder':method(#{},'get') breaks the contract (map(),'Elixir.String':t()) -> map()
lib/swagger_petstore/api/store.ex:79: Function get_order_by_id/2 has no local return
lib/swagger_petstore/api/store.ex:79: Function get_order_by_id/3 has no local return
lib/swagger_petstore/api/store.ex:81: The call 'Elixir.SwaggerPetstore.RequestBuilder':method(#{},'get') breaks the contract (map(),'Elixir.String':t()) -> map()
lib/swagger_petstore/api/store.ex:104: Function place_order/2 has no local return
lib/swagger_petstore/api/store.ex:104: Function place_order/3 has no local return
lib/swagger_petstore/api/store.ex:106: The call 'Elixir.SwaggerPetstore.RequestBuilder':method(#{},'post') breaks the contract (map(),'Elixir.String':t()) -> map()
lib/swagger_petstore/api/user.ex:30: Function create_user/2 has no local return
lib/swagger_petstore/api/user.ex:30: Function create_user/3 has no local return
lib/swagger_petstore/api/user.ex:32: The call 'Elixir.SwaggerPetstore.RequestBuilder':method(#{},'post') breaks the contract (map(),'Elixir.String':t()) -> map()
lib/swagger_petstore/api/user.ex:56: Function create_users_with_array_input/2 has no local return
lib/swagger_petstore/api/user.ex:56: Function create_users_with_array_input/3 has no local return
lib/swagger_petstore/api/user.ex:58: The call 'Elixir.SwaggerPetstore.RequestBuilder':method(#{},'post') breaks the contract (map(),'Elixir.String':t()) -> map()
lib/swagger_petstore/api/user.ex:82: Function create_users_with_list_input/2 has no local return
lib/swagger_petstore/api/user.ex:82: Function create_users_with_list_input/3 has no local return
lib/swagger_petstore/api/user.ex:84: The call 'Elixir.SwaggerPetstore.RequestBuilder':method(#{},'post') breaks the contract (map(),'Elixir.String':t()) -> map()
lib/swagger_petstore/api/user.ex:108: Function delete_user/2 has no local return
lib/swagger_petstore/api/user.ex:108: Function delete_user/3 has no local return
lib/swagger_petstore/api/user.ex:110: The call 'Elixir.SwaggerPetstore.RequestBuilder':method(#{},'delete') breaks the contract (map(),'Elixir.String':t()) -> map()
lib/swagger_petstore/api/user.ex:133: Function get_user_by_name/2 has no local return
lib/swagger_petstore/api/user.ex:133: Function get_user_by_name/3 has no local return
lib/swagger_petstore/api/user.ex:135: The call 'Elixir.SwaggerPetstore.RequestBuilder':method(#{},'get') breaks the contract (map(),'Elixir.String':t()) -> map()
lib/swagger_petstore/api/user.ex:159: Function login_user/3 has no local return
lib/swagger_petstore/api/user.ex:159: Function login_user/4 has no local return
lib/swagger_petstore/api/user.ex:161: The call 'Elixir.SwaggerPetstore.RequestBuilder':method(#{},'get') breaks the contract (map(),'Elixir.String':t()) -> map()
lib/swagger_petstore/api/user.ex:185: Function logout_user/1 has no local return
lib/swagger_petstore/api/user.ex:185: Function logout_user/2 has no local return
lib/swagger_petstore/api/user.ex:187: The call 'Elixir.SwaggerPetstore.RequestBuilder':method(#{},'get') breaks the contract (map(),'Elixir.String':t()) -> map()
lib/swagger_petstore/api/user.ex:211: Function update_user/3 has no local return
lib/swagger_petstore/api/user.ex:211: Function update_user/4 has no local return
lib/swagger_petstore/api/user.ex:213: The call 'Elixir.SwaggerPetstore.RequestBuilder':method(#{},'put') breaks the contract (map(),'Elixir.String':t()) -> map()
```

</details>

You can check dialyzer warnings following like:

```
% git clone https://github.com/jeremyjh/dialyxir
% cd dialyxir
% MIX_ENV=prod mix do compile, archive.build, archive.install
% cd ../swagger-codegen/samples/client/petstore/elixir
% mix do deps.get, dialyzer
```
