### PR TITLE
[qt5cpp] Fixes Issue #6841, Map for accessing additionalProperties is generated.

### DIFF
--- a/modules/swagger-codegen/src/main/resources/qt5cpp/model-body.mustache
+++ b/modules/swagger-codegen/src/main/resources/qt5cpp/model-body.mustache
@@ -58,11 +58,27 @@ void
 void
 {{classname}}::fromJsonObject(QJsonObject &pJson) {
     {{#vars}}
-    {{^isContainer}}::{{cppNamespace}}::setValue(&{{name}}, pJson["{{baseName}}"], "{{baseType}}", "{{complexType}}");{{/isContainer}}
-    {{#isContainer}}
+    {{^isContainer}}::{{cppNamespace}}::setValue(&{{name}}, pJson["{{baseName}}"], "{{baseType}}", "{{complexType}}");{{/isContainer}} 
+    {{#isListContainer}}
     {{#complexType}}::{{cppNamespace}}::setValue(&{{name}}, pJson["{{baseName}}"], "{{baseType}}", "{{complexType}}");{{/complexType}}
     {{^complexType}}::{{cppNamespace}}::setValue(&{{name}}, pJson["{{baseName}}"], "{{baseType}}", "{{items.baseType}}");{{/complexType}}
-    {{/isContainer}}
+    {{/isListContainer}}        
+    {{#isMapContainer}}    
+    if( pJson["{{baseName}}"].isObject()){
+        auto varmap = pJson["{{baseName}}"].toObject().toVariantMap();
+        if(varmap.count() > 0){
+            for(auto val : varmap.keys() ){
+                {                    
+    		    {{items.baseType}} *{{name}}_item = new {{items.baseType}}();
+    		    auto  jsonval = QJsonValue::fromVariant(varmap[val]);
+    		    ::{{cppNamespace}}::setValue(&{{name}}_item, jsonval, "{{items.baseType}}", "{{items.baseType}}");        			                                                                       
+                    {{name}}->insert({{name}}->end(), val, {{name}}_item);
+                }
+            }
+        }
+    }
+           
+    {{/isMapContainer}}        
     {{/vars}}
 }
 
@@ -83,14 +99,28 @@ QJsonObject*
     toJsonValue(QString("{{baseName}}"), {{name}}, obj, QString("{{complexType}}"));{{/complexType}}{{^complexType}}
     if({{name}} != nullptr && *{{name}} != nullptr) { 
         obj->insert("{{name}}", QJsonValue(*{{name}}));
-    }{{/complexType}}{{/isContainer}}{{#isContainer}}
+    }{{/complexType}}{{/isContainer}}{{#isListContainer}}
     QJsonArray {{name}}JsonArray;
     toJsonArray((QList<void*>*){{name}}, &{{name}}JsonArray, "{{name}}", "{{complexType}}");
-    obj->insert("{{baseName}}", {{name}}JsonArray);{{/isContainer}}{{/complexType}}{{^complexType}}{{^isContainer}}
-    obj->insert("{{baseName}}", QJsonValue({{name}}));{{/isContainer}}{{#isContainer}}
+    obj->insert("{{baseName}}", {{name}}JsonArray);{{/isListContainer}}{{#isMapContainer}}
+    QJsonArray {{name}}JsonArray;
+    for(auto keyval : {{name}}->keys()){
+	    QJsonObject {{name}}_jobj;
+	    toJsonValue(keyval, ((*{{name}})[keyval]), &{{name}}_jobj, "{{complexType}}");
+	    {{name}}JsonArray.append({{name}}_jobj);
+	}   
+    obj->insert("{{baseName}}", {{name}}JsonArray);{{/isMapContainer}}{{/complexType}}{{^complexType}}{{^isContainer}}
+    obj->insert("{{baseName}}", QJsonValue({{name}}));{{/isContainer}}{{#isListContainer}}
     QJsonArray {{name}}JsonArray;
     toJsonArray((QList<void*>*){{name}}, &{{name}}JsonArray, "{{name}}", "{{items.baseType}}");
-    obj->insert("{{baseName}}", {{name}}JsonArray);{{/isContainer}}{{/complexType}}
+    obj->insert("{{baseName}}", {{name}}JsonArray);{{/isListContainer}}{{#isMapContainer}}
+    QJsonArray {{name}}JsonArray;
+    for(auto keyval : {{name}}->keys()){
+	    QJsonObject {{name}}_jobj;
+	    toJsonValue(keyval, ((*{{name}})[keyval]), &{{name}}_jobj, "{{items.baseType}}");
+	    {{name}}JsonArray.append(portsobj);
+	}     
+    obj->insert("{{baseName}}", {{name}}JsonArray);{{/isMapContainer}}{{/complexType}}
     {{/vars}}
 
     return obj;


### PR DESCRIPTION
The issue #6884 is still present and requires fixing outside of mustache file as well.

### PR checklist

- [X] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [X] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [X] Filed the PR against the correct branch: `3.0.0` branch for changes related to OpenAPI spec 3.0. Default: `master`.
- [ ] Copied the [technical committee](https://github.com/swagger-api/swagger-codegen/#swagger-codegen-technical-committee) to review the pull request if your PR is targeting a particular programming langauge.

### Description of the PR

(details of the change, additional tests that have been done, reference to the issue for tracking, etc)

Petstore is not impacted by this change. No changes in Petstore examples.

Verified the changes with modified docker swagger yaml.
Docker swagger yaml does not compile fully due to other issues.

