### PR TITLE
Add TypeScript default value mappers

### DIFF
--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/AbstractTypeScriptClientCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/AbstractTypeScriptClientCodegen.java
@@ -18,11 +18,20 @@ import io.swagger.codegen.CodegenProperty;
 import io.swagger.codegen.CodegenType;
 import io.swagger.codegen.DefaultCodegen;
 import io.swagger.models.properties.ArrayProperty;
+import io.swagger.models.properties.BooleanProperty;
+import io.swagger.models.properties.DateProperty;
+import io.swagger.models.properties.DateTimeProperty;
+import io.swagger.models.properties.DoubleProperty;
 import io.swagger.models.properties.FileProperty;
+import io.swagger.models.properties.FloatProperty;
+import io.swagger.models.properties.IntegerProperty;
+import io.swagger.models.properties.LongProperty;
 import io.swagger.models.properties.MapProperty;
 import io.swagger.models.properties.Property;
+import io.swagger.models.properties.StringProperty;
 
 public abstract class AbstractTypeScriptClientCodegen extends DefaultCodegen implements CodegenConfig {
+    private static final String UNDEFINED_VALUE = "undefined";
 
     protected String modelPropertyNaming= "camelCase";
     protected Boolean supportsES6 = true;
@@ -219,6 +228,49 @@ public abstract class AbstractTypeScriptClientCodegen extends DefaultCodegen imp
             return "any";
         }
         return super.getTypeDeclaration(p);
+    }
+
+    @Override
+    public String toDefaultValue(Property p) {
+        if (p instanceof StringProperty) {
+            StringProperty sp = (StringProperty) p;
+            if (sp.getDefault() != null) {
+                return "\"" + sp.getDefault() + "\"";
+            }
+            return UNDEFINED_VALUE;
+        } else if (p instanceof BooleanProperty) {
+            return UNDEFINED_VALUE;
+        } else if (p instanceof DateProperty) {
+            return UNDEFINED_VALUE;
+        } else if (p instanceof DateTimeProperty) {
+            return UNDEFINED_VALUE;
+        } else if (p instanceof DoubleProperty) {
+            DoubleProperty dp = (DoubleProperty) p;
+            if (dp.getDefault() != null) {
+                return dp.getDefault().toString();
+            }
+            return UNDEFINED_VALUE;
+        } else if (p instanceof FloatProperty) {
+            FloatProperty fp = (FloatProperty) p;
+            if (fp.getDefault() != null) {
+                return fp.getDefault().toString();
+            }
+            return UNDEFINED_VALUE;
+        } else if (p instanceof IntegerProperty) {
+            IntegerProperty ip = (IntegerProperty) p;
+            if (ip.getDefault() != null) {
+                return ip.getDefault().toString();
+            }
+            return UNDEFINED_VALUE;
+        } else if (p instanceof LongProperty) {
+            LongProperty lp = (LongProperty) p;
+            if (lp.getDefault() != null) {
+                return lp.getDefault().toString();
+            }
+            return UNDEFINED_VALUE;
+        } else {
+            return UNDEFINED_VALUE;
+        }
     }
 
     @Override

--- a/modules/swagger-codegen/src/test/java/io/swagger/codegen/typescript/fetch/TypeScriptFetchModelTest.java
+++ b/modules/swagger-codegen/src/test/java/io/swagger/codegen/typescript/fetch/TypeScriptFetchModelTest.java
@@ -44,7 +44,7 @@ public class TypeScriptFetchModelTest {
         Assert.assertEquals(property1.baseName, "id");
         Assert.assertEquals(property1.datatype, "number");
         Assert.assertEquals(property1.name, "id");
-        Assert.assertEquals(property1.defaultValue, "null");
+        Assert.assertEquals(property1.defaultValue, "undefined");
         Assert.assertEquals(property1.baseType, "number");
         Assert.assertTrue(property1.hasMore);
         Assert.assertTrue(property1.required);
@@ -54,7 +54,7 @@ public class TypeScriptFetchModelTest {
         Assert.assertEquals(property2.baseName, "name");
         Assert.assertEquals(property2.datatype, "string");
         Assert.assertEquals(property2.name, "name");
-        Assert.assertEquals(property2.defaultValue, "null");
+        Assert.assertEquals(property2.defaultValue, "undefined");
         Assert.assertEquals(property2.baseType, "string");
         Assert.assertTrue(property2.hasMore);
         Assert.assertTrue(property2.required);
@@ -65,7 +65,7 @@ public class TypeScriptFetchModelTest {
         Assert.assertEquals(property3.complexType, null);
         Assert.assertEquals(property3.datatype, "Date");
         Assert.assertEquals(property3.name, "createdAt");
-        Assert.assertEquals(property3.defaultValue, "null");
+        Assert.assertEquals(property3.defaultValue, "undefined");
         Assert.assertTrue(property3.hasMore);
         Assert.assertFalse(property3.required);
         Assert.assertTrue(property3.isNotContainer);
@@ -75,7 +75,7 @@ public class TypeScriptFetchModelTest {
         Assert.assertEquals(property4.complexType, null);
         Assert.assertEquals(property4.datatype, "string");
         Assert.assertEquals(property4.name, "birthDate");
-        Assert.assertEquals(property4.defaultValue, "null");
+        Assert.assertEquals(property4.defaultValue, "undefined");
         Assert.assertFalse(property4.hasMore);
         Assert.assertFalse(property4.required);
         Assert.assertTrue(property4.isNotContainer);
@@ -100,7 +100,7 @@ public class TypeScriptFetchModelTest {
         Assert.assertEquals(property1.baseName, "id");
         Assert.assertEquals(property1.datatype, "number");
         Assert.assertEquals(property1.name, "id");
-        Assert.assertEquals(property1.defaultValue, "null");
+        Assert.assertEquals(property1.defaultValue, "undefined");
         Assert.assertEquals(property1.baseType, "number");
         Assert.assertTrue(property1.hasMore);
         Assert.assertTrue(property1.required);
@@ -133,7 +133,7 @@ public class TypeScriptFetchModelTest {
         Assert.assertEquals(property1.baseName, "children");
         Assert.assertEquals(property1.datatype, "Children");
         Assert.assertEquals(property1.name, "children");
-        Assert.assertEquals(property1.defaultValue, "null");
+        Assert.assertEquals(property1.defaultValue, "undefined");
         Assert.assertEquals(property1.baseType, "Children");
         Assert.assertFalse(property1.required);
         Assert.assertTrue(property1.isNotContainer);

--- a/modules/swagger-codegen/src/test/java/io/swagger/codegen/typescript/typescriptangular/TypeScriptAngularModelTest.java
+++ b/modules/swagger-codegen/src/test/java/io/swagger/codegen/typescript/typescriptangular/TypeScriptAngularModelTest.java
@@ -44,7 +44,7 @@ public class TypeScriptAngularModelTest {
         Assert.assertEquals(property1.baseName, "id");
         Assert.assertEquals(property1.datatype, "number");
         Assert.assertEquals(property1.name, "id");
-        Assert.assertEquals(property1.defaultValue, "null");
+        Assert.assertEquals(property1.defaultValue, "undefined");
         Assert.assertEquals(property1.baseType, "number");
         Assert.assertTrue(property1.hasMore);
         Assert.assertTrue(property1.required);
@@ -54,7 +54,7 @@ public class TypeScriptAngularModelTest {
         Assert.assertEquals(property2.baseName, "name");
         Assert.assertEquals(property2.datatype, "string");
         Assert.assertEquals(property2.name, "name");
-        Assert.assertEquals(property2.defaultValue, "null");
+        Assert.assertEquals(property2.defaultValue, "undefined");
         Assert.assertEquals(property2.baseType, "string");
         Assert.assertTrue(property2.hasMore);
         Assert.assertTrue(property2.required);
@@ -66,7 +66,7 @@ public class TypeScriptAngularModelTest {
         Assert.assertEquals(property3.datatype, "Date");
         Assert.assertEquals(property3.name, "createdAt");
         Assert.assertEquals(property3.baseType, "Date");
-        Assert.assertEquals(property3.defaultValue, "null");
+        Assert.assertEquals(property3.defaultValue, "undefined");
         Assert.assertTrue(property3.hasMore);
         Assert.assertFalse(property3.required);
         Assert.assertTrue(property3.isNotContainer);
@@ -77,7 +77,7 @@ public class TypeScriptAngularModelTest {
         Assert.assertEquals(property4.datatype, "string");
         Assert.assertEquals(property4.name, "birthDate");
         Assert.assertEquals(property4.baseType, "string");
-        Assert.assertEquals(property4.defaultValue, "null");
+        Assert.assertEquals(property4.defaultValue, "undefined");
         Assert.assertFalse(property4.hasMore);
         Assert.assertFalse(property4.required);
         Assert.assertTrue(property4.isNotContainer);
@@ -102,7 +102,7 @@ public class TypeScriptAngularModelTest {
         Assert.assertEquals(property1.baseName, "id");
         Assert.assertEquals(property1.datatype, "number");
         Assert.assertEquals(property1.name, "id");
-        Assert.assertEquals(property1.defaultValue, "null");
+        Assert.assertEquals(property1.defaultValue, "undefined");
         Assert.assertEquals(property1.baseType, "number");
         Assert.assertTrue(property1.hasMore);
         Assert.assertTrue(property1.required);
@@ -135,7 +135,7 @@ public class TypeScriptAngularModelTest {
         Assert.assertEquals(property1.baseName, "children");
         Assert.assertEquals(property1.datatype, "Children");
         Assert.assertEquals(property1.name, "children");
-        Assert.assertEquals(property1.defaultValue, "null");
+        Assert.assertEquals(property1.defaultValue, "undefined");
         Assert.assertEquals(property1.baseType, "Children");
         Assert.assertFalse(property1.required);
         Assert.assertTrue(property1.isNotContainer);

--- a/modules/swagger-codegen/src/test/java/io/swagger/codegen/typescript/typescriptangularjs/TypeScriptAngularJsModelTest.java
+++ b/modules/swagger-codegen/src/test/java/io/swagger/codegen/typescript/typescriptangularjs/TypeScriptAngularJsModelTest.java
@@ -38,7 +38,7 @@ public class TypeScriptAngularJsModelTest {
         Assert.assertEquals(property1.baseName, "id");
         Assert.assertEquals(property1.datatype, "number");
         Assert.assertEquals(property1.name, "id");
-        Assert.assertEquals(property1.defaultValue, "null");
+        Assert.assertEquals(property1.defaultValue, "undefined");
         Assert.assertEquals(property1.baseType, "number");
         Assert.assertTrue(property1.hasMore);
         Assert.assertTrue(property1.required);
@@ -48,7 +48,7 @@ public class TypeScriptAngularJsModelTest {
         Assert.assertEquals(property2.baseName, "name");
         Assert.assertEquals(property2.datatype, "string");
         Assert.assertEquals(property2.name, "name");
-        Assert.assertEquals(property2.defaultValue, "null");
+        Assert.assertEquals(property2.defaultValue, "undefined");
         Assert.assertEquals(property2.baseType, "string");
         Assert.assertTrue(property2.hasMore);
         Assert.assertTrue(property2.required);
@@ -59,7 +59,7 @@ public class TypeScriptAngularJsModelTest {
         Assert.assertEquals(property3.complexType, null);
         Assert.assertEquals(property3.datatype, "Date");
         Assert.assertEquals(property3.name, "createdAt");
-        Assert.assertEquals(property3.defaultValue, "null");
+        Assert.assertEquals(property3.defaultValue, "undefined");
         Assert.assertTrue(property3.hasMore);
         Assert.assertFalse(property3.required);
         Assert.assertTrue(property3.isNotContainer);
@@ -69,7 +69,7 @@ public class TypeScriptAngularJsModelTest {
         Assert.assertEquals(property4.complexType, null);
         Assert.assertEquals(property4.datatype, "string");
         Assert.assertEquals(property4.name, "birthDate");
-        Assert.assertEquals(property4.defaultValue, "null");
+        Assert.assertEquals(property4.defaultValue, "undefined");
         Assert.assertFalse(property4.hasMore);
         Assert.assertFalse(property4.required);
         Assert.assertTrue(property4.isNotContainer);
@@ -94,7 +94,7 @@ public class TypeScriptAngularJsModelTest {
         Assert.assertEquals(property1.baseName, "id");
         Assert.assertEquals(property1.datatype, "number");
         Assert.assertEquals(property1.name, "id");
-        Assert.assertEquals(property1.defaultValue, "null");
+        Assert.assertEquals(property1.defaultValue, "undefined");
         Assert.assertEquals(property1.baseType, "number");
         Assert.assertTrue(property1.hasMore);
         Assert.assertTrue(property1.required);
@@ -127,7 +127,7 @@ public class TypeScriptAngularJsModelTest {
         Assert.assertEquals(property1.baseName, "children");
         Assert.assertEquals(property1.datatype, "models.Children");
         Assert.assertEquals(property1.name, "children");
-        Assert.assertEquals(property1.defaultValue, "null");
+        Assert.assertEquals(property1.defaultValue, "undefined");
         Assert.assertEquals(property1.baseType, "models.Children");
         Assert.assertFalse(property1.required);
         Assert.assertTrue(property1.isNotContainer);

--- a/modules/swagger-codegen/src/test/java/io/swagger/codegen/typescript/typescriptnode/TypeScriptNodeModelTest.java
+++ b/modules/swagger-codegen/src/test/java/io/swagger/codegen/typescript/typescriptnode/TypeScriptNodeModelTest.java
@@ -38,7 +38,7 @@ public class TypeScriptNodeModelTest {
         Assert.assertEquals(property1.baseName, "id");
         Assert.assertEquals(property1.datatype, "number");
         Assert.assertEquals(property1.name, "id");
-        Assert.assertEquals(property1.defaultValue, "null");
+        Assert.assertEquals(property1.defaultValue, "undefined");
         Assert.assertEquals(property1.baseType, "number");
         Assert.assertTrue(property1.hasMore);
         Assert.assertTrue(property1.required);
@@ -48,7 +48,7 @@ public class TypeScriptNodeModelTest {
         Assert.assertEquals(property2.baseName, "name");
         Assert.assertEquals(property2.datatype, "string");
         Assert.assertEquals(property2.name, "name");
-        Assert.assertEquals(property2.defaultValue, "null");
+        Assert.assertEquals(property2.defaultValue, "undefined");
         Assert.assertEquals(property2.baseType, "string");
         Assert.assertTrue(property2.hasMore);
         Assert.assertTrue(property2.required);
@@ -59,7 +59,7 @@ public class TypeScriptNodeModelTest {
         Assert.assertEquals(property3.complexType, null);
         Assert.assertEquals(property3.datatype, "Date");
         Assert.assertEquals(property3.name, "createdAt");
-        Assert.assertEquals(property3.defaultValue, "null");
+        Assert.assertEquals(property3.defaultValue, "undefined");
         Assert.assertTrue(property3.hasMore);
         Assert.assertFalse(property3.required);
         Assert.assertTrue(property3.isNotContainer);
@@ -69,7 +69,7 @@ public class TypeScriptNodeModelTest {
         Assert.assertEquals(property4.complexType, null);
         Assert.assertEquals(property4.datatype, "string");
         Assert.assertEquals(property4.name, "birthDate");
-        Assert.assertEquals(property4.defaultValue, "null");
+        Assert.assertEquals(property4.defaultValue, "undefined");
         Assert.assertFalse(property4.hasMore);
         Assert.assertFalse(property4.required);
         Assert.assertTrue(property4.isNotContainer);
@@ -94,7 +94,7 @@ public class TypeScriptNodeModelTest {
         Assert.assertEquals(property1.baseName, "id");
         Assert.assertEquals(property1.datatype, "number");
         Assert.assertEquals(property1.name, "id");
-        Assert.assertEquals(property1.defaultValue, "null");
+        Assert.assertEquals(property1.defaultValue, "undefined");
         Assert.assertEquals(property1.baseType, "number");
         Assert.assertTrue(property1.hasMore);
         Assert.assertTrue(property1.required);


### PR DESCRIPTION
Fixes #6765.

### PR checklist

- [x] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [x] Filed the PR against the correct branch: `3.0.0` branch for changes related to OpenAPI spec 3.0. Default: `master`.
- [ ] Copied the [technical committee](https://github.com/swagger-api/swagger-codegen/#swagger-codegen-technical-committee) to review the pull request if your PR is targeting a particular programming langauge.

### Description of the PR

Added a method to set the default values for TypeScript conversions.

