### PR TITLE
[CppRest] Remove U macro

### DIFF
--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/CppRestClientCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/CppRestClientCodegen.java
@@ -312,7 +312,7 @@ public class CppRestClientCodegen extends AbstractCppCodegen {
     @Override
     public String toDefaultValue(Property p) {
         if (p instanceof StringProperty) {
-            return "U(\"\")";
+            return "utility::conversions::to_string_t(\"\")";
         } else if (p instanceof BooleanProperty) {
             return "false";
         } else if (p instanceof DateProperty) {

--- a/modules/swagger-codegen/src/main/resources/cpprest/api-source.mustache
+++ b/modules/swagger-codegen/src/main/resources/cpprest/api-source.mustache
@@ -32,13 +32,13 @@ pplx::task<{{#returnType}}{{{returnType}}}{{/returnType}}{{^returnType}}void{{/r
     // verify the required parameter '{{paramName}}' is set
     if ({{paramName}} == nullptr)
     {
-        throw ApiException(400, U("Missing required parameter '{{paramName}}' when calling {{classname}}->{{operationId}}"));
+        throw ApiException(400, utility::conversions::to_string_t("Missing required parameter '{{paramName}}' when calling {{classname}}->{{operationId}}"));
     }
 {{/isContainer}}{{/isPrimitiveType}}{{/required}}{{/allParams}}
 
     std::shared_ptr<ApiConfiguration> apiConfiguration( m_ApiClient->getConfiguration() );
-    utility::string_t path = U("{{{path}}}");
-    {{#pathParams}}boost::replace_all(path, U("{") U("{{baseName}}") U("}"), ApiClient::parameterToString({{{paramName}}}));
+    utility::string_t path = utility::conversions::to_string_t("{{{path}}}");
+    {{#pathParams}}boost::replace_all(path, utility::conversions::to_string_t("{") + utility::conversions::to_string_t("{{baseName}}") + utility::conversions::to_string_t("}"), ApiClient::parameterToString({{{paramName}}}));
     {{/pathParams}}
 
     std::map<utility::string_t, utility::string_t> queryParams;
@@ -48,7 +48,7 @@ pplx::task<{{#returnType}}{{{returnType}}}{{/returnType}}{{^returnType}}void{{/r
 
     std::unordered_set<utility::string_t> responseHttpContentTypes;
     {{#produces}}
-    responseHttpContentTypes.insert( U("{{mediaType}}") );
+    responseHttpContentTypes.insert( utility::conversions::to_string_t("{{mediaType}}") );
     {{/produces}}
 
     utility::string_t responseHttpContentType;
@@ -57,27 +57,27 @@ pplx::task<{{#returnType}}{{{returnType}}}{{/returnType}}{{^returnType}}void{{/r
     if ( responseHttpContentTypes.size() == 0 )
     {
         {{#vendorExtensions.x-codegen-response.isString}}
-        responseHttpContentType = U("text/plain");
+        responseHttpContentType = utility::conversions::to_string_t("text/plain");
         {{/vendorExtensions.x-codegen-response.isString}}
         {{^vendorExtensions.x-codegen-response.isString}}
-        responseHttpContentType = U("application/json");
+        responseHttpContentType = utility::conversions::to_string_t("application/json");
         {{/vendorExtensions.x-codegen-response.isString}}
     }
     // JSON
-    else if ( responseHttpContentTypes.find(U("application/json")) != responseHttpContentTypes.end() )
+    else if ( responseHttpContentTypes.find(utility::conversions::to_string_t("application/json")) != responseHttpContentTypes.end() )
     {
-        responseHttpContentType = U("application/json");
+        responseHttpContentType = utility::conversions::to_string_t("application/json");
     }
     // multipart formdata
-    else if( responseHttpContentTypes.find(U("multipart/form-data")) != responseHttpContentTypes.end() )
+    else if( responseHttpContentTypes.find(utility::conversions::to_string_t("multipart/form-data")) != responseHttpContentTypes.end() )
     {
-        responseHttpContentType = U("multipart/form-data");
+        responseHttpContentType = utility::conversions::to_string_t("multipart/form-data");
     }
     {{#vendorExtensions.x-codegen-response.isString}}
     // plain text
-    else if( responseHttpContentTypes.find(U("text/plain")) != responseHttpContentTypes.end() )
+    else if( responseHttpContentTypes.find(utility::conversions::to_string_t("text/plain")) != responseHttpContentTypes.end() )
     {
-        responseHttpContentType = U("text/plain");
+        responseHttpContentType = utility::conversions::to_string_t("text/plain");
     }
     {{/vendorExtensions.x-codegen-response.isString}}
     {{#vendorExtensions.x-codegen-response-ishttpcontent}}
@@ -90,15 +90,15 @@ pplx::task<{{#returnType}}{{{returnType}}}{{/returnType}}{{^returnType}}void{{/r
     {{^vendorExtensions.x-codegen-response-ishttpcontent}}
     else
     {
-        throw ApiException(400, U("{{classname}}->{{operationId}} does not produce any supported media type"));
+        throw ApiException(400, utility::conversions::to_string_t("{{classname}}->{{operationId}} does not produce any supported media type"));
     }
     {{/vendorExtensions.x-codegen-response-ishttpcontent}}
 
-    headerParams[U("Accept")] = responseHttpContentType;
+    headerParams[utility::conversions::to_string_t("Accept")] = responseHttpContentType;
 
     std::unordered_set<utility::string_t> consumeHttpContentTypes;
     {{#consumes}}
-    consumeHttpContentTypes.insert( U("{{mediaType}}") );
+    consumeHttpContentTypes.insert( utility::conversions::to_string_t("{{mediaType}}") );
     {{/consumes}}
 
     {{#allParams}}
@@ -108,30 +108,30 @@ pplx::task<{{#returnType}}{{{returnType}}}{{/returnType}}{{^returnType}}void{{/r
     {
         {{#isContainer}}
         {{#isQueryParam}}
-        queryParams[U("{{baseName}}")] = ApiClient::parameterToArrayString<{{items.datatype}}>({{paramName}});
+        queryParams[utility::conversions::to_string_t("{{baseName}}")] = ApiClient::parameterToArrayString<{{items.datatype}}>({{paramName}});
         {{/isQueryParam}}
         {{#isHeaderParam}}
-        headerParams[U("{{baseName}}")] = ApiClient::parameterToArrayString<{{items.datatype}}>({{paramName}});
+        headerParams[utility::conversions::to_string_t("{{baseName}}")] = ApiClient::parameterToArrayString<{{items.datatype}}>({{paramName}});
         {{/isHeaderParam}}
         {{#isFormParam}}
         {{^isFile}}
-        formParams[ U("{{baseName}}") ] = ApiClient::parameterToArrayString<{{items.datatype}}>({{paramName}});
+        formParams[ utility::conversions::to_string_t("{{baseName}}") ] = ApiClient::parameterToArrayString<{{items.datatype}}>({{paramName}});
         {{/isFile}}
         {{/isFormParam}}
         {{/isContainer}}
         {{^isContainer}}
         {{#isQueryParam}}
-        queryParams[U("{{baseName}}")] = ApiClient::parameterToString({{paramName}});
+        queryParams[utility::conversions::to_string_t("{{baseName}}")] = ApiClient::parameterToString({{paramName}});
         {{/isQueryParam}}
         {{#isHeaderParam}}
-        headerParams[U("{{baseName}}")] = ApiClient::parameterToString({{paramName}});
+        headerParams[utility::conversions::to_string_t("{{baseName}}")] = ApiClient::parameterToString({{paramName}});
         {{/isHeaderParam}}
         {{#isFormParam}}
         {{#isFile}}
-        fileParams[ U("{{baseName}}") ] = {{paramName}};
+        fileParams[ utility::conversions::to_string_t("{{baseName}}") ] = {{paramName}};
         {{/isFile}}
         {{^isFile}}
-        formParams[ U("{{baseName}}") ] = ApiClient::parameterToString({{paramName}});
+        formParams[ utility::conversions::to_string_t("{{baseName}}") ] = ApiClient::parameterToString({{paramName}});
         {{/isFile}}
         {{/isFormParam}}
         {{/isContainer}}
@@ -144,9 +144,9 @@ pplx::task<{{#returnType}}{{{returnType}}}{{/returnType}}{{^returnType}}void{{/r
     utility::string_t requestHttpContentType;
 
     // use JSON if possible
-    if ( consumeHttpContentTypes.size() == 0 || consumeHttpContentTypes.find(U("application/json")) != consumeHttpContentTypes.end() )
+    if ( consumeHttpContentTypes.size() == 0 || consumeHttpContentTypes.find(utility::conversions::to_string_t("application/json")) != consumeHttpContentTypes.end() )
     {
-        requestHttpContentType = U("application/json");
+        requestHttpContentType = utility::conversions::to_string_t("application/json");
         {{#bodyParam}}
         web::json::value json;
 
@@ -177,9 +177,9 @@ pplx::task<{{#returnType}}{{{returnType}}}{{/returnType}}{{^returnType}}void{{/r
         {{/bodyParam}}
     }
     // multipart formdata
-    else if( consumeHttpContentTypes.find(U("multipart/form-data")) != consumeHttpContentTypes.end() )
+    else if( consumeHttpContentTypes.find(utility::conversions::to_string_t("multipart/form-data")) != consumeHttpContentTypes.end() )
     {
-        requestHttpContentType = U("multipart/form-data");
+        requestHttpContentType = utility::conversions::to_string_t("multipart/form-data");
         {{#bodyParam}}
         std::shared_ptr<MultipartFormData> multipart(new MultipartFormData);
         {{#isPrimitiveType}}
@@ -197,28 +197,28 @@ pplx::task<{{#returnType}}{{{returnType}}}{{/returnType}}{{^returnType}}void{{/r
                 {{/items.isDateTime}}{{^items.isDateTime}}jsonArray.push_back( item.get() ? item->toJson() : web::json::value::null() );
                 {{/items.isDateTime}}{{/items.isString}}{{/items.isPrimitiveType}}
             }
-            multipart->add(ModelBase::toHttpContent(U("{{paramName}}"), web::json::value::array(jsonArray), U("application/json")));
+            multipart->add(ModelBase::toHttpContent(utility::conversions::to_string_t("{{paramName}}"), web::json::value::array(jsonArray), utility::conversions::to_string_t("application/json")));
         }
         {{/isListContainer}}
         {{^isListContainer}}
-        {{#isString}}multipart->add(ModelBase::toHttpContent(U("{{paramName}}"), {{paramName}}));
+        {{#isString}}multipart->add(ModelBase::toHttpContent(utility::conversions::to_string_t("{{paramName}}"), {{paramName}}));
         {{/isString}}
         {{^isString}}
         if({{paramName}}.get())
         {
-            {{paramName}}->toMultipart(multipart, U("{{paramName}}"));
+            {{paramName}}->toMultipart(multipart, utility::conversions::to_string_t("{{paramName}}"));
         }
         {{/isString}}
         {{/isListContainer}}
         {{/isPrimitiveType}}
 
         httpBody = multipart;
-        requestHttpContentType += U("; boundary=") + multipart->getBoundary();
+        requestHttpContentType += utility::conversions::to_string_t("; boundary=") + multipart->getBoundary();
         {{/bodyParam}}
     }
     else
     {
-        throw ApiException(415, U("{{classname}}->{{operationId}} does not consume any supported media type"));
+        throw ApiException(415, utility::conversions::to_string_t("{{classname}}->{{operationId}} does not consume any supported media type"));
     }
 
     {{#authMethods}}
@@ -226,19 +226,19 @@ pplx::task<{{#returnType}}{{{returnType}}}{{/returnType}}{{^returnType}}void{{/r
     {{#isApiKey}}
     {{#isKeyInHeader}}
     {
-        utility::string_t apiKey = apiConfiguration->getApiKey(U("{{keyParamName}}"));
+        utility::string_t apiKey = apiConfiguration->getApiKey(utility::conversions::to_string_t("{{keyParamName}}"));
         if ( apiKey.size() > 0 )
         {
-            headerParams[U("{{keyParamName}}")] = apiKey;
+            headerParams[utility::conversions::to_string_t("{{keyParamName}}")] = apiKey;
         }
     }
     {{/isKeyInHeader}}
     {{#isKeyInQuery}}
     {
-        utility::string_t apiKey = apiConfiguration->getApiKey(U("{{keyParamName}}"));
+        utility::string_t apiKey = apiConfiguration->getApiKey(utility::conversions::to_string_t("{{keyParamName}}"));
         if ( apiKey.size() > 0 )
         {
-            queryParams[U("{{keyParamName}}")] = apiKey;
+            queryParams[utility::conversions::to_string_t("{{keyParamName}}")] = apiKey;
         }
     }
     {{/isKeyInQuery}}
@@ -251,7 +251,7 @@ pplx::task<{{#returnType}}{{{returnType}}}{{/returnType}}{{^returnType}}void{{/r
     {{/isOAuth}}
     {{/authMethods}}
 
-    return m_ApiClient->callApi(path, U("{{httpMethod}}"), queryParams, httpBody, headerParams, formParams, fileParams, requestHttpContentType)
+    return m_ApiClient->callApi(path, utility::conversions::to_string_t("{{httpMethod}}"), queryParams, httpBody, headerParams, formParams, fileParams, requestHttpContentType)
     .then([=](web::http::http_response response)
     {
         // 1xx - informational : OK
@@ -262,18 +262,18 @@ pplx::task<{{#returnType}}{{{returnType}}}{{/returnType}}{{^returnType}}void{{/r
         if (response.status_code() >= 400)
         {
             throw ApiException(response.status_code()
-                , U("error calling {{operationId}}: ") + response.reason_phrase()
+                , utility::conversions::to_string_t("error calling {{operationId}}: ") + response.reason_phrase()
                 , std::make_shared<std::stringstream>(response.extract_utf8string(true).get()));
         }
 
         // check response content type
-        if(response.headers().has(U("Content-Type")))
+        if(response.headers().has(utility::conversions::to_string_t("Content-Type")))
         {
-            utility::string_t contentType = response.headers()[U("Content-Type")];
+            utility::string_t contentType = response.headers()[utility::conversions::to_string_t("Content-Type")];
             if( contentType.find(responseHttpContentType) == std::string::npos )
             {
                 throw ApiException(500
-                    , U("error calling {{operationId}}: unexpected response type: ") + contentType
+                    , utility::conversions::to_string_t("error calling {{operationId}}: unexpected response type: ") + contentType
                     , std::make_shared<std::stringstream>(response.extract_utf8string(true).get()));
             }
         }
@@ -304,7 +304,7 @@ pplx::task<{{#returnType}}{{{returnType}}}{{/returnType}}{{^returnType}}void{{/r
         {{{returnType}}} result({{{defaultResponse}}});
         {{/returnContainer}}
 
-        if(responseHttpContentType == U("application/json"))
+        if(responseHttpContentType == utility::conversions::to_string_t("application/json"))
         {
             web::json::value json = web::json::value::parse(response);
 
@@ -330,18 +330,18 @@ pplx::task<{{#returnType}}{{{returnType}}}{{/returnType}}{{^returnType}}void{{/r
             {{/vendorExtensions.x-codegen-response.isPrimitiveType}}{{^vendorExtensions.x-codegen-response.isPrimitiveType}}{{#vendorExtensions.x-codegen-response.isString}}result = ModelBase::stringFromJson(json);
             {{/vendorExtensions.x-codegen-response.isString}}{{^vendorExtensions.x-codegen-response.isString}}result->fromJson(json);{{/vendorExtensions.x-codegen-response.isString}}{{/vendorExtensions.x-codegen-response.isPrimitiveType}}{{/isMapContainer}}{{/isListContainer}}
         }{{#vendorExtensions.x-codegen-response.isString}}
-        else if(responseHttpContentType == U("text/plain"))
+        else if(responseHttpContentType == utility::conversions::to_string_t("text/plain"))
         {
             result = response;
         }{{/vendorExtensions.x-codegen-response.isString}}
-        // else if(responseHttpContentType == U("multipart/form-data"))
+        // else if(responseHttpContentType == utility::conversions::to_string_t("multipart/form-data"))
         // {
         // TODO multipart response parsing
         // }
         else
         {
             throw ApiException(500
-                , U("error calling {{operationId}}: unsupported response type"));
+                , utility::conversions::to_string_t("error calling {{operationId}}: unsupported response type"));
         }
 
         return result;

--- a/modules/swagger-codegen/src/main/resources/cpprest/apiclient-header.mustache
+++ b/modules/swagger-codegen/src/main/resources/cpprest/apiclient-header.mustache
@@ -48,7 +48,7 @@ public:
 
         for( size_t i = 0; i < value.size(); i++)
         {
-            if( i > 0) ss << U(", ");
+            if( i > 0) ss << utility::conversions::to_string_t(", ");
             ss << ApiClient::parameterToString(value[i]);
         }
 

--- a/modules/swagger-codegen/src/main/resources/cpprest/apiclient-source.mustache
+++ b/modules/swagger-codegen/src/main/resources/cpprest/apiclient-source.mustache
@@ -67,17 +67,17 @@ pplx::task<web::http::http_response> ApiClient::callApi(
 {
     if (postBody != nullptr && formParams.size() != 0)
     {
-        throw ApiException(400, U("Cannot have body and form params"));
+        throw ApiException(400, utility::conversions::to_string_t("Cannot have body and form params"));
     }
 
     if (postBody != nullptr && fileParams.size() != 0)
     {
-        throw ApiException(400, U("Cannot have body and file params"));
+        throw ApiException(400, utility::conversions::to_string_t("Cannot have body and file params"));
     }
 
-    if (fileParams.size() > 0 && contentType != U("multipart/form-data"))
+    if (fileParams.size() > 0 && contentType != utility::conversions::to_string_t("multipart/form-data"))
     {
-        throw ApiException(400, U("Operations with file parameters must be called with multipart/form-data"));
+        throw ApiException(400, utility::conversions::to_string_t("Operations with file parameters must be called with multipart/form-data"));
     }
 
     web::http::client::http_client client(m_Configuration->getBaseUrl(), m_Configuration->getHttpConfig());
@@ -103,7 +103,7 @@ pplx::task<web::http::http_response> ApiClient::callApi(
         uploadData.writeTo(data);
         auto bodyString = data.str();
         auto length = bodyString.size();
-        request.set_body(concurrency::streams::bytestream::open_istream(std::move(bodyString)), length, U("multipart/form-data; boundary=") + uploadData.getBoundary());
+        request.set_body(concurrency::streams::bytestream::open_istream(std::move(bodyString)), length, utility::conversions::to_string_t("multipart/form-data; boundary=") + uploadData.getBoundary());
     }
     else
     {
@@ -117,7 +117,7 @@ pplx::task<web::http::http_response> ApiClient::callApi(
         }
         else
         {
-            if (contentType == U("application/json"))
+            if (contentType == utility::conversions::to_string_t("application/json"))
             {
                 web::json::value body_data = web::json::value::object();
                 for (auto& kvp : formParams)
@@ -138,7 +138,7 @@ pplx::task<web::http::http_response> ApiClient::callApi(
                 }
                 if (!formParams.empty())
                 {
-                    request.set_body(formData.query(), U("application/x-www-form-urlencoded"));
+                    request.set_body(formData.query(), utility::conversions::to_string_t("application/x-www-form-urlencoded"));
                 }
             }
         }

--- a/modules/swagger-codegen/src/main/resources/cpprest/apiconfiguration-source.mustache
+++ b/modules/swagger-codegen/src/main/resources/cpprest/apiconfiguration-source.mustache
@@ -55,7 +55,7 @@ utility::string_t ApiConfiguration::getApiKey( const utility::string_t& prefix) 
     {
         return result->second;
     }
-    return U("");
+    return utility::conversions::to_string_t("");
 }
 
 void ApiConfiguration::setApiKey( const utility::string_t& prefix, const utility::string_t& apiKey )

--- a/modules/swagger-codegen/src/main/resources/cpprest/model-source.mustache
+++ b/modules/swagger-codegen/src/main/resources/cpprest/model-source.mustache
@@ -57,11 +57,11 @@ web::json::value {{classname}}::toJson() const
     {{^required}}
     if(m_{{name}}IsSet)
     {
-        val[U("{{baseName}}")] = ModelBase::toJson(m_{{name}});
+        val[utility::conversions::to_string_t("{{baseName}}")] = ModelBase::toJson(m_{{name}});
     }
     {{/required}}
     {{#required}}
-    val[U("{{baseName}}")] = ModelBase::toJson(m_{{name}});
+    val[utility::conversions::to_string_t("{{baseName}}")] = ModelBase::toJson(m_{{name}});
     {{/required}}
     {{/isMapContainer}}
     {{/isListContainer}}
@@ -74,12 +74,12 @@ web::json::value {{classname}}::toJson() const
             jsonArray.push_back(ModelBase::toJson(item));
         }
         {{#required}}
-        val[U("{{baseName}}")] = web::json::value::array(jsonArray);
+        val[utility::conversions::to_string_t("{{baseName}}")] = web::json::value::array(jsonArray);
         {{/required}}
         {{^required}}
         if(jsonArray.size() > 0)
         {
-            val[U("{{baseName}}")] = web::json::value::array(jsonArray);
+            val[utility::conversions::to_string_t("{{baseName}}")] = web::json::value::array(jsonArray);
         }
         {{/required}}
     }
@@ -90,17 +90,17 @@ web::json::value {{classname}}::toJson() const
         for( auto& item : m_{{name}} )
         {
             web::json::value tmp = web::json::value::object();
-            tmp[U("key")] = ModelBase::toJson(item.first);
-            tmp[U("value")] = ModelBase::toJson(item.second);
+            tmp[utility::conversions::to_string_t("key")] = ModelBase::toJson(item.first);
+            tmp[utility::conversions::to_string_t("value")] = ModelBase::toJson(item.second);
             jsonArray.push_back(tmp);
         }
         {{#required}}
-        val[U("{{baseName}}")] = web::json::value::array(jsonArray);
+        val[utility::conversions::to_string_t("{{baseName}}")] = web::json::value::array(jsonArray);
         {{/required}}
         {{^required}}
         if(jsonArray.size() > 0)
         {
-            val[U("{{baseName}}")] = web::json::value::array(jsonArray);
+            val[utility::conversions::to_string_t("{{baseName}}")] = web::json::value::array(jsonArray);
         }
         {{/required}}
     }
@@ -111,11 +111,11 @@ web::json::value {{classname}}::toJson() const
     {{^required}}
     if(m_{{name}}IsSet)
     {
-        val[U("{{baseName}}")] = ModelBase::toJson(m_{{name}});
+        val[utility::conversions::to_string_t("{{baseName}}")] = ModelBase::toJson(m_{{name}});
     }
     {{/required}}
     {{#required}}
-    val[U("{{baseName}}")] = ModelBase::toJson(m_{{name}});
+    val[utility::conversions::to_string_t("{{baseName}}")] = ModelBase::toJson(m_{{name}});
     {{/required}}
     {{/isPrimitiveType}}
     {{/isMapContainer}}
@@ -138,13 +138,13 @@ void {{classname}}::fromJson(web::json::value& val)
     {{^isListContainer}}
     {{^isMapContainer}}
     {{^required}}
-    if(val.has_field(U("{{baseName}}")))
+    if(val.has_field(utility::conversions::to_string_t("{{baseName}}")))
     {
-        {{setter}}(ModelBase::{{baseType}}FromJson(val[U("{{baseName}}")]));
+        {{setter}}(ModelBase::{{baseType}}FromJson(val[utility::conversions::to_string_t("{{baseName}}")]));
     }
     {{/required}}
     {{#required}}
-    {{setter}}(ModelBase::{{baseType}}FromJson(val[U("{{baseName}}")]));
+    {{setter}}(ModelBase::{{baseType}}FromJson(val[utility::conversions::to_string_t("{{baseName}}")]));
     {{/required}}
     {{/isMapContainer}}
     {{/isListContainer}}
@@ -154,10 +154,10 @@ void {{classname}}::fromJson(web::json::value& val)
         m_{{name}}.clear();
         std::vector<web::json::value> jsonArray;
         {{^required}}
-        if(val.has_field(U("{{baseName}}")))
+        if(val.has_field(utility::conversions::to_string_t("{{baseName}}")))
         {
         {{/required}}
-        for( auto& item : val[U("{{baseName}}")].as_array() )
+        for( auto& item : val[utility::conversions::to_string_t("{{baseName}}")].as_array() )
         {
             {{#items.isPrimitiveType}}
             m_{{name}}.push_back(ModelBase::{{items.baseType}}FromJson(item));
@@ -195,26 +195,26 @@ void {{classname}}::fromJson(web::json::value& val)
         m_{{name}}.clear();
         std::vector<web::json::value> jsonArray;
         {{^required}}
-        if(val.has_field(U("{{baseName}}")))
+        if(val.has_field(utility::conversions::to_string_t("{{baseName}}")))
         {
         {{/required}}
-        for( auto& item : val[U("{{baseName}}")].as_array() )
+        for( auto& item : val[utility::conversions::to_string_t("{{baseName}}")].as_array() )
         {  
             utility::string_t key;
-            if(item.has_field(U("key")))
+            if(item.has_field(utility::conversions::to_string_t("key")))
             {
-                key = ModelBase::stringFromJson(item[U("key")]);
+                key = ModelBase::stringFromJson(item[utility::conversions::to_string_t("key")]);
             }
             {{#items.isPrimitiveType}}
-            m_{{name}}.insert(std::pair<utility::string_t,{{{items.datatype}}}>( key, ModelBase::{{items.baseType}}FromJson(item[U("value")])));
+            m_{{name}}.insert(std::pair<utility::string_t,{{{items.datatype}}}>( key, ModelBase::{{items.baseType}}FromJson(item[utility::conversions::to_string_t("value")])));
             {{/items.isPrimitiveType}}
             {{^items.isPrimitiveType}}
             {{#items.isString}}
-            m_{{name}}.insert(std::pair<utility::string_t,{{{items.datatype}}}>( key, ModelBase::stringFromJson(item[U("value")])));
+            m_{{name}}.insert(std::pair<utility::string_t,{{{items.datatype}}}>( key, ModelBase::stringFromJson(item[utility::conversions::to_string_t("value")])));
             {{/items.isString}}
             {{^items.isString}}
             {{#items.isDateTime}}
-            m_{{name}}.insert(std::pair<utility::string_t,{{{items.datatype}}}>( key, ModelBase::dateFromJson(item[U("value")])));
+            m_{{name}}.insert(std::pair<utility::string_t,{{{items.datatype}}}>( key, ModelBase::dateFromJson(item[utility::conversions::to_string_t("value")])));
             {{/items.isDateTime}}
             {{^items.isDateTime}}
             if(item.is_null())
@@ -224,7 +224,7 @@ void {{classname}}::fromJson(web::json::value& val)
             else
             {
                 {{{items.datatype}}} newItem({{{items.defaultValue}}});
-                newItem->fromJson(item[U("value")]);
+                newItem->fromJson(item[utility::conversions::to_string_t("value")]);
                 m_{{name}}.insert(std::pair<utility::string_t,{{{items.datatype}}}>( key, newItem ));
             }
             {{/items.isDateTime}}
@@ -240,20 +240,20 @@ void {{classname}}::fromJson(web::json::value& val)
     {{^isMapContainer}}
     {{^isPrimitiveType}}
     {{^required}}
-    if(val.has_field(U("{{baseName}}")))
+    if(val.has_field(utility::conversions::to_string_t("{{baseName}}")))
     {
         {{#isString}}
-        {{setter}}(ModelBase::stringFromJson(val[U("{{baseName}}")]));
+        {{setter}}(ModelBase::stringFromJson(val[utility::conversions::to_string_t("{{baseName}}")]));
         {{/isString}}
         {{^isString}}
         {{#isDateTime}}
-        {{setter}}(ModelBase::dateFromJson(val[U("{{baseName}}")]));
+        {{setter}}(ModelBase::dateFromJson(val[utility::conversions::to_string_t("{{baseName}}")]));
         {{/isDateTime}}
         {{^isDateTime}}
-        if(!val[U("{{baseName}}")].is_null())
+        if(!val[utility::conversions::to_string_t("{{baseName}}")].is_null())
         {
             {{{datatype}}} newItem({{{defaultValue}}});
-            newItem->fromJson(val[U("{{baseName}}")]);
+            newItem->fromJson(val[utility::conversions::to_string_t("{{baseName}}")]);
             {{setter}}( newItem );
         }
         {{/isDateTime}}
@@ -262,20 +262,20 @@ void {{classname}}::fromJson(web::json::value& val)
     {{/required}}
     {{#required}}
     {{#isString}}
-    {{setter}}(ModelBase::stringFromJson(val[U("{{baseName}}")]));
+    {{setter}}(ModelBase::stringFromJson(val[utility::conversions::to_string_t("{{baseName}}")]));
     {{/isString}}
     {{^isString}}
     {{#isDateTime}}
     {{setter}}
-    (ModelBase::dateFromJson(val[U("{{baseName}}")]));
+    (ModelBase::dateFromJson(val[utility::conversions::to_string_t("{{baseName}}")]));
     {{/isDateTime}}
     {{^isDateTime}}
     {{#vendorExtensions.x-codegen-file}}
-    {{setter}}(ModelBase::fileFromJson(val[U("{{baseName}}")]));
+    {{setter}}(ModelBase::fileFromJson(val[utility::conversions::to_string_t("{{baseName}}")]));
     {{/vendorExtensions.x-codegen-file}}
     {{^vendorExtensions.x-codegen-file}}
     {{{datatype}}} new{{name}}({{{defaultValue}}});
-    new{{name}}->fromJson(val[U("{{baseName}}")]);
+    new{{name}}->fromJson(val[utility::conversions::to_string_t("{{baseName}}")]);
     {{setter}}( new{{name}} );
     {{/vendorExtensions.x-codegen-file}}
     {{/isDateTime}}
@@ -291,9 +291,9 @@ void {{classname}}::fromJson(web::json::value& val)
 void {{classname}}::toMultipart(std::shared_ptr<MultipartFormData> multipart, const utility::string_t& prefix) const
 {
     utility::string_t namePrefix = prefix;
-    if(namePrefix.size() > 0 && namePrefix[namePrefix.size() - 1] != U('.'))
+    if(namePrefix.size() > 0 && namePrefix.substr(namePrefix.size() - 1) != utility::conversions::to_string_t("."))
     {
-        namePrefix += U(".");
+        namePrefix += utility::conversions::to_string_t(".");
     }
 
     {{#vars}}
@@ -303,11 +303,11 @@ void {{classname}}::toMultipart(std::shared_ptr<MultipartFormData> multipart, co
     {{^required}}
     if(m_{{name}}IsSet)
     {
-        multipart->add(ModelBase::toHttpContent(namePrefix + U("{{baseName}}"), m_{{name}}));
+        multipart->add(ModelBase::toHttpContent(namePrefix + utility::conversions::to_string_t("{{baseName}}"), m_{{name}}));
     }
     {{/required}}
     {{#required}}
-    multipart->add(ModelBase::toHttpContent(namePrefix + U("{{baseName}}"), m_{{name}}));
+    multipart->add(ModelBase::toHttpContent(namePrefix + utility::conversions::to_string_t("{{baseName}}"), m_{{name}}));
     {{/required}}
     {{/isListContainer}}
     {{/isMapContainer}}
@@ -319,11 +319,11 @@ void {{classname}}::toMultipart(std::shared_ptr<MultipartFormData> multipart, co
         {
             jsonArray.push_back(ModelBase::toJson(item));
         }
-        {{#required}}multipart->add(ModelBase::toHttpContent(namePrefix + U("{{baseName}}"), web::json::value::array(jsonArray), U("application/json")));
+        {{#required}}multipart->add(ModelBase::toHttpContent(namePrefix + utility::conversions::to_string_t("{{baseName}}"), web::json::value::array(jsonArray), utility::conversions::to_string_t("application/json")));
         {{/required}}{{^required}}
         if(jsonArray.size() > 0)
         {
-            multipart->add(ModelBase::toHttpContent(namePrefix + U("{{baseName}}"), web::json::value::array(jsonArray), U("application/json")));
+            multipart->add(ModelBase::toHttpContent(namePrefix + utility::conversions::to_string_t("{{baseName}}"), web::json::value::array(jsonArray), utility::conversions::to_string_t("application/json")));
         }
         {{/required}}
     }
@@ -334,15 +334,15 @@ void {{classname}}::toMultipart(std::shared_ptr<MultipartFormData> multipart, co
         for( auto& item : m_{{name}} )
         {
             web::json::value tmp = web::json::value::object();
-            tmp[U("key")] = ModelBase::toJson(item.first);
-            tmp[U("value")] = ModelBase::toJson(item.second);
+            tmp[utility::conversions::to_string_t("key")] = ModelBase::toJson(item.first);
+            tmp[utility::conversions::to_string_t("value")] = ModelBase::toJson(item.second);
             jsonArray.push_back(tmp);
         }
-        {{#required}}multipart->add(ModelBase::toHttpContent(namePrefix + U("{{baseName}}"), web::json::value::array(jsonArray), U("application/json")));
+        {{#required}}multipart->add(ModelBase::toHttpContent(namePrefix + utility::conversions::to_string_t("{{baseName}}"), web::json::value::array(jsonArray), utility::conversions::to_string_t("application/json")));
         {{/required}}{{^required}}
         if(jsonArray.size() > 0)
         {
-            multipart->add(ModelBase::toHttpContent(namePrefix + U("{{baseName}}"), web::json::value::array(jsonArray), U("application/json")));
+            multipart->add(ModelBase::toHttpContent(namePrefix + utility::conversions::to_string_t("{{baseName}}"), web::json::value::array(jsonArray), utility::conversions::to_string_t("application/json")));
         }
         {{/required}}
     }
@@ -353,29 +353,29 @@ void {{classname}}::toMultipart(std::shared_ptr<MultipartFormData> multipart, co
     {{^required}}
     if(m_{{name}}IsSet)
     {
-        {{#isString}}multipart->add(ModelBase::toHttpContent(namePrefix + U("{{baseName}}"), m_{{name}}));
-        {{/isString}}{{^isString}}{{#isDateTime}}multipart->add(ModelBase::toHttpContent(namePrefix + U("{{baseName}}"), m_{{name}}));
+        {{#isString}}multipart->add(ModelBase::toHttpContent(namePrefix + utility::conversions::to_string_t("{{baseName}}"), m_{{name}}));
+        {{/isString}}{{^isString}}{{#isDateTime}}multipart->add(ModelBase::toHttpContent(namePrefix + utility::conversions::to_string_t("{{baseName}}"), m_{{name}}));
         {{/isDateTime}}{{^isDateTime}}if (m_{{name}}.get())
         {
-            m_{{name}}->toMultipart(multipart, U("{{baseName}}."));
+            m_{{name}}->toMultipart(multipart, utility::conversions::to_string_t("{{baseName}}."));
         }
         {{/isDateTime}}{{/isString}}
     }
     {{/required}}
     {{#required}}
     {{#isString}}
-    multipart->add(ModelBase::toHttpContent(namePrefix + U("{{baseName}}"), m_{{name}}));
+    multipart->add(ModelBase::toHttpContent(namePrefix + utility::conversions::to_string_t("{{baseName}}"), m_{{name}}));
     {{/isString}}
     {{^isString}}
     {{#isDateTime}}
-    multipart->add(ModelBase::toHttpContent(namePrefix + U("{{baseName}}"), m_{{name}}));
+    multipart->add(ModelBase::toHttpContent(namePrefix + utility::conversions::to_string_t("{{baseName}}"), m_{{name}}));
     {{/isDateTime}}
     {{^isDateTime}}
     {{#vendorExtensions.x-codegen-file}}
-    multipart->add(ModelBase::toHttpContent(namePrefix + U("{{baseName}}"), m_{{name}}));
+    multipart->add(ModelBase::toHttpContent(namePrefix + utility::conversions::to_string_t("{{baseName}}"), m_{{name}}));
     {{/vendorExtensions.x-codegen-file}}
     {{^vendorExtensions.x-codegen-file}}
-    m_{{name}}->toMultipart(multipart, U("{{baseName}}."));
+    m_{{name}}->toMultipart(multipart, utility::conversions::to_string_t("{{baseName}}."));
     {{/vendorExtensions.x-codegen-file}}
     {{/isDateTime}}
     {{/isString}}
@@ -389,9 +389,9 @@ void {{classname}}::toMultipart(std::shared_ptr<MultipartFormData> multipart, co
 void {{classname}}::fromMultiPart(std::shared_ptr<MultipartFormData> multipart, const utility::string_t& prefix)
 {
     utility::string_t namePrefix = prefix;
-    if(namePrefix.size() > 0 && namePrefix[namePrefix.size() - 1] != U('.'))
+    if(namePrefix.size() > 0 && namePrefix.substr(namePrefix.size() - 1) != utility::conversions::to_string_t("."))
     {
-        namePrefix += U(".");
+        namePrefix += utility::conversions::to_string_t(".");
     }
 
     {{#vars}}
@@ -399,13 +399,13 @@ void {{classname}}::fromMultiPart(std::shared_ptr<MultipartFormData> multipart, 
     {{^isListContainer}}
     {{^isMapContainer}}
     {{^required}}
-    if(multipart->hasContent(U("{{baseName}}")))
+    if(multipart->hasContent(utility::conversions::to_string_t("{{baseName}}")))
     {
-        {{setter}}(ModelBase::{{baseType}}FromHttpContent(multipart->getContent(U("{{baseName}}"))));
+        {{setter}}(ModelBase::{{baseType}}FromHttpContent(multipart->getContent(utility::conversions::to_string_t("{{baseName}}"))));
     }
     {{/required}}
     {{#required}}
-    {{setter}}(ModelBase::{{baseType}}FromHttpContent(multipart->getContent(U("{{baseName}}"))));
+    {{setter}}(ModelBase::{{baseType}}FromHttpContent(multipart->getContent(utility::conversions::to_string_t("{{baseName}}"))));
     {{/required}}
     {{/isMapContainer}}
     {{/isListContainer}}
@@ -414,11 +414,11 @@ void {{classname}}::fromMultiPart(std::shared_ptr<MultipartFormData> multipart, 
     {
         m_{{name}}.clear();
         {{^required}}
-        if(multipart->hasContent(U("{{baseName}}")))
+        if(multipart->hasContent(utility::conversions::to_string_t("{{baseName}}")))
         {
         {{/required}}
 
-        web::json::value jsonArray = web::json::value::parse(ModelBase::stringFromHttpContent(multipart->getContent(U("{{baseName}}"))));
+        web::json::value jsonArray = web::json::value::parse(ModelBase::stringFromHttpContent(multipart->getContent(utility::conversions::to_string_t("{{baseName}}"))));
         for( auto& item : jsonArray.as_array() )
         {
             {{#isPrimitiveType}}
@@ -456,28 +456,28 @@ void {{classname}}::fromMultiPart(std::shared_ptr<MultipartFormData> multipart, 
     {
         m_{{name}}.clear();
         {{^required}}
-        if(multipart->hasContent(U("{{baseName}}")))
+        if(multipart->hasContent(utility::conversions::to_string_t("{{baseName}}")))
         {
         {{/required}}
 
-        web::json::value jsonArray = web::json::value::parse(ModelBase::stringFromHttpContent(multipart->getContent(U("{{baseName}}"))));
+        web::json::value jsonArray = web::json::value::parse(ModelBase::stringFromHttpContent(multipart->getContent(utility::conversions::to_string_t("{{baseName}}"))));
         for( auto& item : jsonArray.as_array() )
         {
             utility::string_t key;
-            if(item.has_field(U("key")))
+            if(item.has_field(utility::conversions::to_string_t("key")))
             {
-                key = ModelBase::stringFromJson(item[U("key")]);
+                key = ModelBase::stringFromJson(item[utility::conversions::to_string_t("key")]);
             }
             {{#items.isPrimitiveType}}
-            m_{{name}}.insert(std::pair<utility::string_t,{{{items.datatype}}}>( key, ModelBase::{{items.baseType}}FromJson(item[U("value")])));
+            m_{{name}}.insert(std::pair<utility::string_t,{{{items.datatype}}}>( key, ModelBase::{{items.baseType}}FromJson(item[utility::conversions::to_string_t("value")])));
             {{/items.isPrimitiveType}}
             {{^items.isPrimitiveType}}
             {{#items.isString}}
-            m_{{name}}.insert(std::pair<utility::string_t,{{{items.datatype}}}>( key, ModelBase::stringFromJson(item[U("value")])));
+            m_{{name}}.insert(std::pair<utility::string_t,{{{items.datatype}}}>( key, ModelBase::stringFromJson(item[utility::conversions::to_string_t("value")])));
             {{/items.isString}}
             {{^items.isString}}
             {{#items.isDateTime}}
-            m_{{name}}.insert(std::pair<utility::string_t,{{{items.datatype}}}>( key, ModelBase::dateFromJson(item[U("value")])));
+            m_{{name}}.insert(std::pair<utility::string_t,{{{items.datatype}}}>( key, ModelBase::dateFromJson(item[utility::conversions::to_string_t("value")])));
             {{/items.isDateTime}}
             {{^items.isDateTime}}
             if(item.is_null())
@@ -487,7 +487,7 @@ void {{classname}}::fromMultiPart(std::shared_ptr<MultipartFormData> multipart, 
             else
             {
                 {{{items.datatype}}} newItem({{{items.defaultValue}}});
-                newItem->fromJson(item[U("value")]);
+                newItem->fromJson(item[utility::conversions::to_string_t("value")]);
                 m_{{name}}.insert(std::pair<utility::string_t,{{{items.datatype}}}>( key, newItem ));
             }
             {{/items.isDateTime}}
@@ -503,20 +503,20 @@ void {{classname}}::fromMultiPart(std::shared_ptr<MultipartFormData> multipart, 
     {{^isMapContainer}}
     {{^isPrimitiveType}}
     {{^required}}
-    if(multipart->hasContent(U("{{baseName}}")))
+    if(multipart->hasContent(utility::conversions::to_string_t("{{baseName}}")))
     {
         {{#isString}}
-        {{setter}}(ModelBase::stringFromHttpContent(multipart->getContent(U("{{baseName}}"))));
+        {{setter}}(ModelBase::stringFromHttpContent(multipart->getContent(utility::conversions::to_string_t("{{baseName}}"))));
         {{/isString}}
         {{^isString}}
         {{#isDateTime}}
-        {{setter}}(ModelBase::dateFromHttpContent(multipart->getContent(U("{{baseName}}"))));
+        {{setter}}(ModelBase::dateFromHttpContent(multipart->getContent(utility::conversions::to_string_t("{{baseName}}"))));
         {{/isDateTime}}
         {{^isDateTime}}
-        if(multipart->hasContent(U("{{baseName}}")))
+        if(multipart->hasContent(utility::conversions::to_string_t("{{baseName}}")))
         {
             {{{datatype}}} newItem({{{defaultValue}}});
-            newItem->fromMultiPart(multipart, U("{{baseName}}."));
+            newItem->fromMultiPart(multipart, utility::conversions::to_string_t("{{baseName}}."));
             {{setter}}( newItem );
         }
         {{/isDateTime}}
@@ -525,19 +525,19 @@ void {{classname}}::fromMultiPart(std::shared_ptr<MultipartFormData> multipart, 
     {{/required}}
     {{#required}}
     {{#isString}}
-    {{setter}}(ModelBase::stringFromHttpContent(multipart->getContent(U("{{baseName}}"))));
+    {{setter}}(ModelBase::stringFromHttpContent(multipart->getContent(utility::conversions::to_string_t("{{baseName}}"))));
     {{/isString}}
     {{^isString}}
     {{#isDateTime}}
-    {{setter}}(ModelBase::dateFromHttpContent(multipart->getContent(U("{{baseName}}"))));
+    {{setter}}(ModelBase::dateFromHttpContent(multipart->getContent(utility::conversions::to_string_t("{{baseName}}"))));
     {{/isDateTime}}
     {{^isDateTime}}
     {{#vendorExtensions.x-codegen-file}}
-    {{setter}}(multipart->getContent(U("{{baseName}}")));
+    {{setter}}(multipart->getContent(utility::conversions::to_string_t("{{baseName}}")));
     {{/vendorExtensions.x-codegen-file}}
     {{^vendorExtensions.x-codegen-file}}
     {{{datatype}}} new{{name}}({{{defaultValue}}});
-    new{{name}}->fromMultiPart(multipart, U("{{baseName}}."));
+    new{{name}}->fromMultiPart(multipart, utility::conversions::to_string_t("{{baseName}}."));
     {{setter}}( new{{name}} );
     {{/vendorExtensions.x-codegen-file}}
     {{/isDateTime}}

--- a/modules/swagger-codegen/src/main/resources/cpprest/modelbase-header.mustache
+++ b/modules/swagger-codegen/src/main/resources/cpprest/modelbase-header.mustache
@@ -51,13 +51,13 @@ public:
     static bool boolFromJson(web::json::value& val);
     static std::shared_ptr<HttpContent> fileFromJson(web::json::value& val);
 
-    static std::shared_ptr<HttpContent> toHttpContent( const utility::string_t& name, const utility::string_t& value, const utility::string_t& contentType = U(""));
-    static std::shared_ptr<HttpContent> toHttpContent( const utility::string_t& name, const utility::datetime& value, const utility::string_t& contentType = U(""));
+    static std::shared_ptr<HttpContent> toHttpContent( const utility::string_t& name, const utility::string_t& value, const utility::string_t& contentType = utility::conversions::to_string_t(""));
+    static std::shared_ptr<HttpContent> toHttpContent( const utility::string_t& name, const utility::datetime& value, const utility::string_t& contentType = utility::conversions::to_string_t(""));
     static std::shared_ptr<HttpContent> toHttpContent( const utility::string_t& name, std::shared_ptr<HttpContent> value );
-    static std::shared_ptr<HttpContent> toHttpContent( const utility::string_t& name, const web::json::value& value, const utility::string_t& contentType = U("application/json") );
-    static std::shared_ptr<HttpContent> toHttpContent( const utility::string_t& name, int32_t value, const utility::string_t& contentType = U("") );
-    static std::shared_ptr<HttpContent> toHttpContent( const utility::string_t& name, int64_t value, const utility::string_t& contentType = U("") );
-    static std::shared_ptr<HttpContent> toHttpContent( const utility::string_t& name, double value, const utility::string_t& contentType = U("") );
+    static std::shared_ptr<HttpContent> toHttpContent( const utility::string_t& name, const web::json::value& value, const utility::string_t& contentType = utility::conversions::to_string_t("application/json") );
+    static std::shared_ptr<HttpContent> toHttpContent( const utility::string_t& name, int32_t value, const utility::string_t& contentType = utility::conversions::to_string_t("") );
+    static std::shared_ptr<HttpContent> toHttpContent( const utility::string_t& name, int64_t value, const utility::string_t& contentType = utility::conversions::to_string_t("") );
+    static std::shared_ptr<HttpContent> toHttpContent( const utility::string_t& name, double value, const utility::string_t& contentType = utility::conversions::to_string_t("") );
 
     static int64_t int64_tFromHttpContent(std::shared_ptr<HttpContent> val);
     static int32_t int32_tFromHttpContent(std::shared_ptr<HttpContent> val);

--- a/modules/swagger-codegen/src/main/resources/cpprest/modelbase-source.mustache
+++ b/modules/swagger-codegen/src/main/resources/cpprest/modelbase-source.mustache
@@ -39,10 +39,10 @@ web::json::value ModelBase::toJson(bool value) {
 web::json::value ModelBase::toJson( std::shared_ptr<HttpContent> content )
 {
     web::json::value value;
-    value[U("ContentDisposition")] = ModelBase::toJson(content->getContentDisposition());
-    value[U("ContentType")] = ModelBase::toJson(content->getContentType());
-    value[U("FileName")] = ModelBase::toJson(content->getFileName());
-    value[U("InputStream")] = web::json::value::string( ModelBase::toBase64(content->getData()) );
+    value[utility::conversions::to_string_t("ContentDisposition")] = ModelBase::toJson(content->getContentDisposition());
+    value[utility::conversions::to_string_t("ContentType")] = ModelBase::toJson(content->getContentType());
+    value[utility::conversions::to_string_t("FileName")] = ModelBase::toJson(content->getFileName());
+    value[utility::conversions::to_string_t("InputStream")] = web::json::value::string( ModelBase::toBase64(content->getData()) );
     return value;
 }
 
@@ -50,21 +50,21 @@ std::shared_ptr<HttpContent> ModelBase::fileFromJson(web::json::value& val)
 {
     std::shared_ptr<HttpContent> content(new HttpContent);
 
-    if(val.has_field(U("ContentDisposition")))
+    if(val.has_field(utility::conversions::to_string_t("ContentDisposition")))
     {
-        content->setContentDisposition( ModelBase::stringFromJson(val[U("ContentDisposition")]) );
+        content->setContentDisposition( ModelBase::stringFromJson(val[utility::conversions::to_string_t("ContentDisposition")]) );
     }
-    if(val.has_field(U("ContentType")))
+    if(val.has_field(utility::conversions::to_string_t("ContentType")))
     {
-        content->setContentType( ModelBase::stringFromJson(val[U("ContentType")]) );
+        content->setContentType( ModelBase::stringFromJson(val[utility::conversions::to_string_t("ContentType")]) );
     }
-    if(val.has_field(U("FileName")))
+    if(val.has_field(utility::conversions::to_string_t("FileName")))
     {
-        content->setFileName( ModelBase::stringFromJson(val[U("FileName")]) );
+        content->setFileName( ModelBase::stringFromJson(val[utility::conversions::to_string_t("FileName")]) );
     }
-    if(val.has_field(U("InputStream")))
+    if(val.has_field(utility::conversions::to_string_t("InputStream")))
     {
-        content->setData( ModelBase::fromBase64( ModelBase::stringFromJson(val[U("InputStream")]) ) );
+        content->setData( ModelBase::fromBase64( ModelBase::stringFromJson(val[utility::conversions::to_string_t("InputStream")]) ) );
     }
 
     return content;
@@ -79,7 +79,7 @@ std::shared_ptr<HttpContent> ModelBase::toHttpContent( const utility::string_t& 
 {
     std::shared_ptr<HttpContent> content(new HttpContent);
     content->setName( name );
-    content->setContentDisposition( U("form-data") );
+    content->setContentDisposition( utility::conversions::to_string_t("form-data") );
     content->setContentType( contentType );
     content->setData( std::shared_ptr<std::istream>( new std::stringstream( utility::conversions::to_utf8string(value) ) ) );
     return content;
@@ -88,7 +88,7 @@ std::shared_ptr<HttpContent> ModelBase::toHttpContent( const utility::string_t& 
 {
     std::shared_ptr<HttpContent> content( new HttpContent );
     content->setName( name );
-    content->setContentDisposition( U("form-data") );
+    content->setContentDisposition( utility::conversions::to_string_t("form-data") );
     content->setContentType( contentType );
     content->setData( std::shared_ptr<std::istream>( new std::stringstream( utility::conversions::to_utf8string(value.to_string(utility::datetime::ISO_8601) ) ) ) );
     return content;
@@ -107,7 +107,7 @@ std::shared_ptr<HttpContent> ModelBase::toHttpContent( const utility::string_t& 
 {
     std::shared_ptr<HttpContent> content( new HttpContent );
     content->setName( name );
-    content->setContentDisposition( U("form-data") );
+    content->setContentDisposition( utility::conversions::to_string_t("form-data") );
     content->setContentType( contentType );
     content->setData( std::shared_ptr<std::istream>( new std::stringstream( utility::conversions::to_utf8string(value.serialize()) ) ) );
     return content;
@@ -116,7 +116,7 @@ std::shared_ptr<HttpContent> ModelBase::toHttpContent( const utility::string_t& 
 {
     std::shared_ptr<HttpContent> content( new HttpContent );
     content->setName( name );
-    content->setContentDisposition( U("form-data") );
+    content->setContentDisposition( utility::conversions::to_string_t("form-data") );
     content->setContentType( contentType );
 	std::stringstream* valueAsStringStream = new std::stringstream();
 	(*valueAsStringStream) << value;
@@ -127,7 +127,7 @@ std::shared_ptr<HttpContent> ModelBase::toHttpContent( const utility::string_t& 
 {
     std::shared_ptr<HttpContent> content( new HttpContent );
     content->setName( name );
-    content->setContentDisposition( U("form-data") );
+    content->setContentDisposition( utility::conversions::to_string_t("form-data") );
     content->setContentType( contentType );
 	std::stringstream* valueAsStringStream = new std::stringstream();
 	(*valueAsStringStream) << value;
@@ -138,7 +138,7 @@ std::shared_ptr<HttpContent> ModelBase::toHttpContent( const utility::string_t& 
 {
     std::shared_ptr<HttpContent> content( new HttpContent );
     content->setName( name );
-    content->setContentDisposition( U("form-data") );
+    content->setContentDisposition( utility::conversions::to_string_t("form-data") );
     content->setContentType( contentType );
 	std::stringstream* valueAsStringStream = new std::stringstream();
 	(*valueAsStringStream) << value;
@@ -244,12 +244,12 @@ std::shared_ptr<std::istream> ModelBase::fromBase64( const utility::string_t& en
                         result->write( outBuf, 1 );
                         return result;
                     default:
-                        throw web::json::json_exception( U( "Invalid Padding in Base 64!" ) );
+                        throw web::json::json_exception( utility::conversions::to_string_t( "Invalid Padding in Base 64!" ).c_str() );
                 }
             }
             else
             {
-                throw web::json::json_exception( U( "Non-Valid Character in Base 64!" ) );
+                throw web::json::json_exception( utility::conversions::to_string_t( "Non-Valid Character in Base 64!" ).c_str() );
             }
             ++cursor;
         }
@@ -277,7 +277,7 @@ float ModelBase::floatFromJson(web::json::value& val)
 }
 utility::string_t ModelBase::stringFromJson(web::json::value& val)
 {
-    return val.is_string() ? val.as_string() : U("");
+    return val.is_string() ? val.as_string() : utility::conversions::to_string_t("");
 }
 
 utility::datetime ModelBase::dateFromJson(web::json::value& val)

--- a/samples/client/petstore/cpprest/ApiClient.cpp
+++ b/samples/client/petstore/cpprest/ApiClient.cpp
@@ -79,17 +79,17 @@ pplx::task<web::http::http_response> ApiClient::callApi(
 {
     if (postBody != nullptr && formParams.size() != 0)
     {
-        throw ApiException(400, U("Cannot have body and form params"));
+        throw ApiException(400, utility::conversions::to_string_t("Cannot have body and form params"));
     }
 
     if (postBody != nullptr && fileParams.size() != 0)
     {
-        throw ApiException(400, U("Cannot have body and file params"));
+        throw ApiException(400, utility::conversions::to_string_t("Cannot have body and file params"));
     }
 
-    if (fileParams.size() > 0 && contentType != U("multipart/form-data"))
+    if (fileParams.size() > 0 && contentType != utility::conversions::to_string_t("multipart/form-data"))
     {
-        throw ApiException(400, U("Operations with file parameters must be called with multipart/form-data"));
+        throw ApiException(400, utility::conversions::to_string_t("Operations with file parameters must be called with multipart/form-data"));
     }
 
     web::http::client::http_client client(m_Configuration->getBaseUrl(), m_Configuration->getHttpConfig());
@@ -115,7 +115,7 @@ pplx::task<web::http::http_response> ApiClient::callApi(
         uploadData.writeTo(data);
         auto bodyString = data.str();
         auto length = bodyString.size();
-        request.set_body(concurrency::streams::bytestream::open_istream(std::move(bodyString)), length, U("multipart/form-data; boundary=") + uploadData.getBoundary());
+        request.set_body(concurrency::streams::bytestream::open_istream(std::move(bodyString)), length, utility::conversions::to_string_t("multipart/form-data; boundary=") + uploadData.getBoundary());
     }
     else
     {
@@ -129,7 +129,7 @@ pplx::task<web::http::http_response> ApiClient::callApi(
         }
         else
         {
-            if (contentType == U("application/json"))
+            if (contentType == utility::conversions::to_string_t("application/json"))
             {
                 web::json::value body_data = web::json::value::object();
                 for (auto& kvp : formParams)
@@ -150,7 +150,7 @@ pplx::task<web::http::http_response> ApiClient::callApi(
                 }
                 if (!formParams.empty())
                 {
-                    request.set_body(formData.query(), U("application/x-www-form-urlencoded"));
+                    request.set_body(formData.query(), utility::conversions::to_string_t("application/x-www-form-urlencoded"));
                 }
             }
         }

--- a/samples/client/petstore/cpprest/ApiClient.h
+++ b/samples/client/petstore/cpprest/ApiClient.h
@@ -60,7 +60,7 @@ public:
 
         for( size_t i = 0; i < value.size(); i++)
         {
-            if( i > 0) ss << U(", ");
+            if( i > 0) ss << utility::conversions::to_string_t(", ");
             ss << ApiClient::parameterToString(value[i]);
         }
 

--- a/samples/client/petstore/cpprest/ApiConfiguration.cpp
+++ b/samples/client/petstore/cpprest/ApiConfiguration.cpp
@@ -67,7 +67,7 @@ utility::string_t ApiConfiguration::getApiKey( const utility::string_t& prefix) 
     {
         return result->second;
     }
-    return U("");
+    return utility::conversions::to_string_t("");
 }
 
 void ApiConfiguration::setApiKey( const utility::string_t& prefix, const utility::string_t& apiKey )

--- a/samples/client/petstore/cpprest/ModelBase.cpp
+++ b/samples/client/petstore/cpprest/ModelBase.cpp
@@ -51,10 +51,10 @@ web::json::value ModelBase::toJson(bool value) {
 web::json::value ModelBase::toJson( std::shared_ptr<HttpContent> content )
 {
     web::json::value value;
-    value[U("ContentDisposition")] = ModelBase::toJson(content->getContentDisposition());
-    value[U("ContentType")] = ModelBase::toJson(content->getContentType());
-    value[U("FileName")] = ModelBase::toJson(content->getFileName());
-    value[U("InputStream")] = web::json::value::string( ModelBase::toBase64(content->getData()) );
+    value[utility::conversions::to_string_t("ContentDisposition")] = ModelBase::toJson(content->getContentDisposition());
+    value[utility::conversions::to_string_t("ContentType")] = ModelBase::toJson(content->getContentType());
+    value[utility::conversions::to_string_t("FileName")] = ModelBase::toJson(content->getFileName());
+    value[utility::conversions::to_string_t("InputStream")] = web::json::value::string( ModelBase::toBase64(content->getData()) );
     return value;
 }
 
@@ -62,21 +62,21 @@ std::shared_ptr<HttpContent> ModelBase::fileFromJson(web::json::value& val)
 {
     std::shared_ptr<HttpContent> content(new HttpContent);
 
-    if(val.has_field(U("ContentDisposition")))
+    if(val.has_field(utility::conversions::to_string_t("ContentDisposition")))
     {
-        content->setContentDisposition( ModelBase::stringFromJson(val[U("ContentDisposition")]) );
+        content->setContentDisposition( ModelBase::stringFromJson(val[utility::conversions::to_string_t("ContentDisposition")]) );
     }
-    if(val.has_field(U("ContentType")))
+    if(val.has_field(utility::conversions::to_string_t("ContentType")))
     {
-        content->setContentType( ModelBase::stringFromJson(val[U("ContentType")]) );
+        content->setContentType( ModelBase::stringFromJson(val[utility::conversions::to_string_t("ContentType")]) );
     }
-    if(val.has_field(U("FileName")))
+    if(val.has_field(utility::conversions::to_string_t("FileName")))
     {
-        content->setFileName( ModelBase::stringFromJson(val[U("FileName")]) );
+        content->setFileName( ModelBase::stringFromJson(val[utility::conversions::to_string_t("FileName")]) );
     }
-    if(val.has_field(U("InputStream")))
+    if(val.has_field(utility::conversions::to_string_t("InputStream")))
     {
-        content->setData( ModelBase::fromBase64( ModelBase::stringFromJson(val[U("InputStream")]) ) );
+        content->setData( ModelBase::fromBase64( ModelBase::stringFromJson(val[utility::conversions::to_string_t("InputStream")]) ) );
     }
 
     return content;
@@ -91,7 +91,7 @@ std::shared_ptr<HttpContent> ModelBase::toHttpContent( const utility::string_t& 
 {
     std::shared_ptr<HttpContent> content(new HttpContent);
     content->setName( name );
-    content->setContentDisposition( U("form-data") );
+    content->setContentDisposition( utility::conversions::to_string_t("form-data") );
     content->setContentType( contentType );
     content->setData( std::shared_ptr<std::istream>( new std::stringstream( utility::conversions::to_utf8string(value) ) ) );
     return content;
@@ -100,7 +100,7 @@ std::shared_ptr<HttpContent> ModelBase::toHttpContent( const utility::string_t& 
 {
     std::shared_ptr<HttpContent> content( new HttpContent );
     content->setName( name );
-    content->setContentDisposition( U("form-data") );
+    content->setContentDisposition( utility::conversions::to_string_t("form-data") );
     content->setContentType( contentType );
     content->setData( std::shared_ptr<std::istream>( new std::stringstream( utility::conversions::to_utf8string(value.to_string(utility::datetime::ISO_8601) ) ) ) );
     return content;
@@ -119,7 +119,7 @@ std::shared_ptr<HttpContent> ModelBase::toHttpContent( const utility::string_t& 
 {
     std::shared_ptr<HttpContent> content( new HttpContent );
     content->setName( name );
-    content->setContentDisposition( U("form-data") );
+    content->setContentDisposition( utility::conversions::to_string_t("form-data") );
     content->setContentType( contentType );
     content->setData( std::shared_ptr<std::istream>( new std::stringstream( utility::conversions::to_utf8string(value.serialize()) ) ) );
     return content;
@@ -128,7 +128,7 @@ std::shared_ptr<HttpContent> ModelBase::toHttpContent( const utility::string_t& 
 {
     std::shared_ptr<HttpContent> content( new HttpContent );
     content->setName( name );
-    content->setContentDisposition( U("form-data") );
+    content->setContentDisposition( utility::conversions::to_string_t("form-data") );
     content->setContentType( contentType );
 	std::stringstream* valueAsStringStream = new std::stringstream();
 	(*valueAsStringStream) << value;
@@ -139,7 +139,7 @@ std::shared_ptr<HttpContent> ModelBase::toHttpContent( const utility::string_t& 
 {
     std::shared_ptr<HttpContent> content( new HttpContent );
     content->setName( name );
-    content->setContentDisposition( U("form-data") );
+    content->setContentDisposition( utility::conversions::to_string_t("form-data") );
     content->setContentType( contentType );
 	std::stringstream* valueAsStringStream = new std::stringstream();
 	(*valueAsStringStream) << value;
@@ -150,7 +150,7 @@ std::shared_ptr<HttpContent> ModelBase::toHttpContent( const utility::string_t& 
 {
     std::shared_ptr<HttpContent> content( new HttpContent );
     content->setName( name );
-    content->setContentDisposition( U("form-data") );
+    content->setContentDisposition( utility::conversions::to_string_t("form-data") );
     content->setContentType( contentType );
 	std::stringstream* valueAsStringStream = new std::stringstream();
 	(*valueAsStringStream) << value;
@@ -256,12 +256,12 @@ std::shared_ptr<std::istream> ModelBase::fromBase64( const utility::string_t& en
                         result->write( outBuf, 1 );
                         return result;
                     default:
-                        throw web::json::json_exception( U( "Invalid Padding in Base 64!" ) );
+                        throw web::json::json_exception( utility::conversions::to_string_t( "Invalid Padding in Base 64!" ).c_str() );
                 }
             }
             else
             {
-                throw web::json::json_exception( U( "Non-Valid Character in Base 64!" ) );
+                throw web::json::json_exception( utility::conversions::to_string_t( "Non-Valid Character in Base 64!" ).c_str() );
             }
             ++cursor;
         }
@@ -289,7 +289,7 @@ float ModelBase::floatFromJson(web::json::value& val)
 }
 utility::string_t ModelBase::stringFromJson(web::json::value& val)
 {
-    return val.is_string() ? val.as_string() : U("");
+    return val.is_string() ? val.as_string() : utility::conversions::to_string_t("");
 }
 
 utility::datetime ModelBase::dateFromJson(web::json::value& val)

--- a/samples/client/petstore/cpprest/ModelBase.h
+++ b/samples/client/petstore/cpprest/ModelBase.h
@@ -63,13 +63,13 @@ public:
     static bool boolFromJson(web::json::value& val);
     static std::shared_ptr<HttpContent> fileFromJson(web::json::value& val);
 
-    static std::shared_ptr<HttpContent> toHttpContent( const utility::string_t& name, const utility::string_t& value, const utility::string_t& contentType = U(""));
-    static std::shared_ptr<HttpContent> toHttpContent( const utility::string_t& name, const utility::datetime& value, const utility::string_t& contentType = U(""));
+    static std::shared_ptr<HttpContent> toHttpContent( const utility::string_t& name, const utility::string_t& value, const utility::string_t& contentType = utility::conversions::to_string_t(""));
+    static std::shared_ptr<HttpContent> toHttpContent( const utility::string_t& name, const utility::datetime& value, const utility::string_t& contentType = utility::conversions::to_string_t(""));
     static std::shared_ptr<HttpContent> toHttpContent( const utility::string_t& name, std::shared_ptr<HttpContent> value );
-    static std::shared_ptr<HttpContent> toHttpContent( const utility::string_t& name, const web::json::value& value, const utility::string_t& contentType = U("application/json") );
-    static std::shared_ptr<HttpContent> toHttpContent( const utility::string_t& name, int32_t value, const utility::string_t& contentType = U("") );
-    static std::shared_ptr<HttpContent> toHttpContent( const utility::string_t& name, int64_t value, const utility::string_t& contentType = U("") );
-    static std::shared_ptr<HttpContent> toHttpContent( const utility::string_t& name, double value, const utility::string_t& contentType = U("") );
+    static std::shared_ptr<HttpContent> toHttpContent( const utility::string_t& name, const web::json::value& value, const utility::string_t& contentType = utility::conversions::to_string_t("application/json") );
+    static std::shared_ptr<HttpContent> toHttpContent( const utility::string_t& name, int32_t value, const utility::string_t& contentType = utility::conversions::to_string_t("") );
+    static std::shared_ptr<HttpContent> toHttpContent( const utility::string_t& name, int64_t value, const utility::string_t& contentType = utility::conversions::to_string_t("") );
+    static std::shared_ptr<HttpContent> toHttpContent( const utility::string_t& name, double value, const utility::string_t& contentType = utility::conversions::to_string_t("") );
 
     static int64_t int64_tFromHttpContent(std::shared_ptr<HttpContent> val);
     static int32_t int32_tFromHttpContent(std::shared_ptr<HttpContent> val);

--- a/samples/client/petstore/cpprest/api/PetApi.cpp
+++ b/samples/client/petstore/cpprest/api/PetApi.cpp
@@ -42,12 +42,12 @@ pplx::task<void> PetApi::addPet(std::shared_ptr<Pet> body)
     // verify the required parameter 'body' is set
     if (body == nullptr)
     {
-        throw ApiException(400, U("Missing required parameter 'body' when calling PetApi->addPet"));
+        throw ApiException(400, utility::conversions::to_string_t("Missing required parameter 'body' when calling PetApi->addPet"));
     }
 
 
     std::shared_ptr<ApiConfiguration> apiConfiguration( m_ApiClient->getConfiguration() );
-    utility::string_t path = U("/pet");
+    utility::string_t path = utility::conversions::to_string_t("/pet");
     
     std::map<utility::string_t, utility::string_t> queryParams;
     std::map<utility::string_t, utility::string_t> headerParams( apiConfiguration->getDefaultHeaders() );
@@ -55,45 +55,45 @@ pplx::task<void> PetApi::addPet(std::shared_ptr<Pet> body)
     std::map<utility::string_t, std::shared_ptr<HttpContent>> fileParams;
 
     std::unordered_set<utility::string_t> responseHttpContentTypes;
-    responseHttpContentTypes.insert( U("application/xml") );
-    responseHttpContentTypes.insert( U("application/json") );
+    responseHttpContentTypes.insert( utility::conversions::to_string_t("application/xml") );
+    responseHttpContentTypes.insert( utility::conversions::to_string_t("application/json") );
 
     utility::string_t responseHttpContentType;
 
     // use JSON if possible
     if ( responseHttpContentTypes.size() == 0 )
     {
-        responseHttpContentType = U("application/json");
+        responseHttpContentType = utility::conversions::to_string_t("application/json");
     }
     // JSON
-    else if ( responseHttpContentTypes.find(U("application/json")) != responseHttpContentTypes.end() )
+    else if ( responseHttpContentTypes.find(utility::conversions::to_string_t("application/json")) != responseHttpContentTypes.end() )
     {
-        responseHttpContentType = U("application/json");
+        responseHttpContentType = utility::conversions::to_string_t("application/json");
     }
     // multipart formdata
-    else if( responseHttpContentTypes.find(U("multipart/form-data")) != responseHttpContentTypes.end() )
+    else if( responseHttpContentTypes.find(utility::conversions::to_string_t("multipart/form-data")) != responseHttpContentTypes.end() )
     {
-        responseHttpContentType = U("multipart/form-data");
+        responseHttpContentType = utility::conversions::to_string_t("multipart/form-data");
     }
     else
     {
-        throw ApiException(400, U("PetApi->addPet does not produce any supported media type"));
+        throw ApiException(400, utility::conversions::to_string_t("PetApi->addPet does not produce any supported media type"));
     }
 
-    headerParams[U("Accept")] = responseHttpContentType;
+    headerParams[utility::conversions::to_string_t("Accept")] = responseHttpContentType;
 
     std::unordered_set<utility::string_t> consumeHttpContentTypes;
-    consumeHttpContentTypes.insert( U("application/json") );
-    consumeHttpContentTypes.insert( U("application/xml") );
+    consumeHttpContentTypes.insert( utility::conversions::to_string_t("application/json") );
+    consumeHttpContentTypes.insert( utility::conversions::to_string_t("application/xml") );
 
 
     std::shared_ptr<IHttpBody> httpBody;
     utility::string_t requestHttpContentType;
 
     // use JSON if possible
-    if ( consumeHttpContentTypes.size() == 0 || consumeHttpContentTypes.find(U("application/json")) != consumeHttpContentTypes.end() )
+    if ( consumeHttpContentTypes.size() == 0 || consumeHttpContentTypes.find(utility::conversions::to_string_t("application/json")) != consumeHttpContentTypes.end() )
     {
-        requestHttpContentType = U("application/json");
+        requestHttpContentType = utility::conversions::to_string_t("application/json");
         web::json::value json;
 
         json = ModelBase::toJson(body);
@@ -101,27 +101,27 @@ pplx::task<void> PetApi::addPet(std::shared_ptr<Pet> body)
         httpBody = std::shared_ptr<IHttpBody>( new JsonBody( json ) );
     }
     // multipart formdata
-    else if( consumeHttpContentTypes.find(U("multipart/form-data")) != consumeHttpContentTypes.end() )
+    else if( consumeHttpContentTypes.find(utility::conversions::to_string_t("multipart/form-data")) != consumeHttpContentTypes.end() )
     {
-        requestHttpContentType = U("multipart/form-data");
+        requestHttpContentType = utility::conversions::to_string_t("multipart/form-data");
         std::shared_ptr<MultipartFormData> multipart(new MultipartFormData);
                 if(body.get())
         {
-            body->toMultipart(multipart, U("body"));
+            body->toMultipart(multipart, utility::conversions::to_string_t("body"));
         }
 
         httpBody = multipart;
-        requestHttpContentType += U("; boundary=") + multipart->getBoundary();
+        requestHttpContentType += utility::conversions::to_string_t("; boundary=") + multipart->getBoundary();
     }
     else
     {
-        throw ApiException(415, U("PetApi->addPet does not consume any supported media type"));
+        throw ApiException(415, utility::conversions::to_string_t("PetApi->addPet does not consume any supported media type"));
     }
 
     // authentication (petstore_auth) required
     // oauth2 authentication is added automatically as part of the http_client_config
 
-    return m_ApiClient->callApi(path, U("POST"), queryParams, httpBody, headerParams, formParams, fileParams, requestHttpContentType)
+    return m_ApiClient->callApi(path, utility::conversions::to_string_t("POST"), queryParams, httpBody, headerParams, formParams, fileParams, requestHttpContentType)
     .then([=](web::http::http_response response)
     {
         // 1xx - informational : OK
@@ -132,18 +132,18 @@ pplx::task<void> PetApi::addPet(std::shared_ptr<Pet> body)
         if (response.status_code() >= 400)
         {
             throw ApiException(response.status_code()
-                , U("error calling addPet: ") + response.reason_phrase()
+                , utility::conversions::to_string_t("error calling addPet: ") + response.reason_phrase()
                 , std::make_shared<std::stringstream>(response.extract_utf8string(true).get()));
         }
 
         // check response content type
-        if(response.headers().has(U("Content-Type")))
+        if(response.headers().has(utility::conversions::to_string_t("Content-Type")))
         {
-            utility::string_t contentType = response.headers()[U("Content-Type")];
+            utility::string_t contentType = response.headers()[utility::conversions::to_string_t("Content-Type")];
             if( contentType.find(responseHttpContentType) == std::string::npos )
             {
                 throw ApiException(500
-                    , U("error calling addPet: unexpected response type: ") + contentType
+                    , utility::conversions::to_string_t("error calling addPet: unexpected response type: ") + contentType
                     , std::make_shared<std::stringstream>(response.extract_utf8string(true).get()));
             }
         }
@@ -160,8 +160,8 @@ pplx::task<void> PetApi::deletePet(int64_t petId, utility::string_t apiKey)
 
 
     std::shared_ptr<ApiConfiguration> apiConfiguration( m_ApiClient->getConfiguration() );
-    utility::string_t path = U("/pet/{petId}");
-    boost::replace_all(path, U("{") U("petId") U("}"), ApiClient::parameterToString(petId));
+    utility::string_t path = utility::conversions::to_string_t("/pet/{petId}");
+    boost::replace_all(path, utility::conversions::to_string_t("{") + utility::conversions::to_string_t("petId") + utility::conversions::to_string_t("}"), ApiClient::parameterToString(petId));
 
     std::map<utility::string_t, utility::string_t> queryParams;
     std::map<utility::string_t, utility::string_t> headerParams( apiConfiguration->getDefaultHeaders() );
@@ -169,62 +169,62 @@ pplx::task<void> PetApi::deletePet(int64_t petId, utility::string_t apiKey)
     std::map<utility::string_t, std::shared_ptr<HttpContent>> fileParams;
 
     std::unordered_set<utility::string_t> responseHttpContentTypes;
-    responseHttpContentTypes.insert( U("application/xml") );
-    responseHttpContentTypes.insert( U("application/json") );
+    responseHttpContentTypes.insert( utility::conversions::to_string_t("application/xml") );
+    responseHttpContentTypes.insert( utility::conversions::to_string_t("application/json") );
 
     utility::string_t responseHttpContentType;
 
     // use JSON if possible
     if ( responseHttpContentTypes.size() == 0 )
     {
-        responseHttpContentType = U("application/json");
+        responseHttpContentType = utility::conversions::to_string_t("application/json");
     }
     // JSON
-    else if ( responseHttpContentTypes.find(U("application/json")) != responseHttpContentTypes.end() )
+    else if ( responseHttpContentTypes.find(utility::conversions::to_string_t("application/json")) != responseHttpContentTypes.end() )
     {
-        responseHttpContentType = U("application/json");
+        responseHttpContentType = utility::conversions::to_string_t("application/json");
     }
     // multipart formdata
-    else if( responseHttpContentTypes.find(U("multipart/form-data")) != responseHttpContentTypes.end() )
+    else if( responseHttpContentTypes.find(utility::conversions::to_string_t("multipart/form-data")) != responseHttpContentTypes.end() )
     {
-        responseHttpContentType = U("multipart/form-data");
+        responseHttpContentType = utility::conversions::to_string_t("multipart/form-data");
     }
     else
     {
-        throw ApiException(400, U("PetApi->deletePet does not produce any supported media type"));
+        throw ApiException(400, utility::conversions::to_string_t("PetApi->deletePet does not produce any supported media type"));
     }
 
-    headerParams[U("Accept")] = responseHttpContentType;
+    headerParams[utility::conversions::to_string_t("Accept")] = responseHttpContentType;
 
     std::unordered_set<utility::string_t> consumeHttpContentTypes;
 
     
     {
-        headerParams[U("api_key")] = ApiClient::parameterToString(apiKey);
+        headerParams[utility::conversions::to_string_t("api_key")] = ApiClient::parameterToString(apiKey);
     }
 
     std::shared_ptr<IHttpBody> httpBody;
     utility::string_t requestHttpContentType;
 
     // use JSON if possible
-    if ( consumeHttpContentTypes.size() == 0 || consumeHttpContentTypes.find(U("application/json")) != consumeHttpContentTypes.end() )
+    if ( consumeHttpContentTypes.size() == 0 || consumeHttpContentTypes.find(utility::conversions::to_string_t("application/json")) != consumeHttpContentTypes.end() )
     {
-        requestHttpContentType = U("application/json");
+        requestHttpContentType = utility::conversions::to_string_t("application/json");
     }
     // multipart formdata
-    else if( consumeHttpContentTypes.find(U("multipart/form-data")) != consumeHttpContentTypes.end() )
+    else if( consumeHttpContentTypes.find(utility::conversions::to_string_t("multipart/form-data")) != consumeHttpContentTypes.end() )
     {
-        requestHttpContentType = U("multipart/form-data");
+        requestHttpContentType = utility::conversions::to_string_t("multipart/form-data");
     }
     else
     {
-        throw ApiException(415, U("PetApi->deletePet does not consume any supported media type"));
+        throw ApiException(415, utility::conversions::to_string_t("PetApi->deletePet does not consume any supported media type"));
     }
 
     // authentication (petstore_auth) required
     // oauth2 authentication is added automatically as part of the http_client_config
 
-    return m_ApiClient->callApi(path, U("DELETE"), queryParams, httpBody, headerParams, formParams, fileParams, requestHttpContentType)
+    return m_ApiClient->callApi(path, utility::conversions::to_string_t("DELETE"), queryParams, httpBody, headerParams, formParams, fileParams, requestHttpContentType)
     .then([=](web::http::http_response response)
     {
         // 1xx - informational : OK
@@ -235,18 +235,18 @@ pplx::task<void> PetApi::deletePet(int64_t petId, utility::string_t apiKey)
         if (response.status_code() >= 400)
         {
             throw ApiException(response.status_code()
-                , U("error calling deletePet: ") + response.reason_phrase()
+                , utility::conversions::to_string_t("error calling deletePet: ") + response.reason_phrase()
                 , std::make_shared<std::stringstream>(response.extract_utf8string(true).get()));
         }
 
         // check response content type
-        if(response.headers().has(U("Content-Type")))
+        if(response.headers().has(utility::conversions::to_string_t("Content-Type")))
         {
-            utility::string_t contentType = response.headers()[U("Content-Type")];
+            utility::string_t contentType = response.headers()[utility::conversions::to_string_t("Content-Type")];
             if( contentType.find(responseHttpContentType) == std::string::npos )
             {
                 throw ApiException(500
-                    , U("error calling deletePet: unexpected response type: ") + contentType
+                    , utility::conversions::to_string_t("error calling deletePet: unexpected response type: ") + contentType
                     , std::make_shared<std::stringstream>(response.extract_utf8string(true).get()));
             }
         }
@@ -263,7 +263,7 @@ pplx::task<std::vector<std::shared_ptr<Pet>>> PetApi::findPetsByStatus(std::vect
 
 
     std::shared_ptr<ApiConfiguration> apiConfiguration( m_ApiClient->getConfiguration() );
-    utility::string_t path = U("/pet/findByStatus");
+    utility::string_t path = utility::conversions::to_string_t("/pet/findByStatus");
     
     std::map<utility::string_t, utility::string_t> queryParams;
     std::map<utility::string_t, utility::string_t> headerParams( apiConfiguration->getDefaultHeaders() );
@@ -271,62 +271,62 @@ pplx::task<std::vector<std::shared_ptr<Pet>>> PetApi::findPetsByStatus(std::vect
     std::map<utility::string_t, std::shared_ptr<HttpContent>> fileParams;
 
     std::unordered_set<utility::string_t> responseHttpContentTypes;
-    responseHttpContentTypes.insert( U("application/xml") );
-    responseHttpContentTypes.insert( U("application/json") );
+    responseHttpContentTypes.insert( utility::conversions::to_string_t("application/xml") );
+    responseHttpContentTypes.insert( utility::conversions::to_string_t("application/json") );
 
     utility::string_t responseHttpContentType;
 
     // use JSON if possible
     if ( responseHttpContentTypes.size() == 0 )
     {
-        responseHttpContentType = U("application/json");
+        responseHttpContentType = utility::conversions::to_string_t("application/json");
     }
     // JSON
-    else if ( responseHttpContentTypes.find(U("application/json")) != responseHttpContentTypes.end() )
+    else if ( responseHttpContentTypes.find(utility::conversions::to_string_t("application/json")) != responseHttpContentTypes.end() )
     {
-        responseHttpContentType = U("application/json");
+        responseHttpContentType = utility::conversions::to_string_t("application/json");
     }
     // multipart formdata
-    else if( responseHttpContentTypes.find(U("multipart/form-data")) != responseHttpContentTypes.end() )
+    else if( responseHttpContentTypes.find(utility::conversions::to_string_t("multipart/form-data")) != responseHttpContentTypes.end() )
     {
-        responseHttpContentType = U("multipart/form-data");
+        responseHttpContentType = utility::conversions::to_string_t("multipart/form-data");
     }
     else
     {
-        throw ApiException(400, U("PetApi->findPetsByStatus does not produce any supported media type"));
+        throw ApiException(400, utility::conversions::to_string_t("PetApi->findPetsByStatus does not produce any supported media type"));
     }
 
-    headerParams[U("Accept")] = responseHttpContentType;
+    headerParams[utility::conversions::to_string_t("Accept")] = responseHttpContentType;
 
     std::unordered_set<utility::string_t> consumeHttpContentTypes;
 
     
     {
-        queryParams[U("status")] = ApiClient::parameterToArrayString<utility::string_t>(status);
+        queryParams[utility::conversions::to_string_t("status")] = ApiClient::parameterToArrayString<utility::string_t>(status);
     }
 
     std::shared_ptr<IHttpBody> httpBody;
     utility::string_t requestHttpContentType;
 
     // use JSON if possible
-    if ( consumeHttpContentTypes.size() == 0 || consumeHttpContentTypes.find(U("application/json")) != consumeHttpContentTypes.end() )
+    if ( consumeHttpContentTypes.size() == 0 || consumeHttpContentTypes.find(utility::conversions::to_string_t("application/json")) != consumeHttpContentTypes.end() )
     {
-        requestHttpContentType = U("application/json");
+        requestHttpContentType = utility::conversions::to_string_t("application/json");
     }
     // multipart formdata
-    else if( consumeHttpContentTypes.find(U("multipart/form-data")) != consumeHttpContentTypes.end() )
+    else if( consumeHttpContentTypes.find(utility::conversions::to_string_t("multipart/form-data")) != consumeHttpContentTypes.end() )
     {
-        requestHttpContentType = U("multipart/form-data");
+        requestHttpContentType = utility::conversions::to_string_t("multipart/form-data");
     }
     else
     {
-        throw ApiException(415, U("PetApi->findPetsByStatus does not consume any supported media type"));
+        throw ApiException(415, utility::conversions::to_string_t("PetApi->findPetsByStatus does not consume any supported media type"));
     }
 
     // authentication (petstore_auth) required
     // oauth2 authentication is added automatically as part of the http_client_config
 
-    return m_ApiClient->callApi(path, U("GET"), queryParams, httpBody, headerParams, formParams, fileParams, requestHttpContentType)
+    return m_ApiClient->callApi(path, utility::conversions::to_string_t("GET"), queryParams, httpBody, headerParams, formParams, fileParams, requestHttpContentType)
     .then([=](web::http::http_response response)
     {
         // 1xx - informational : OK
@@ -337,18 +337,18 @@ pplx::task<std::vector<std::shared_ptr<Pet>>> PetApi::findPetsByStatus(std::vect
         if (response.status_code() >= 400)
         {
             throw ApiException(response.status_code()
-                , U("error calling findPetsByStatus: ") + response.reason_phrase()
+                , utility::conversions::to_string_t("error calling findPetsByStatus: ") + response.reason_phrase()
                 , std::make_shared<std::stringstream>(response.extract_utf8string(true).get()));
         }
 
         // check response content type
-        if(response.headers().has(U("Content-Type")))
+        if(response.headers().has(utility::conversions::to_string_t("Content-Type")))
         {
-            utility::string_t contentType = response.headers()[U("Content-Type")];
+            utility::string_t contentType = response.headers()[utility::conversions::to_string_t("Content-Type")];
             if( contentType.find(responseHttpContentType) == std::string::npos )
             {
                 throw ApiException(500
-                    , U("error calling findPetsByStatus: unexpected response type: ") + contentType
+                    , utility::conversions::to_string_t("error calling findPetsByStatus: unexpected response type: ") + contentType
                     , std::make_shared<std::stringstream>(response.extract_utf8string(true).get()));
             }
         }
@@ -359,7 +359,7 @@ pplx::task<std::vector<std::shared_ptr<Pet>>> PetApi::findPetsByStatus(std::vect
     {
         std::vector<std::shared_ptr<Pet>> result;
 
-        if(responseHttpContentType == U("application/json"))
+        if(responseHttpContentType == utility::conversions::to_string_t("application/json"))
         {
             web::json::value json = web::json::value::parse(response);
 
@@ -372,14 +372,14 @@ pplx::task<std::vector<std::shared_ptr<Pet>>> PetApi::findPetsByStatus(std::vect
             }
             
         }
-        // else if(responseHttpContentType == U("multipart/form-data"))
+        // else if(responseHttpContentType == utility::conversions::to_string_t("multipart/form-data"))
         // {
         // TODO multipart response parsing
         // }
         else
         {
             throw ApiException(500
-                , U("error calling findPetsByStatus: unsupported response type"));
+                , utility::conversions::to_string_t("error calling findPetsByStatus: unsupported response type"));
         }
 
         return result;
@@ -390,7 +390,7 @@ pplx::task<std::vector<std::shared_ptr<Pet>>> PetApi::findPetsByTags(std::vector
 
 
     std::shared_ptr<ApiConfiguration> apiConfiguration( m_ApiClient->getConfiguration() );
-    utility::string_t path = U("/pet/findByTags");
+    utility::string_t path = utility::conversions::to_string_t("/pet/findByTags");
     
     std::map<utility::string_t, utility::string_t> queryParams;
     std::map<utility::string_t, utility::string_t> headerParams( apiConfiguration->getDefaultHeaders() );
@@ -398,62 +398,62 @@ pplx::task<std::vector<std::shared_ptr<Pet>>> PetApi::findPetsByTags(std::vector
     std::map<utility::string_t, std::shared_ptr<HttpContent>> fileParams;
 
     std::unordered_set<utility::string_t> responseHttpContentTypes;
-    responseHttpContentTypes.insert( U("application/xml") );
-    responseHttpContentTypes.insert( U("application/json") );
+    responseHttpContentTypes.insert( utility::conversions::to_string_t("application/xml") );
+    responseHttpContentTypes.insert( utility::conversions::to_string_t("application/json") );
 
     utility::string_t responseHttpContentType;
 
     // use JSON if possible
     if ( responseHttpContentTypes.size() == 0 )
     {
-        responseHttpContentType = U("application/json");
+        responseHttpContentType = utility::conversions::to_string_t("application/json");
     }
     // JSON
-    else if ( responseHttpContentTypes.find(U("application/json")) != responseHttpContentTypes.end() )
+    else if ( responseHttpContentTypes.find(utility::conversions::to_string_t("application/json")) != responseHttpContentTypes.end() )
     {
-        responseHttpContentType = U("application/json");
+        responseHttpContentType = utility::conversions::to_string_t("application/json");
     }
     // multipart formdata
-    else if( responseHttpContentTypes.find(U("multipart/form-data")) != responseHttpContentTypes.end() )
+    else if( responseHttpContentTypes.find(utility::conversions::to_string_t("multipart/form-data")) != responseHttpContentTypes.end() )
     {
-        responseHttpContentType = U("multipart/form-data");
+        responseHttpContentType = utility::conversions::to_string_t("multipart/form-data");
     }
     else
     {
-        throw ApiException(400, U("PetApi->findPetsByTags does not produce any supported media type"));
+        throw ApiException(400, utility::conversions::to_string_t("PetApi->findPetsByTags does not produce any supported media type"));
     }
 
-    headerParams[U("Accept")] = responseHttpContentType;
+    headerParams[utility::conversions::to_string_t("Accept")] = responseHttpContentType;
 
     std::unordered_set<utility::string_t> consumeHttpContentTypes;
 
     
     {
-        queryParams[U("tags")] = ApiClient::parameterToArrayString<utility::string_t>(tags);
+        queryParams[utility::conversions::to_string_t("tags")] = ApiClient::parameterToArrayString<utility::string_t>(tags);
     }
 
     std::shared_ptr<IHttpBody> httpBody;
     utility::string_t requestHttpContentType;
 
     // use JSON if possible
-    if ( consumeHttpContentTypes.size() == 0 || consumeHttpContentTypes.find(U("application/json")) != consumeHttpContentTypes.end() )
+    if ( consumeHttpContentTypes.size() == 0 || consumeHttpContentTypes.find(utility::conversions::to_string_t("application/json")) != consumeHttpContentTypes.end() )
     {
-        requestHttpContentType = U("application/json");
+        requestHttpContentType = utility::conversions::to_string_t("application/json");
     }
     // multipart formdata
-    else if( consumeHttpContentTypes.find(U("multipart/form-data")) != consumeHttpContentTypes.end() )
+    else if( consumeHttpContentTypes.find(utility::conversions::to_string_t("multipart/form-data")) != consumeHttpContentTypes.end() )
     {
-        requestHttpContentType = U("multipart/form-data");
+        requestHttpContentType = utility::conversions::to_string_t("multipart/form-data");
     }
     else
     {
-        throw ApiException(415, U("PetApi->findPetsByTags does not consume any supported media type"));
+        throw ApiException(415, utility::conversions::to_string_t("PetApi->findPetsByTags does not consume any supported media type"));
     }
 
     // authentication (petstore_auth) required
     // oauth2 authentication is added automatically as part of the http_client_config
 
-    return m_ApiClient->callApi(path, U("GET"), queryParams, httpBody, headerParams, formParams, fileParams, requestHttpContentType)
+    return m_ApiClient->callApi(path, utility::conversions::to_string_t("GET"), queryParams, httpBody, headerParams, formParams, fileParams, requestHttpContentType)
     .then([=](web::http::http_response response)
     {
         // 1xx - informational : OK
@@ -464,18 +464,18 @@ pplx::task<std::vector<std::shared_ptr<Pet>>> PetApi::findPetsByTags(std::vector
         if (response.status_code() >= 400)
         {
             throw ApiException(response.status_code()
-                , U("error calling findPetsByTags: ") + response.reason_phrase()
+                , utility::conversions::to_string_t("error calling findPetsByTags: ") + response.reason_phrase()
                 , std::make_shared<std::stringstream>(response.extract_utf8string(true).get()));
         }
 
         // check response content type
-        if(response.headers().has(U("Content-Type")))
+        if(response.headers().has(utility::conversions::to_string_t("Content-Type")))
         {
-            utility::string_t contentType = response.headers()[U("Content-Type")];
+            utility::string_t contentType = response.headers()[utility::conversions::to_string_t("Content-Type")];
             if( contentType.find(responseHttpContentType) == std::string::npos )
             {
                 throw ApiException(500
-                    , U("error calling findPetsByTags: unexpected response type: ") + contentType
+                    , utility::conversions::to_string_t("error calling findPetsByTags: unexpected response type: ") + contentType
                     , std::make_shared<std::stringstream>(response.extract_utf8string(true).get()));
             }
         }
@@ -486,7 +486,7 @@ pplx::task<std::vector<std::shared_ptr<Pet>>> PetApi::findPetsByTags(std::vector
     {
         std::vector<std::shared_ptr<Pet>> result;
 
-        if(responseHttpContentType == U("application/json"))
+        if(responseHttpContentType == utility::conversions::to_string_t("application/json"))
         {
             web::json::value json = web::json::value::parse(response);
 
@@ -499,14 +499,14 @@ pplx::task<std::vector<std::shared_ptr<Pet>>> PetApi::findPetsByTags(std::vector
             }
             
         }
-        // else if(responseHttpContentType == U("multipart/form-data"))
+        // else if(responseHttpContentType == utility::conversions::to_string_t("multipart/form-data"))
         // {
         // TODO multipart response parsing
         // }
         else
         {
             throw ApiException(500
-                , U("error calling findPetsByTags: unsupported response type"));
+                , utility::conversions::to_string_t("error calling findPetsByTags: unsupported response type"));
         }
 
         return result;
@@ -517,8 +517,8 @@ pplx::task<std::shared_ptr<Pet>> PetApi::getPetById(int64_t petId)
 
 
     std::shared_ptr<ApiConfiguration> apiConfiguration( m_ApiClient->getConfiguration() );
-    utility::string_t path = U("/pet/{petId}");
-    boost::replace_all(path, U("{") U("petId") U("}"), ApiClient::parameterToString(petId));
+    utility::string_t path = utility::conversions::to_string_t("/pet/{petId}");
+    boost::replace_all(path, utility::conversions::to_string_t("{") + utility::conversions::to_string_t("petId") + utility::conversions::to_string_t("}"), ApiClient::parameterToString(petId));
 
     std::map<utility::string_t, utility::string_t> queryParams;
     std::map<utility::string_t, utility::string_t> headerParams( apiConfiguration->getDefaultHeaders() );
@@ -526,32 +526,32 @@ pplx::task<std::shared_ptr<Pet>> PetApi::getPetById(int64_t petId)
     std::map<utility::string_t, std::shared_ptr<HttpContent>> fileParams;
 
     std::unordered_set<utility::string_t> responseHttpContentTypes;
-    responseHttpContentTypes.insert( U("application/xml") );
-    responseHttpContentTypes.insert( U("application/json") );
+    responseHttpContentTypes.insert( utility::conversions::to_string_t("application/xml") );
+    responseHttpContentTypes.insert( utility::conversions::to_string_t("application/json") );
 
     utility::string_t responseHttpContentType;
 
     // use JSON if possible
     if ( responseHttpContentTypes.size() == 0 )
     {
-        responseHttpContentType = U("application/json");
+        responseHttpContentType = utility::conversions::to_string_t("application/json");
     }
     // JSON
-    else if ( responseHttpContentTypes.find(U("application/json")) != responseHttpContentTypes.end() )
+    else if ( responseHttpContentTypes.find(utility::conversions::to_string_t("application/json")) != responseHttpContentTypes.end() )
     {
-        responseHttpContentType = U("application/json");
+        responseHttpContentType = utility::conversions::to_string_t("application/json");
     }
     // multipart formdata
-    else if( responseHttpContentTypes.find(U("multipart/form-data")) != responseHttpContentTypes.end() )
+    else if( responseHttpContentTypes.find(utility::conversions::to_string_t("multipart/form-data")) != responseHttpContentTypes.end() )
     {
-        responseHttpContentType = U("multipart/form-data");
+        responseHttpContentType = utility::conversions::to_string_t("multipart/form-data");
     }
     else
     {
-        throw ApiException(400, U("PetApi->getPetById does not produce any supported media type"));
+        throw ApiException(400, utility::conversions::to_string_t("PetApi->getPetById does not produce any supported media type"));
     }
 
-    headerParams[U("Accept")] = responseHttpContentType;
+    headerParams[utility::conversions::to_string_t("Accept")] = responseHttpContentType;
 
     std::unordered_set<utility::string_t> consumeHttpContentTypes;
 
@@ -560,30 +560,30 @@ pplx::task<std::shared_ptr<Pet>> PetApi::getPetById(int64_t petId)
     utility::string_t requestHttpContentType;
 
     // use JSON if possible
-    if ( consumeHttpContentTypes.size() == 0 || consumeHttpContentTypes.find(U("application/json")) != consumeHttpContentTypes.end() )
+    if ( consumeHttpContentTypes.size() == 0 || consumeHttpContentTypes.find(utility::conversions::to_string_t("application/json")) != consumeHttpContentTypes.end() )
     {
-        requestHttpContentType = U("application/json");
+        requestHttpContentType = utility::conversions::to_string_t("application/json");
     }
     // multipart formdata
-    else if( consumeHttpContentTypes.find(U("multipart/form-data")) != consumeHttpContentTypes.end() )
+    else if( consumeHttpContentTypes.find(utility::conversions::to_string_t("multipart/form-data")) != consumeHttpContentTypes.end() )
     {
-        requestHttpContentType = U("multipart/form-data");
+        requestHttpContentType = utility::conversions::to_string_t("multipart/form-data");
     }
     else
     {
-        throw ApiException(415, U("PetApi->getPetById does not consume any supported media type"));
+        throw ApiException(415, utility::conversions::to_string_t("PetApi->getPetById does not consume any supported media type"));
     }
 
     // authentication (api_key) required
     {
-        utility::string_t apiKey = apiConfiguration->getApiKey(U("api_key"));
+        utility::string_t apiKey = apiConfiguration->getApiKey(utility::conversions::to_string_t("api_key"));
         if ( apiKey.size() > 0 )
         {
-            headerParams[U("api_key")] = apiKey;
+            headerParams[utility::conversions::to_string_t("api_key")] = apiKey;
         }
     }
 
-    return m_ApiClient->callApi(path, U("GET"), queryParams, httpBody, headerParams, formParams, fileParams, requestHttpContentType)
+    return m_ApiClient->callApi(path, utility::conversions::to_string_t("GET"), queryParams, httpBody, headerParams, formParams, fileParams, requestHttpContentType)
     .then([=](web::http::http_response response)
     {
         // 1xx - informational : OK
@@ -594,18 +594,18 @@ pplx::task<std::shared_ptr<Pet>> PetApi::getPetById(int64_t petId)
         if (response.status_code() >= 400)
         {
             throw ApiException(response.status_code()
-                , U("error calling getPetById: ") + response.reason_phrase()
+                , utility::conversions::to_string_t("error calling getPetById: ") + response.reason_phrase()
                 , std::make_shared<std::stringstream>(response.extract_utf8string(true).get()));
         }
 
         // check response content type
-        if(response.headers().has(U("Content-Type")))
+        if(response.headers().has(utility::conversions::to_string_t("Content-Type")))
         {
-            utility::string_t contentType = response.headers()[U("Content-Type")];
+            utility::string_t contentType = response.headers()[utility::conversions::to_string_t("Content-Type")];
             if( contentType.find(responseHttpContentType) == std::string::npos )
             {
                 throw ApiException(500
-                    , U("error calling getPetById: unexpected response type: ") + contentType
+                    , utility::conversions::to_string_t("error calling getPetById: unexpected response type: ") + contentType
                     , std::make_shared<std::stringstream>(response.extract_utf8string(true).get()));
             }
         }
@@ -616,20 +616,20 @@ pplx::task<std::shared_ptr<Pet>> PetApi::getPetById(int64_t petId)
     {
         std::shared_ptr<Pet> result(new Pet());
 
-        if(responseHttpContentType == U("application/json"))
+        if(responseHttpContentType == utility::conversions::to_string_t("application/json"))
         {
             web::json::value json = web::json::value::parse(response);
 
             result->fromJson(json);
         }
-        // else if(responseHttpContentType == U("multipart/form-data"))
+        // else if(responseHttpContentType == utility::conversions::to_string_t("multipart/form-data"))
         // {
         // TODO multipart response parsing
         // }
         else
         {
             throw ApiException(500
-                , U("error calling getPetById: unsupported response type"));
+                , utility::conversions::to_string_t("error calling getPetById: unsupported response type"));
         }
 
         return result;
@@ -641,12 +641,12 @@ pplx::task<void> PetApi::updatePet(std::shared_ptr<Pet> body)
     // verify the required parameter 'body' is set
     if (body == nullptr)
     {
-        throw ApiException(400, U("Missing required parameter 'body' when calling PetApi->updatePet"));
+        throw ApiException(400, utility::conversions::to_string_t("Missing required parameter 'body' when calling PetApi->updatePet"));
     }
 
 
     std::shared_ptr<ApiConfiguration> apiConfiguration( m_ApiClient->getConfiguration() );
-    utility::string_t path = U("/pet");
+    utility::string_t path = utility::conversions::to_string_t("/pet");
     
     std::map<utility::string_t, utility::string_t> queryParams;
     std::map<utility::string_t, utility::string_t> headerParams( apiConfiguration->getDefaultHeaders() );
@@ -654,45 +654,45 @@ pplx::task<void> PetApi::updatePet(std::shared_ptr<Pet> body)
     std::map<utility::string_t, std::shared_ptr<HttpContent>> fileParams;
 
     std::unordered_set<utility::string_t> responseHttpContentTypes;
-    responseHttpContentTypes.insert( U("application/xml") );
-    responseHttpContentTypes.insert( U("application/json") );
+    responseHttpContentTypes.insert( utility::conversions::to_string_t("application/xml") );
+    responseHttpContentTypes.insert( utility::conversions::to_string_t("application/json") );
 
     utility::string_t responseHttpContentType;
 
     // use JSON if possible
     if ( responseHttpContentTypes.size() == 0 )
     {
-        responseHttpContentType = U("application/json");
+        responseHttpContentType = utility::conversions::to_string_t("application/json");
     }
     // JSON
-    else if ( responseHttpContentTypes.find(U("application/json")) != responseHttpContentTypes.end() )
+    else if ( responseHttpContentTypes.find(utility::conversions::to_string_t("application/json")) != responseHttpContentTypes.end() )
     {
-        responseHttpContentType = U("application/json");
+        responseHttpContentType = utility::conversions::to_string_t("application/json");
     }
     // multipart formdata
-    else if( responseHttpContentTypes.find(U("multipart/form-data")) != responseHttpContentTypes.end() )
+    else if( responseHttpContentTypes.find(utility::conversions::to_string_t("multipart/form-data")) != responseHttpContentTypes.end() )
     {
-        responseHttpContentType = U("multipart/form-data");
+        responseHttpContentType = utility::conversions::to_string_t("multipart/form-data");
     }
     else
     {
-        throw ApiException(400, U("PetApi->updatePet does not produce any supported media type"));
+        throw ApiException(400, utility::conversions::to_string_t("PetApi->updatePet does not produce any supported media type"));
     }
 
-    headerParams[U("Accept")] = responseHttpContentType;
+    headerParams[utility::conversions::to_string_t("Accept")] = responseHttpContentType;
 
     std::unordered_set<utility::string_t> consumeHttpContentTypes;
-    consumeHttpContentTypes.insert( U("application/json") );
-    consumeHttpContentTypes.insert( U("application/xml") );
+    consumeHttpContentTypes.insert( utility::conversions::to_string_t("application/json") );
+    consumeHttpContentTypes.insert( utility::conversions::to_string_t("application/xml") );
 
 
     std::shared_ptr<IHttpBody> httpBody;
     utility::string_t requestHttpContentType;
 
     // use JSON if possible
-    if ( consumeHttpContentTypes.size() == 0 || consumeHttpContentTypes.find(U("application/json")) != consumeHttpContentTypes.end() )
+    if ( consumeHttpContentTypes.size() == 0 || consumeHttpContentTypes.find(utility::conversions::to_string_t("application/json")) != consumeHttpContentTypes.end() )
     {
-        requestHttpContentType = U("application/json");
+        requestHttpContentType = utility::conversions::to_string_t("application/json");
         web::json::value json;
 
         json = ModelBase::toJson(body);
@@ -700,27 +700,27 @@ pplx::task<void> PetApi::updatePet(std::shared_ptr<Pet> body)
         httpBody = std::shared_ptr<IHttpBody>( new JsonBody( json ) );
     }
     // multipart formdata
-    else if( consumeHttpContentTypes.find(U("multipart/form-data")) != consumeHttpContentTypes.end() )
+    else if( consumeHttpContentTypes.find(utility::conversions::to_string_t("multipart/form-data")) != consumeHttpContentTypes.end() )
     {
-        requestHttpContentType = U("multipart/form-data");
+        requestHttpContentType = utility::conversions::to_string_t("multipart/form-data");
         std::shared_ptr<MultipartFormData> multipart(new MultipartFormData);
                 if(body.get())
         {
-            body->toMultipart(multipart, U("body"));
+            body->toMultipart(multipart, utility::conversions::to_string_t("body"));
         }
 
         httpBody = multipart;
-        requestHttpContentType += U("; boundary=") + multipart->getBoundary();
+        requestHttpContentType += utility::conversions::to_string_t("; boundary=") + multipart->getBoundary();
     }
     else
     {
-        throw ApiException(415, U("PetApi->updatePet does not consume any supported media type"));
+        throw ApiException(415, utility::conversions::to_string_t("PetApi->updatePet does not consume any supported media type"));
     }
 
     // authentication (petstore_auth) required
     // oauth2 authentication is added automatically as part of the http_client_config
 
-    return m_ApiClient->callApi(path, U("PUT"), queryParams, httpBody, headerParams, formParams, fileParams, requestHttpContentType)
+    return m_ApiClient->callApi(path, utility::conversions::to_string_t("PUT"), queryParams, httpBody, headerParams, formParams, fileParams, requestHttpContentType)
     .then([=](web::http::http_response response)
     {
         // 1xx - informational : OK
@@ -731,18 +731,18 @@ pplx::task<void> PetApi::updatePet(std::shared_ptr<Pet> body)
         if (response.status_code() >= 400)
         {
             throw ApiException(response.status_code()
-                , U("error calling updatePet: ") + response.reason_phrase()
+                , utility::conversions::to_string_t("error calling updatePet: ") + response.reason_phrase()
                 , std::make_shared<std::stringstream>(response.extract_utf8string(true).get()));
         }
 
         // check response content type
-        if(response.headers().has(U("Content-Type")))
+        if(response.headers().has(utility::conversions::to_string_t("Content-Type")))
         {
-            utility::string_t contentType = response.headers()[U("Content-Type")];
+            utility::string_t contentType = response.headers()[utility::conversions::to_string_t("Content-Type")];
             if( contentType.find(responseHttpContentType) == std::string::npos )
             {
                 throw ApiException(500
-                    , U("error calling updatePet: unexpected response type: ") + contentType
+                    , utility::conversions::to_string_t("error calling updatePet: unexpected response type: ") + contentType
                     , std::make_shared<std::stringstream>(response.extract_utf8string(true).get()));
             }
         }
@@ -759,8 +759,8 @@ pplx::task<void> PetApi::updatePetWithForm(int64_t petId, utility::string_t name
 
 
     std::shared_ptr<ApiConfiguration> apiConfiguration( m_ApiClient->getConfiguration() );
-    utility::string_t path = U("/pet/{petId}");
-    boost::replace_all(path, U("{") U("petId") U("}"), ApiClient::parameterToString(petId));
+    utility::string_t path = utility::conversions::to_string_t("/pet/{petId}");
+    boost::replace_all(path, utility::conversions::to_string_t("{") + utility::conversions::to_string_t("petId") + utility::conversions::to_string_t("}"), ApiClient::parameterToString(petId));
 
     std::map<utility::string_t, utility::string_t> queryParams;
     std::map<utility::string_t, utility::string_t> headerParams( apiConfiguration->getDefaultHeaders() );
@@ -768,67 +768,67 @@ pplx::task<void> PetApi::updatePetWithForm(int64_t petId, utility::string_t name
     std::map<utility::string_t, std::shared_ptr<HttpContent>> fileParams;
 
     std::unordered_set<utility::string_t> responseHttpContentTypes;
-    responseHttpContentTypes.insert( U("application/xml") );
-    responseHttpContentTypes.insert( U("application/json") );
+    responseHttpContentTypes.insert( utility::conversions::to_string_t("application/xml") );
+    responseHttpContentTypes.insert( utility::conversions::to_string_t("application/json") );
 
     utility::string_t responseHttpContentType;
 
     // use JSON if possible
     if ( responseHttpContentTypes.size() == 0 )
     {
-        responseHttpContentType = U("application/json");
+        responseHttpContentType = utility::conversions::to_string_t("application/json");
     }
     // JSON
-    else if ( responseHttpContentTypes.find(U("application/json")) != responseHttpContentTypes.end() )
+    else if ( responseHttpContentTypes.find(utility::conversions::to_string_t("application/json")) != responseHttpContentTypes.end() )
     {
-        responseHttpContentType = U("application/json");
+        responseHttpContentType = utility::conversions::to_string_t("application/json");
     }
     // multipart formdata
-    else if( responseHttpContentTypes.find(U("multipart/form-data")) != responseHttpContentTypes.end() )
+    else if( responseHttpContentTypes.find(utility::conversions::to_string_t("multipart/form-data")) != responseHttpContentTypes.end() )
     {
-        responseHttpContentType = U("multipart/form-data");
+        responseHttpContentType = utility::conversions::to_string_t("multipart/form-data");
     }
     else
     {
-        throw ApiException(400, U("PetApi->updatePetWithForm does not produce any supported media type"));
+        throw ApiException(400, utility::conversions::to_string_t("PetApi->updatePetWithForm does not produce any supported media type"));
     }
 
-    headerParams[U("Accept")] = responseHttpContentType;
+    headerParams[utility::conversions::to_string_t("Accept")] = responseHttpContentType;
 
     std::unordered_set<utility::string_t> consumeHttpContentTypes;
-    consumeHttpContentTypes.insert( U("application/x-www-form-urlencoded") );
+    consumeHttpContentTypes.insert( utility::conversions::to_string_t("application/x-www-form-urlencoded") );
 
     
     {
-        formParams[ U("name") ] = ApiClient::parameterToString(name);
+        formParams[ utility::conversions::to_string_t("name") ] = ApiClient::parameterToString(name);
     }
     
     {
-        formParams[ U("status") ] = ApiClient::parameterToString(status);
+        formParams[ utility::conversions::to_string_t("status") ] = ApiClient::parameterToString(status);
     }
 
     std::shared_ptr<IHttpBody> httpBody;
     utility::string_t requestHttpContentType;
 
     // use JSON if possible
-    if ( consumeHttpContentTypes.size() == 0 || consumeHttpContentTypes.find(U("application/json")) != consumeHttpContentTypes.end() )
+    if ( consumeHttpContentTypes.size() == 0 || consumeHttpContentTypes.find(utility::conversions::to_string_t("application/json")) != consumeHttpContentTypes.end() )
     {
-        requestHttpContentType = U("application/json");
+        requestHttpContentType = utility::conversions::to_string_t("application/json");
     }
     // multipart formdata
-    else if( consumeHttpContentTypes.find(U("multipart/form-data")) != consumeHttpContentTypes.end() )
+    else if( consumeHttpContentTypes.find(utility::conversions::to_string_t("multipart/form-data")) != consumeHttpContentTypes.end() )
     {
-        requestHttpContentType = U("multipart/form-data");
+        requestHttpContentType = utility::conversions::to_string_t("multipart/form-data");
     }
     else
     {
-        throw ApiException(415, U("PetApi->updatePetWithForm does not consume any supported media type"));
+        throw ApiException(415, utility::conversions::to_string_t("PetApi->updatePetWithForm does not consume any supported media type"));
     }
 
     // authentication (petstore_auth) required
     // oauth2 authentication is added automatically as part of the http_client_config
 
-    return m_ApiClient->callApi(path, U("POST"), queryParams, httpBody, headerParams, formParams, fileParams, requestHttpContentType)
+    return m_ApiClient->callApi(path, utility::conversions::to_string_t("POST"), queryParams, httpBody, headerParams, formParams, fileParams, requestHttpContentType)
     .then([=](web::http::http_response response)
     {
         // 1xx - informational : OK
@@ -839,18 +839,18 @@ pplx::task<void> PetApi::updatePetWithForm(int64_t petId, utility::string_t name
         if (response.status_code() >= 400)
         {
             throw ApiException(response.status_code()
-                , U("error calling updatePetWithForm: ") + response.reason_phrase()
+                , utility::conversions::to_string_t("error calling updatePetWithForm: ") + response.reason_phrase()
                 , std::make_shared<std::stringstream>(response.extract_utf8string(true).get()));
         }
 
         // check response content type
-        if(response.headers().has(U("Content-Type")))
+        if(response.headers().has(utility::conversions::to_string_t("Content-Type")))
         {
-            utility::string_t contentType = response.headers()[U("Content-Type")];
+            utility::string_t contentType = response.headers()[utility::conversions::to_string_t("Content-Type")];
             if( contentType.find(responseHttpContentType) == std::string::npos )
             {
                 throw ApiException(500
-                    , U("error calling updatePetWithForm: unexpected response type: ") + contentType
+                    , utility::conversions::to_string_t("error calling updatePetWithForm: unexpected response type: ") + contentType
                     , std::make_shared<std::stringstream>(response.extract_utf8string(true).get()));
             }
         }
@@ -867,8 +867,8 @@ pplx::task<std::shared_ptr<ApiResponse>> PetApi::uploadFile(int64_t petId, utili
 
 
     std::shared_ptr<ApiConfiguration> apiConfiguration( m_ApiClient->getConfiguration() );
-    utility::string_t path = U("/pet/{petId}/uploadImage");
-    boost::replace_all(path, U("{") U("petId") U("}"), ApiClient::parameterToString(petId));
+    utility::string_t path = utility::conversions::to_string_t("/pet/{petId}/uploadImage");
+    boost::replace_all(path, utility::conversions::to_string_t("{") + utility::conversions::to_string_t("petId") + utility::conversions::to_string_t("}"), ApiClient::parameterToString(petId));
 
     std::map<utility::string_t, utility::string_t> queryParams;
     std::map<utility::string_t, utility::string_t> headerParams( apiConfiguration->getDefaultHeaders() );
@@ -876,66 +876,66 @@ pplx::task<std::shared_ptr<ApiResponse>> PetApi::uploadFile(int64_t petId, utili
     std::map<utility::string_t, std::shared_ptr<HttpContent>> fileParams;
 
     std::unordered_set<utility::string_t> responseHttpContentTypes;
-    responseHttpContentTypes.insert( U("application/json") );
+    responseHttpContentTypes.insert( utility::conversions::to_string_t("application/json") );
 
     utility::string_t responseHttpContentType;
 
     // use JSON if possible
     if ( responseHttpContentTypes.size() == 0 )
     {
-        responseHttpContentType = U("application/json");
+        responseHttpContentType = utility::conversions::to_string_t("application/json");
     }
     // JSON
-    else if ( responseHttpContentTypes.find(U("application/json")) != responseHttpContentTypes.end() )
+    else if ( responseHttpContentTypes.find(utility::conversions::to_string_t("application/json")) != responseHttpContentTypes.end() )
     {
-        responseHttpContentType = U("application/json");
+        responseHttpContentType = utility::conversions::to_string_t("application/json");
     }
     // multipart formdata
-    else if( responseHttpContentTypes.find(U("multipart/form-data")) != responseHttpContentTypes.end() )
+    else if( responseHttpContentTypes.find(utility::conversions::to_string_t("multipart/form-data")) != responseHttpContentTypes.end() )
     {
-        responseHttpContentType = U("multipart/form-data");
+        responseHttpContentType = utility::conversions::to_string_t("multipart/form-data");
     }
     else
     {
-        throw ApiException(400, U("PetApi->uploadFile does not produce any supported media type"));
+        throw ApiException(400, utility::conversions::to_string_t("PetApi->uploadFile does not produce any supported media type"));
     }
 
-    headerParams[U("Accept")] = responseHttpContentType;
+    headerParams[utility::conversions::to_string_t("Accept")] = responseHttpContentType;
 
     std::unordered_set<utility::string_t> consumeHttpContentTypes;
-    consumeHttpContentTypes.insert( U("multipart/form-data") );
+    consumeHttpContentTypes.insert( utility::conversions::to_string_t("multipart/form-data") );
 
     
     {
-        formParams[ U("additionalMetadata") ] = ApiClient::parameterToString(additionalMetadata);
+        formParams[ utility::conversions::to_string_t("additionalMetadata") ] = ApiClient::parameterToString(additionalMetadata);
     }
     if (file != nullptr)
     {
-        fileParams[ U("file") ] = file;
+        fileParams[ utility::conversions::to_string_t("file") ] = file;
     }
 
     std::shared_ptr<IHttpBody> httpBody;
     utility::string_t requestHttpContentType;
 
     // use JSON if possible
-    if ( consumeHttpContentTypes.size() == 0 || consumeHttpContentTypes.find(U("application/json")) != consumeHttpContentTypes.end() )
+    if ( consumeHttpContentTypes.size() == 0 || consumeHttpContentTypes.find(utility::conversions::to_string_t("application/json")) != consumeHttpContentTypes.end() )
     {
-        requestHttpContentType = U("application/json");
+        requestHttpContentType = utility::conversions::to_string_t("application/json");
     }
     // multipart formdata
-    else if( consumeHttpContentTypes.find(U("multipart/form-data")) != consumeHttpContentTypes.end() )
+    else if( consumeHttpContentTypes.find(utility::conversions::to_string_t("multipart/form-data")) != consumeHttpContentTypes.end() )
     {
-        requestHttpContentType = U("multipart/form-data");
+        requestHttpContentType = utility::conversions::to_string_t("multipart/form-data");
     }
     else
     {
-        throw ApiException(415, U("PetApi->uploadFile does not consume any supported media type"));
+        throw ApiException(415, utility::conversions::to_string_t("PetApi->uploadFile does not consume any supported media type"));
     }
 
     // authentication (petstore_auth) required
     // oauth2 authentication is added automatically as part of the http_client_config
 
-    return m_ApiClient->callApi(path, U("POST"), queryParams, httpBody, headerParams, formParams, fileParams, requestHttpContentType)
+    return m_ApiClient->callApi(path, utility::conversions::to_string_t("POST"), queryParams, httpBody, headerParams, formParams, fileParams, requestHttpContentType)
     .then([=](web::http::http_response response)
     {
         // 1xx - informational : OK
@@ -946,18 +946,18 @@ pplx::task<std::shared_ptr<ApiResponse>> PetApi::uploadFile(int64_t petId, utili
         if (response.status_code() >= 400)
         {
             throw ApiException(response.status_code()
-                , U("error calling uploadFile: ") + response.reason_phrase()
+                , utility::conversions::to_string_t("error calling uploadFile: ") + response.reason_phrase()
                 , std::make_shared<std::stringstream>(response.extract_utf8string(true).get()));
         }
 
         // check response content type
-        if(response.headers().has(U("Content-Type")))
+        if(response.headers().has(utility::conversions::to_string_t("Content-Type")))
         {
-            utility::string_t contentType = response.headers()[U("Content-Type")];
+            utility::string_t contentType = response.headers()[utility::conversions::to_string_t("Content-Type")];
             if( contentType.find(responseHttpContentType) == std::string::npos )
             {
                 throw ApiException(500
-                    , U("error calling uploadFile: unexpected response type: ") + contentType
+                    , utility::conversions::to_string_t("error calling uploadFile: unexpected response type: ") + contentType
                     , std::make_shared<std::stringstream>(response.extract_utf8string(true).get()));
             }
         }
@@ -968,20 +968,20 @@ pplx::task<std::shared_ptr<ApiResponse>> PetApi::uploadFile(int64_t petId, utili
     {
         std::shared_ptr<ApiResponse> result(new ApiResponse());
 
-        if(responseHttpContentType == U("application/json"))
+        if(responseHttpContentType == utility::conversions::to_string_t("application/json"))
         {
             web::json::value json = web::json::value::parse(response);
 
             result->fromJson(json);
         }
-        // else if(responseHttpContentType == U("multipart/form-data"))
+        // else if(responseHttpContentType == utility::conversions::to_string_t("multipart/form-data"))
         // {
         // TODO multipart response parsing
         // }
         else
         {
             throw ApiException(500
-                , U("error calling uploadFile: unsupported response type"));
+                , utility::conversions::to_string_t("error calling uploadFile: unsupported response type"));
         }
 
         return result;

--- a/samples/client/petstore/cpprest/api/StoreApi.cpp
+++ b/samples/client/petstore/cpprest/api/StoreApi.cpp
@@ -41,8 +41,8 @@ pplx::task<void> StoreApi::deleteOrder(utility::string_t orderId)
 
 
     std::shared_ptr<ApiConfiguration> apiConfiguration( m_ApiClient->getConfiguration() );
-    utility::string_t path = U("/store/order/{orderId}");
-    boost::replace_all(path, U("{") U("orderId") U("}"), ApiClient::parameterToString(orderId));
+    utility::string_t path = utility::conversions::to_string_t("/store/order/{orderId}");
+    boost::replace_all(path, utility::conversions::to_string_t("{") + utility::conversions::to_string_t("orderId") + utility::conversions::to_string_t("}"), ApiClient::parameterToString(orderId));
 
     std::map<utility::string_t, utility::string_t> queryParams;
     std::map<utility::string_t, utility::string_t> headerParams( apiConfiguration->getDefaultHeaders() );
@@ -50,32 +50,32 @@ pplx::task<void> StoreApi::deleteOrder(utility::string_t orderId)
     std::map<utility::string_t, std::shared_ptr<HttpContent>> fileParams;
 
     std::unordered_set<utility::string_t> responseHttpContentTypes;
-    responseHttpContentTypes.insert( U("application/xml") );
-    responseHttpContentTypes.insert( U("application/json") );
+    responseHttpContentTypes.insert( utility::conversions::to_string_t("application/xml") );
+    responseHttpContentTypes.insert( utility::conversions::to_string_t("application/json") );
 
     utility::string_t responseHttpContentType;
 
     // use JSON if possible
     if ( responseHttpContentTypes.size() == 0 )
     {
-        responseHttpContentType = U("application/json");
+        responseHttpContentType = utility::conversions::to_string_t("application/json");
     }
     // JSON
-    else if ( responseHttpContentTypes.find(U("application/json")) != responseHttpContentTypes.end() )
+    else if ( responseHttpContentTypes.find(utility::conversions::to_string_t("application/json")) != responseHttpContentTypes.end() )
     {
-        responseHttpContentType = U("application/json");
+        responseHttpContentType = utility::conversions::to_string_t("application/json");
     }
     // multipart formdata
-    else if( responseHttpContentTypes.find(U("multipart/form-data")) != responseHttpContentTypes.end() )
+    else if( responseHttpContentTypes.find(utility::conversions::to_string_t("multipart/form-data")) != responseHttpContentTypes.end() )
     {
-        responseHttpContentType = U("multipart/form-data");
+        responseHttpContentType = utility::conversions::to_string_t("multipart/form-data");
     }
     else
     {
-        throw ApiException(400, U("StoreApi->deleteOrder does not produce any supported media type"));
+        throw ApiException(400, utility::conversions::to_string_t("StoreApi->deleteOrder does not produce any supported media type"));
     }
 
-    headerParams[U("Accept")] = responseHttpContentType;
+    headerParams[utility::conversions::to_string_t("Accept")] = responseHttpContentType;
 
     std::unordered_set<utility::string_t> consumeHttpContentTypes;
 
@@ -84,22 +84,22 @@ pplx::task<void> StoreApi::deleteOrder(utility::string_t orderId)
     utility::string_t requestHttpContentType;
 
     // use JSON if possible
-    if ( consumeHttpContentTypes.size() == 0 || consumeHttpContentTypes.find(U("application/json")) != consumeHttpContentTypes.end() )
+    if ( consumeHttpContentTypes.size() == 0 || consumeHttpContentTypes.find(utility::conversions::to_string_t("application/json")) != consumeHttpContentTypes.end() )
     {
-        requestHttpContentType = U("application/json");
+        requestHttpContentType = utility::conversions::to_string_t("application/json");
     }
     // multipart formdata
-    else if( consumeHttpContentTypes.find(U("multipart/form-data")) != consumeHttpContentTypes.end() )
+    else if( consumeHttpContentTypes.find(utility::conversions::to_string_t("multipart/form-data")) != consumeHttpContentTypes.end() )
     {
-        requestHttpContentType = U("multipart/form-data");
+        requestHttpContentType = utility::conversions::to_string_t("multipart/form-data");
     }
     else
     {
-        throw ApiException(415, U("StoreApi->deleteOrder does not consume any supported media type"));
+        throw ApiException(415, utility::conversions::to_string_t("StoreApi->deleteOrder does not consume any supported media type"));
     }
 
 
-    return m_ApiClient->callApi(path, U("DELETE"), queryParams, httpBody, headerParams, formParams, fileParams, requestHttpContentType)
+    return m_ApiClient->callApi(path, utility::conversions::to_string_t("DELETE"), queryParams, httpBody, headerParams, formParams, fileParams, requestHttpContentType)
     .then([=](web::http::http_response response)
     {
         // 1xx - informational : OK
@@ -110,18 +110,18 @@ pplx::task<void> StoreApi::deleteOrder(utility::string_t orderId)
         if (response.status_code() >= 400)
         {
             throw ApiException(response.status_code()
-                , U("error calling deleteOrder: ") + response.reason_phrase()
+                , utility::conversions::to_string_t("error calling deleteOrder: ") + response.reason_phrase()
                 , std::make_shared<std::stringstream>(response.extract_utf8string(true).get()));
         }
 
         // check response content type
-        if(response.headers().has(U("Content-Type")))
+        if(response.headers().has(utility::conversions::to_string_t("Content-Type")))
         {
-            utility::string_t contentType = response.headers()[U("Content-Type")];
+            utility::string_t contentType = response.headers()[utility::conversions::to_string_t("Content-Type")];
             if( contentType.find(responseHttpContentType) == std::string::npos )
             {
                 throw ApiException(500
-                    , U("error calling deleteOrder: unexpected response type: ") + contentType
+                    , utility::conversions::to_string_t("error calling deleteOrder: unexpected response type: ") + contentType
                     , std::make_shared<std::stringstream>(response.extract_utf8string(true).get()));
             }
         }
@@ -138,7 +138,7 @@ pplx::task<std::map<utility::string_t, int32_t>> StoreApi::getInventory()
 
 
     std::shared_ptr<ApiConfiguration> apiConfiguration( m_ApiClient->getConfiguration() );
-    utility::string_t path = U("/store/inventory");
+    utility::string_t path = utility::conversions::to_string_t("/store/inventory");
     
     std::map<utility::string_t, utility::string_t> queryParams;
     std::map<utility::string_t, utility::string_t> headerParams( apiConfiguration->getDefaultHeaders() );
@@ -146,31 +146,31 @@ pplx::task<std::map<utility::string_t, int32_t>> StoreApi::getInventory()
     std::map<utility::string_t, std::shared_ptr<HttpContent>> fileParams;
 
     std::unordered_set<utility::string_t> responseHttpContentTypes;
-    responseHttpContentTypes.insert( U("application/json") );
+    responseHttpContentTypes.insert( utility::conversions::to_string_t("application/json") );
 
     utility::string_t responseHttpContentType;
 
     // use JSON if possible
     if ( responseHttpContentTypes.size() == 0 )
     {
-        responseHttpContentType = U("application/json");
+        responseHttpContentType = utility::conversions::to_string_t("application/json");
     }
     // JSON
-    else if ( responseHttpContentTypes.find(U("application/json")) != responseHttpContentTypes.end() )
+    else if ( responseHttpContentTypes.find(utility::conversions::to_string_t("application/json")) != responseHttpContentTypes.end() )
     {
-        responseHttpContentType = U("application/json");
+        responseHttpContentType = utility::conversions::to_string_t("application/json");
     }
     // multipart formdata
-    else if( responseHttpContentTypes.find(U("multipart/form-data")) != responseHttpContentTypes.end() )
+    else if( responseHttpContentTypes.find(utility::conversions::to_string_t("multipart/form-data")) != responseHttpContentTypes.end() )
     {
-        responseHttpContentType = U("multipart/form-data");
+        responseHttpContentType = utility::conversions::to_string_t("multipart/form-data");
     }
     else
     {
-        throw ApiException(400, U("StoreApi->getInventory does not produce any supported media type"));
+        throw ApiException(400, utility::conversions::to_string_t("StoreApi->getInventory does not produce any supported media type"));
     }
 
-    headerParams[U("Accept")] = responseHttpContentType;
+    headerParams[utility::conversions::to_string_t("Accept")] = responseHttpContentType;
 
     std::unordered_set<utility::string_t> consumeHttpContentTypes;
 
@@ -179,30 +179,30 @@ pplx::task<std::map<utility::string_t, int32_t>> StoreApi::getInventory()
     utility::string_t requestHttpContentType;
 
     // use JSON if possible
-    if ( consumeHttpContentTypes.size() == 0 || consumeHttpContentTypes.find(U("application/json")) != consumeHttpContentTypes.end() )
+    if ( consumeHttpContentTypes.size() == 0 || consumeHttpContentTypes.find(utility::conversions::to_string_t("application/json")) != consumeHttpContentTypes.end() )
     {
-        requestHttpContentType = U("application/json");
+        requestHttpContentType = utility::conversions::to_string_t("application/json");
     }
     // multipart formdata
-    else if( consumeHttpContentTypes.find(U("multipart/form-data")) != consumeHttpContentTypes.end() )
+    else if( consumeHttpContentTypes.find(utility::conversions::to_string_t("multipart/form-data")) != consumeHttpContentTypes.end() )
     {
-        requestHttpContentType = U("multipart/form-data");
+        requestHttpContentType = utility::conversions::to_string_t("multipart/form-data");
     }
     else
     {
-        throw ApiException(415, U("StoreApi->getInventory does not consume any supported media type"));
+        throw ApiException(415, utility::conversions::to_string_t("StoreApi->getInventory does not consume any supported media type"));
     }
 
     // authentication (api_key) required
     {
-        utility::string_t apiKey = apiConfiguration->getApiKey(U("api_key"));
+        utility::string_t apiKey = apiConfiguration->getApiKey(utility::conversions::to_string_t("api_key"));
         if ( apiKey.size() > 0 )
         {
-            headerParams[U("api_key")] = apiKey;
+            headerParams[utility::conversions::to_string_t("api_key")] = apiKey;
         }
     }
 
-    return m_ApiClient->callApi(path, U("GET"), queryParams, httpBody, headerParams, formParams, fileParams, requestHttpContentType)
+    return m_ApiClient->callApi(path, utility::conversions::to_string_t("GET"), queryParams, httpBody, headerParams, formParams, fileParams, requestHttpContentType)
     .then([=](web::http::http_response response)
     {
         // 1xx - informational : OK
@@ -213,18 +213,18 @@ pplx::task<std::map<utility::string_t, int32_t>> StoreApi::getInventory()
         if (response.status_code() >= 400)
         {
             throw ApiException(response.status_code()
-                , U("error calling getInventory: ") + response.reason_phrase()
+                , utility::conversions::to_string_t("error calling getInventory: ") + response.reason_phrase()
                 , std::make_shared<std::stringstream>(response.extract_utf8string(true).get()));
         }
 
         // check response content type
-        if(response.headers().has(U("Content-Type")))
+        if(response.headers().has(utility::conversions::to_string_t("Content-Type")))
         {
-            utility::string_t contentType = response.headers()[U("Content-Type")];
+            utility::string_t contentType = response.headers()[utility::conversions::to_string_t("Content-Type")];
             if( contentType.find(responseHttpContentType) == std::string::npos )
             {
                 throw ApiException(500
-                    , U("error calling getInventory: unexpected response type: ") + contentType
+                    , utility::conversions::to_string_t("error calling getInventory: unexpected response type: ") + contentType
                     , std::make_shared<std::stringstream>(response.extract_utf8string(true).get()));
             }
         }
@@ -235,7 +235,7 @@ pplx::task<std::map<utility::string_t, int32_t>> StoreApi::getInventory()
     {
         std::map<utility::string_t, int32_t> result;
 
-        if(responseHttpContentType == U("application/json"))
+        if(responseHttpContentType == utility::conversions::to_string_t("application/json"))
         {
             web::json::value json = web::json::value::parse(response);
 
@@ -246,14 +246,14 @@ pplx::task<std::map<utility::string_t, int32_t>> StoreApi::getInventory()
             }
             
         }
-        // else if(responseHttpContentType == U("multipart/form-data"))
+        // else if(responseHttpContentType == utility::conversions::to_string_t("multipart/form-data"))
         // {
         // TODO multipart response parsing
         // }
         else
         {
             throw ApiException(500
-                , U("error calling getInventory: unsupported response type"));
+                , utility::conversions::to_string_t("error calling getInventory: unsupported response type"));
         }
 
         return result;
@@ -264,8 +264,8 @@ pplx::task<std::shared_ptr<Order>> StoreApi::getOrderById(int64_t orderId)
 
 
     std::shared_ptr<ApiConfiguration> apiConfiguration( m_ApiClient->getConfiguration() );
-    utility::string_t path = U("/store/order/{orderId}");
-    boost::replace_all(path, U("{") U("orderId") U("}"), ApiClient::parameterToString(orderId));
+    utility::string_t path = utility::conversions::to_string_t("/store/order/{orderId}");
+    boost::replace_all(path, utility::conversions::to_string_t("{") + utility::conversions::to_string_t("orderId") + utility::conversions::to_string_t("}"), ApiClient::parameterToString(orderId));
 
     std::map<utility::string_t, utility::string_t> queryParams;
     std::map<utility::string_t, utility::string_t> headerParams( apiConfiguration->getDefaultHeaders() );
@@ -273,32 +273,32 @@ pplx::task<std::shared_ptr<Order>> StoreApi::getOrderById(int64_t orderId)
     std::map<utility::string_t, std::shared_ptr<HttpContent>> fileParams;
 
     std::unordered_set<utility::string_t> responseHttpContentTypes;
-    responseHttpContentTypes.insert( U("application/xml") );
-    responseHttpContentTypes.insert( U("application/json") );
+    responseHttpContentTypes.insert( utility::conversions::to_string_t("application/xml") );
+    responseHttpContentTypes.insert( utility::conversions::to_string_t("application/json") );
 
     utility::string_t responseHttpContentType;
 
     // use JSON if possible
     if ( responseHttpContentTypes.size() == 0 )
     {
-        responseHttpContentType = U("application/json");
+        responseHttpContentType = utility::conversions::to_string_t("application/json");
     }
     // JSON
-    else if ( responseHttpContentTypes.find(U("application/json")) != responseHttpContentTypes.end() )
+    else if ( responseHttpContentTypes.find(utility::conversions::to_string_t("application/json")) != responseHttpContentTypes.end() )
     {
-        responseHttpContentType = U("application/json");
+        responseHttpContentType = utility::conversions::to_string_t("application/json");
     }
     // multipart formdata
-    else if( responseHttpContentTypes.find(U("multipart/form-data")) != responseHttpContentTypes.end() )
+    else if( responseHttpContentTypes.find(utility::conversions::to_string_t("multipart/form-data")) != responseHttpContentTypes.end() )
     {
-        responseHttpContentType = U("multipart/form-data");
+        responseHttpContentType = utility::conversions::to_string_t("multipart/form-data");
     }
     else
     {
-        throw ApiException(400, U("StoreApi->getOrderById does not produce any supported media type"));
+        throw ApiException(400, utility::conversions::to_string_t("StoreApi->getOrderById does not produce any supported media type"));
     }
 
-    headerParams[U("Accept")] = responseHttpContentType;
+    headerParams[utility::conversions::to_string_t("Accept")] = responseHttpContentType;
 
     std::unordered_set<utility::string_t> consumeHttpContentTypes;
 
@@ -307,22 +307,22 @@ pplx::task<std::shared_ptr<Order>> StoreApi::getOrderById(int64_t orderId)
     utility::string_t requestHttpContentType;
 
     // use JSON if possible
-    if ( consumeHttpContentTypes.size() == 0 || consumeHttpContentTypes.find(U("application/json")) != consumeHttpContentTypes.end() )
+    if ( consumeHttpContentTypes.size() == 0 || consumeHttpContentTypes.find(utility::conversions::to_string_t("application/json")) != consumeHttpContentTypes.end() )
     {
-        requestHttpContentType = U("application/json");
+        requestHttpContentType = utility::conversions::to_string_t("application/json");
     }
     // multipart formdata
-    else if( consumeHttpContentTypes.find(U("multipart/form-data")) != consumeHttpContentTypes.end() )
+    else if( consumeHttpContentTypes.find(utility::conversions::to_string_t("multipart/form-data")) != consumeHttpContentTypes.end() )
     {
-        requestHttpContentType = U("multipart/form-data");
+        requestHttpContentType = utility::conversions::to_string_t("multipart/form-data");
     }
     else
     {
-        throw ApiException(415, U("StoreApi->getOrderById does not consume any supported media type"));
+        throw ApiException(415, utility::conversions::to_string_t("StoreApi->getOrderById does not consume any supported media type"));
     }
 
 
-    return m_ApiClient->callApi(path, U("GET"), queryParams, httpBody, headerParams, formParams, fileParams, requestHttpContentType)
+    return m_ApiClient->callApi(path, utility::conversions::to_string_t("GET"), queryParams, httpBody, headerParams, formParams, fileParams, requestHttpContentType)
     .then([=](web::http::http_response response)
     {
         // 1xx - informational : OK
@@ -333,18 +333,18 @@ pplx::task<std::shared_ptr<Order>> StoreApi::getOrderById(int64_t orderId)
         if (response.status_code() >= 400)
         {
             throw ApiException(response.status_code()
-                , U("error calling getOrderById: ") + response.reason_phrase()
+                , utility::conversions::to_string_t("error calling getOrderById: ") + response.reason_phrase()
                 , std::make_shared<std::stringstream>(response.extract_utf8string(true).get()));
         }
 
         // check response content type
-        if(response.headers().has(U("Content-Type")))
+        if(response.headers().has(utility::conversions::to_string_t("Content-Type")))
         {
-            utility::string_t contentType = response.headers()[U("Content-Type")];
+            utility::string_t contentType = response.headers()[utility::conversions::to_string_t("Content-Type")];
             if( contentType.find(responseHttpContentType) == std::string::npos )
             {
                 throw ApiException(500
-                    , U("error calling getOrderById: unexpected response type: ") + contentType
+                    , utility::conversions::to_string_t("error calling getOrderById: unexpected response type: ") + contentType
                     , std::make_shared<std::stringstream>(response.extract_utf8string(true).get()));
             }
         }
@@ -355,20 +355,20 @@ pplx::task<std::shared_ptr<Order>> StoreApi::getOrderById(int64_t orderId)
     {
         std::shared_ptr<Order> result(new Order());
 
-        if(responseHttpContentType == U("application/json"))
+        if(responseHttpContentType == utility::conversions::to_string_t("application/json"))
         {
             web::json::value json = web::json::value::parse(response);
 
             result->fromJson(json);
         }
-        // else if(responseHttpContentType == U("multipart/form-data"))
+        // else if(responseHttpContentType == utility::conversions::to_string_t("multipart/form-data"))
         // {
         // TODO multipart response parsing
         // }
         else
         {
             throw ApiException(500
-                , U("error calling getOrderById: unsupported response type"));
+                , utility::conversions::to_string_t("error calling getOrderById: unsupported response type"));
         }
 
         return result;
@@ -380,12 +380,12 @@ pplx::task<std::shared_ptr<Order>> StoreApi::placeOrder(std::shared_ptr<Order> b
     // verify the required parameter 'body' is set
     if (body == nullptr)
     {
-        throw ApiException(400, U("Missing required parameter 'body' when calling StoreApi->placeOrder"));
+        throw ApiException(400, utility::conversions::to_string_t("Missing required parameter 'body' when calling StoreApi->placeOrder"));
     }
 
 
     std::shared_ptr<ApiConfiguration> apiConfiguration( m_ApiClient->getConfiguration() );
-    utility::string_t path = U("/store/order");
+    utility::string_t path = utility::conversions::to_string_t("/store/order");
     
     std::map<utility::string_t, utility::string_t> queryParams;
     std::map<utility::string_t, utility::string_t> headerParams( apiConfiguration->getDefaultHeaders() );
@@ -393,32 +393,32 @@ pplx::task<std::shared_ptr<Order>> StoreApi::placeOrder(std::shared_ptr<Order> b
     std::map<utility::string_t, std::shared_ptr<HttpContent>> fileParams;
 
     std::unordered_set<utility::string_t> responseHttpContentTypes;
-    responseHttpContentTypes.insert( U("application/xml") );
-    responseHttpContentTypes.insert( U("application/json") );
+    responseHttpContentTypes.insert( utility::conversions::to_string_t("application/xml") );
+    responseHttpContentTypes.insert( utility::conversions::to_string_t("application/json") );
 
     utility::string_t responseHttpContentType;
 
     // use JSON if possible
     if ( responseHttpContentTypes.size() == 0 )
     {
-        responseHttpContentType = U("application/json");
+        responseHttpContentType = utility::conversions::to_string_t("application/json");
     }
     // JSON
-    else if ( responseHttpContentTypes.find(U("application/json")) != responseHttpContentTypes.end() )
+    else if ( responseHttpContentTypes.find(utility::conversions::to_string_t("application/json")) != responseHttpContentTypes.end() )
     {
-        responseHttpContentType = U("application/json");
+        responseHttpContentType = utility::conversions::to_string_t("application/json");
     }
     // multipart formdata
-    else if( responseHttpContentTypes.find(U("multipart/form-data")) != responseHttpContentTypes.end() )
+    else if( responseHttpContentTypes.find(utility::conversions::to_string_t("multipart/form-data")) != responseHttpContentTypes.end() )
     {
-        responseHttpContentType = U("multipart/form-data");
+        responseHttpContentType = utility::conversions::to_string_t("multipart/form-data");
     }
     else
     {
-        throw ApiException(400, U("StoreApi->placeOrder does not produce any supported media type"));
+        throw ApiException(400, utility::conversions::to_string_t("StoreApi->placeOrder does not produce any supported media type"));
     }
 
-    headerParams[U("Accept")] = responseHttpContentType;
+    headerParams[utility::conversions::to_string_t("Accept")] = responseHttpContentType;
 
     std::unordered_set<utility::string_t> consumeHttpContentTypes;
 
@@ -427,9 +427,9 @@ pplx::task<std::shared_ptr<Order>> StoreApi::placeOrder(std::shared_ptr<Order> b
     utility::string_t requestHttpContentType;
 
     // use JSON if possible
-    if ( consumeHttpContentTypes.size() == 0 || consumeHttpContentTypes.find(U("application/json")) != consumeHttpContentTypes.end() )
+    if ( consumeHttpContentTypes.size() == 0 || consumeHttpContentTypes.find(utility::conversions::to_string_t("application/json")) != consumeHttpContentTypes.end() )
     {
-        requestHttpContentType = U("application/json");
+        requestHttpContentType = utility::conversions::to_string_t("application/json");
         web::json::value json;
 
         json = ModelBase::toJson(body);
@@ -437,25 +437,25 @@ pplx::task<std::shared_ptr<Order>> StoreApi::placeOrder(std::shared_ptr<Order> b
         httpBody = std::shared_ptr<IHttpBody>( new JsonBody( json ) );
     }
     // multipart formdata
-    else if( consumeHttpContentTypes.find(U("multipart/form-data")) != consumeHttpContentTypes.end() )
+    else if( consumeHttpContentTypes.find(utility::conversions::to_string_t("multipart/form-data")) != consumeHttpContentTypes.end() )
     {
-        requestHttpContentType = U("multipart/form-data");
+        requestHttpContentType = utility::conversions::to_string_t("multipart/form-data");
         std::shared_ptr<MultipartFormData> multipart(new MultipartFormData);
                 if(body.get())
         {
-            body->toMultipart(multipart, U("body"));
+            body->toMultipart(multipart, utility::conversions::to_string_t("body"));
         }
 
         httpBody = multipart;
-        requestHttpContentType += U("; boundary=") + multipart->getBoundary();
+        requestHttpContentType += utility::conversions::to_string_t("; boundary=") + multipart->getBoundary();
     }
     else
     {
-        throw ApiException(415, U("StoreApi->placeOrder does not consume any supported media type"));
+        throw ApiException(415, utility::conversions::to_string_t("StoreApi->placeOrder does not consume any supported media type"));
     }
 
 
-    return m_ApiClient->callApi(path, U("POST"), queryParams, httpBody, headerParams, formParams, fileParams, requestHttpContentType)
+    return m_ApiClient->callApi(path, utility::conversions::to_string_t("POST"), queryParams, httpBody, headerParams, formParams, fileParams, requestHttpContentType)
     .then([=](web::http::http_response response)
     {
         // 1xx - informational : OK
@@ -466,18 +466,18 @@ pplx::task<std::shared_ptr<Order>> StoreApi::placeOrder(std::shared_ptr<Order> b
         if (response.status_code() >= 400)
         {
             throw ApiException(response.status_code()
-                , U("error calling placeOrder: ") + response.reason_phrase()
+                , utility::conversions::to_string_t("error calling placeOrder: ") + response.reason_phrase()
                 , std::make_shared<std::stringstream>(response.extract_utf8string(true).get()));
         }
 
         // check response content type
-        if(response.headers().has(U("Content-Type")))
+        if(response.headers().has(utility::conversions::to_string_t("Content-Type")))
         {
-            utility::string_t contentType = response.headers()[U("Content-Type")];
+            utility::string_t contentType = response.headers()[utility::conversions::to_string_t("Content-Type")];
             if( contentType.find(responseHttpContentType) == std::string::npos )
             {
                 throw ApiException(500
-                    , U("error calling placeOrder: unexpected response type: ") + contentType
+                    , utility::conversions::to_string_t("error calling placeOrder: unexpected response type: ") + contentType
                     , std::make_shared<std::stringstream>(response.extract_utf8string(true).get()));
             }
         }
@@ -488,20 +488,20 @@ pplx::task<std::shared_ptr<Order>> StoreApi::placeOrder(std::shared_ptr<Order> b
     {
         std::shared_ptr<Order> result(new Order());
 
-        if(responseHttpContentType == U("application/json"))
+        if(responseHttpContentType == utility::conversions::to_string_t("application/json"))
         {
             web::json::value json = web::json::value::parse(response);
 
             result->fromJson(json);
         }
-        // else if(responseHttpContentType == U("multipart/form-data"))
+        // else if(responseHttpContentType == utility::conversions::to_string_t("multipart/form-data"))
         // {
         // TODO multipart response parsing
         // }
         else
         {
             throw ApiException(500
-                , U("error calling placeOrder: unsupported response type"));
+                , utility::conversions::to_string_t("error calling placeOrder: unsupported response type"));
         }
 
         return result;

--- a/samples/client/petstore/cpprest/api/UserApi.cpp
+++ b/samples/client/petstore/cpprest/api/UserApi.cpp
@@ -42,12 +42,12 @@ pplx::task<void> UserApi::createUser(std::shared_ptr<User> body)
     // verify the required parameter 'body' is set
     if (body == nullptr)
     {
-        throw ApiException(400, U("Missing required parameter 'body' when calling UserApi->createUser"));
+        throw ApiException(400, utility::conversions::to_string_t("Missing required parameter 'body' when calling UserApi->createUser"));
     }
 
 
     std::shared_ptr<ApiConfiguration> apiConfiguration( m_ApiClient->getConfiguration() );
-    utility::string_t path = U("/user");
+    utility::string_t path = utility::conversions::to_string_t("/user");
     
     std::map<utility::string_t, utility::string_t> queryParams;
     std::map<utility::string_t, utility::string_t> headerParams( apiConfiguration->getDefaultHeaders() );
@@ -55,32 +55,32 @@ pplx::task<void> UserApi::createUser(std::shared_ptr<User> body)
     std::map<utility::string_t, std::shared_ptr<HttpContent>> fileParams;
 
     std::unordered_set<utility::string_t> responseHttpContentTypes;
-    responseHttpContentTypes.insert( U("application/xml") );
-    responseHttpContentTypes.insert( U("application/json") );
+    responseHttpContentTypes.insert( utility::conversions::to_string_t("application/xml") );
+    responseHttpContentTypes.insert( utility::conversions::to_string_t("application/json") );
 
     utility::string_t responseHttpContentType;
 
     // use JSON if possible
     if ( responseHttpContentTypes.size() == 0 )
     {
-        responseHttpContentType = U("application/json");
+        responseHttpContentType = utility::conversions::to_string_t("application/json");
     }
     // JSON
-    else if ( responseHttpContentTypes.find(U("application/json")) != responseHttpContentTypes.end() )
+    else if ( responseHttpContentTypes.find(utility::conversions::to_string_t("application/json")) != responseHttpContentTypes.end() )
     {
-        responseHttpContentType = U("application/json");
+        responseHttpContentType = utility::conversions::to_string_t("application/json");
     }
     // multipart formdata
-    else if( responseHttpContentTypes.find(U("multipart/form-data")) != responseHttpContentTypes.end() )
+    else if( responseHttpContentTypes.find(utility::conversions::to_string_t("multipart/form-data")) != responseHttpContentTypes.end() )
     {
-        responseHttpContentType = U("multipart/form-data");
+        responseHttpContentType = utility::conversions::to_string_t("multipart/form-data");
     }
     else
     {
-        throw ApiException(400, U("UserApi->createUser does not produce any supported media type"));
+        throw ApiException(400, utility::conversions::to_string_t("UserApi->createUser does not produce any supported media type"));
     }
 
-    headerParams[U("Accept")] = responseHttpContentType;
+    headerParams[utility::conversions::to_string_t("Accept")] = responseHttpContentType;
 
     std::unordered_set<utility::string_t> consumeHttpContentTypes;
 
@@ -89,9 +89,9 @@ pplx::task<void> UserApi::createUser(std::shared_ptr<User> body)
     utility::string_t requestHttpContentType;
 
     // use JSON if possible
-    if ( consumeHttpContentTypes.size() == 0 || consumeHttpContentTypes.find(U("application/json")) != consumeHttpContentTypes.end() )
+    if ( consumeHttpContentTypes.size() == 0 || consumeHttpContentTypes.find(utility::conversions::to_string_t("application/json")) != consumeHttpContentTypes.end() )
     {
-        requestHttpContentType = U("application/json");
+        requestHttpContentType = utility::conversions::to_string_t("application/json");
         web::json::value json;
 
         json = ModelBase::toJson(body);
@@ -99,25 +99,25 @@ pplx::task<void> UserApi::createUser(std::shared_ptr<User> body)
         httpBody = std::shared_ptr<IHttpBody>( new JsonBody( json ) );
     }
     // multipart formdata
-    else if( consumeHttpContentTypes.find(U("multipart/form-data")) != consumeHttpContentTypes.end() )
+    else if( consumeHttpContentTypes.find(utility::conversions::to_string_t("multipart/form-data")) != consumeHttpContentTypes.end() )
     {
-        requestHttpContentType = U("multipart/form-data");
+        requestHttpContentType = utility::conversions::to_string_t("multipart/form-data");
         std::shared_ptr<MultipartFormData> multipart(new MultipartFormData);
                 if(body.get())
         {
-            body->toMultipart(multipart, U("body"));
+            body->toMultipart(multipart, utility::conversions::to_string_t("body"));
         }
 
         httpBody = multipart;
-        requestHttpContentType += U("; boundary=") + multipart->getBoundary();
+        requestHttpContentType += utility::conversions::to_string_t("; boundary=") + multipart->getBoundary();
     }
     else
     {
-        throw ApiException(415, U("UserApi->createUser does not consume any supported media type"));
+        throw ApiException(415, utility::conversions::to_string_t("UserApi->createUser does not consume any supported media type"));
     }
 
 
-    return m_ApiClient->callApi(path, U("POST"), queryParams, httpBody, headerParams, formParams, fileParams, requestHttpContentType)
+    return m_ApiClient->callApi(path, utility::conversions::to_string_t("POST"), queryParams, httpBody, headerParams, formParams, fileParams, requestHttpContentType)
     .then([=](web::http::http_response response)
     {
         // 1xx - informational : OK
@@ -128,18 +128,18 @@ pplx::task<void> UserApi::createUser(std::shared_ptr<User> body)
         if (response.status_code() >= 400)
         {
             throw ApiException(response.status_code()
-                , U("error calling createUser: ") + response.reason_phrase()
+                , utility::conversions::to_string_t("error calling createUser: ") + response.reason_phrase()
                 , std::make_shared<std::stringstream>(response.extract_utf8string(true).get()));
         }
 
         // check response content type
-        if(response.headers().has(U("Content-Type")))
+        if(response.headers().has(utility::conversions::to_string_t("Content-Type")))
         {
-            utility::string_t contentType = response.headers()[U("Content-Type")];
+            utility::string_t contentType = response.headers()[utility::conversions::to_string_t("Content-Type")];
             if( contentType.find(responseHttpContentType) == std::string::npos )
             {
                 throw ApiException(500
-                    , U("error calling createUser: unexpected response type: ") + contentType
+                    , utility::conversions::to_string_t("error calling createUser: unexpected response type: ") + contentType
                     , std::make_shared<std::stringstream>(response.extract_utf8string(true).get()));
             }
         }
@@ -156,7 +156,7 @@ pplx::task<void> UserApi::createUsersWithArrayInput(std::vector<std::shared_ptr<
 
 
     std::shared_ptr<ApiConfiguration> apiConfiguration( m_ApiClient->getConfiguration() );
-    utility::string_t path = U("/user/createWithArray");
+    utility::string_t path = utility::conversions::to_string_t("/user/createWithArray");
     
     std::map<utility::string_t, utility::string_t> queryParams;
     std::map<utility::string_t, utility::string_t> headerParams( apiConfiguration->getDefaultHeaders() );
@@ -164,32 +164,32 @@ pplx::task<void> UserApi::createUsersWithArrayInput(std::vector<std::shared_ptr<
     std::map<utility::string_t, std::shared_ptr<HttpContent>> fileParams;
 
     std::unordered_set<utility::string_t> responseHttpContentTypes;
-    responseHttpContentTypes.insert( U("application/xml") );
-    responseHttpContentTypes.insert( U("application/json") );
+    responseHttpContentTypes.insert( utility::conversions::to_string_t("application/xml") );
+    responseHttpContentTypes.insert( utility::conversions::to_string_t("application/json") );
 
     utility::string_t responseHttpContentType;
 
     // use JSON if possible
     if ( responseHttpContentTypes.size() == 0 )
     {
-        responseHttpContentType = U("application/json");
+        responseHttpContentType = utility::conversions::to_string_t("application/json");
     }
     // JSON
-    else if ( responseHttpContentTypes.find(U("application/json")) != responseHttpContentTypes.end() )
+    else if ( responseHttpContentTypes.find(utility::conversions::to_string_t("application/json")) != responseHttpContentTypes.end() )
     {
-        responseHttpContentType = U("application/json");
+        responseHttpContentType = utility::conversions::to_string_t("application/json");
     }
     // multipart formdata
-    else if( responseHttpContentTypes.find(U("multipart/form-data")) != responseHttpContentTypes.end() )
+    else if( responseHttpContentTypes.find(utility::conversions::to_string_t("multipart/form-data")) != responseHttpContentTypes.end() )
     {
-        responseHttpContentType = U("multipart/form-data");
+        responseHttpContentType = utility::conversions::to_string_t("multipart/form-data");
     }
     else
     {
-        throw ApiException(400, U("UserApi->createUsersWithArrayInput does not produce any supported media type"));
+        throw ApiException(400, utility::conversions::to_string_t("UserApi->createUsersWithArrayInput does not produce any supported media type"));
     }
 
-    headerParams[U("Accept")] = responseHttpContentType;
+    headerParams[utility::conversions::to_string_t("Accept")] = responseHttpContentType;
 
     std::unordered_set<utility::string_t> consumeHttpContentTypes;
 
@@ -198,9 +198,9 @@ pplx::task<void> UserApi::createUsersWithArrayInput(std::vector<std::shared_ptr<
     utility::string_t requestHttpContentType;
 
     // use JSON if possible
-    if ( consumeHttpContentTypes.size() == 0 || consumeHttpContentTypes.find(U("application/json")) != consumeHttpContentTypes.end() )
+    if ( consumeHttpContentTypes.size() == 0 || consumeHttpContentTypes.find(utility::conversions::to_string_t("application/json")) != consumeHttpContentTypes.end() )
     {
-        requestHttpContentType = U("application/json");
+        requestHttpContentType = utility::conversions::to_string_t("application/json");
         web::json::value json;
 
         {
@@ -216,9 +216,9 @@ pplx::task<void> UserApi::createUsersWithArrayInput(std::vector<std::shared_ptr<
         httpBody = std::shared_ptr<IHttpBody>( new JsonBody( json ) );
     }
     // multipart formdata
-    else if( consumeHttpContentTypes.find(U("multipart/form-data")) != consumeHttpContentTypes.end() )
+    else if( consumeHttpContentTypes.find(utility::conversions::to_string_t("multipart/form-data")) != consumeHttpContentTypes.end() )
     {
-        requestHttpContentType = U("multipart/form-data");
+        requestHttpContentType = utility::conversions::to_string_t("multipart/form-data");
         std::shared_ptr<MultipartFormData> multipart(new MultipartFormData);
         {
             std::vector<web::json::value> jsonArray;
@@ -227,19 +227,19 @@ pplx::task<void> UserApi::createUsersWithArrayInput(std::vector<std::shared_ptr<
                 jsonArray.push_back( item.get() ? item->toJson() : web::json::value::null() );
                 
             }
-            multipart->add(ModelBase::toHttpContent(U("body"), web::json::value::array(jsonArray), U("application/json")));
+            multipart->add(ModelBase::toHttpContent(utility::conversions::to_string_t("body"), web::json::value::array(jsonArray), utility::conversions::to_string_t("application/json")));
         }
 
         httpBody = multipart;
-        requestHttpContentType += U("; boundary=") + multipart->getBoundary();
+        requestHttpContentType += utility::conversions::to_string_t("; boundary=") + multipart->getBoundary();
     }
     else
     {
-        throw ApiException(415, U("UserApi->createUsersWithArrayInput does not consume any supported media type"));
+        throw ApiException(415, utility::conversions::to_string_t("UserApi->createUsersWithArrayInput does not consume any supported media type"));
     }
 
 
-    return m_ApiClient->callApi(path, U("POST"), queryParams, httpBody, headerParams, formParams, fileParams, requestHttpContentType)
+    return m_ApiClient->callApi(path, utility::conversions::to_string_t("POST"), queryParams, httpBody, headerParams, formParams, fileParams, requestHttpContentType)
     .then([=](web::http::http_response response)
     {
         // 1xx - informational : OK
@@ -250,18 +250,18 @@ pplx::task<void> UserApi::createUsersWithArrayInput(std::vector<std::shared_ptr<
         if (response.status_code() >= 400)
         {
             throw ApiException(response.status_code()
-                , U("error calling createUsersWithArrayInput: ") + response.reason_phrase()
+                , utility::conversions::to_string_t("error calling createUsersWithArrayInput: ") + response.reason_phrase()
                 , std::make_shared<std::stringstream>(response.extract_utf8string(true).get()));
         }
 
         // check response content type
-        if(response.headers().has(U("Content-Type")))
+        if(response.headers().has(utility::conversions::to_string_t("Content-Type")))
         {
-            utility::string_t contentType = response.headers()[U("Content-Type")];
+            utility::string_t contentType = response.headers()[utility::conversions::to_string_t("Content-Type")];
             if( contentType.find(responseHttpContentType) == std::string::npos )
             {
                 throw ApiException(500
-                    , U("error calling createUsersWithArrayInput: unexpected response type: ") + contentType
+                    , utility::conversions::to_string_t("error calling createUsersWithArrayInput: unexpected response type: ") + contentType
                     , std::make_shared<std::stringstream>(response.extract_utf8string(true).get()));
             }
         }
@@ -278,7 +278,7 @@ pplx::task<void> UserApi::createUsersWithListInput(std::vector<std::shared_ptr<U
 
 
     std::shared_ptr<ApiConfiguration> apiConfiguration( m_ApiClient->getConfiguration() );
-    utility::string_t path = U("/user/createWithList");
+    utility::string_t path = utility::conversions::to_string_t("/user/createWithList");
     
     std::map<utility::string_t, utility::string_t> queryParams;
     std::map<utility::string_t, utility::string_t> headerParams( apiConfiguration->getDefaultHeaders() );
@@ -286,32 +286,32 @@ pplx::task<void> UserApi::createUsersWithListInput(std::vector<std::shared_ptr<U
     std::map<utility::string_t, std::shared_ptr<HttpContent>> fileParams;
 
     std::unordered_set<utility::string_t> responseHttpContentTypes;
-    responseHttpContentTypes.insert( U("application/xml") );
-    responseHttpContentTypes.insert( U("application/json") );
+    responseHttpContentTypes.insert( utility::conversions::to_string_t("application/xml") );
+    responseHttpContentTypes.insert( utility::conversions::to_string_t("application/json") );
 
     utility::string_t responseHttpContentType;
 
     // use JSON if possible
     if ( responseHttpContentTypes.size() == 0 )
     {
-        responseHttpContentType = U("application/json");
+        responseHttpContentType = utility::conversions::to_string_t("application/json");
     }
     // JSON
-    else if ( responseHttpContentTypes.find(U("application/json")) != responseHttpContentTypes.end() )
+    else if ( responseHttpContentTypes.find(utility::conversions::to_string_t("application/json")) != responseHttpContentTypes.end() )
     {
-        responseHttpContentType = U("application/json");
+        responseHttpContentType = utility::conversions::to_string_t("application/json");
     }
     // multipart formdata
-    else if( responseHttpContentTypes.find(U("multipart/form-data")) != responseHttpContentTypes.end() )
+    else if( responseHttpContentTypes.find(utility::conversions::to_string_t("multipart/form-data")) != responseHttpContentTypes.end() )
     {
-        responseHttpContentType = U("multipart/form-data");
+        responseHttpContentType = utility::conversions::to_string_t("multipart/form-data");
     }
     else
     {
-        throw ApiException(400, U("UserApi->createUsersWithListInput does not produce any supported media type"));
+        throw ApiException(400, utility::conversions::to_string_t("UserApi->createUsersWithListInput does not produce any supported media type"));
     }
 
-    headerParams[U("Accept")] = responseHttpContentType;
+    headerParams[utility::conversions::to_string_t("Accept")] = responseHttpContentType;
 
     std::unordered_set<utility::string_t> consumeHttpContentTypes;
 
@@ -320,9 +320,9 @@ pplx::task<void> UserApi::createUsersWithListInput(std::vector<std::shared_ptr<U
     utility::string_t requestHttpContentType;
 
     // use JSON if possible
-    if ( consumeHttpContentTypes.size() == 0 || consumeHttpContentTypes.find(U("application/json")) != consumeHttpContentTypes.end() )
+    if ( consumeHttpContentTypes.size() == 0 || consumeHttpContentTypes.find(utility::conversions::to_string_t("application/json")) != consumeHttpContentTypes.end() )
     {
-        requestHttpContentType = U("application/json");
+        requestHttpContentType = utility::conversions::to_string_t("application/json");
         web::json::value json;
 
         {
@@ -338,9 +338,9 @@ pplx::task<void> UserApi::createUsersWithListInput(std::vector<std::shared_ptr<U
         httpBody = std::shared_ptr<IHttpBody>( new JsonBody( json ) );
     }
     // multipart formdata
-    else if( consumeHttpContentTypes.find(U("multipart/form-data")) != consumeHttpContentTypes.end() )
+    else if( consumeHttpContentTypes.find(utility::conversions::to_string_t("multipart/form-data")) != consumeHttpContentTypes.end() )
     {
-        requestHttpContentType = U("multipart/form-data");
+        requestHttpContentType = utility::conversions::to_string_t("multipart/form-data");
         std::shared_ptr<MultipartFormData> multipart(new MultipartFormData);
         {
             std::vector<web::json::value> jsonArray;
@@ -349,19 +349,19 @@ pplx::task<void> UserApi::createUsersWithListInput(std::vector<std::shared_ptr<U
                 jsonArray.push_back( item.get() ? item->toJson() : web::json::value::null() );
                 
             }
-            multipart->add(ModelBase::toHttpContent(U("body"), web::json::value::array(jsonArray), U("application/json")));
+            multipart->add(ModelBase::toHttpContent(utility::conversions::to_string_t("body"), web::json::value::array(jsonArray), utility::conversions::to_string_t("application/json")));
         }
 
         httpBody = multipart;
-        requestHttpContentType += U("; boundary=") + multipart->getBoundary();
+        requestHttpContentType += utility::conversions::to_string_t("; boundary=") + multipart->getBoundary();
     }
     else
     {
-        throw ApiException(415, U("UserApi->createUsersWithListInput does not consume any supported media type"));
+        throw ApiException(415, utility::conversions::to_string_t("UserApi->createUsersWithListInput does not consume any supported media type"));
     }
 
 
-    return m_ApiClient->callApi(path, U("POST"), queryParams, httpBody, headerParams, formParams, fileParams, requestHttpContentType)
+    return m_ApiClient->callApi(path, utility::conversions::to_string_t("POST"), queryParams, httpBody, headerParams, formParams, fileParams, requestHttpContentType)
     .then([=](web::http::http_response response)
     {
         // 1xx - informational : OK
@@ -372,18 +372,18 @@ pplx::task<void> UserApi::createUsersWithListInput(std::vector<std::shared_ptr<U
         if (response.status_code() >= 400)
         {
             throw ApiException(response.status_code()
-                , U("error calling createUsersWithListInput: ") + response.reason_phrase()
+                , utility::conversions::to_string_t("error calling createUsersWithListInput: ") + response.reason_phrase()
                 , std::make_shared<std::stringstream>(response.extract_utf8string(true).get()));
         }
 
         // check response content type
-        if(response.headers().has(U("Content-Type")))
+        if(response.headers().has(utility::conversions::to_string_t("Content-Type")))
         {
-            utility::string_t contentType = response.headers()[U("Content-Type")];
+            utility::string_t contentType = response.headers()[utility::conversions::to_string_t("Content-Type")];
             if( contentType.find(responseHttpContentType) == std::string::npos )
             {
                 throw ApiException(500
-                    , U("error calling createUsersWithListInput: unexpected response type: ") + contentType
+                    , utility::conversions::to_string_t("error calling createUsersWithListInput: unexpected response type: ") + contentType
                     , std::make_shared<std::stringstream>(response.extract_utf8string(true).get()));
             }
         }
@@ -400,8 +400,8 @@ pplx::task<void> UserApi::deleteUser(utility::string_t username)
 
 
     std::shared_ptr<ApiConfiguration> apiConfiguration( m_ApiClient->getConfiguration() );
-    utility::string_t path = U("/user/{username}");
-    boost::replace_all(path, U("{") U("username") U("}"), ApiClient::parameterToString(username));
+    utility::string_t path = utility::conversions::to_string_t("/user/{username}");
+    boost::replace_all(path, utility::conversions::to_string_t("{") + utility::conversions::to_string_t("username") + utility::conversions::to_string_t("}"), ApiClient::parameterToString(username));
 
     std::map<utility::string_t, utility::string_t> queryParams;
     std::map<utility::string_t, utility::string_t> headerParams( apiConfiguration->getDefaultHeaders() );
@@ -409,32 +409,32 @@ pplx::task<void> UserApi::deleteUser(utility::string_t username)
     std::map<utility::string_t, std::shared_ptr<HttpContent>> fileParams;
 
     std::unordered_set<utility::string_t> responseHttpContentTypes;
-    responseHttpContentTypes.insert( U("application/xml") );
-    responseHttpContentTypes.insert( U("application/json") );
+    responseHttpContentTypes.insert( utility::conversions::to_string_t("application/xml") );
+    responseHttpContentTypes.insert( utility::conversions::to_string_t("application/json") );
 
     utility::string_t responseHttpContentType;
 
     // use JSON if possible
     if ( responseHttpContentTypes.size() == 0 )
     {
-        responseHttpContentType = U("application/json");
+        responseHttpContentType = utility::conversions::to_string_t("application/json");
     }
     // JSON
-    else if ( responseHttpContentTypes.find(U("application/json")) != responseHttpContentTypes.end() )
+    else if ( responseHttpContentTypes.find(utility::conversions::to_string_t("application/json")) != responseHttpContentTypes.end() )
     {
-        responseHttpContentType = U("application/json");
+        responseHttpContentType = utility::conversions::to_string_t("application/json");
     }
     // multipart formdata
-    else if( responseHttpContentTypes.find(U("multipart/form-data")) != responseHttpContentTypes.end() )
+    else if( responseHttpContentTypes.find(utility::conversions::to_string_t("multipart/form-data")) != responseHttpContentTypes.end() )
     {
-        responseHttpContentType = U("multipart/form-data");
+        responseHttpContentType = utility::conversions::to_string_t("multipart/form-data");
     }
     else
     {
-        throw ApiException(400, U("UserApi->deleteUser does not produce any supported media type"));
+        throw ApiException(400, utility::conversions::to_string_t("UserApi->deleteUser does not produce any supported media type"));
     }
 
-    headerParams[U("Accept")] = responseHttpContentType;
+    headerParams[utility::conversions::to_string_t("Accept")] = responseHttpContentType;
 
     std::unordered_set<utility::string_t> consumeHttpContentTypes;
 
@@ -443,22 +443,22 @@ pplx::task<void> UserApi::deleteUser(utility::string_t username)
     utility::string_t requestHttpContentType;
 
     // use JSON if possible
-    if ( consumeHttpContentTypes.size() == 0 || consumeHttpContentTypes.find(U("application/json")) != consumeHttpContentTypes.end() )
+    if ( consumeHttpContentTypes.size() == 0 || consumeHttpContentTypes.find(utility::conversions::to_string_t("application/json")) != consumeHttpContentTypes.end() )
     {
-        requestHttpContentType = U("application/json");
+        requestHttpContentType = utility::conversions::to_string_t("application/json");
     }
     // multipart formdata
-    else if( consumeHttpContentTypes.find(U("multipart/form-data")) != consumeHttpContentTypes.end() )
+    else if( consumeHttpContentTypes.find(utility::conversions::to_string_t("multipart/form-data")) != consumeHttpContentTypes.end() )
     {
-        requestHttpContentType = U("multipart/form-data");
+        requestHttpContentType = utility::conversions::to_string_t("multipart/form-data");
     }
     else
     {
-        throw ApiException(415, U("UserApi->deleteUser does not consume any supported media type"));
+        throw ApiException(415, utility::conversions::to_string_t("UserApi->deleteUser does not consume any supported media type"));
     }
 
 
-    return m_ApiClient->callApi(path, U("DELETE"), queryParams, httpBody, headerParams, formParams, fileParams, requestHttpContentType)
+    return m_ApiClient->callApi(path, utility::conversions::to_string_t("DELETE"), queryParams, httpBody, headerParams, formParams, fileParams, requestHttpContentType)
     .then([=](web::http::http_response response)
     {
         // 1xx - informational : OK
@@ -469,18 +469,18 @@ pplx::task<void> UserApi::deleteUser(utility::string_t username)
         if (response.status_code() >= 400)
         {
             throw ApiException(response.status_code()
-                , U("error calling deleteUser: ") + response.reason_phrase()
+                , utility::conversions::to_string_t("error calling deleteUser: ") + response.reason_phrase()
                 , std::make_shared<std::stringstream>(response.extract_utf8string(true).get()));
         }
 
         // check response content type
-        if(response.headers().has(U("Content-Type")))
+        if(response.headers().has(utility::conversions::to_string_t("Content-Type")))
         {
-            utility::string_t contentType = response.headers()[U("Content-Type")];
+            utility::string_t contentType = response.headers()[utility::conversions::to_string_t("Content-Type")];
             if( contentType.find(responseHttpContentType) == std::string::npos )
             {
                 throw ApiException(500
-                    , U("error calling deleteUser: unexpected response type: ") + contentType
+                    , utility::conversions::to_string_t("error calling deleteUser: unexpected response type: ") + contentType
                     , std::make_shared<std::stringstream>(response.extract_utf8string(true).get()));
             }
         }
@@ -497,8 +497,8 @@ pplx::task<std::shared_ptr<User>> UserApi::getUserByName(utility::string_t usern
 
 
     std::shared_ptr<ApiConfiguration> apiConfiguration( m_ApiClient->getConfiguration() );
-    utility::string_t path = U("/user/{username}");
-    boost::replace_all(path, U("{") U("username") U("}"), ApiClient::parameterToString(username));
+    utility::string_t path = utility::conversions::to_string_t("/user/{username}");
+    boost::replace_all(path, utility::conversions::to_string_t("{") + utility::conversions::to_string_t("username") + utility::conversions::to_string_t("}"), ApiClient::parameterToString(username));
 
     std::map<utility::string_t, utility::string_t> queryParams;
     std::map<utility::string_t, utility::string_t> headerParams( apiConfiguration->getDefaultHeaders() );
@@ -506,32 +506,32 @@ pplx::task<std::shared_ptr<User>> UserApi::getUserByName(utility::string_t usern
     std::map<utility::string_t, std::shared_ptr<HttpContent>> fileParams;
 
     std::unordered_set<utility::string_t> responseHttpContentTypes;
-    responseHttpContentTypes.insert( U("application/xml") );
-    responseHttpContentTypes.insert( U("application/json") );
+    responseHttpContentTypes.insert( utility::conversions::to_string_t("application/xml") );
+    responseHttpContentTypes.insert( utility::conversions::to_string_t("application/json") );
 
     utility::string_t responseHttpContentType;
 
     // use JSON if possible
     if ( responseHttpContentTypes.size() == 0 )
     {
-        responseHttpContentType = U("application/json");
+        responseHttpContentType = utility::conversions::to_string_t("application/json");
     }
     // JSON
-    else if ( responseHttpContentTypes.find(U("application/json")) != responseHttpContentTypes.end() )
+    else if ( responseHttpContentTypes.find(utility::conversions::to_string_t("application/json")) != responseHttpContentTypes.end() )
     {
-        responseHttpContentType = U("application/json");
+        responseHttpContentType = utility::conversions::to_string_t("application/json");
     }
     // multipart formdata
-    else if( responseHttpContentTypes.find(U("multipart/form-data")) != responseHttpContentTypes.end() )
+    else if( responseHttpContentTypes.find(utility::conversions::to_string_t("multipart/form-data")) != responseHttpContentTypes.end() )
     {
-        responseHttpContentType = U("multipart/form-data");
+        responseHttpContentType = utility::conversions::to_string_t("multipart/form-data");
     }
     else
     {
-        throw ApiException(400, U("UserApi->getUserByName does not produce any supported media type"));
+        throw ApiException(400, utility::conversions::to_string_t("UserApi->getUserByName does not produce any supported media type"));
     }
 
-    headerParams[U("Accept")] = responseHttpContentType;
+    headerParams[utility::conversions::to_string_t("Accept")] = responseHttpContentType;
 
     std::unordered_set<utility::string_t> consumeHttpContentTypes;
 
@@ -540,22 +540,22 @@ pplx::task<std::shared_ptr<User>> UserApi::getUserByName(utility::string_t usern
     utility::string_t requestHttpContentType;
 
     // use JSON if possible
-    if ( consumeHttpContentTypes.size() == 0 || consumeHttpContentTypes.find(U("application/json")) != consumeHttpContentTypes.end() )
+    if ( consumeHttpContentTypes.size() == 0 || consumeHttpContentTypes.find(utility::conversions::to_string_t("application/json")) != consumeHttpContentTypes.end() )
     {
-        requestHttpContentType = U("application/json");
+        requestHttpContentType = utility::conversions::to_string_t("application/json");
     }
     // multipart formdata
-    else if( consumeHttpContentTypes.find(U("multipart/form-data")) != consumeHttpContentTypes.end() )
+    else if( consumeHttpContentTypes.find(utility::conversions::to_string_t("multipart/form-data")) != consumeHttpContentTypes.end() )
     {
-        requestHttpContentType = U("multipart/form-data");
+        requestHttpContentType = utility::conversions::to_string_t("multipart/form-data");
     }
     else
     {
-        throw ApiException(415, U("UserApi->getUserByName does not consume any supported media type"));
+        throw ApiException(415, utility::conversions::to_string_t("UserApi->getUserByName does not consume any supported media type"));
     }
 
 
-    return m_ApiClient->callApi(path, U("GET"), queryParams, httpBody, headerParams, formParams, fileParams, requestHttpContentType)
+    return m_ApiClient->callApi(path, utility::conversions::to_string_t("GET"), queryParams, httpBody, headerParams, formParams, fileParams, requestHttpContentType)
     .then([=](web::http::http_response response)
     {
         // 1xx - informational : OK
@@ -566,18 +566,18 @@ pplx::task<std::shared_ptr<User>> UserApi::getUserByName(utility::string_t usern
         if (response.status_code() >= 400)
         {
             throw ApiException(response.status_code()
-                , U("error calling getUserByName: ") + response.reason_phrase()
+                , utility::conversions::to_string_t("error calling getUserByName: ") + response.reason_phrase()
                 , std::make_shared<std::stringstream>(response.extract_utf8string(true).get()));
         }
 
         // check response content type
-        if(response.headers().has(U("Content-Type")))
+        if(response.headers().has(utility::conversions::to_string_t("Content-Type")))
         {
-            utility::string_t contentType = response.headers()[U("Content-Type")];
+            utility::string_t contentType = response.headers()[utility::conversions::to_string_t("Content-Type")];
             if( contentType.find(responseHttpContentType) == std::string::npos )
             {
                 throw ApiException(500
-                    , U("error calling getUserByName: unexpected response type: ") + contentType
+                    , utility::conversions::to_string_t("error calling getUserByName: unexpected response type: ") + contentType
                     , std::make_shared<std::stringstream>(response.extract_utf8string(true).get()));
             }
         }
@@ -588,20 +588,20 @@ pplx::task<std::shared_ptr<User>> UserApi::getUserByName(utility::string_t usern
     {
         std::shared_ptr<User> result(new User());
 
-        if(responseHttpContentType == U("application/json"))
+        if(responseHttpContentType == utility::conversions::to_string_t("application/json"))
         {
             web::json::value json = web::json::value::parse(response);
 
             result->fromJson(json);
         }
-        // else if(responseHttpContentType == U("multipart/form-data"))
+        // else if(responseHttpContentType == utility::conversions::to_string_t("multipart/form-data"))
         // {
         // TODO multipart response parsing
         // }
         else
         {
             throw ApiException(500
-                , U("error calling getUserByName: unsupported response type"));
+                , utility::conversions::to_string_t("error calling getUserByName: unsupported response type"));
         }
 
         return result;
@@ -612,7 +612,7 @@ pplx::task<utility::string_t> UserApi::loginUser(utility::string_t username, uti
 
 
     std::shared_ptr<ApiConfiguration> apiConfiguration( m_ApiClient->getConfiguration() );
-    utility::string_t path = U("/user/login");
+    utility::string_t path = utility::conversions::to_string_t("/user/login");
     
     std::map<utility::string_t, utility::string_t> queryParams;
     std::map<utility::string_t, utility::string_t> headerParams( apiConfiguration->getDefaultHeaders() );
@@ -620,69 +620,69 @@ pplx::task<utility::string_t> UserApi::loginUser(utility::string_t username, uti
     std::map<utility::string_t, std::shared_ptr<HttpContent>> fileParams;
 
     std::unordered_set<utility::string_t> responseHttpContentTypes;
-    responseHttpContentTypes.insert( U("application/xml") );
-    responseHttpContentTypes.insert( U("application/json") );
+    responseHttpContentTypes.insert( utility::conversions::to_string_t("application/xml") );
+    responseHttpContentTypes.insert( utility::conversions::to_string_t("application/json") );
 
     utility::string_t responseHttpContentType;
 
     // use JSON if possible
     if ( responseHttpContentTypes.size() == 0 )
     {
-        responseHttpContentType = U("text/plain");
+        responseHttpContentType = utility::conversions::to_string_t("text/plain");
     }
     // JSON
-    else if ( responseHttpContentTypes.find(U("application/json")) != responseHttpContentTypes.end() )
+    else if ( responseHttpContentTypes.find(utility::conversions::to_string_t("application/json")) != responseHttpContentTypes.end() )
     {
-        responseHttpContentType = U("application/json");
+        responseHttpContentType = utility::conversions::to_string_t("application/json");
     }
     // multipart formdata
-    else if( responseHttpContentTypes.find(U("multipart/form-data")) != responseHttpContentTypes.end() )
+    else if( responseHttpContentTypes.find(utility::conversions::to_string_t("multipart/form-data")) != responseHttpContentTypes.end() )
     {
-        responseHttpContentType = U("multipart/form-data");
+        responseHttpContentType = utility::conversions::to_string_t("multipart/form-data");
     }
     // plain text
-    else if( responseHttpContentTypes.find(U("text/plain")) != responseHttpContentTypes.end() )
+    else if( responseHttpContentTypes.find(utility::conversions::to_string_t("text/plain")) != responseHttpContentTypes.end() )
     {
-        responseHttpContentType = U("text/plain");
+        responseHttpContentType = utility::conversions::to_string_t("text/plain");
     }
     else
     {
-        throw ApiException(400, U("UserApi->loginUser does not produce any supported media type"));
+        throw ApiException(400, utility::conversions::to_string_t("UserApi->loginUser does not produce any supported media type"));
     }
 
-    headerParams[U("Accept")] = responseHttpContentType;
+    headerParams[utility::conversions::to_string_t("Accept")] = responseHttpContentType;
 
     std::unordered_set<utility::string_t> consumeHttpContentTypes;
 
     
     {
-        queryParams[U("username")] = ApiClient::parameterToString(username);
+        queryParams[utility::conversions::to_string_t("username")] = ApiClient::parameterToString(username);
     }
     
     {
-        queryParams[U("password")] = ApiClient::parameterToString(password);
+        queryParams[utility::conversions::to_string_t("password")] = ApiClient::parameterToString(password);
     }
 
     std::shared_ptr<IHttpBody> httpBody;
     utility::string_t requestHttpContentType;
 
     // use JSON if possible
-    if ( consumeHttpContentTypes.size() == 0 || consumeHttpContentTypes.find(U("application/json")) != consumeHttpContentTypes.end() )
+    if ( consumeHttpContentTypes.size() == 0 || consumeHttpContentTypes.find(utility::conversions::to_string_t("application/json")) != consumeHttpContentTypes.end() )
     {
-        requestHttpContentType = U("application/json");
+        requestHttpContentType = utility::conversions::to_string_t("application/json");
     }
     // multipart formdata
-    else if( consumeHttpContentTypes.find(U("multipart/form-data")) != consumeHttpContentTypes.end() )
+    else if( consumeHttpContentTypes.find(utility::conversions::to_string_t("multipart/form-data")) != consumeHttpContentTypes.end() )
     {
-        requestHttpContentType = U("multipart/form-data");
+        requestHttpContentType = utility::conversions::to_string_t("multipart/form-data");
     }
     else
     {
-        throw ApiException(415, U("UserApi->loginUser does not consume any supported media type"));
+        throw ApiException(415, utility::conversions::to_string_t("UserApi->loginUser does not consume any supported media type"));
     }
 
 
-    return m_ApiClient->callApi(path, U("GET"), queryParams, httpBody, headerParams, formParams, fileParams, requestHttpContentType)
+    return m_ApiClient->callApi(path, utility::conversions::to_string_t("GET"), queryParams, httpBody, headerParams, formParams, fileParams, requestHttpContentType)
     .then([=](web::http::http_response response)
     {
         // 1xx - informational : OK
@@ -693,18 +693,18 @@ pplx::task<utility::string_t> UserApi::loginUser(utility::string_t username, uti
         if (response.status_code() >= 400)
         {
             throw ApiException(response.status_code()
-                , U("error calling loginUser: ") + response.reason_phrase()
+                , utility::conversions::to_string_t("error calling loginUser: ") + response.reason_phrase()
                 , std::make_shared<std::stringstream>(response.extract_utf8string(true).get()));
         }
 
         // check response content type
-        if(response.headers().has(U("Content-Type")))
+        if(response.headers().has(utility::conversions::to_string_t("Content-Type")))
         {
-            utility::string_t contentType = response.headers()[U("Content-Type")];
+            utility::string_t contentType = response.headers()[utility::conversions::to_string_t("Content-Type")];
             if( contentType.find(responseHttpContentType) == std::string::npos )
             {
                 throw ApiException(500
-                    , U("error calling loginUser: unexpected response type: ") + contentType
+                    , utility::conversions::to_string_t("error calling loginUser: unexpected response type: ") + contentType
                     , std::make_shared<std::stringstream>(response.extract_utf8string(true).get()));
             }
         }
@@ -713,27 +713,27 @@ pplx::task<utility::string_t> UserApi::loginUser(utility::string_t username, uti
     })
     .then([=](utility::string_t response)
     {
-        utility::string_t result(U(""));
+        utility::string_t result(utility::conversions::to_string_t(""));
 
-        if(responseHttpContentType == U("application/json"))
+        if(responseHttpContentType == utility::conversions::to_string_t("application/json"))
         {
             web::json::value json = web::json::value::parse(response);
 
             result = ModelBase::stringFromJson(json);
             
         }
-        else if(responseHttpContentType == U("text/plain"))
+        else if(responseHttpContentType == utility::conversions::to_string_t("text/plain"))
         {
             result = response;
         }
-        // else if(responseHttpContentType == U("multipart/form-data"))
+        // else if(responseHttpContentType == utility::conversions::to_string_t("multipart/form-data"))
         // {
         // TODO multipart response parsing
         // }
         else
         {
             throw ApiException(500
-                , U("error calling loginUser: unsupported response type"));
+                , utility::conversions::to_string_t("error calling loginUser: unsupported response type"));
         }
 
         return result;
@@ -744,7 +744,7 @@ pplx::task<void> UserApi::logoutUser()
 
 
     std::shared_ptr<ApiConfiguration> apiConfiguration( m_ApiClient->getConfiguration() );
-    utility::string_t path = U("/user/logout");
+    utility::string_t path = utility::conversions::to_string_t("/user/logout");
     
     std::map<utility::string_t, utility::string_t> queryParams;
     std::map<utility::string_t, utility::string_t> headerParams( apiConfiguration->getDefaultHeaders() );
@@ -752,32 +752,32 @@ pplx::task<void> UserApi::logoutUser()
     std::map<utility::string_t, std::shared_ptr<HttpContent>> fileParams;
 
     std::unordered_set<utility::string_t> responseHttpContentTypes;
-    responseHttpContentTypes.insert( U("application/xml") );
-    responseHttpContentTypes.insert( U("application/json") );
+    responseHttpContentTypes.insert( utility::conversions::to_string_t("application/xml") );
+    responseHttpContentTypes.insert( utility::conversions::to_string_t("application/json") );
 
     utility::string_t responseHttpContentType;
 
     // use JSON if possible
     if ( responseHttpContentTypes.size() == 0 )
     {
-        responseHttpContentType = U("application/json");
+        responseHttpContentType = utility::conversions::to_string_t("application/json");
     }
     // JSON
-    else if ( responseHttpContentTypes.find(U("application/json")) != responseHttpContentTypes.end() )
+    else if ( responseHttpContentTypes.find(utility::conversions::to_string_t("application/json")) != responseHttpContentTypes.end() )
     {
-        responseHttpContentType = U("application/json");
+        responseHttpContentType = utility::conversions::to_string_t("application/json");
     }
     // multipart formdata
-    else if( responseHttpContentTypes.find(U("multipart/form-data")) != responseHttpContentTypes.end() )
+    else if( responseHttpContentTypes.find(utility::conversions::to_string_t("multipart/form-data")) != responseHttpContentTypes.end() )
     {
-        responseHttpContentType = U("multipart/form-data");
+        responseHttpContentType = utility::conversions::to_string_t("multipart/form-data");
     }
     else
     {
-        throw ApiException(400, U("UserApi->logoutUser does not produce any supported media type"));
+        throw ApiException(400, utility::conversions::to_string_t("UserApi->logoutUser does not produce any supported media type"));
     }
 
-    headerParams[U("Accept")] = responseHttpContentType;
+    headerParams[utility::conversions::to_string_t("Accept")] = responseHttpContentType;
 
     std::unordered_set<utility::string_t> consumeHttpContentTypes;
 
@@ -786,22 +786,22 @@ pplx::task<void> UserApi::logoutUser()
     utility::string_t requestHttpContentType;
 
     // use JSON if possible
-    if ( consumeHttpContentTypes.size() == 0 || consumeHttpContentTypes.find(U("application/json")) != consumeHttpContentTypes.end() )
+    if ( consumeHttpContentTypes.size() == 0 || consumeHttpContentTypes.find(utility::conversions::to_string_t("application/json")) != consumeHttpContentTypes.end() )
     {
-        requestHttpContentType = U("application/json");
+        requestHttpContentType = utility::conversions::to_string_t("application/json");
     }
     // multipart formdata
-    else if( consumeHttpContentTypes.find(U("multipart/form-data")) != consumeHttpContentTypes.end() )
+    else if( consumeHttpContentTypes.find(utility::conversions::to_string_t("multipart/form-data")) != consumeHttpContentTypes.end() )
     {
-        requestHttpContentType = U("multipart/form-data");
+        requestHttpContentType = utility::conversions::to_string_t("multipart/form-data");
     }
     else
     {
-        throw ApiException(415, U("UserApi->logoutUser does not consume any supported media type"));
+        throw ApiException(415, utility::conversions::to_string_t("UserApi->logoutUser does not consume any supported media type"));
     }
 
 
-    return m_ApiClient->callApi(path, U("GET"), queryParams, httpBody, headerParams, formParams, fileParams, requestHttpContentType)
+    return m_ApiClient->callApi(path, utility::conversions::to_string_t("GET"), queryParams, httpBody, headerParams, formParams, fileParams, requestHttpContentType)
     .then([=](web::http::http_response response)
     {
         // 1xx - informational : OK
@@ -812,18 +812,18 @@ pplx::task<void> UserApi::logoutUser()
         if (response.status_code() >= 400)
         {
             throw ApiException(response.status_code()
-                , U("error calling logoutUser: ") + response.reason_phrase()
+                , utility::conversions::to_string_t("error calling logoutUser: ") + response.reason_phrase()
                 , std::make_shared<std::stringstream>(response.extract_utf8string(true).get()));
         }
 
         // check response content type
-        if(response.headers().has(U("Content-Type")))
+        if(response.headers().has(utility::conversions::to_string_t("Content-Type")))
         {
-            utility::string_t contentType = response.headers()[U("Content-Type")];
+            utility::string_t contentType = response.headers()[utility::conversions::to_string_t("Content-Type")];
             if( contentType.find(responseHttpContentType) == std::string::npos )
             {
                 throw ApiException(500
-                    , U("error calling logoutUser: unexpected response type: ") + contentType
+                    , utility::conversions::to_string_t("error calling logoutUser: unexpected response type: ") + contentType
                     , std::make_shared<std::stringstream>(response.extract_utf8string(true).get()));
             }
         }
@@ -841,13 +841,13 @@ pplx::task<void> UserApi::updateUser(utility::string_t username, std::shared_ptr
     // verify the required parameter 'body' is set
     if (body == nullptr)
     {
-        throw ApiException(400, U("Missing required parameter 'body' when calling UserApi->updateUser"));
+        throw ApiException(400, utility::conversions::to_string_t("Missing required parameter 'body' when calling UserApi->updateUser"));
     }
 
 
     std::shared_ptr<ApiConfiguration> apiConfiguration( m_ApiClient->getConfiguration() );
-    utility::string_t path = U("/user/{username}");
-    boost::replace_all(path, U("{") U("username") U("}"), ApiClient::parameterToString(username));
+    utility::string_t path = utility::conversions::to_string_t("/user/{username}");
+    boost::replace_all(path, utility::conversions::to_string_t("{") + utility::conversions::to_string_t("username") + utility::conversions::to_string_t("}"), ApiClient::parameterToString(username));
 
     std::map<utility::string_t, utility::string_t> queryParams;
     std::map<utility::string_t, utility::string_t> headerParams( apiConfiguration->getDefaultHeaders() );
@@ -855,32 +855,32 @@ pplx::task<void> UserApi::updateUser(utility::string_t username, std::shared_ptr
     std::map<utility::string_t, std::shared_ptr<HttpContent>> fileParams;
 
     std::unordered_set<utility::string_t> responseHttpContentTypes;
-    responseHttpContentTypes.insert( U("application/xml") );
-    responseHttpContentTypes.insert( U("application/json") );
+    responseHttpContentTypes.insert( utility::conversions::to_string_t("application/xml") );
+    responseHttpContentTypes.insert( utility::conversions::to_string_t("application/json") );
 
     utility::string_t responseHttpContentType;
 
     // use JSON if possible
     if ( responseHttpContentTypes.size() == 0 )
     {
-        responseHttpContentType = U("application/json");
+        responseHttpContentType = utility::conversions::to_string_t("application/json");
     }
     // JSON
-    else if ( responseHttpContentTypes.find(U("application/json")) != responseHttpContentTypes.end() )
+    else if ( responseHttpContentTypes.find(utility::conversions::to_string_t("application/json")) != responseHttpContentTypes.end() )
     {
-        responseHttpContentType = U("application/json");
+        responseHttpContentType = utility::conversions::to_string_t("application/json");
     }
     // multipart formdata
-    else if( responseHttpContentTypes.find(U("multipart/form-data")) != responseHttpContentTypes.end() )
+    else if( responseHttpContentTypes.find(utility::conversions::to_string_t("multipart/form-data")) != responseHttpContentTypes.end() )
     {
-        responseHttpContentType = U("multipart/form-data");
+        responseHttpContentType = utility::conversions::to_string_t("multipart/form-data");
     }
     else
     {
-        throw ApiException(400, U("UserApi->updateUser does not produce any supported media type"));
+        throw ApiException(400, utility::conversions::to_string_t("UserApi->updateUser does not produce any supported media type"));
     }
 
-    headerParams[U("Accept")] = responseHttpContentType;
+    headerParams[utility::conversions::to_string_t("Accept")] = responseHttpContentType;
 
     std::unordered_set<utility::string_t> consumeHttpContentTypes;
 
@@ -889,9 +889,9 @@ pplx::task<void> UserApi::updateUser(utility::string_t username, std::shared_ptr
     utility::string_t requestHttpContentType;
 
     // use JSON if possible
-    if ( consumeHttpContentTypes.size() == 0 || consumeHttpContentTypes.find(U("application/json")) != consumeHttpContentTypes.end() )
+    if ( consumeHttpContentTypes.size() == 0 || consumeHttpContentTypes.find(utility::conversions::to_string_t("application/json")) != consumeHttpContentTypes.end() )
     {
-        requestHttpContentType = U("application/json");
+        requestHttpContentType = utility::conversions::to_string_t("application/json");
         web::json::value json;
 
         json = ModelBase::toJson(body);
@@ -899,25 +899,25 @@ pplx::task<void> UserApi::updateUser(utility::string_t username, std::shared_ptr
         httpBody = std::shared_ptr<IHttpBody>( new JsonBody( json ) );
     }
     // multipart formdata
-    else if( consumeHttpContentTypes.find(U("multipart/form-data")) != consumeHttpContentTypes.end() )
+    else if( consumeHttpContentTypes.find(utility::conversions::to_string_t("multipart/form-data")) != consumeHttpContentTypes.end() )
     {
-        requestHttpContentType = U("multipart/form-data");
+        requestHttpContentType = utility::conversions::to_string_t("multipart/form-data");
         std::shared_ptr<MultipartFormData> multipart(new MultipartFormData);
                 if(body.get())
         {
-            body->toMultipart(multipart, U("body"));
+            body->toMultipart(multipart, utility::conversions::to_string_t("body"));
         }
 
         httpBody = multipart;
-        requestHttpContentType += U("; boundary=") + multipart->getBoundary();
+        requestHttpContentType += utility::conversions::to_string_t("; boundary=") + multipart->getBoundary();
     }
     else
     {
-        throw ApiException(415, U("UserApi->updateUser does not consume any supported media type"));
+        throw ApiException(415, utility::conversions::to_string_t("UserApi->updateUser does not consume any supported media type"));
     }
 
 
-    return m_ApiClient->callApi(path, U("PUT"), queryParams, httpBody, headerParams, formParams, fileParams, requestHttpContentType)
+    return m_ApiClient->callApi(path, utility::conversions::to_string_t("PUT"), queryParams, httpBody, headerParams, formParams, fileParams, requestHttpContentType)
     .then([=](web::http::http_response response)
     {
         // 1xx - informational : OK
@@ -928,18 +928,18 @@ pplx::task<void> UserApi::updateUser(utility::string_t username, std::shared_ptr
         if (response.status_code() >= 400)
         {
             throw ApiException(response.status_code()
-                , U("error calling updateUser: ") + response.reason_phrase()
+                , utility::conversions::to_string_t("error calling updateUser: ") + response.reason_phrase()
                 , std::make_shared<std::stringstream>(response.extract_utf8string(true).get()));
         }
 
         // check response content type
-        if(response.headers().has(U("Content-Type")))
+        if(response.headers().has(utility::conversions::to_string_t("Content-Type")))
         {
-            utility::string_t contentType = response.headers()[U("Content-Type")];
+            utility::string_t contentType = response.headers()[utility::conversions::to_string_t("Content-Type")];
             if( contentType.find(responseHttpContentType) == std::string::npos )
             {
                 throw ApiException(500
-                    , U("error calling updateUser: unexpected response type: ") + contentType
+                    , utility::conversions::to_string_t("error calling updateUser: unexpected response type: ") + contentType
                     , std::make_shared<std::stringstream>(response.extract_utf8string(true).get()));
             }
         }

--- a/samples/client/petstore/cpprest/model/ApiResponse.cpp
+++ b/samples/client/petstore/cpprest/model/ApiResponse.cpp
@@ -23,9 +23,9 @@ ApiResponse::ApiResponse()
 {
     m_Code = 0;
     m_CodeIsSet = false;
-    m_Type = U("");
+    m_Type = utility::conversions::to_string_t("");
     m_TypeIsSet = false;
-    m_Message = U("");
+    m_Message = utility::conversions::to_string_t("");
     m_MessageIsSet = false;
 }
 
@@ -44,15 +44,15 @@ web::json::value ApiResponse::toJson() const
 
     if(m_CodeIsSet)
     {
-        val[U("code")] = ModelBase::toJson(m_Code);
+        val[utility::conversions::to_string_t("code")] = ModelBase::toJson(m_Code);
     }
     if(m_TypeIsSet)
     {
-        val[U("type")] = ModelBase::toJson(m_Type);
+        val[utility::conversions::to_string_t("type")] = ModelBase::toJson(m_Type);
     }
     if(m_MessageIsSet)
     {
-        val[U("message")] = ModelBase::toJson(m_Message);
+        val[utility::conversions::to_string_t("message")] = ModelBase::toJson(m_Message);
     }
 
     return val;
@@ -60,40 +60,40 @@ web::json::value ApiResponse::toJson() const
 
 void ApiResponse::fromJson(web::json::value& val)
 {
-    if(val.has_field(U("code")))
+    if(val.has_field(utility::conversions::to_string_t("code")))
     {
-        setCode(ModelBase::int32_tFromJson(val[U("code")]));
+        setCode(ModelBase::int32_tFromJson(val[utility::conversions::to_string_t("code")]));
     }
-    if(val.has_field(U("type")))
+    if(val.has_field(utility::conversions::to_string_t("type")))
     {
-        setType(ModelBase::stringFromJson(val[U("type")]));
+        setType(ModelBase::stringFromJson(val[utility::conversions::to_string_t("type")]));
     }
-    if(val.has_field(U("message")))
+    if(val.has_field(utility::conversions::to_string_t("message")))
     {
-        setMessage(ModelBase::stringFromJson(val[U("message")]));
+        setMessage(ModelBase::stringFromJson(val[utility::conversions::to_string_t("message")]));
     }
 }
 
 void ApiResponse::toMultipart(std::shared_ptr<MultipartFormData> multipart, const utility::string_t& prefix) const
 {
     utility::string_t namePrefix = prefix;
-    if(namePrefix.size() > 0 && namePrefix[namePrefix.size() - 1] != U('.'))
+    if(namePrefix.size() > 0 && namePrefix.substr(namePrefix.size() - 1) != utility::conversions::to_string_t("."))
     {
-        namePrefix += U(".");
+        namePrefix += utility::conversions::to_string_t(".");
     }
 
     if(m_CodeIsSet)
     {
-        multipart->add(ModelBase::toHttpContent(namePrefix + U("code"), m_Code));
+        multipart->add(ModelBase::toHttpContent(namePrefix + utility::conversions::to_string_t("code"), m_Code));
     }
     if(m_TypeIsSet)
     {
-        multipart->add(ModelBase::toHttpContent(namePrefix + U("type"), m_Type));
+        multipart->add(ModelBase::toHttpContent(namePrefix + utility::conversions::to_string_t("type"), m_Type));
         
     }
     if(m_MessageIsSet)
     {
-        multipart->add(ModelBase::toHttpContent(namePrefix + U("message"), m_Message));
+        multipart->add(ModelBase::toHttpContent(namePrefix + utility::conversions::to_string_t("message"), m_Message));
         
     }
 }
@@ -101,22 +101,22 @@ void ApiResponse::toMultipart(std::shared_ptr<MultipartFormData> multipart, cons
 void ApiResponse::fromMultiPart(std::shared_ptr<MultipartFormData> multipart, const utility::string_t& prefix)
 {
     utility::string_t namePrefix = prefix;
-    if(namePrefix.size() > 0 && namePrefix[namePrefix.size() - 1] != U('.'))
+    if(namePrefix.size() > 0 && namePrefix.substr(namePrefix.size() - 1) != utility::conversions::to_string_t("."))
     {
-        namePrefix += U(".");
+        namePrefix += utility::conversions::to_string_t(".");
     }
 
-    if(multipart->hasContent(U("code")))
+    if(multipart->hasContent(utility::conversions::to_string_t("code")))
     {
-        setCode(ModelBase::int32_tFromHttpContent(multipart->getContent(U("code"))));
+        setCode(ModelBase::int32_tFromHttpContent(multipart->getContent(utility::conversions::to_string_t("code"))));
     }
-    if(multipart->hasContent(U("type")))
+    if(multipart->hasContent(utility::conversions::to_string_t("type")))
     {
-        setType(ModelBase::stringFromHttpContent(multipart->getContent(U("type"))));
+        setType(ModelBase::stringFromHttpContent(multipart->getContent(utility::conversions::to_string_t("type"))));
     }
-    if(multipart->hasContent(U("message")))
+    if(multipart->hasContent(utility::conversions::to_string_t("message")))
     {
-        setMessage(ModelBase::stringFromHttpContent(multipart->getContent(U("message"))));
+        setMessage(ModelBase::stringFromHttpContent(multipart->getContent(utility::conversions::to_string_t("message"))));
     }
 }
 

--- a/samples/client/petstore/cpprest/model/Category.cpp
+++ b/samples/client/petstore/cpprest/model/Category.cpp
@@ -23,7 +23,7 @@ Category::Category()
 {
     m_Id = 0L;
     m_IdIsSet = false;
-    m_Name = U("");
+    m_Name = utility::conversions::to_string_t("");
     m_NameIsSet = false;
 }
 
@@ -42,11 +42,11 @@ web::json::value Category::toJson() const
 
     if(m_IdIsSet)
     {
-        val[U("id")] = ModelBase::toJson(m_Id);
+        val[utility::conversions::to_string_t("id")] = ModelBase::toJson(m_Id);
     }
     if(m_NameIsSet)
     {
-        val[U("name")] = ModelBase::toJson(m_Name);
+        val[utility::conversions::to_string_t("name")] = ModelBase::toJson(m_Name);
     }
 
     return val;
@@ -54,31 +54,31 @@ web::json::value Category::toJson() const
 
 void Category::fromJson(web::json::value& val)
 {
-    if(val.has_field(U("id")))
+    if(val.has_field(utility::conversions::to_string_t("id")))
     {
-        setId(ModelBase::int64_tFromJson(val[U("id")]));
+        setId(ModelBase::int64_tFromJson(val[utility::conversions::to_string_t("id")]));
     }
-    if(val.has_field(U("name")))
+    if(val.has_field(utility::conversions::to_string_t("name")))
     {
-        setName(ModelBase::stringFromJson(val[U("name")]));
+        setName(ModelBase::stringFromJson(val[utility::conversions::to_string_t("name")]));
     }
 }
 
 void Category::toMultipart(std::shared_ptr<MultipartFormData> multipart, const utility::string_t& prefix) const
 {
     utility::string_t namePrefix = prefix;
-    if(namePrefix.size() > 0 && namePrefix[namePrefix.size() - 1] != U('.'))
+    if(namePrefix.size() > 0 && namePrefix.substr(namePrefix.size() - 1) != utility::conversions::to_string_t("."))
     {
-        namePrefix += U(".");
+        namePrefix += utility::conversions::to_string_t(".");
     }
 
     if(m_IdIsSet)
     {
-        multipart->add(ModelBase::toHttpContent(namePrefix + U("id"), m_Id));
+        multipart->add(ModelBase::toHttpContent(namePrefix + utility::conversions::to_string_t("id"), m_Id));
     }
     if(m_NameIsSet)
     {
-        multipart->add(ModelBase::toHttpContent(namePrefix + U("name"), m_Name));
+        multipart->add(ModelBase::toHttpContent(namePrefix + utility::conversions::to_string_t("name"), m_Name));
         
     }
 }
@@ -86,18 +86,18 @@ void Category::toMultipart(std::shared_ptr<MultipartFormData> multipart, const u
 void Category::fromMultiPart(std::shared_ptr<MultipartFormData> multipart, const utility::string_t& prefix)
 {
     utility::string_t namePrefix = prefix;
-    if(namePrefix.size() > 0 && namePrefix[namePrefix.size() - 1] != U('.'))
+    if(namePrefix.size() > 0 && namePrefix.substr(namePrefix.size() - 1) != utility::conversions::to_string_t("."))
     {
-        namePrefix += U(".");
+        namePrefix += utility::conversions::to_string_t(".");
     }
 
-    if(multipart->hasContent(U("id")))
+    if(multipart->hasContent(utility::conversions::to_string_t("id")))
     {
-        setId(ModelBase::int64_tFromHttpContent(multipart->getContent(U("id"))));
+        setId(ModelBase::int64_tFromHttpContent(multipart->getContent(utility::conversions::to_string_t("id"))));
     }
-    if(multipart->hasContent(U("name")))
+    if(multipart->hasContent(utility::conversions::to_string_t("name")))
     {
-        setName(ModelBase::stringFromHttpContent(multipart->getContent(U("name"))));
+        setName(ModelBase::stringFromHttpContent(multipart->getContent(utility::conversions::to_string_t("name"))));
     }
 }
 

--- a/samples/client/petstore/cpprest/model/Order.cpp
+++ b/samples/client/petstore/cpprest/model/Order.cpp
@@ -29,7 +29,7 @@ Order::Order()
     m_QuantityIsSet = false;
     m_ShipDate = utility::datetime();
     m_ShipDateIsSet = false;
-    m_Status = U("");
+    m_Status = utility::conversions::to_string_t("");
     m_StatusIsSet = false;
     m_Complete = false;
     m_CompleteIsSet = false;
@@ -50,27 +50,27 @@ web::json::value Order::toJson() const
 
     if(m_IdIsSet)
     {
-        val[U("id")] = ModelBase::toJson(m_Id);
+        val[utility::conversions::to_string_t("id")] = ModelBase::toJson(m_Id);
     }
     if(m_PetIdIsSet)
     {
-        val[U("petId")] = ModelBase::toJson(m_PetId);
+        val[utility::conversions::to_string_t("petId")] = ModelBase::toJson(m_PetId);
     }
     if(m_QuantityIsSet)
     {
-        val[U("quantity")] = ModelBase::toJson(m_Quantity);
+        val[utility::conversions::to_string_t("quantity")] = ModelBase::toJson(m_Quantity);
     }
     if(m_ShipDateIsSet)
     {
-        val[U("shipDate")] = ModelBase::toJson(m_ShipDate);
+        val[utility::conversions::to_string_t("shipDate")] = ModelBase::toJson(m_ShipDate);
     }
     if(m_StatusIsSet)
     {
-        val[U("status")] = ModelBase::toJson(m_Status);
+        val[utility::conversions::to_string_t("status")] = ModelBase::toJson(m_Status);
     }
     if(m_CompleteIsSet)
     {
-        val[U("complete")] = ModelBase::toJson(m_Complete);
+        val[utility::conversions::to_string_t("complete")] = ModelBase::toJson(m_Complete);
     }
 
     return val;
@@ -78,99 +78,99 @@ web::json::value Order::toJson() const
 
 void Order::fromJson(web::json::value& val)
 {
-    if(val.has_field(U("id")))
+    if(val.has_field(utility::conversions::to_string_t("id")))
     {
-        setId(ModelBase::int64_tFromJson(val[U("id")]));
+        setId(ModelBase::int64_tFromJson(val[utility::conversions::to_string_t("id")]));
     }
-    if(val.has_field(U("petId")))
+    if(val.has_field(utility::conversions::to_string_t("petId")))
     {
-        setPetId(ModelBase::int64_tFromJson(val[U("petId")]));
+        setPetId(ModelBase::int64_tFromJson(val[utility::conversions::to_string_t("petId")]));
     }
-    if(val.has_field(U("quantity")))
+    if(val.has_field(utility::conversions::to_string_t("quantity")))
     {
-        setQuantity(ModelBase::int32_tFromJson(val[U("quantity")]));
+        setQuantity(ModelBase::int32_tFromJson(val[utility::conversions::to_string_t("quantity")]));
     }
-    if(val.has_field(U("shipDate")))
+    if(val.has_field(utility::conversions::to_string_t("shipDate")))
     {
-        setShipDate(ModelBase::dateFromJson(val[U("shipDate")]));
+        setShipDate(ModelBase::dateFromJson(val[utility::conversions::to_string_t("shipDate")]));
     }
-    if(val.has_field(U("status")))
+    if(val.has_field(utility::conversions::to_string_t("status")))
     {
-        setStatus(ModelBase::stringFromJson(val[U("status")]));
+        setStatus(ModelBase::stringFromJson(val[utility::conversions::to_string_t("status")]));
     }
-    if(val.has_field(U("complete")))
+    if(val.has_field(utility::conversions::to_string_t("complete")))
     {
-        setComplete(ModelBase::boolFromJson(val[U("complete")]));
+        setComplete(ModelBase::boolFromJson(val[utility::conversions::to_string_t("complete")]));
     }
 }
 
 void Order::toMultipart(std::shared_ptr<MultipartFormData> multipart, const utility::string_t& prefix) const
 {
     utility::string_t namePrefix = prefix;
-    if(namePrefix.size() > 0 && namePrefix[namePrefix.size() - 1] != U('.'))
+    if(namePrefix.size() > 0 && namePrefix.substr(namePrefix.size() - 1) != utility::conversions::to_string_t("."))
     {
-        namePrefix += U(".");
+        namePrefix += utility::conversions::to_string_t(".");
     }
 
     if(m_IdIsSet)
     {
-        multipart->add(ModelBase::toHttpContent(namePrefix + U("id"), m_Id));
+        multipart->add(ModelBase::toHttpContent(namePrefix + utility::conversions::to_string_t("id"), m_Id));
     }
     if(m_PetIdIsSet)
     {
-        multipart->add(ModelBase::toHttpContent(namePrefix + U("petId"), m_PetId));
+        multipart->add(ModelBase::toHttpContent(namePrefix + utility::conversions::to_string_t("petId"), m_PetId));
     }
     if(m_QuantityIsSet)
     {
-        multipart->add(ModelBase::toHttpContent(namePrefix + U("quantity"), m_Quantity));
+        multipart->add(ModelBase::toHttpContent(namePrefix + utility::conversions::to_string_t("quantity"), m_Quantity));
     }
     if(m_ShipDateIsSet)
     {
-        multipart->add(ModelBase::toHttpContent(namePrefix + U("shipDate"), m_ShipDate));
+        multipart->add(ModelBase::toHttpContent(namePrefix + utility::conversions::to_string_t("shipDate"), m_ShipDate));
         
     }
     if(m_StatusIsSet)
     {
-        multipart->add(ModelBase::toHttpContent(namePrefix + U("status"), m_Status));
+        multipart->add(ModelBase::toHttpContent(namePrefix + utility::conversions::to_string_t("status"), m_Status));
         
     }
     if(m_CompleteIsSet)
     {
-        multipart->add(ModelBase::toHttpContent(namePrefix + U("complete"), m_Complete));
+        multipart->add(ModelBase::toHttpContent(namePrefix + utility::conversions::to_string_t("complete"), m_Complete));
     }
 }
 
 void Order::fromMultiPart(std::shared_ptr<MultipartFormData> multipart, const utility::string_t& prefix)
 {
     utility::string_t namePrefix = prefix;
-    if(namePrefix.size() > 0 && namePrefix[namePrefix.size() - 1] != U('.'))
+    if(namePrefix.size() > 0 && namePrefix.substr(namePrefix.size() - 1) != utility::conversions::to_string_t("."))
     {
-        namePrefix += U(".");
+        namePrefix += utility::conversions::to_string_t(".");
     }
 
-    if(multipart->hasContent(U("id")))
+    if(multipart->hasContent(utility::conversions::to_string_t("id")))
     {
-        setId(ModelBase::int64_tFromHttpContent(multipart->getContent(U("id"))));
+        setId(ModelBase::int64_tFromHttpContent(multipart->getContent(utility::conversions::to_string_t("id"))));
     }
-    if(multipart->hasContent(U("petId")))
+    if(multipart->hasContent(utility::conversions::to_string_t("petId")))
     {
-        setPetId(ModelBase::int64_tFromHttpContent(multipart->getContent(U("petId"))));
+        setPetId(ModelBase::int64_tFromHttpContent(multipart->getContent(utility::conversions::to_string_t("petId"))));
     }
-    if(multipart->hasContent(U("quantity")))
+    if(multipart->hasContent(utility::conversions::to_string_t("quantity")))
     {
-        setQuantity(ModelBase::int32_tFromHttpContent(multipart->getContent(U("quantity"))));
+        setQuantity(ModelBase::int32_tFromHttpContent(multipart->getContent(utility::conversions::to_string_t("quantity"))));
     }
-    if(multipart->hasContent(U("shipDate")))
+    if(multipart->hasContent(utility::conversions::to_string_t("shipDate")))
     {
-        setShipDate(ModelBase::dateFromHttpContent(multipart->getContent(U("shipDate"))));
+        setShipDate(ModelBase::dateFromHttpContent(multipart->getContent(utility::conversions::to_string_t("shipDate"))));
     }
-    if(multipart->hasContent(U("status")))
+    if(multipart->hasContent(utility::conversions::to_string_t("status")))
     {
-        setStatus(ModelBase::stringFromHttpContent(multipart->getContent(U("status"))));
+        setStatus(ModelBase::stringFromHttpContent(multipart->getContent(utility::conversions::to_string_t("status"))));
     }
-    if(multipart->hasContent(U("complete")))
+    if(multipart->hasContent(utility::conversions::to_string_t("complete")))
     {
-        setComplete(ModelBase::boolFromHttpContent(multipart->getContent(U("complete"))));
+        setComplete(ModelBase::boolFromHttpContent(multipart->getContent(utility::conversions::to_string_t("complete"))));
     }
 }
 

--- a/samples/client/petstore/cpprest/model/Pet.cpp
+++ b/samples/client/petstore/cpprest/model/Pet.cpp
@@ -24,9 +24,9 @@ Pet::Pet()
     m_Id = 0L;
     m_IdIsSet = false;
     m_CategoryIsSet = false;
-    m_Name = U("");
+    m_Name = utility::conversions::to_string_t("");
     m_TagsIsSet = false;
-    m_Status = U("");
+    m_Status = utility::conversions::to_string_t("");
     m_StatusIsSet = false;
 }
 
@@ -45,20 +45,20 @@ web::json::value Pet::toJson() const
 
     if(m_IdIsSet)
     {
-        val[U("id")] = ModelBase::toJson(m_Id);
+        val[utility::conversions::to_string_t("id")] = ModelBase::toJson(m_Id);
     }
     if(m_CategoryIsSet)
     {
-        val[U("category")] = ModelBase::toJson(m_Category);
+        val[utility::conversions::to_string_t("category")] = ModelBase::toJson(m_Category);
     }
-    val[U("name")] = ModelBase::toJson(m_Name);
+    val[utility::conversions::to_string_t("name")] = ModelBase::toJson(m_Name);
     {
         std::vector<web::json::value> jsonArray;
         for( auto& item : m_PhotoUrls )
         {
             jsonArray.push_back(ModelBase::toJson(item));
         }
-        val[U("photoUrls")] = web::json::value::array(jsonArray);
+        val[utility::conversions::to_string_t("photoUrls")] = web::json::value::array(jsonArray);
     }
     {
         std::vector<web::json::value> jsonArray;
@@ -68,12 +68,12 @@ web::json::value Pet::toJson() const
         }
         if(jsonArray.size() > 0)
         {
-            val[U("tags")] = web::json::value::array(jsonArray);
+            val[utility::conversions::to_string_t("tags")] = web::json::value::array(jsonArray);
         }
     }
     if(m_StatusIsSet)
     {
-        val[U("status")] = ModelBase::toJson(m_Status);
+        val[utility::conversions::to_string_t("status")] = ModelBase::toJson(m_Status);
     }
 
     return val;
@@ -81,24 +81,24 @@ web::json::value Pet::toJson() const
 
 void Pet::fromJson(web::json::value& val)
 {
-    if(val.has_field(U("id")))
+    if(val.has_field(utility::conversions::to_string_t("id")))
     {
-        setId(ModelBase::int64_tFromJson(val[U("id")]));
+        setId(ModelBase::int64_tFromJson(val[utility::conversions::to_string_t("id")]));
     }
-    if(val.has_field(U("category")))
+    if(val.has_field(utility::conversions::to_string_t("category")))
     {
-        if(!val[U("category")].is_null())
+        if(!val[utility::conversions::to_string_t("category")].is_null())
         {
             std::shared_ptr<Category> newItem(new Category());
-            newItem->fromJson(val[U("category")]);
+            newItem->fromJson(val[utility::conversions::to_string_t("category")]);
             setCategory( newItem );
         }
     }
-    setName(ModelBase::stringFromJson(val[U("name")]));
+    setName(ModelBase::stringFromJson(val[utility::conversions::to_string_t("name")]));
     {
         m_PhotoUrls.clear();
         std::vector<web::json::value> jsonArray;
-        for( auto& item : val[U("photoUrls")].as_array() )
+        for( auto& item : val[utility::conversions::to_string_t("photoUrls")].as_array() )
         {
             m_PhotoUrls.push_back(ModelBase::stringFromJson(item));
         }
@@ -106,9 +106,9 @@ void Pet::fromJson(web::json::value& val)
     {
         m_Tags.clear();
         std::vector<web::json::value> jsonArray;
-        if(val.has_field(U("tags")))
+        if(val.has_field(utility::conversions::to_string_t("tags")))
         {
-        for( auto& item : val[U("tags")].as_array() )
+        for( auto& item : val[utility::conversions::to_string_t("tags")].as_array() )
         {
             if(item.is_null())
             {
@@ -123,40 +123,40 @@ void Pet::fromJson(web::json::value& val)
         }
         }
     }
-    if(val.has_field(U("status")))
+    if(val.has_field(utility::conversions::to_string_t("status")))
     {
-        setStatus(ModelBase::stringFromJson(val[U("status")]));
+        setStatus(ModelBase::stringFromJson(val[utility::conversions::to_string_t("status")]));
     }
 }
 
 void Pet::toMultipart(std::shared_ptr<MultipartFormData> multipart, const utility::string_t& prefix) const
 {
     utility::string_t namePrefix = prefix;
-    if(namePrefix.size() > 0 && namePrefix[namePrefix.size() - 1] != U('.'))
+    if(namePrefix.size() > 0 && namePrefix.substr(namePrefix.size() - 1) != utility::conversions::to_string_t("."))
     {
-        namePrefix += U(".");
+        namePrefix += utility::conversions::to_string_t(".");
     }
 
     if(m_IdIsSet)
     {
-        multipart->add(ModelBase::toHttpContent(namePrefix + U("id"), m_Id));
+        multipart->add(ModelBase::toHttpContent(namePrefix + utility::conversions::to_string_t("id"), m_Id));
     }
     if(m_CategoryIsSet)
     {
         if (m_Category.get())
         {
-            m_Category->toMultipart(multipart, U("category."));
+            m_Category->toMultipart(multipart, utility::conversions::to_string_t("category."));
         }
         
     }
-    multipart->add(ModelBase::toHttpContent(namePrefix + U("name"), m_Name));
+    multipart->add(ModelBase::toHttpContent(namePrefix + utility::conversions::to_string_t("name"), m_Name));
     {
         std::vector<web::json::value> jsonArray;
         for( auto& item : m_PhotoUrls )
         {
             jsonArray.push_back(ModelBase::toJson(item));
         }
-        multipart->add(ModelBase::toHttpContent(namePrefix + U("photoUrls"), web::json::value::array(jsonArray), U("application/json")));
+        multipart->add(ModelBase::toHttpContent(namePrefix + utility::conversions::to_string_t("photoUrls"), web::json::value::array(jsonArray), utility::conversions::to_string_t("application/json")));
             }
     {
         std::vector<web::json::value> jsonArray;
@@ -167,12 +167,12 @@ void Pet::toMultipart(std::shared_ptr<MultipartFormData> multipart, const utilit
         
         if(jsonArray.size() > 0)
         {
-            multipart->add(ModelBase::toHttpContent(namePrefix + U("tags"), web::json::value::array(jsonArray), U("application/json")));
+            multipart->add(ModelBase::toHttpContent(namePrefix + utility::conversions::to_string_t("tags"), web::json::value::array(jsonArray), utility::conversions::to_string_t("application/json")));
         }
     }
     if(m_StatusIsSet)
     {
-        multipart->add(ModelBase::toHttpContent(namePrefix + U("status"), m_Status));
+        multipart->add(ModelBase::toHttpContent(namePrefix + utility::conversions::to_string_t("status"), m_Status));
         
     }
 }
@@ -180,29 +180,29 @@ void Pet::toMultipart(std::shared_ptr<MultipartFormData> multipart, const utilit
 void Pet::fromMultiPart(std::shared_ptr<MultipartFormData> multipart, const utility::string_t& prefix)
 {
     utility::string_t namePrefix = prefix;
-    if(namePrefix.size() > 0 && namePrefix[namePrefix.size() - 1] != U('.'))
+    if(namePrefix.size() > 0 && namePrefix.substr(namePrefix.size() - 1) != utility::conversions::to_string_t("."))
     {
-        namePrefix += U(".");
+        namePrefix += utility::conversions::to_string_t(".");
     }
 
-    if(multipart->hasContent(U("id")))
+    if(multipart->hasContent(utility::conversions::to_string_t("id")))
     {
-        setId(ModelBase::int64_tFromHttpContent(multipart->getContent(U("id"))));
+        setId(ModelBase::int64_tFromHttpContent(multipart->getContent(utility::conversions::to_string_t("id"))));
     }
-    if(multipart->hasContent(U("category")))
+    if(multipart->hasContent(utility::conversions::to_string_t("category")))
     {
-        if(multipart->hasContent(U("category")))
+        if(multipart->hasContent(utility::conversions::to_string_t("category")))
         {
             std::shared_ptr<Category> newItem(new Category());
-            newItem->fromMultiPart(multipart, U("category."));
+            newItem->fromMultiPart(multipart, utility::conversions::to_string_t("category."));
             setCategory( newItem );
         }
     }
-    setName(ModelBase::stringFromHttpContent(multipart->getContent(U("name"))));
+    setName(ModelBase::stringFromHttpContent(multipart->getContent(utility::conversions::to_string_t("name"))));
     {
         m_PhotoUrls.clear();
 
-        web::json::value jsonArray = web::json::value::parse(ModelBase::stringFromHttpContent(multipart->getContent(U("photoUrls"))));
+        web::json::value jsonArray = web::json::value::parse(ModelBase::stringFromHttpContent(multipart->getContent(utility::conversions::to_string_t("photoUrls"))));
         for( auto& item : jsonArray.as_array() )
         {
             m_PhotoUrls.push_back(ModelBase::stringFromJson(item));
@@ -210,10 +210,10 @@ void Pet::fromMultiPart(std::shared_ptr<MultipartFormData> multipart, const util
     }
     {
         m_Tags.clear();
-        if(multipart->hasContent(U("tags")))
+        if(multipart->hasContent(utility::conversions::to_string_t("tags")))
         {
 
-        web::json::value jsonArray = web::json::value::parse(ModelBase::stringFromHttpContent(multipart->getContent(U("tags"))));
+        web::json::value jsonArray = web::json::value::parse(ModelBase::stringFromHttpContent(multipart->getContent(utility::conversions::to_string_t("tags"))));
         for( auto& item : jsonArray.as_array() )
         {
             if(item.is_null())
@@ -229,9 +229,9 @@ void Pet::fromMultiPart(std::shared_ptr<MultipartFormData> multipart, const util
         }
         }
     }
-    if(multipart->hasContent(U("status")))
+    if(multipart->hasContent(utility::conversions::to_string_t("status")))
     {
-        setStatus(ModelBase::stringFromHttpContent(multipart->getContent(U("status"))));
+        setStatus(ModelBase::stringFromHttpContent(multipart->getContent(utility::conversions::to_string_t("status"))));
     }
 }
 

--- a/samples/client/petstore/cpprest/model/Tag.cpp
+++ b/samples/client/petstore/cpprest/model/Tag.cpp
@@ -23,7 +23,7 @@ Tag::Tag()
 {
     m_Id = 0L;
     m_IdIsSet = false;
-    m_Name = U("");
+    m_Name = utility::conversions::to_string_t("");
     m_NameIsSet = false;
 }
 
@@ -42,11 +42,11 @@ web::json::value Tag::toJson() const
 
     if(m_IdIsSet)
     {
-        val[U("id")] = ModelBase::toJson(m_Id);
+        val[utility::conversions::to_string_t("id")] = ModelBase::toJson(m_Id);
     }
     if(m_NameIsSet)
     {
-        val[U("name")] = ModelBase::toJson(m_Name);
+        val[utility::conversions::to_string_t("name")] = ModelBase::toJson(m_Name);
     }
 
     return val;
@@ -54,31 +54,31 @@ web::json::value Tag::toJson() const
 
 void Tag::fromJson(web::json::value& val)
 {
-    if(val.has_field(U("id")))
+    if(val.has_field(utility::conversions::to_string_t("id")))
     {
-        setId(ModelBase::int64_tFromJson(val[U("id")]));
+        setId(ModelBase::int64_tFromJson(val[utility::conversions::to_string_t("id")]));
     }
-    if(val.has_field(U("name")))
+    if(val.has_field(utility::conversions::to_string_t("name")))
     {
-        setName(ModelBase::stringFromJson(val[U("name")]));
+        setName(ModelBase::stringFromJson(val[utility::conversions::to_string_t("name")]));
     }
 }
 
 void Tag::toMultipart(std::shared_ptr<MultipartFormData> multipart, const utility::string_t& prefix) const
 {
     utility::string_t namePrefix = prefix;
-    if(namePrefix.size() > 0 && namePrefix[namePrefix.size() - 1] != U('.'))
+    if(namePrefix.size() > 0 && namePrefix.substr(namePrefix.size() - 1) != utility::conversions::to_string_t("."))
     {
-        namePrefix += U(".");
+        namePrefix += utility::conversions::to_string_t(".");
     }
 
     if(m_IdIsSet)
     {
-        multipart->add(ModelBase::toHttpContent(namePrefix + U("id"), m_Id));
+        multipart->add(ModelBase::toHttpContent(namePrefix + utility::conversions::to_string_t("id"), m_Id));
     }
     if(m_NameIsSet)
     {
-        multipart->add(ModelBase::toHttpContent(namePrefix + U("name"), m_Name));
+        multipart->add(ModelBase::toHttpContent(namePrefix + utility::conversions::to_string_t("name"), m_Name));
         
     }
 }
@@ -86,18 +86,18 @@ void Tag::toMultipart(std::shared_ptr<MultipartFormData> multipart, const utilit
 void Tag::fromMultiPart(std::shared_ptr<MultipartFormData> multipart, const utility::string_t& prefix)
 {
     utility::string_t namePrefix = prefix;
-    if(namePrefix.size() > 0 && namePrefix[namePrefix.size() - 1] != U('.'))
+    if(namePrefix.size() > 0 && namePrefix.substr(namePrefix.size() - 1) != utility::conversions::to_string_t("."))
     {
-        namePrefix += U(".");
+        namePrefix += utility::conversions::to_string_t(".");
     }
 
-    if(multipart->hasContent(U("id")))
+    if(multipart->hasContent(utility::conversions::to_string_t("id")))
     {
-        setId(ModelBase::int64_tFromHttpContent(multipart->getContent(U("id"))));
+        setId(ModelBase::int64_tFromHttpContent(multipart->getContent(utility::conversions::to_string_t("id"))));
     }
-    if(multipart->hasContent(U("name")))
+    if(multipart->hasContent(utility::conversions::to_string_t("name")))
     {
-        setName(ModelBase::stringFromHttpContent(multipart->getContent(U("name"))));
+        setName(ModelBase::stringFromHttpContent(multipart->getContent(utility::conversions::to_string_t("name"))));
     }
 }
 

--- a/samples/client/petstore/cpprest/model/User.cpp
+++ b/samples/client/petstore/cpprest/model/User.cpp
@@ -23,17 +23,17 @@ User::User()
 {
     m_Id = 0L;
     m_IdIsSet = false;
-    m_Username = U("");
+    m_Username = utility::conversions::to_string_t("");
     m_UsernameIsSet = false;
-    m_FirstName = U("");
+    m_FirstName = utility::conversions::to_string_t("");
     m_FirstNameIsSet = false;
-    m_LastName = U("");
+    m_LastName = utility::conversions::to_string_t("");
     m_LastNameIsSet = false;
-    m_Email = U("");
+    m_Email = utility::conversions::to_string_t("");
     m_EmailIsSet = false;
-    m_Password = U("");
+    m_Password = utility::conversions::to_string_t("");
     m_PasswordIsSet = false;
-    m_Phone = U("");
+    m_Phone = utility::conversions::to_string_t("");
     m_PhoneIsSet = false;
     m_UserStatus = 0;
     m_UserStatusIsSet = false;
@@ -54,35 +54,35 @@ web::json::value User::toJson() const
 
     if(m_IdIsSet)
     {
-        val[U("id")] = ModelBase::toJson(m_Id);
+        val[utility::conversions::to_string_t("id")] = ModelBase::toJson(m_Id);
     }
     if(m_UsernameIsSet)
     {
-        val[U("username")] = ModelBase::toJson(m_Username);
+        val[utility::conversions::to_string_t("username")] = ModelBase::toJson(m_Username);
     }
     if(m_FirstNameIsSet)
     {
-        val[U("firstName")] = ModelBase::toJson(m_FirstName);
+        val[utility::conversions::to_string_t("firstName")] = ModelBase::toJson(m_FirstName);
     }
     if(m_LastNameIsSet)
     {
-        val[U("lastName")] = ModelBase::toJson(m_LastName);
+        val[utility::conversions::to_string_t("lastName")] = ModelBase::toJson(m_LastName);
     }
     if(m_EmailIsSet)
     {
-        val[U("email")] = ModelBase::toJson(m_Email);
+        val[utility::conversions::to_string_t("email")] = ModelBase::toJson(m_Email);
     }
     if(m_PasswordIsSet)
     {
-        val[U("password")] = ModelBase::toJson(m_Password);
+        val[utility::conversions::to_string_t("password")] = ModelBase::toJson(m_Password);
     }
     if(m_PhoneIsSet)
     {
-        val[U("phone")] = ModelBase::toJson(m_Phone);
+        val[utility::conversions::to_string_t("phone")] = ModelBase::toJson(m_Phone);
     }
     if(m_UserStatusIsSet)
     {
-        val[U("userStatus")] = ModelBase::toJson(m_UserStatus);
+        val[utility::conversions::to_string_t("userStatus")] = ModelBase::toJson(m_UserStatus);
     }
 
     return val;
@@ -90,127 +90,127 @@ web::json::value User::toJson() const
 
 void User::fromJson(web::json::value& val)
 {
-    if(val.has_field(U("id")))
+    if(val.has_field(utility::conversions::to_string_t("id")))
     {
-        setId(ModelBase::int64_tFromJson(val[U("id")]));
+        setId(ModelBase::int64_tFromJson(val[utility::conversions::to_string_t("id")]));
     }
-    if(val.has_field(U("username")))
+    if(val.has_field(utility::conversions::to_string_t("username")))
     {
-        setUsername(ModelBase::stringFromJson(val[U("username")]));
+        setUsername(ModelBase::stringFromJson(val[utility::conversions::to_string_t("username")]));
     }
-    if(val.has_field(U("firstName")))
+    if(val.has_field(utility::conversions::to_string_t("firstName")))
     {
-        setFirstName(ModelBase::stringFromJson(val[U("firstName")]));
+        setFirstName(ModelBase::stringFromJson(val[utility::conversions::to_string_t("firstName")]));
     }
-    if(val.has_field(U("lastName")))
+    if(val.has_field(utility::conversions::to_string_t("lastName")))
     {
-        setLastName(ModelBase::stringFromJson(val[U("lastName")]));
+        setLastName(ModelBase::stringFromJson(val[utility::conversions::to_string_t("lastName")]));
     }
-    if(val.has_field(U("email")))
+    if(val.has_field(utility::conversions::to_string_t("email")))
     {
-        setEmail(ModelBase::stringFromJson(val[U("email")]));
+        setEmail(ModelBase::stringFromJson(val[utility::conversions::to_string_t("email")]));
     }
-    if(val.has_field(U("password")))
+    if(val.has_field(utility::conversions::to_string_t("password")))
     {
-        setPassword(ModelBase::stringFromJson(val[U("password")]));
+        setPassword(ModelBase::stringFromJson(val[utility::conversions::to_string_t("password")]));
     }
-    if(val.has_field(U("phone")))
+    if(val.has_field(utility::conversions::to_string_t("phone")))
     {
-        setPhone(ModelBase::stringFromJson(val[U("phone")]));
+        setPhone(ModelBase::stringFromJson(val[utility::conversions::to_string_t("phone")]));
     }
-    if(val.has_field(U("userStatus")))
+    if(val.has_field(utility::conversions::to_string_t("userStatus")))
     {
-        setUserStatus(ModelBase::int32_tFromJson(val[U("userStatus")]));
+        setUserStatus(ModelBase::int32_tFromJson(val[utility::conversions::to_string_t("userStatus")]));
     }
 }
 
 void User::toMultipart(std::shared_ptr<MultipartFormData> multipart, const utility::string_t& prefix) const
 {
     utility::string_t namePrefix = prefix;
-    if(namePrefix.size() > 0 && namePrefix[namePrefix.size() - 1] != U('.'))
+    if(namePrefix.size() > 0 && namePrefix.substr(namePrefix.size() - 1) != utility::conversions::to_string_t("."))
     {
-        namePrefix += U(".");
+        namePrefix += utility::conversions::to_string_t(".");
     }
 
     if(m_IdIsSet)
     {
-        multipart->add(ModelBase::toHttpContent(namePrefix + U("id"), m_Id));
+        multipart->add(ModelBase::toHttpContent(namePrefix + utility::conversions::to_string_t("id"), m_Id));
     }
     if(m_UsernameIsSet)
     {
-        multipart->add(ModelBase::toHttpContent(namePrefix + U("username"), m_Username));
+        multipart->add(ModelBase::toHttpContent(namePrefix + utility::conversions::to_string_t("username"), m_Username));
         
     }
     if(m_FirstNameIsSet)
     {
-        multipart->add(ModelBase::toHttpContent(namePrefix + U("firstName"), m_FirstName));
+        multipart->add(ModelBase::toHttpContent(namePrefix + utility::conversions::to_string_t("firstName"), m_FirstName));
         
     }
     if(m_LastNameIsSet)
     {
-        multipart->add(ModelBase::toHttpContent(namePrefix + U("lastName"), m_LastName));
+        multipart->add(ModelBase::toHttpContent(namePrefix + utility::conversions::to_string_t("lastName"), m_LastName));
         
     }
     if(m_EmailIsSet)
     {
-        multipart->add(ModelBase::toHttpContent(namePrefix + U("email"), m_Email));
+        multipart->add(ModelBase::toHttpContent(namePrefix + utility::conversions::to_string_t("email"), m_Email));
         
     }
     if(m_PasswordIsSet)
     {
-        multipart->add(ModelBase::toHttpContent(namePrefix + U("password"), m_Password));
+        multipart->add(ModelBase::toHttpContent(namePrefix + utility::conversions::to_string_t("password"), m_Password));
         
     }
     if(m_PhoneIsSet)
     {
-        multipart->add(ModelBase::toHttpContent(namePrefix + U("phone"), m_Phone));
+        multipart->add(ModelBase::toHttpContent(namePrefix + utility::conversions::to_string_t("phone"), m_Phone));
         
     }
     if(m_UserStatusIsSet)
     {
-        multipart->add(ModelBase::toHttpContent(namePrefix + U("userStatus"), m_UserStatus));
+        multipart->add(ModelBase::toHttpContent(namePrefix + utility::conversions::to_string_t("userStatus"), m_UserStatus));
     }
 }
 
 void User::fromMultiPart(std::shared_ptr<MultipartFormData> multipart, const utility::string_t& prefix)
 {
     utility::string_t namePrefix = prefix;
-    if(namePrefix.size() > 0 && namePrefix[namePrefix.size() - 1] != U('.'))
+    if(namePrefix.size() > 0 && namePrefix.substr(namePrefix.size() - 1) != utility::conversions::to_string_t("."))
     {
-        namePrefix += U(".");
+        namePrefix += utility::conversions::to_string_t(".");
     }
 
-    if(multipart->hasContent(U("id")))
+    if(multipart->hasContent(utility::conversions::to_string_t("id")))
     {
-        setId(ModelBase::int64_tFromHttpContent(multipart->getContent(U("id"))));
+        setId(ModelBase::int64_tFromHttpContent(multipart->getContent(utility::conversions::to_string_t("id"))));
     }
-    if(multipart->hasContent(U("username")))
+    if(multipart->hasContent(utility::conversions::to_string_t("username")))
     {
-        setUsername(ModelBase::stringFromHttpContent(multipart->getContent(U("username"))));
+        setUsername(ModelBase::stringFromHttpContent(multipart->getContent(utility::conversions::to_string_t("username"))));
     }
-    if(multipart->hasContent(U("firstName")))
+    if(multipart->hasContent(utility::conversions::to_string_t("firstName")))
     {
-        setFirstName(ModelBase::stringFromHttpContent(multipart->getContent(U("firstName"))));
+        setFirstName(ModelBase::stringFromHttpContent(multipart->getContent(utility::conversions::to_string_t("firstName"))));
     }
-    if(multipart->hasContent(U("lastName")))
+    if(multipart->hasContent(utility::conversions::to_string_t("lastName")))
     {
-        setLastName(ModelBase::stringFromHttpContent(multipart->getContent(U("lastName"))));
+        setLastName(ModelBase::stringFromHttpContent(multipart->getContent(utility::conversions::to_string_t("lastName"))));
     }
-    if(multipart->hasContent(U("email")))
+    if(multipart->hasContent(utility::conversions::to_string_t("email")))
     {
-        setEmail(ModelBase::stringFromHttpContent(multipart->getContent(U("email"))));
+        setEmail(ModelBase::stringFromHttpContent(multipart->getContent(utility::conversions::to_string_t("email"))));
     }
-    if(multipart->hasContent(U("password")))
+    if(multipart->hasContent(utility::conversions::to_string_t("password")))
     {
-        setPassword(ModelBase::stringFromHttpContent(multipart->getContent(U("password"))));
+        setPassword(ModelBase::stringFromHttpContent(multipart->getContent(utility::conversions::to_string_t("password"))));
     }
-    if(multipart->hasContent(U("phone")))
+    if(multipart->hasContent(utility::conversions::to_string_t("phone")))
     {
-        setPhone(ModelBase::stringFromHttpContent(multipart->getContent(U("phone"))));
+        setPhone(ModelBase::stringFromHttpContent(multipart->getContent(utility::conversions::to_string_t("phone"))));
     }
-    if(multipart->hasContent(U("userStatus")))
+    if(multipart->hasContent(utility::conversions::to_string_t("userStatus")))
     {
-        setUserStatus(ModelBase::int32_tFromHttpContent(multipart->getContent(U("userStatus"))));
+        setUserStatus(ModelBase::int32_tFromHttpContent(multipart->getContent(utility::conversions::to_string_t("userStatus"))));
     }
 }
 


### PR DESCRIPTION
### PR checklist

- [X] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [X] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [X] Filed the PR against the correct branch: `3.0.0` branch for changes related to OpenAPI spec 3.0. Default: `master`.
- [X] Copied the [technical committee](https://github.com/swagger-api/swagger-codegen/#swagger-codegen-technical-committee) to review the pull request if your PR is targeting a particular programming langauge.

### Description of the PR

This PR removes all usages of the infamous casablanca `U(x)` macro, and replaces them with a safer conversion function (also provided by casablanca).
The rationale for this change is that users of the generator might need to disable that macro entirely in casablanca, as it can easily cause conflicts (see [the Casablanca FAQ](https://github.com/Microsoft/cpprestsdk/wiki/FAQ#what-is-utilitystring_t-and-the-u-macro) for more info). The generated code should therefore not rely on it.

I've updated the sample code accordingly and managed to compile it without any problems.
This change has also been tested on code generated for actual (non-public) APIs successfully.