### PR TITLE
[all] Better error message for missing libraries

### DIFF
--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/DefaultCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/DefaultCodegen.java
@@ -3382,8 +3382,17 @@ public class DefaultCodegen {
      * @param library Library template
      */
     public void setLibrary(String library) {
-        if (library != null && !supportedLibraries.containsKey(library))
-            throw new RuntimeException("unknown library: " + library);
+        if (library != null && !supportedLibraries.containsKey(library)) {
+            StringBuilder sb = new StringBuilder("Unknown library: " + library + "\nAvailable libraries:");
+            if(supportedLibraries.size() == 0) {
+                sb.append("\n  ").append("NONE");
+            } else {
+                for (String lib : supportedLibraries.keySet()) {
+                    sb.append("\n  ").append(lib);
+                }
+            }
+            throw new RuntimeException(sb.toString());
+        }
         this.library = library;
     }
 


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [ ] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [x] Filed the PR against the correct branch: `3.0.0` branch for changes related to OpenAPI spec 3.0. Default: `master`.
- [x] Copied the [technical committee](https://github.com/swagger-api/swagger-codegen/#swagger-codegen-technical-committee) to review the pull request if your PR is targeting a particular programming langauge.

### Description of the PR

New error message when an unsupported library is specified:

For example, passing `--library asdfasdfasdf` to the java client generator:

```
Removing files and folders under samples/client/petstore/java/feign/src/main
Java HotSpot(TM) 64-Bit Server VM warning: ignoring option MaxPermSize=256M; support was removed in 8.0
Exception in thread "main" java.lang.RuntimeException: Unknown library: asdfasdfasdf
Available libraries:
  jersey1
  feign
  jersey2
  okhttp-gson
  retrofit
  retrofit2
  resttemplate
  resteasy
  vertx
	at io.swagger.codegen.DefaultCodegen.setLibrary(DefaultCodegen.java:3394)
	at io.swagger.codegen.config.CodegenConfigurator.toClientOptInput(CodegenConfigurator.java:421)
	at io.swagger.codegen.cmd.Generate.run(Generate.java:283)
	at io.swagger.codegen.SwaggerCodegen.main(SwaggerCodegen.java:35)
```

When a generator doesn't support libraries, it will now have a single `NONE` item in the above example.

This answers a concern in #6368 and is generally good usability for error messages.