### PR TITLE
[C++] Updated C++ generators to name boolean getters correctly

### DIFF
--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/AbstractCppCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/AbstractCppCodegen.java
@@ -166,4 +166,14 @@ abstract public class AbstractCppCodegen extends DefaultCodegen implements Codeg
         property.nameInCamelCase = nameInCamelCase;
         return property;
     }
+    
+    /**
+     * Output the Getter name for boolean property, e.g. isActive
+     *
+     * @param name the name of the property
+     * @return getter name based on naming convention
+     */
+    public String toBooleanGetter(String name) {
+        return "is" + getterAndSetterCapitalize(name);
+    }
 }

--- a/samples/client/petstore/cpprest/model/Order.cpp
+++ b/samples/client/petstore/cpprest/model/Order.cpp
@@ -279,7 +279,7 @@ void Order::unsetStatus()
     m_StatusIsSet = false;
 }
 
-bool Order::getComplete() const
+bool Order::isComplete() const
 {
     return m_Complete;
 }

--- a/samples/client/petstore/cpprest/model/Order.h
+++ b/samples/client/petstore/cpprest/model/Order.h
@@ -91,7 +91,7 @@ public:
     /// <summary>
     /// 
     /// </summary>
-    bool getComplete() const;
+    bool isComplete() const;
     bool completeIsSet() const;
     void unsetComplete();
     void setComplete(bool value);

--- a/samples/client/petstore/cpprest/model/Pet.h
+++ b/samples/client/petstore/cpprest/model/Pet.h
@@ -22,10 +22,10 @@
 
 #include "ModelBase.h"
 
-#include "Category.h"
-#include <cpprest/details/basic_types.h>
-#include <vector>
 #include "Tag.h"
+#include <cpprest/details/basic_types.h>
+#include "Category.h"
+#include <vector>
 
 namespace io {
 namespace swagger {

--- a/samples/client/petstore/qt5cpp/client/SWGOrder.cpp
+++ b/samples/client/petstore/qt5cpp/client/SWGOrder.cpp
@@ -155,7 +155,7 @@ SWGOrder::setStatus(QString* status) {
 }
 
 bool
-SWGOrder::getComplete() {
+SWGOrder::isComplete() {
     return complete;
 }
 void

--- a/samples/client/petstore/qt5cpp/client/SWGOrder.h
+++ b/samples/client/petstore/qt5cpp/client/SWGOrder.h
@@ -58,7 +58,7 @@ public:
     QString* getStatus();
     void setStatus(QString* status);
 
-    bool getComplete();
+    bool isComplete();
     void setComplete(bool complete);
 
 

--- a/samples/server/petstore/restbed/model/Order.cpp
+++ b/samples/server/petstore/restbed/model/Order.cpp
@@ -110,7 +110,7 @@ void Order::setStatus(std::string value)
 {
     m_Status = value;
 }
-bool Order::getComplete() const
+bool Order::isComplete() const
 {
     return m_Complete;
 }

--- a/samples/server/petstore/restbed/model/Order.h
+++ b/samples/server/petstore/restbed/model/Order.h
@@ -72,7 +72,7 @@ public:
     /// <summary>
     /// 
     /// </summary>
-    bool getComplete() const;
+    bool isComplete() const;
     void setComplete(bool value);
 
 protected:


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [x] Filed the PR against the correct branch: `3.0.0` branch for changes related to OpenAPI spec 3.0. Default: `master`.
- [x] Copied the [technical committee](https://github.com/swagger-api/swagger-codegen/#swagger-codegen-technical-committee) to review the pull request if your PR is targeting a particular programming langauge.

@wing328 

