### PR TITLE
Removed wrong import of StrictJsonDeserializationVisitor

### DIFF
--- a/modules/swagger-codegen/src/main/resources/php-symfony/serialization/JmsSerializer.mustache
+++ b/modules/swagger-codegen/src/main/resources/php-symfony/serialization/JmsSerializer.mustache
@@ -5,7 +5,6 @@ namespace {{servicePackage}};
 use JMS\Serializer\SerializerBuilder;
 use JMS\Serializer\Naming\CamelCaseNamingStrategy;
 use JMS\Serializer\Naming\SerializedNameAnnotationStrategy;
-use Swagger\Server\Service\StrictJsonDeserializationVisitor;
 use JMS\Serializer\XmlDeserializationVisitor;
 
 class JmsSerializer implements SerializerInterface

--- a/samples/server/petstore/php-symfony/SymfonyBundle-php/README.md
+++ b/samples/server/petstore/php-symfony/SymfonyBundle-php/README.md
@@ -124,36 +124,36 @@ All URIs are relative to *http://petstore.swagger.io/v2*
 
 Class | Method | HTTP request | Description
 ------------ | ------------- | ------------- | -------------
-*PetApiInterface* | [**addPet**](Resources/docs/Api/PetApiInterface.md#addpet) | **POST** /pet | Add a new pet to the store
-*PetApiInterface* | [**deletePet**](Resources/docs/Api/PetApiInterface.md#deletepet) | **DELETE** /pet/{petId} | Deletes a pet
-*PetApiInterface* | [**findPetsByStatus**](Resources/docs/Api/PetApiInterface.md#findpetsbystatus) | **GET** /pet/findByStatus | Finds Pets by status
-*PetApiInterface* | [**findPetsByTags**](Resources/docs/Api/PetApiInterface.md#findpetsbytags) | **GET** /pet/findByTags | Finds Pets by tags
-*PetApiInterface* | [**getPetById**](Resources/docs/Api/PetApiInterface.md#getpetbyid) | **GET** /pet/{petId} | Find pet by ID
-*PetApiInterface* | [**updatePet**](Resources/docs/Api/PetApiInterface.md#updatepet) | **PUT** /pet | Update an existing pet
-*PetApiInterface* | [**updatePetWithForm**](Resources/docs/Api/PetApiInterface.md#updatepetwithform) | **POST** /pet/{petId} | Updates a pet in the store with form data
-*PetApiInterface* | [**uploadFile**](Resources/docs/Api/PetApiInterface.md#uploadfile) | **POST** /pet/{petId}/uploadImage | uploads an image
-*StoreApiInterface* | [**deleteOrder**](Resources/docs/Api/StoreApiInterface.md#deleteorder) | **DELETE** /store/order/{orderId} | Delete purchase order by ID
-*StoreApiInterface* | [**getInventory**](Resources/docs/Api/StoreApiInterface.md#getinventory) | **GET** /store/inventory | Returns pet inventories by status
-*StoreApiInterface* | [**getOrderById**](Resources/docs/Api/StoreApiInterface.md#getorderbyid) | **GET** /store/order/{orderId} | Find purchase order by ID
-*StoreApiInterface* | [**placeOrder**](Resources/docs/Api/StoreApiInterface.md#placeorder) | **POST** /store/order | Place an order for a pet
-*UserApiInterface* | [**createUser**](Resources/docs/Api/UserApiInterface.md#createuser) | **POST** /user | Create user
-*UserApiInterface* | [**createUsersWithArrayInput**](Resources/docs/Api/UserApiInterface.md#createuserswitharrayinput) | **POST** /user/createWithArray | Creates list of users with given input array
-*UserApiInterface* | [**createUsersWithListInput**](Resources/docs/Api/UserApiInterface.md#createuserswithlistinput) | **POST** /user/createWithList | Creates list of users with given input array
-*UserApiInterface* | [**deleteUser**](Resources/docs/Api/UserApiInterface.md#deleteuser) | **DELETE** /user/{username} | Delete user
-*UserApiInterface* | [**getUserByName**](Resources/docs/Api/UserApiInterface.md#getuserbyname) | **GET** /user/{username} | Get user by user name
-*UserApiInterface* | [**loginUser**](Resources/docs/Api/UserApiInterface.md#loginuser) | **GET** /user/login | Logs user into the system
-*UserApiInterface* | [**logoutUser**](Resources/docs/Api/UserApiInterface.md#logoutuser) | **GET** /user/logout | Logs out current logged in user session
-*UserApiInterface* | [**updateUser**](Resources/docs/Api/UserApiInterface.md#updateuser) | **PUT** /user/{username} | Updated user
+*PetApiInterface* | [**addPet**](Resources\docs\Api/PetApiInterface.md#addpet) | **POST** /pet | Add a new pet to the store
+*PetApiInterface* | [**deletePet**](Resources\docs\Api/PetApiInterface.md#deletepet) | **DELETE** /pet/{petId} | Deletes a pet
+*PetApiInterface* | [**findPetsByStatus**](Resources\docs\Api/PetApiInterface.md#findpetsbystatus) | **GET** /pet/findByStatus | Finds Pets by status
+*PetApiInterface* | [**findPetsByTags**](Resources\docs\Api/PetApiInterface.md#findpetsbytags) | **GET** /pet/findByTags | Finds Pets by tags
+*PetApiInterface* | [**getPetById**](Resources\docs\Api/PetApiInterface.md#getpetbyid) | **GET** /pet/{petId} | Find pet by ID
+*PetApiInterface* | [**updatePet**](Resources\docs\Api/PetApiInterface.md#updatepet) | **PUT** /pet | Update an existing pet
+*PetApiInterface* | [**updatePetWithForm**](Resources\docs\Api/PetApiInterface.md#updatepetwithform) | **POST** /pet/{petId} | Updates a pet in the store with form data
+*PetApiInterface* | [**uploadFile**](Resources\docs\Api/PetApiInterface.md#uploadfile) | **POST** /pet/{petId}/uploadImage | uploads an image
+*StoreApiInterface* | [**deleteOrder**](Resources\docs\Api/StoreApiInterface.md#deleteorder) | **DELETE** /store/order/{orderId} | Delete purchase order by ID
+*StoreApiInterface* | [**getInventory**](Resources\docs\Api/StoreApiInterface.md#getinventory) | **GET** /store/inventory | Returns pet inventories by status
+*StoreApiInterface* | [**getOrderById**](Resources\docs\Api/StoreApiInterface.md#getorderbyid) | **GET** /store/order/{orderId} | Find purchase order by ID
+*StoreApiInterface* | [**placeOrder**](Resources\docs\Api/StoreApiInterface.md#placeorder) | **POST** /store/order | Place an order for a pet
+*UserApiInterface* | [**createUser**](Resources\docs\Api/UserApiInterface.md#createuser) | **POST** /user | Create user
+*UserApiInterface* | [**createUsersWithArrayInput**](Resources\docs\Api/UserApiInterface.md#createuserswitharrayinput) | **POST** /user/createWithArray | Creates list of users with given input array
+*UserApiInterface* | [**createUsersWithListInput**](Resources\docs\Api/UserApiInterface.md#createuserswithlistinput) | **POST** /user/createWithList | Creates list of users with given input array
+*UserApiInterface* | [**deleteUser**](Resources\docs\Api/UserApiInterface.md#deleteuser) | **DELETE** /user/{username} | Delete user
+*UserApiInterface* | [**getUserByName**](Resources\docs\Api/UserApiInterface.md#getuserbyname) | **GET** /user/{username} | Get user by user name
+*UserApiInterface* | [**loginUser**](Resources\docs\Api/UserApiInterface.md#loginuser) | **GET** /user/login | Logs user into the system
+*UserApiInterface* | [**logoutUser**](Resources\docs\Api/UserApiInterface.md#logoutuser) | **GET** /user/logout | Logs out current logged in user session
+*UserApiInterface* | [**updateUser**](Resources\docs\Api/UserApiInterface.md#updateuser) | **PUT** /user/{username} | Updated user
 
 
 ## Documentation For Models
 
- - [ApiResponse](Resources/docs/Model/ApiResponse.md)
- - [Category](Resources/docs/Model/Category.md)
- - [Order](Resources/docs/Model/Order.md)
- - [Pet](Resources/docs/Model/Pet.md)
- - [Tag](Resources/docs/Model/Tag.md)
- - [User](Resources/docs/Model/User.md)
+ - [ApiResponse](Resources\docs\Model/ApiResponse.md)
+ - [Category](Resources\docs\Model/Category.md)
+ - [Order](Resources\docs\Model/Order.md)
+ - [Pet](Resources\docs\Model/Pet.md)
+ - [Tag](Resources\docs\Model/Tag.md)
+ - [User](Resources\docs\Model/User.md)
 
 
 ## Documentation For Authorization

--- a/samples/server/petstore/php-symfony/SymfonyBundle-php/Service/JmsSerializer.php
+++ b/samples/server/petstore/php-symfony/SymfonyBundle-php/Service/JmsSerializer.php
@@ -5,7 +5,6 @@ namespace Swagger\Server\Service;
 use JMS\Serializer\SerializerBuilder;
 use JMS\Serializer\Naming\CamelCaseNamingStrategy;
 use JMS\Serializer\Naming\SerializedNameAnnotationStrategy;
-use Swagger\Server\Service\StrictJsonDeserializationVisitor;
 use JMS\Serializer\XmlDeserializationVisitor;
 
 class JmsSerializer implements SerializerInterface

--- a/samples/server/petstore/php-symfony/SymfonyBundle-php/git_push.sh
+++ b/samples/server/petstore/php-symfony/SymfonyBundle-php/git_push.sh
@@ -36,7 +36,7 @@ git_remote=`git remote`
 if [ "$git_remote" = "" ]; then # git remote not defined
 
     if [ "$GIT_TOKEN" = "" ]; then
-        echo "[INFO] \$GIT_TOKEN (environment variable) is not set. Using the git crediential in your environment."
+        echo "[INFO] \$GIT_TOKEN (environment variable) is not set. Using the git credential in your environment."
         git remote add origin https://github.com/${git_user_id}/${git_repo_id}.git
     else
         git remote add origin https://${git_user_id}:${GIT_TOKEN}@github.com/${git_user_id}/${git_repo_id}.git

--- a/samples/server/petstore/php-symfony/SymfonyBundle-php/phpunit.xml.dist
+++ b/samples/server/petstore/php-symfony/SymfonyBundle-php/phpunit.xml.dist
@@ -7,8 +7,8 @@
          stopOnFailure="false">
     <testsuites>
         <testsuite>
-            <directory>./Tests/Api</directory>
-            <directory>./Tests/Model</directory>
+            <directory>.\Tests\Api</directory>
+            <directory>.\Tests\Model</directory>
         </testsuite>
     </testsuites>
 
@@ -18,8 +18,8 @@
 
     <filter>
         <whitelist processUncoveredFilesFromWhitelist="true">
-            <directory suffix=".php">././Api</directory>
-            <directory suffix=".php">././Model</directory>
+            <directory suffix=".php">.\.\Api</directory>
+            <directory suffix=".php">.\.\Model</directory>
         </whitelist>
     </filter>
 </phpunit>


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [X] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [X] Filed the PR against the correct branch: `3.0.0` branch for changes related to OpenAPI spec 3.0. Default: `master`.
- [X] Copied the [technical committee](https://github.com/swagger-api/swagger-codegen/#swagger-codegen-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

For the PHP Symfony generation this import

```php
use` Swagger\Server\Service\StrictJsonDeserializationVisitor;
```  
is wrong as the class is sitting in the same package as the JMSSerializer class.
This results in exception when the serializer is used

@jebentier  @dkarlovi  @mandrean  @jfastnacht  @ackintosh @naelrashdeen 