### PR TITLE
Swagger Codegen Dockerfile Entrypoint

### DIFF
--- a/modules/swagger-generator/Dockerfile
+++ b/modules/swagger-generator/Dockerfile
@@ -2,6 +2,7 @@ FROM openjdk:8-jre-alpine
 
 WORKDIR /generator
 
+COPY entrypoint.sh entrypoint.sh
 COPY target/lib/jetty-runner* /generator/jetty-runner.jar
 COPY target/*.war /generator/swagger-generator.war
 
@@ -9,5 +10,5 @@ ENV GENERATOR_HOST=https://generator.swaggerhub.com/api/swagger.json
 
 EXPOSE 8080
 
-CMD ["java", "-jar", "/generator/jetty-runner.jar", "/generator/swagger-generator.war"]
+ENTRYPOINT entrypoint.sh
 

--- a/modules/swagger-generator/entrypoint.sh
+++ b/modules/swagger-generator/entrypoint.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+if [-z $PORT]; then
+  PORT=8080
+fi
+
+java -jar /generator/jetty-runner.jar --port $PORT /generator/swagger-generator.war


### PR DESCRIPTION
### PR checklist

- [ ] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [ ] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [ ] Filed the PR against the correct branch: `3.0.0` branch for changes related to OpenAPI spec 3.0. Default: `master`.
- [ ] Copied the [technical committee](https://github.com/swagger-api/swagger-codegen/#swagger-codegen-technical-committee) to review the pull request if your PR is targeting a particular programming langauge.

### Description of the PR

I've done the work to add an entrypoint to the code-generator dockerfile in an attempt to resolve any complaints of not being able to easily specify a different port for the java process to run on.

fix #3386

