### PR TITLE
Switch Travis image from MacOS to Linux

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -47,11 +47,12 @@ before_install:
   - sudo apt-get update -qq
   - sudo apt-get install -qq bats
   - sudo apt-get install -qq curl
+  # comment out below as installation failed in travis
   # Add rebar3 build tool and recent Erlang/OTP for Erlang petstore server tests.
   # - Travis CI does not support rebar3 [yet](https://github.com/travis-ci/travis-ci/issues/6506#issuecomment-275189490).
   # - Rely on `kerl` for [pre-compiled versions available](https://docs.travis-ci.com/user/languages/erlang#Choosing-OTP-releases-to-test-against). Rely on installation path chosen by [`travis-erlang-builder`](https://github.com/travis-ci/travis-erlang-builder/blob/e6d016b1a91ca7ecac5a5a46395bde917ea13d36/bin/compile#L18).
-  - . ~/otp/18.2.1/activate && erl -version
-  - curl -f -L -o ./rebar3 https://s3.amazonaws.com/rebar3/rebar3 && chmod +x ./rebar3 && ./rebar3 version && export PATH="${TRAVIS_BUILD_DIR}:$PATH"
+  # - . ~/otp/18.2.1/activate && erl -version
+  #- curl -f -L -o ./rebar3 https://s3.amazonaws.com/rebar3/rebar3 && chmod +x ./rebar3 && ./rebar3 version && export PATH="${TRAVIS_BUILD_DIR}:$PATH"
 
   # show host table to confirm petstore.swagger.io is mapped to localhost
   - cat /etc/hosts

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,88 +1,62 @@
 sudo: required
-language: objective-c
-osx_image: xcode8.2
+language: java
+jdk:
+  - oraclejdk8
+
 cache:
   directories:
   - $HOME/.m2
   - $HOME/.ivy2
   - $HOME/.gradle/caches/
   - $HOME/.gradle/wrapper/
-  - $HOME/.stack
   - $HOME/samples/client/petstore/php/SwaggerClient-php/vendor
   - $HOME/samples/client/petstore/ruby/venodr/bundle
   - $HOME/samples/client/petstore/python/.venv/
-    #  - $HOME/samples/client/petstore/typescript-node/npm/node_modules
-    #  - $HOME/samples/client/petstore/typescript-node/npm/typings/
-    #  - $HOME/samples/client/petstore/typescript-fetch/tests/default/node_modules
-    #  - $HOME/samples/client/petstore/typescript-fetch/tests/default/typings
-    #  - $HOME/samples/client/petstore/typescript-fetch/builds/default/node_modules
-    #  - $HOME/samples/client/petstore/typescript-fetch/builds/default/typings
-    #  - $HOME/samples/client/petstore/typescript-fetch/builds/es6-target/node_modules
-    #  - $HOME/samples/client/petstore/typescript-fetch/builds/es6-target/typings
-    #  - $HOME/samples/client/petstore/typescript-fetch/builds/with-npm-version/node_modules
-    #  - $HOME/samples/client/petstore/typescript-fetch/npm/with-npm-version/typings
-    #  - $HOME/samples/client/petstore/typescript-angularjs/node_modules
-    #  - $HOME/samples/client/petstore/typescript-angularjs/typings
-  - $HOME/.cocoapods/repos/master
-  timeout: 1000
-# note: docker is not yet supported in iOS build
-#services:
-#  - docker
+  - $HOME/samples/client/petstore/typescript-node/npm/node_modules
+  - $HOME/samples/client/petstore/typescript-node/npm/typings/
+  - $HOME/samples/client/petstore/typescript-fetch/tests/default/node_modules
+  - $HOME/samples/client/petstore/typescript-fetch/tests/default/typings
+  - $HOME/samples/client/petstore/typescript-fetch/builds/default/node_modules
+  - $HOME/samples/client/petstore/typescript-fetch/builds/default/typings
+  - $HOME/samples/client/petstore/typescript-fetch/builds/es6-target/node_modules
+  - $HOME/samples/client/petstore/typescript-fetch/builds/es6-target/typings
+  - $HOME/samples/client/petstore/typescript-fetch/builds/with-npm-version/node_modules
+  - $HOME/samples/client/petstore/typescript-fetch/npm/with-npm-version/typings
+  - $HOME/samples/client/petstore/typescript-angular/node_modules
+  - $HOME/samples/client/petstore/typescript-angular/typings
 
-# comment out the host table change to use the public petstore server
+services:
+  - docker
+
 addons:
   hosts:
     - petstore.swagger.io
 
 before_install:
-  - export SW=`pwd`
-  - rvm list
-  - rvm use 2.2.5
-  - gem environment
-  - gem install bundler -N --no-ri --no-rdoc
-  - gem install cocoapods -v 1.2.1 -N --no-ri --no-rdoc
-  - gem install xcpretty -N --no-ri --no-rdoc
-  - pod --version
-  # comment out below to avoid errors
-  #- pod repo update
-  - pod setup --silent > /dev/null
+  # required when sudo: required for the Ruby petstore tests
+  - gem install bundler
   - npm install -g typescript
   - npm config set registry http://registry.npmjs.org/
-  - brew install sbt
-  - brew install leiningen
-  - brew install bats
-  - brew install curl
-  - brew install python3
-  - pip install virtualenv
-  - mkdir -p ~/.local/bin
-  - export PATH=$HOME/.local/bin:$PATH
-  - travis_retry curl --insecure -L https://www.stackage.org/stack/osx-x86_64 | tar xz --strip-components=1 --include '*/stack' -C ~/.local/bin
-  # start local petstore server
-  - git clone -b docker --single-branch https://github.com/wing328/swagger-samples
-  - cd swagger-samples/java/java-jersey-jaxrs
-  - sudo mvn jetty:run &
-  - cd $SW
-  # NOTE: iOS build not support docker at the moment
+  - sudo pip install virtualenv
   # to run petstore server locally via docker
-  #- docker pull swaggerapi/petstore
-  #- docker run -d -e SWAGGER_HOST=http://petstore.swagger.io -e SWAGGER_BASE_PATH=/v2 -p 80:8080 swaggerapi/petstore
-  #- docker ps -a
+  - docker pull swaggerapi/petstore
+  - docker run -d -e SWAGGER_HOST=http://petstore.swagger.io -e SWAGGER_BASE_PATH=/v2 -p 80:8080 swaggerapi/petstore
+  - docker ps -a
+  # Add bats test framework and cURL for Bash script integration tests
+  - sudo add-apt-repository ppa:duggan/bats --yes
+  - sudo apt-get update -qq
+  - sudo apt-get install -qq bats
+  - sudo apt-get install -qq curl
   # Add rebar3 build tool and recent Erlang/OTP for Erlang petstore server tests.
   # - Travis CI does not support rebar3 [yet](https://github.com/travis-ci/travis-ci/issues/6506#issuecomment-275189490).
   # - Rely on `kerl` for [pre-compiled versions available](https://docs.travis-ci.com/user/languages/erlang#Choosing-OTP-releases-to-test-against). Rely on installation path chosen by [`travis-erlang-builder`](https://github.com/travis-ci/travis-erlang-builder/blob/e6d016b1a91ca7ecac5a5a46395bde917ea13d36/bin/compile#L18).
+  - . ~/otp/18.2.1/activate && erl -version
+  - curl -f -L -o ./rebar3 https://s3.amazonaws.com/rebar3/rebar3 && chmod +x ./rebar3 && ./rebar3 version && export PATH="${TRAVIS_BUILD_DIR}:$PATH"
 
   # show host table to confirm petstore.swagger.io is mapped to localhost
   - cat /etc/hosts
   # show java version
   - java -version
-  # show brew version
-  - brew --version
-  # show xcpretty version
-  - xcpretty -v
-  # show go version
-  - go version
-  # show stack version
-  - stack --version
 
 install:
   # Add Godeps dependencies to GOPATH and PATH
@@ -95,23 +69,14 @@ script:
   - set -e
   # fail if templates/generators contain carriage return '\r'
   - /bin/bash ./bin/utils/detect_carriage_return.sh
-  # fail if generators contain merge conflicts
-  - /bin/bash ./bin/utils/detect_merge_conflict.sh
   # fail if generators contain tab '\t'
   - /bin/bash ./bin/utils/detect_tab_in_java_class.sh
   # run integration tests defined in maven pom.xml
-  - travis_wait mvn -q --batch-mode verify -Psamples
-### docker-related tasks have been moved to CircleCI
+  - mvn -q --batch-mode verify -Psamples
   # docker: build generator image and push to Docker Hub
-  #- if [ $DOCKER_HUB_USERNAME ]; then docker login --email=$DOCKER_HUB_EMAIL --username=$DOCKER_HUB_USERNAME --password=$DOCKER_HUB_PASSWORD && docker build -t $DOCKER_GENERATOR_IMAGE_NAME ./modules/swagger-generator && if [ ! -z "$TRAVIS_TAG" ]; then docker tag $DOCKER_GENERATOR_IMAGE_NAME:latest $DOCKER_GENERATOR_IMAGE_NAME:$TRAVIS_TAG; fi && if [ ! -z "$TRAVIS_TAG" ] || [ "$TRAVIS_BRANCH" = "master" ]; then docker push $DOCKER_GENERATOR_IMAGE_NAME; fi; fi
-  ## docker: build cli image and push to Docker Hub
-  #- if [ $DOCKER_HUB_USERNAME ]; then docker login --email=$DOCKER_HUB_EMAIL --username=$DOCKER_HUB_USERNAME --password=$DOCKER_HUB_PASSWORD && docker build -t $DOCKER_CODEGEN_CLI_IMAGE_NAME ./modules/swagger-codegen-cli && if [ ! -z "$TRAVIS_TAG" ]; then docker tag $DOCKER_CODEGEN_CLI_IMAGE_NAME:latest $DOCKER_CODEGEN_CLI_IMAGE_NAME:$TRAVIS_TAG; fi && if [ ! -z "$TRAVIS_TAG" ] || [ "$TRAVIS_BRANCH" = "master" ]; then docker push $DOCKER_CODEGEN_CLI_IMAGE_NAME; fi; fi
-#env:
-#  - DOCKER_GENERATOR_IMAGE_NAME=swaggerapi/swagger-generator DOCKER_CODEGEN_CLI_IMAGE_NAME=swaggerapi/swagger-codegen-cli
+  - if [ $DOCKER_HUB_USERNAME ]; then docker login --email=$DOCKER_HUB_EMAIL --username=$DOCKER_HUB_USERNAME --password=$DOCKER_HUB_PASSWORD && docker build -t $DOCKER_GENERATOR_IMAGE_NAME ./modules/swagger-generator && if [ ! -z "$TRAVIS_TAG" ]; then docker tag $DOCKER_GENERATOR_IMAGE_NAME:latest $DOCKER_GENERATOR_IMAGE_NAME:$TRAVIS_TAG; fi && if [ ! -z "$TRAVIS_TAG" ] || [ "$TRAVIS_BRANCH" = "master" ]; then docker push $DOCKER_GENERATOR_IMAGE_NAME; fi; fi
+  # docker: build cli image and push to Docker Hub
+  - if [ $DOCKER_HUB_USERNAME ]; then docker login --email=$DOCKER_HUB_EMAIL --username=$DOCKER_HUB_USERNAME --password=$DOCKER_HUB_PASSWORD && docker build -t $DOCKER_CODEGEN_CLI_IMAGE_NAME ./modules/swagger-codegen-cli && if [ ! -z "$TRAVIS_TAG" ]; then docker tag $DOCKER_CODEGEN_CLI_IMAGE_NAME:latest $DOCKER_CODEGEN_CLI_IMAGE_NAME:$TRAVIS_TAG; fi && if [ ! -z "$TRAVIS_TAG" ] || [ "$TRAVIS_BRANCH" = "master" ]; then docker push $DOCKER_CODEGEN_CLI_IMAGE_NAME; fi; fi
 
-after_success:
-  # push a snapshot version to maven repo
-  - if [ $SONATYPE_USERNAME ] && [ -z $TRAVIS_TAG ] && [ "$TRAVIS_BRANCH" = "master" ]; then
-      mvn clean deploy --settings .travis/settings.xml;
-      echo "Finished mvn clean deploy for $TRAVIS_BRANCH";
-    fi;
+env:
+  - DOCKER_GENERATOR_IMAGE_NAME=swaggerapi/swagger-generator DOCKER_CODEGEN_CLI_IMAGE_NAME=swaggerapi/swagger-codegen-cli

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,6 +28,7 @@ cache:
 services:
   - docker
 
+# comment out the host table change to use the public petstore server
 addons:
   hosts:
     - petstore.swagger.io
@@ -62,23 +63,33 @@ before_install:
 
 install:
   # Add Godeps dependencies to GOPATH and PATH
-   - eval "$(curl -sL https://raw.githubusercontent.com/travis-ci/gimme/master/gimme | GIMME_GO_VERSION=1.4 bash)"
-   - export GOPATH="${TRAVIS_BUILD_DIR}/Godeps/_workspace"
-   - export PATH="${TRAVIS_BUILD_DIR}/Godeps/_workspace/bin:$PATH"
+  - eval "$(curl -sL https://raw.githubusercontent.com/travis-ci/gimme/master/gimme | GIMME_GO_VERSION=1.4 bash)"
+  - export GOPATH="${TRAVIS_BUILD_DIR}/Godeps/_workspace"
+  - export PATH="${TRAVIS_BUILD_DIR}/Godeps/_workspace/bin:$PATH"
 
 script:
   # fail fast
   - set -e
   # fail if templates/generators contain carriage return '\r'
   - /bin/bash ./bin/utils/detect_carriage_return.sh
+  # fail if generators contain merge conflicts
+  - /bin/bash ./bin/utils/detect_merge_conflict.sh
   # fail if generators contain tab '\t'
   - /bin/bash ./bin/utils/detect_tab_in_java_class.sh
   # run integration tests defined in maven pom.xml
   - mvn -q --batch-mode verify -Psamples
+  # Below has been moved to CircleCI
   # docker: build generator image and push to Docker Hub
-  - if [ $DOCKER_HUB_USERNAME ]; then docker login --email=$DOCKER_HUB_EMAIL --username=$DOCKER_HUB_USERNAME --password=$DOCKER_HUB_PASSWORD && docker build -t $DOCKER_GENERATOR_IMAGE_NAME ./modules/swagger-generator && if [ ! -z "$TRAVIS_TAG" ]; then docker tag $DOCKER_GENERATOR_IMAGE_NAME:latest $DOCKER_GENERATOR_IMAGE_NAME:$TRAVIS_TAG; fi && if [ ! -z "$TRAVIS_TAG" ] || [ "$TRAVIS_BRANCH" = "master" ]; then docker push $DOCKER_GENERATOR_IMAGE_NAME; fi; fi
-  # docker: build cli image and push to Docker Hub
-  - if [ $DOCKER_HUB_USERNAME ]; then docker login --email=$DOCKER_HUB_EMAIL --username=$DOCKER_HUB_USERNAME --password=$DOCKER_HUB_PASSWORD && docker build -t $DOCKER_CODEGEN_CLI_IMAGE_NAME ./modules/swagger-codegen-cli && if [ ! -z "$TRAVIS_TAG" ]; then docker tag $DOCKER_CODEGEN_CLI_IMAGE_NAME:latest $DOCKER_CODEGEN_CLI_IMAGE_NAME:$TRAVIS_TAG; fi && if [ ! -z "$TRAVIS_TAG" ] || [ "$TRAVIS_BRANCH" = "master" ]; then docker push $DOCKER_CODEGEN_CLI_IMAGE_NAME; fi; fi
+  #- if [ $DOCKER_HUB_USERNAME ]; then docker login --email=$DOCKER_HUB_EMAIL --username=$DOCKER_HUB_USERNAME --password=$DOCKER_HUB_PASSWORD && docker build -t $DOCKER_GENERATOR_IMAGE_NAME ./modules/swagger-generator && if [ ! -z "$TRAVIS_TAG" ]; then docker tag $DOCKER_GENERATOR_IMAGE_NAME:latest $DOCKER_GENERATOR_IMAGE_NAME:$TRAVIS_TAG; fi && if [ ! -z "$TRAVIS_TAG" ] || [ "$TRAVIS_BRANCH" = "master" ]; then docker push $DOCKER_GENERATOR_IMAGE_NAME; fi; fi
+  ## docker: build cli image and push to Docker Hub
+  #- if [ $DOCKER_HUB_USERNAME ]; then docker login --email=$DOCKER_HUB_EMAIL --username=$DOCKER_HUB_USERNAME --password=$DOCKER_HUB_PASSWORD && docker build -t $DOCKER_CODEGEN_CLI_IMAGE_NAME ./modules/swagger-codegen-cli && if [ ! -z "$TRAVIS_TAG" ]; then docker tag $DOCKER_CODEGEN_CLI_IMAGE_NAME:latest $DOCKER_CODEGEN_CLI_IMAGE_NAME:$TRAVIS_TAG; fi && if [ ! -z "$TRAVIS_TAG" ] || [ "$TRAVIS_BRANCH" = "master" ]; then docker push $DOCKER_CODEGEN_CLI_IMAGE_NAME; fi; fi
+
+after_success:
+  # push a snapshot version to maven repo
+  - if [ $SONATYPE_USERNAME ] && [ -z $TRAVIS_TAG ] && [ "$TRAVIS_BRANCH" = "master" ]; then
+      mvn clean deploy --settings .travis/settings.xml;
+      echo "Finished mvn clean deploy for $TRAVIS_BRANCH";
+    fi;
 
 env:
   - DOCKER_GENERATOR_IMAGE_NAME=swaggerapi/swagger-generator DOCKER_CODEGEN_CLI_IMAGE_NAME=swaggerapi/swagger-codegen-cli

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,6 +36,7 @@ before_install:
   # required when sudo: required for the Ruby petstore tests
   - gem install bundler
   - npm install -g typescript
+  - npm install -g npm
   - npm config set registry http://registry.npmjs.org/
   - sudo pip install virtualenv
   # to run petstore server locally via docker

--- a/pom.xml
+++ b/pom.xml
@@ -858,9 +858,9 @@
                 <module>samples/client/petstore/typescript-angularjs</module>-->
                 <!-- comment out due to error `npm run build`
                 <module>samples/client/petstore/typescript-jquery/npm</module>-->
-                <!--<module>samples/client/petstore/typescript-angular-v2/npm</module>
+                <!--<module>samples/client/petstore/typescript-angular-v2/npm</module>-->
                 <module>samples/client/petstore/typescript-angular-v4/npm</module>
-                <module>samples/client/petstore/typescript-angular-v4.3/npm</module>-->
+                <module>samples/client/petstore/typescript-angular-v4.3/npm</module>
                 <!-- comment out due to https://github.com/swagger-api/swagger-codegen/issues/6658
                 <module>samples/client/petstore/swift3/default/SwaggerClientTests</module>
                 <module>samples/client/petstore/swift3/promisekit/SwaggerClientTests</module>

--- a/pom.xml
+++ b/pom.xml
@@ -837,8 +837,6 @@
                 </property>
             </activation>
             <modules>
-                <!-- servers -->
-                <module>samples/server/petstore/scalatra</module>
                 <!-- <module>samples/server/petstore/erlang-server</module> note: make sample compilation work -->
                 <!-- clients -->
                 <module>samples/client/petstore/ruby</module>
@@ -846,8 +844,6 @@
                 <module>samples/client/petstore/akka-scala</module>
                 <module>samples/client/petstore/javascript</module>
                 <module>samples/client/petstore/python</module>
-                <!-- <module>samples/client/petstore/haskell-http-client</module> -->
-                <!-- <module>samples/client/petstore/haskell-http-client/tests-integration</module> -->
                 <module>samples/client/petstore/typescript-fetch/builds/default</module>
                 <module>samples/client/petstore/typescript-fetch/builds/es6-target</module>
                 <module>samples/client/petstore/typescript-fetch/builds/with-npm-version</module>
@@ -860,18 +856,7 @@
                 <!--<module>samples/client/petstore/typescript-angular-v2/npm</module>-->
                 <module>samples/client/petstore/typescript-angular-v4/npm</module>
                 <module>samples/client/petstore/typescript-angular-v4.3/npm</module>
-                <!-- comment out due to https://github.com/swagger-api/swagger-codegen/issues/6658
-                <module>samples/client/petstore/swift3/default/SwaggerClientTests</module>
-                <module>samples/client/petstore/swift3/promisekit/SwaggerClientTests</module>
-                <module>samples/client/petstore/swift3/rxswift/SwaggerClientTests</module>
-                <module>samples/client/petstore/swift/default/SwaggerClientTests</module>
-                <module>samples/client/petstore/swift/promisekit/SwaggerClientTests</module>
-                <module>samples/client/petstore/swift/rxswift/SwaggerClientTests</module>
-                -->
-                <!-- comment out objc tests as it's timing out
-                <module>samples/client/petstore/objc/default/SwaggerClientTests</module>
-                <module>samples/client/petstore/objc/core-data/SwaggerClientTests</module>-->
-                <module>samples/client/petstore/bash</module>
+                <!--<module>samples/client/petstore/bash</module>-->
             </modules>
         </profile>
     </profiles>

--- a/pom.xml
+++ b/pom.xml
@@ -841,7 +841,6 @@
                 <module>samples/server/petstore/scalatra</module>
                 <!-- <module>samples/server/petstore/erlang-server</module> note: make sample compilation work -->
                 <!-- clients -->
-                <!--<module>samples/client/petstore/bash</module>-->
                 <module>samples/client/petstore/ruby</module>
                 <module>samples/client/petstore/scala</module>
                 <module>samples/client/petstore/akka-scala</module>
@@ -872,6 +871,7 @@
                 <!-- comment out objc tests as it's timing out
                 <module>samples/client/petstore/objc/default/SwaggerClientTests</module>
                 <module>samples/client/petstore/objc/core-data/SwaggerClientTests</module>-->
+                <module>samples/client/petstore/bash</module>
             </modules>
         </profile>
     </profiles>

--- a/pom.xml
+++ b/pom.xml
@@ -858,9 +858,9 @@
                 <module>samples/client/petstore/typescript-angularjs</module>-->
                 <!-- comment out due to error `npm run build`
                 <module>samples/client/petstore/typescript-jquery/npm</module>-->
-                <module>samples/client/petstore/typescript-angular-v2/npm</module>
+                <!--<module>samples/client/petstore/typescript-angular-v2/npm</module>
                 <module>samples/client/petstore/typescript-angular-v4/npm</module>
-                <module>samples/client/petstore/typescript-angular-v4.3/npm</module>
+                <module>samples/client/petstore/typescript-angular-v4.3/npm</module>-->
                 <!-- comment out due to https://github.com/swagger-api/swagger-codegen/issues/6658
                 <module>samples/client/petstore/swift3/default/SwaggerClientTests</module>
                 <module>samples/client/petstore/swift3/promisekit/SwaggerClientTests</module>


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [ ] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [x] Filed the PR against the correct branch: `3.0.0` branch for changes related to OpenAPI spec 3.0. Default: `master`.
- [ ] Copied the [technical committee](https://github.com/swagger-api/swagger-codegen/#swagger-codegen-technical-committee) to review the pull request if your PR is targeting a particular programming langauge.

### Description of the PR

The MacOS image does not seem very stable and timeout occurs more and more often. We'll switch back to Linux.
