### PR TITLE
[CppRest] Unique header guards

### DIFF
--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/CppRestClientCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/CppRestClientCodegen.java
@@ -179,8 +179,10 @@ public class CppRestClientCodegen extends AbstractCppCodegen {
 
         additionalProperties.put("modelNamespaceDeclarations", modelPackage.split("\\."));
         additionalProperties.put("modelNamespace", modelPackage.replaceAll("\\.", "::"));
+        additionalProperties.put("modelHeaderGuardPrefix", modelPackage.replaceAll("\\.", "_").toUpperCase());
         additionalProperties.put("apiNamespaceDeclarations", apiPackage.split("\\."));
         additionalProperties.put("apiNamespace", apiPackage.replaceAll("\\.", "::"));
+        additionalProperties.put("apiHeaderGuardPrefix", apiPackage.replaceAll("\\.", "_").toUpperCase());
         additionalProperties.put("declspec", declspec);
         additionalProperties.put("defaultInclude", defaultInclude);
     }

--- a/modules/swagger-codegen/src/main/resources/cpprest/api-header.mustache
+++ b/modules/swagger-codegen/src/main/resources/cpprest/api-header.mustache
@@ -5,8 +5,8 @@
  * {{description}}
  */
 
-#ifndef {{classname}}_H_
-#define {{classname}}_H_
+#ifndef {{apiHeaderGuardPrefix}}_{{classname}}_H_
+#define {{apiHeaderGuardPrefix}}_{{classname}}_H_
 
 {{{defaultInclude}}}
 #include "ApiClient.h"
@@ -44,6 +44,6 @@ protected:
 }
 {{/apiNamespaceDeclarations}}
 
-#endif /* {{classname}}_H_ */
+#endif /* {{apiHeaderGuardPrefix}}_{{classname}}_H_ */
 
 {{/operations}}

--- a/modules/swagger-codegen/src/main/resources/cpprest/apiclient-header.mustache
+++ b/modules/swagger-codegen/src/main/resources/cpprest/apiclient-header.mustache
@@ -5,8 +5,8 @@
  * This is an API client responsible for stating the HTTP calls
  */
 
-#ifndef ApiClient_H_
-#define ApiClient_H_
+#ifndef {{apiHeaderGuardPrefix}}_ApiClient_H_
+#define {{apiHeaderGuardPrefix}}_ApiClient_H_
 
 {{{defaultInclude}}}
 #include "ApiConfiguration.h"
@@ -75,4 +75,4 @@ protected:
 }
 {{/apiNamespaceDeclarations}}
 
-#endif /* ApiClient_H_ */
+#endif /* {{apiHeaderGuardPrefix}}_ApiClient_H_ */

--- a/modules/swagger-codegen/src/main/resources/cpprest/apiconfiguration-header.mustache
+++ b/modules/swagger-codegen/src/main/resources/cpprest/apiconfiguration-header.mustache
@@ -5,8 +5,8 @@
  * This class represents a single item of a multipart-formdata request.
  */
 
-#ifndef ApiConfiguration_H_
-#define ApiConfiguration_H_
+#ifndef {{apiHeaderGuardPrefix}}_ApiConfiguration_H_
+#define {{apiHeaderGuardPrefix}}_ApiConfiguration_H_
 
 {{{defaultInclude}}}
 
@@ -49,4 +49,4 @@ protected:
 {{#apiNamespaceDeclarations}}
 }
 {{/apiNamespaceDeclarations}}
-#endif /* ApiConfiguration_H_ */
+#endif /* {{apiHeaderGuardPrefix}}_ApiConfiguration_H_ */

--- a/modules/swagger-codegen/src/main/resources/cpprest/apiexception-header.mustache
+++ b/modules/swagger-codegen/src/main/resources/cpprest/apiexception-header.mustache
@@ -5,8 +5,8 @@
  * This is the exception being thrown in case the api call was not successful
  */
 
-#ifndef ApiException_H_
-#define ApiException_H_
+#ifndef {{apiHeaderGuardPrefix}}_ApiException_H_
+#define {{apiHeaderGuardPrefix}}_ApiException_H_
 
 {{{defaultInclude}}}
 
@@ -46,4 +46,4 @@ protected:
 }
 {{/apiNamespaceDeclarations}}
 
-#endif /* ApiBase_H_ */
+#endif /* {{apiHeaderGuardPrefix}}_ApiBase_H_ */

--- a/modules/swagger-codegen/src/main/resources/cpprest/httpcontent-header.mustache
+++ b/modules/swagger-codegen/src/main/resources/cpprest/httpcontent-header.mustache
@@ -5,8 +5,8 @@
  * This class represents a single item of a multipart-formdata request.
  */
 
-#ifndef HttpContent_H_
-#define HttpContent_H_
+#ifndef {{modelHeaderGuardPrefix}}_HttpContent_H_
+#define {{modelHeaderGuardPrefix}}_HttpContent_H_
 
 {{{defaultInclude}}}
 
@@ -54,4 +54,4 @@ protected:
 }
 {{/modelNamespaceDeclarations}}
 
-#endif /* HttpContent_H_ */
+#endif /* {{modelHeaderGuardPrefix}}_HttpContent_H_ */

--- a/modules/swagger-codegen/src/main/resources/cpprest/ihttpbody-header.mustache
+++ b/modules/swagger-codegen/src/main/resources/cpprest/ihttpbody-header.mustache
@@ -5,8 +5,8 @@
  * This is the interface for contents that can be sent to a remote HTTP server.
  */
 
-#ifndef IHttpBody_H_
-#define IHttpBody_H_
+#ifndef {{modelHeaderGuardPrefix}}_IHttpBody_H_
+#define {{modelHeaderGuardPrefix}}_IHttpBody_H_
 
 {{{defaultInclude}}}
 #include <iostream>
@@ -27,4 +27,4 @@ public:
 }
 {{/modelNamespaceDeclarations}}
 
-#endif /* IHttpBody_H_ */
+#endif /* {{modelHeaderGuardPrefix}}_IHttpBody_H_ */

--- a/modules/swagger-codegen/src/main/resources/cpprest/jsonbody-header.mustache
+++ b/modules/swagger-codegen/src/main/resources/cpprest/jsonbody-header.mustache
@@ -5,8 +5,8 @@
  * This is a JSON http body which can be submitted via http
  */
 
-#ifndef JsonBody_H_
-#define JsonBody_H_
+#ifndef {{modelHeaderGuardPrefix}}_JsonBody_H_
+#define {{modelHeaderGuardPrefix}}_JsonBody_H_
 
 {{{defaultInclude}}}
 #include "IHttpBody.h"
@@ -34,4 +34,4 @@ protected:
 }
 {{/modelNamespaceDeclarations}}
 
-#endif /* JsonBody_H_ */
+#endif /* {{modelHeaderGuardPrefix}}_JsonBody_H_ */

--- a/modules/swagger-codegen/src/main/resources/cpprest/model-header.mustache
+++ b/modules/swagger-codegen/src/main/resources/cpprest/model-header.mustache
@@ -5,8 +5,8 @@
  * {{description}}
  */
 
-#ifndef {{classname}}_H_
-#define {{classname}}_H_
+#ifndef {{modelHeaderGuardPrefix}}_{{classname}}_H_
+#define {{modelHeaderGuardPrefix}}_{{classname}}_H_
 
 {{^parent}}
 {{{defaultInclude}}}
@@ -72,6 +72,6 @@ protected:
 }
 {{/modelNamespaceDeclarations}}
 
-#endif /* {{classname}}_H_ */
+#endif /* {{modelHeaderGuardPrefix}}_{{classname}}_H_ */
 {{/model}}
 {{/models}}

--- a/modules/swagger-codegen/src/main/resources/cpprest/modelbase-header.mustache
+++ b/modules/swagger-codegen/src/main/resources/cpprest/modelbase-header.mustache
@@ -5,8 +5,8 @@
  * This is the base class for all model classes
  */
 
-#ifndef ModelBase_H_
-#define ModelBase_H_
+#ifndef {{modelHeaderGuardPrefix}}_ModelBase_H_
+#define {{modelHeaderGuardPrefix}}_ModelBase_H_
 
 {{{defaultInclude}}}
 #include "HttpContent.h"
@@ -77,4 +77,4 @@ public:
 }
 {{/modelNamespaceDeclarations}}
 
-#endif /* ModelBase_H_ */
+#endif /* {{modelHeaderGuardPrefix}}_ModelBase_H_ */

--- a/modules/swagger-codegen/src/main/resources/cpprest/multipart-header.mustache
+++ b/modules/swagger-codegen/src/main/resources/cpprest/multipart-header.mustache
@@ -5,8 +5,8 @@
  * This class represents a container for building a application/x-multipart-formdata requests.
  */
 
-#ifndef MultipartFormData_H_
-#define MultipartFormData_H_
+#ifndef {{modelHeaderGuardPrefix}}_MultipartFormData_H_
+#define {{modelHeaderGuardPrefix}}_MultipartFormData_H_
 
 {{{defaultInclude}}}
 #include "IHttpBody.h"
@@ -47,4 +47,4 @@ protected:
 }
 {{/modelNamespaceDeclarations}}
 
-#endif /* MultipartFormData_H_ */
+#endif /* {{modelHeaderGuardPrefix}}_MultipartFormData_H_ */

--- a/samples/client/petstore/cpprest/ApiClient.h
+++ b/samples/client/petstore/cpprest/ApiClient.h
@@ -16,8 +16,8 @@
  * This is an API client responsible for stating the HTTP calls
  */
 
-#ifndef ApiClient_H_
-#define ApiClient_H_
+#ifndef IO_SWAGGER_CLIENT_API_ApiClient_H_
+#define IO_SWAGGER_CLIENT_API_ApiClient_H_
 
 
 #include "ApiConfiguration.h"
@@ -88,4 +88,4 @@ protected:
 }
 }
 
-#endif /* ApiClient_H_ */
+#endif /* IO_SWAGGER_CLIENT_API_ApiClient_H_ */

--- a/samples/client/petstore/cpprest/ApiConfiguration.h
+++ b/samples/client/petstore/cpprest/ApiConfiguration.h
@@ -16,8 +16,8 @@
  * This class represents a single item of a multipart-formdata request.
  */
 
-#ifndef ApiConfiguration_H_
-#define ApiConfiguration_H_
+#ifndef IO_SWAGGER_CLIENT_API_ApiConfiguration_H_
+#define IO_SWAGGER_CLIENT_API_ApiConfiguration_H_
 
 
 
@@ -62,4 +62,4 @@ protected:
 }
 }
 }
-#endif /* ApiConfiguration_H_ */
+#endif /* IO_SWAGGER_CLIENT_API_ApiConfiguration_H_ */

--- a/samples/client/petstore/cpprest/ApiException.h
+++ b/samples/client/petstore/cpprest/ApiException.h
@@ -16,8 +16,8 @@
  * This is the exception being thrown in case the api call was not successful
  */
 
-#ifndef ApiException_H_
-#define ApiException_H_
+#ifndef IO_SWAGGER_CLIENT_API_ApiException_H_
+#define IO_SWAGGER_CLIENT_API_ApiException_H_
 
 
 
@@ -59,4 +59,4 @@ protected:
 }
 }
 
-#endif /* ApiBase_H_ */
+#endif /* IO_SWAGGER_CLIENT_API_ApiBase_H_ */

--- a/samples/client/petstore/cpprest/HttpContent.h
+++ b/samples/client/petstore/cpprest/HttpContent.h
@@ -16,8 +16,8 @@
  * This class represents a single item of a multipart-formdata request.
  */
 
-#ifndef HttpContent_H_
-#define HttpContent_H_
+#ifndef IO_SWAGGER_CLIENT_MODEL_HttpContent_H_
+#define IO_SWAGGER_CLIENT_MODEL_HttpContent_H_
 
 
 
@@ -67,4 +67,4 @@ protected:
 }
 }
 
-#endif /* HttpContent_H_ */
+#endif /* IO_SWAGGER_CLIENT_MODEL_HttpContent_H_ */

--- a/samples/client/petstore/cpprest/IHttpBody.h
+++ b/samples/client/petstore/cpprest/IHttpBody.h
@@ -16,8 +16,8 @@
  * This is the interface for contents that can be sent to a remote HTTP server.
  */
 
-#ifndef IHttpBody_H_
-#define IHttpBody_H_
+#ifndef IO_SWAGGER_CLIENT_MODEL_IHttpBody_H_
+#define IO_SWAGGER_CLIENT_MODEL_IHttpBody_H_
 
 
 #include <iostream>
@@ -40,4 +40,4 @@ public:
 }
 }
 
-#endif /* IHttpBody_H_ */
+#endif /* IO_SWAGGER_CLIENT_MODEL_IHttpBody_H_ */

--- a/samples/client/petstore/cpprest/JsonBody.h
+++ b/samples/client/petstore/cpprest/JsonBody.h
@@ -16,8 +16,8 @@
  * This is a JSON http body which can be submitted via http
  */
 
-#ifndef JsonBody_H_
-#define JsonBody_H_
+#ifndef IO_SWAGGER_CLIENT_MODEL_JsonBody_H_
+#define IO_SWAGGER_CLIENT_MODEL_JsonBody_H_
 
 
 #include "IHttpBody.h"
@@ -47,4 +47,4 @@ protected:
 }
 }
 
-#endif /* JsonBody_H_ */
+#endif /* IO_SWAGGER_CLIENT_MODEL_JsonBody_H_ */

--- a/samples/client/petstore/cpprest/ModelBase.h
+++ b/samples/client/petstore/cpprest/ModelBase.h
@@ -16,8 +16,8 @@
  * This is the base class for all model classes
  */
 
-#ifndef ModelBase_H_
-#define ModelBase_H_
+#ifndef IO_SWAGGER_CLIENT_MODEL_ModelBase_H_
+#define IO_SWAGGER_CLIENT_MODEL_ModelBase_H_
 
 
 #include "HttpContent.h"
@@ -90,4 +90,4 @@ public:
 }
 }
 
-#endif /* ModelBase_H_ */
+#endif /* IO_SWAGGER_CLIENT_MODEL_ModelBase_H_ */

--- a/samples/client/petstore/cpprest/MultipartFormData.h
+++ b/samples/client/petstore/cpprest/MultipartFormData.h
@@ -16,8 +16,8 @@
  * This class represents a container for building a application/x-multipart-formdata requests.
  */
 
-#ifndef MultipartFormData_H_
-#define MultipartFormData_H_
+#ifndef IO_SWAGGER_CLIENT_MODEL_MultipartFormData_H_
+#define IO_SWAGGER_CLIENT_MODEL_MultipartFormData_H_
 
 
 #include "IHttpBody.h"
@@ -60,4 +60,4 @@ protected:
 }
 }
 
-#endif /* MultipartFormData_H_ */
+#endif /* IO_SWAGGER_CLIENT_MODEL_MultipartFormData_H_ */

--- a/samples/client/petstore/cpprest/api/PetApi.h
+++ b/samples/client/petstore/cpprest/api/PetApi.h
@@ -16,8 +16,8 @@
  * 
  */
 
-#ifndef PetApi_H_
-#define PetApi_H_
+#ifndef IO_SWAGGER_CLIENT_API_PetApi_H_
+#define IO_SWAGGER_CLIENT_API_PetApi_H_
 
 
 #include "ApiClient.h"
@@ -113,5 +113,5 @@ protected:
 }
 }
 
-#endif /* PetApi_H_ */
+#endif /* IO_SWAGGER_CLIENT_API_PetApi_H_ */
 

--- a/samples/client/petstore/cpprest/api/StoreApi.h
+++ b/samples/client/petstore/cpprest/api/StoreApi.h
@@ -16,8 +16,8 @@
  * 
  */
 
-#ifndef StoreApi_H_
-#define StoreApi_H_
+#ifndef IO_SWAGGER_CLIENT_API_StoreApi_H_
+#define IO_SWAGGER_CLIENT_API_StoreApi_H_
 
 
 #include "ApiClient.h"
@@ -80,5 +80,5 @@ protected:
 }
 }
 
-#endif /* StoreApi_H_ */
+#endif /* IO_SWAGGER_CLIENT_API_StoreApi_H_ */
 

--- a/samples/client/petstore/cpprest/api/UserApi.h
+++ b/samples/client/petstore/cpprest/api/UserApi.h
@@ -16,8 +16,8 @@
  * 
  */
 
-#ifndef UserApi_H_
-#define UserApi_H_
+#ifndef IO_SWAGGER_CLIENT_API_UserApi_H_
+#define IO_SWAGGER_CLIENT_API_UserApi_H_
 
 
 #include "ApiClient.h"
@@ -112,5 +112,5 @@ protected:
 }
 }
 
-#endif /* UserApi_H_ */
+#endif /* IO_SWAGGER_CLIENT_API_UserApi_H_ */
 

--- a/samples/client/petstore/cpprest/model/ApiResponse.h
+++ b/samples/client/petstore/cpprest/model/ApiResponse.h
@@ -16,8 +16,8 @@
  * Describes the result of uploading an image resource
  */
 
-#ifndef ApiResponse_H_
-#define ApiResponse_H_
+#ifndef IO_SWAGGER_CLIENT_MODEL_ApiResponse_H_
+#define IO_SWAGGER_CLIENT_MODEL_ApiResponse_H_
 
 
 #include "ModelBase.h"
@@ -89,4 +89,4 @@ protected:
 }
 }
 
-#endif /* ApiResponse_H_ */
+#endif /* IO_SWAGGER_CLIENT_MODEL_ApiResponse_H_ */

--- a/samples/client/petstore/cpprest/model/Category.h
+++ b/samples/client/petstore/cpprest/model/Category.h
@@ -16,8 +16,8 @@
  * A category for a pet
  */
 
-#ifndef Category_H_
-#define Category_H_
+#ifndef IO_SWAGGER_CLIENT_MODEL_Category_H_
+#define IO_SWAGGER_CLIENT_MODEL_Category_H_
 
 
 #include "ModelBase.h"
@@ -80,4 +80,4 @@ protected:
 }
 }
 
-#endif /* Category_H_ */
+#endif /* IO_SWAGGER_CLIENT_MODEL_Category_H_ */

--- a/samples/client/petstore/cpprest/model/Order.h
+++ b/samples/client/petstore/cpprest/model/Order.h
@@ -16,8 +16,8 @@
  * An order for a pets from the pet store
  */
 
-#ifndef Order_H_
-#define Order_H_
+#ifndef IO_SWAGGER_CLIENT_MODEL_Order_H_
+#define IO_SWAGGER_CLIENT_MODEL_Order_H_
 
 
 #include "ModelBase.h"
@@ -116,4 +116,4 @@ protected:
 }
 }
 
-#endif /* Order_H_ */
+#endif /* IO_SWAGGER_CLIENT_MODEL_Order_H_ */

--- a/samples/client/petstore/cpprest/model/Pet.h
+++ b/samples/client/petstore/cpprest/model/Pet.h
@@ -16,8 +16,8 @@
  * A pet for sale in the pet store
  */
 
-#ifndef Pet_H_
-#define Pet_H_
+#ifndef IO_SWAGGER_CLIENT_MODEL_Pet_H_
+#define IO_SWAGGER_CLIENT_MODEL_Pet_H_
 
 
 #include "ModelBase.h"
@@ -113,4 +113,4 @@ protected:
 }
 }
 
-#endif /* Pet_H_ */
+#endif /* IO_SWAGGER_CLIENT_MODEL_Pet_H_ */

--- a/samples/client/petstore/cpprest/model/Tag.h
+++ b/samples/client/petstore/cpprest/model/Tag.h
@@ -16,8 +16,8 @@
  * A tag for a pet
  */
 
-#ifndef Tag_H_
-#define Tag_H_
+#ifndef IO_SWAGGER_CLIENT_MODEL_Tag_H_
+#define IO_SWAGGER_CLIENT_MODEL_Tag_H_
 
 
 #include "ModelBase.h"
@@ -80,4 +80,4 @@ protected:
 }
 }
 
-#endif /* Tag_H_ */
+#endif /* IO_SWAGGER_CLIENT_MODEL_Tag_H_ */

--- a/samples/client/petstore/cpprest/model/User.h
+++ b/samples/client/petstore/cpprest/model/User.h
@@ -16,8 +16,8 @@
  * A User who is purchasing from the pet store
  */
 
-#ifndef User_H_
-#define User_H_
+#ifndef IO_SWAGGER_CLIENT_MODEL_User_H_
+#define IO_SWAGGER_CLIENT_MODEL_User_H_
 
 
 #include "ModelBase.h"
@@ -134,4 +134,4 @@ protected:
 }
 }
 
-#endif /* User_H_ */
+#endif /* IO_SWAGGER_CLIENT_MODEL_User_H_ */


### PR DESCRIPTION
### PR checklist

- [X] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [X] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [X] Filed the PR against the correct branch: `3.0.0` branch for changes related to OpenAPI spec 3.0. Default: `master`.
- [X] Copied the [technical committee](https://github.com/swagger-api/swagger-codegen/#swagger-codegen-technical-committee) to review the pull request if your PR is targeting a particular programming langauge.

### Description of the PR

This PR adds package names in the generated header guards, in order to avoid clashes when generating code from two or more different API spec files.

I've updated the sample code accordingly and managed to compile it without any problems.
This change has also been tested successfully on a codebase where two separate APIs coexist (which wasn't possible at all before).