### PR TITLE
Updated swagger-ui wget url to https

### DIFF
--- a/modules/swagger-generator/pom.xml
+++ b/modules/swagger-generator/pom.xml
@@ -111,7 +111,7 @@
                             <goal>wget</goal>
                         </goals>
                         <configuration>
-                            <url>http://github.com/swagger-api/swagger-ui/archive/master.tar.gz</url>
+                            <url>https://github.com/swagger-api/swagger-ui/archive/master.tar.gz</url>
 
                             <unpack>true</unpack>
                             <skipCache>true</skipCache>


### PR DESCRIPTION
### PR checklist

- [ ] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [ ] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [ ] Filed the PR against the correct branch: `3.0.0` branch for changes related to OpenAPI spec 3.0. Default: `master`.

### Description of the PR

Had problems getting the swagger-api download set in pom.xml on http.  I assume this is to networking issues that other people could have as well so I updated this.

@wing328 
