### PR TITLE
Kotlin sanitize model names 6864

### DIFF
--- a/modules/swagger-codegen/src/test/java/io/swagger/codegen/kotlin/KotlinClientCodegenModelTest.java
+++ b/modules/swagger-codegen/src/test/java/io/swagger/codegen/kotlin/KotlinClientCodegenModelTest.java
@@ -6,6 +6,7 @@ import io.swagger.models.*;
 import io.swagger.models.properties.*;
 
 import org.testng.Assert;
+import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
 @SuppressWarnings("static-method")
@@ -152,6 +153,42 @@ public class KotlinClientCodegenModelTest {
         Assert.assertEquals(property1.baseType, "Child");
         Assert.assertFalse(property1.required);
         Assert.assertTrue(property1.isNotContainer);
+    }
+
+    @DataProvider(name = "modelNames")
+    public static Object[][] modelNames(){
+        return new Object[][] {
+                { "TestNs.TestClass" , new ModelNameTest("TestNs.TestClass", "TestNsTestClass") },
+                { "$", new ModelNameTest("$", "Dollar") },
+                { "for", new ModelNameTest("`for`","`for`")},
+                { "One<Two", new ModelNameTest("One<Two", "OneLess_ThanTwo")},
+                { "this is a test", new ModelNameTest("this is a test", "This_is_a_test")}
+        };
+    }
+
+    @Test(dataProvider = "modelNames", description = "sanitize model names")
+    public void sanitizeModelNames(final String name, final ModelNameTest testCase) {
+        final Model model = getComplexModel();
+        final DefaultCodegen codegen = new KotlinClientCodegen();
+        final CodegenModel cm = codegen.fromModel(name, model);
+
+        Assert.assertEquals(cm.name, testCase.expectedName);
+        Assert.assertEquals(cm.classname, testCase.expectedClassName);
+    }
+
+    private static class ModelNameTest {
+        private String expectedName;
+        private String expectedClassName;
+
+        private ModelNameTest(String nameAndClass) {
+            this.expectedName = nameAndClass;
+            this.expectedClassName = nameAndClass;
+        }
+
+        private ModelNameTest(String expectedName, String expectedClassName) {
+            this.expectedName = expectedName;
+            this.expectedClassName = expectedClassName;
+        }
     }
 }
 

--- a/samples/client/petstore/kotlin/src/main/kotlin/io/swagger/client/models/ApiResponse.kt
+++ b/samples/client/petstore/kotlin/src/main/kotlin/io/swagger/client/models/ApiResponse.kt
@@ -25,3 +25,4 @@ data class ApiResponse (
 ) {
 
 }
+

--- a/samples/client/petstore/kotlin/src/main/kotlin/io/swagger/client/models/Category.kt
+++ b/samples/client/petstore/kotlin/src/main/kotlin/io/swagger/client/models/Category.kt
@@ -23,3 +23,4 @@ data class Category (
 ) {
 
 }
+

--- a/samples/client/petstore/kotlin/src/main/kotlin/io/swagger/client/models/Order.kt
+++ b/samples/client/petstore/kotlin/src/main/kotlin/io/swagger/client/models/Order.kt
@@ -31,11 +31,19 @@ data class Order (
     val complete: kotlin.Boolean? = null
 ) {
 
-    enum class Status(val value: kotlin.String) {
+    /**
+    * Order Status
+    * Values: placed,approved,delivered
+    */
+    enum class Status(val value: kotlin.Any){
+    
         placed("placed"),
+    
         approved("approved"),
+    
         delivered("delivered");
+    
     }
 
-
 }
+

--- a/samples/client/petstore/kotlin/src/main/kotlin/io/swagger/client/models/Pet.kt
+++ b/samples/client/petstore/kotlin/src/main/kotlin/io/swagger/client/models/Pet.kt
@@ -33,11 +33,19 @@ data class Pet (
     val status: Pet.Status? = null
 ) {
 
-    enum class Status(val value: kotlin.String) {
+    /**
+    * pet status in the store
+    * Values: available,pending,sold
+    */
+    enum class Status(val value: kotlin.Any){
+    
         available("available"),
+    
         pending("pending"),
+    
         sold("sold");
+    
     }
 
-
 }
+

--- a/samples/client/petstore/kotlin/src/main/kotlin/io/swagger/client/models/Tag.kt
+++ b/samples/client/petstore/kotlin/src/main/kotlin/io/swagger/client/models/Tag.kt
@@ -23,3 +23,4 @@ data class Tag (
 ) {
 
 }
+

--- a/samples/client/petstore/kotlin/src/main/kotlin/io/swagger/client/models/User.kt
+++ b/samples/client/petstore/kotlin/src/main/kotlin/io/swagger/client/models/User.kt
@@ -36,3 +36,4 @@ data class User (
 ) {
 
 }
+


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [ ] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [x] Filed the PR against the correct branch: `3.0.0` branch for changes related to OpenAPI spec 3.0. Default: `master`.
- [x] Copied the [technical committee](https://github.com/swagger-api/swagger-codegen/#swagger-codegen-technical-committee) to review the pull request if your PR is targeting a particular programming langauge.

### Description of the PR

Kotlin names weren't being cleanly sanitized. This adds some additional constraints related to kotlin.

See #6864.

