### PR TITLE
[kotlin] Nested enum naming fix, and naming options via CLI

### DIFF
--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/CodegenConstants.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/CodegenConstants.java
@@ -146,6 +146,10 @@ public class CodegenConstants {
     public static final String DOTNET_FRAMEWORK_DESC = "The target .NET framework version.";
 
     public static enum MODEL_PROPERTY_NAMING_TYPE {camelCase, PascalCase, snake_case, original}
+    public static enum ENUM_PROPERTY_NAMING_TYPE {camelCase, PascalCase, snake_case, original, UPPERCASE}
+
+    public static final String ENUM_PROPERTY_NAMING = "enumPropertyNaming";
+    public static final String ENUM_PROPERTY_NAMING_DESC = "Naming convention for enum properties: 'camelCase', 'PascalCase', 'snake_case', 'UPPERCASE', and 'original'";
 
     public static final String MODEL_NAME_PREFIX = "modelNamePrefix";
     public static final String MODEL_NAME_PREFIX_DESC = "Prefix that will be prepended to all model names. Default is the empty string.";

--- a/modules/swagger-codegen/src/main/resources/kotlin-client/data_class.mustache
+++ b/modules/swagger-codegen/src/main/resources/kotlin-client/data_class.mustache
@@ -14,11 +14,11 @@ data class {{classname}} (
 {{#hasEnums}}{{#vars}}{{#isEnum}}
     /**
     * {{{description}}}
-    * Values: {{#allowableValues}}{{#enumVars}}{{name}}{{^-last}},{{/-last}}{{/enumVars}}{{/allowableValues}}
+    * Values: {{#allowableValues}}{{#enumVars}}{{&name}}{{^-last}},{{/-last}}{{/enumVars}}{{/allowableValues}}
     */
     enum class {{nameInCamelCase}}(val value: {{dataType}}){
     {{#allowableValues}}{{#enumVars}}
-        {{name}}({{{value}}}){{^-last}},{{/-last}}{{#-last}};{{/-last}}
+        {{&name}}({{{value}}}){{^-last}},{{/-last}}{{#-last}};{{/-last}}
     {{/enumVars}}{{/allowableValues}}
     }
 {{/isEnum}}{{/vars}}{{/hasEnums}}

--- a/modules/swagger-codegen/src/main/resources/kotlin-client/data_class.mustache
+++ b/modules/swagger-codegen/src/main/resources/kotlin-client/data_class.mustache
@@ -12,11 +12,14 @@ data class {{classname}} (
 {{/-last}}{{/optionalVars}}
 ) {
 {{#hasEnums}}{{#vars}}{{#isEnum}}
-    enum class {{nameInCamelCase}}(val value: {{datatype}}) {
-    {{#_enum}}
-        {{{this}}}({{#isString}}"{{/isString}}{{{this}}}{{#isString}}"{{/isString}}){{^-last}},{{/-last}}{{#-last}};{{/-last}}
-    {{/_enum}}
+    /**
+    * {{{description}}}
+    * Values: {{#allowableValues}}{{#enumVars}}{{name}}{{^-last}},{{/-last}}{{/enumVars}}{{/allowableValues}}
+    */
+    enum class {{nameInCamelCase}}(val value: {{dataType}}){
+    {{#allowableValues}}{{#enumVars}}
+        {{name}}({{{value}}}){{^-last}},{{/-last}}{{#-last}};{{/-last}}
+    {{/enumVars}}{{/allowableValues}}
     }
-
 {{/isEnum}}{{/vars}}{{/hasEnums}}
 }

--- a/modules/swagger-codegen/src/main/resources/kotlin-client/enum_class.mustache
+++ b/modules/swagger-codegen/src/main/resources/kotlin-client/enum_class.mustache
@@ -1,9 +1,9 @@
 /**
 * {{{description}}}
-* Values: {{#allowableValues}}{{#enumVars}}{{name}}{{^-last}},{{/-last}}{{/enumVars}}{{/allowableValues}}
+* Values: {{#allowableValues}}{{#enumVars}}{{&name}}{{^-last}},{{/-last}}{{/enumVars}}{{/allowableValues}}
 */
 enum class {{classname}}(val value: {{dataType}}){
 {{#allowableValues}}{{#enumVars}}
-    {{name}}({{{value}}}){{^-last}},{{/-last}}{{#-last}};{{/-last}}
+    {{&name}}({{{value}}}){{^-last}},{{/-last}}{{#-last}};{{/-last}}
 {{/enumVars}}{{/allowableValues}}
 }

--- a/modules/swagger-codegen/src/test/java/io/swagger/codegen/kotlin/KotlinClientCodegenOptionsTest.java
+++ b/modules/swagger-codegen/src/test/java/io/swagger/codegen/kotlin/KotlinClientCodegenOptionsTest.java
@@ -36,6 +36,8 @@ public class KotlinClientCodegenOptionsTest extends AbstractOptionsTest {
             times = 1;
             codegen.setSourceFolder(KotlinClientCodegenOptionsProvider.SOURCE_FOLDER);
             times = 1;
+            codegen.setEnumPropertyNaming(KotlinClientCodegenOptionsProvider.ENUM_PROPERTY_NAMING);
+            times = 1;
         }};
     }
 }

--- a/modules/swagger-codegen/src/test/java/io/swagger/codegen/options/KotlinClientCodegenOptionsProvider.java
+++ b/modules/swagger-codegen/src/test/java/io/swagger/codegen/options/KotlinClientCodegenOptionsProvider.java
@@ -12,6 +12,7 @@ public class KotlinClientCodegenOptionsProvider implements OptionsProvider {
     public static final String ARTIFACT_ID = "swagger-kotlin-test";
     public static final String GROUP_ID = "io.swagger.tests";
     public static final String SOURCE_FOLDER = "./generated/kotlin";
+    public static final String ENUM_PROPERTY_NAMING = "camelCase";
 
     @Override
     public String getLanguage() {
@@ -27,6 +28,7 @@ public class KotlinClientCodegenOptionsProvider implements OptionsProvider {
                 .put(CodegenConstants.ARTIFACT_ID, ARTIFACT_ID)
                 .put(CodegenConstants.GROUP_ID, GROUP_ID)
                 .put(CodegenConstants.SOURCE_FOLDER, SOURCE_FOLDER)
+                .put(CodegenConstants.ENUM_PROPERTY_NAMING, ENUM_PROPERTY_NAMING)
                 .build();
     }
 


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [ ] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [x] Filed the PR against the correct branch: `3.0.0` branch for changes related to OpenAPI spec 3.0. Default: `master`.
- [x] Copied the [technical committee](https://github.com/swagger-api/swagger-codegen/#swagger-codegen-technical-committee) to review the pull request if your PR is targeting a particular programming langauge.

### Description of the PR

See #6830 This should resolve issues with nested enums, as well as providing a CLI option to allow for customization of enums. For example:

```
--additional-properties=enumPropertyNaming=PascalCase
```

Default is camelCase, which removes hyphens and underscores. I'd be happy to change the default if there's enough concern.

