### PR TITLE
[docker] Update root Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,22 +1,31 @@
 FROM jimschubert/8-jdk-alpine-mvn:1.0
 
-ENV GEN_DIR /opt/swagger-codegen
-
 RUN set -x && \
     apk add --no-cache bash
 
-RUN mkdir /opt
-
-ADD . ${GEN_DIR}
-
+ENV GEN_DIR /opt/swagger-codegen
+WORKDIR ${GEN_DIR}
 VOLUME  ${MAVEN_HOME}/.m2/repository
 
-WORKDIR ${GEN_DIR}
+# Required from a licensing standpoint
+COPY ./LICENSE ${GEN_DIR}
 
+# Required to compile swagger-codegen
+COPY ./google_checkstyle.xml ${GEN_DIR}
+
+# Modules are copied individually here to allow for caching of docker layers between major.minor versions
+# NOTE: swagger-generator is not included here, it is available as swaggerapi/swagger-generator
+COPY ./modules/swagger-codegen-maven-plugin ${GEN_DIR}/modules/swagger-codegen-maven-plugin
+COPY ./modules/swagger-codegen-cli ${GEN_DIR}/modules/swagger-codegen-cli
+COPY ./modules/swagger-codegen ${GEN_DIR}/modules/swagger-codegen
+COPY ./pom.xml ${GEN_DIR}
+
+# Pre-compile swagger-codegen-cli
 RUN mvn -am -pl "modules/swagger-codegen-cli" package
 
+# This exists at the end of the file to benefit from cached layers when modifying docker-entrypoint.sh.
 COPY docker-entrypoint.sh /usr/local/bin/
 
 ENTRYPOINT ["docker-entrypoint.sh"]
 
-CMD ["build"]
+CMD ["help"]


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [ ] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [x] Filed the PR against the correct branch: `3.0.0` branch for changes related to OpenAPI spec 3.0. Default: `master`.
- [ ] Copied the [technical committee](https://github.com/swagger-api/swagger-codegen/#swagger-codegen-technical-committee) to review the pull request if your PR is targeting a particular programming langauge.

### Description of the PR

Based on discussions in #6836, this is a modification to the root Dockerfile which is intended to allow developers a clean sandbox to evaluate local changes.

NOTES:

1. This image is not the image published to [swaggerapi/swagger-codegen-cli](https://hub.docker.com/r/swaggerapi/swagger-codegen-cli/) or [swaggerapi/swagger-generator](https://hub.docker.com/r/swaggerapi/swagger-generator/).  Those images are containers encapsulating the compiled .jars and a java runtime for each.

2. I've removed swagger-generator from being cached within this image. The assumption here is that anyone working on local swagger-generator modifications will likely be running that locally. Since this root Dockerfile is specifically setup to run as the locally modified CLI code, it doesn't make a lot of sense to include the ~129MB layer for swagger-generator (which doesn't get built by maven in the image). This could be revisited if it's a concern.

3. Some layering optimizations were made (see linked PR).

/cc @kenjones-cisco 

