### PR TITLE
[Typescript][Angular]Issue #6902 Return Client Response for Angular 4.3 and above with Observe string

### DIFF
--- a/modules/swagger-codegen/src/main/resources/typescript-angular/api.service.mustache
+++ b/modules/swagger-codegen/src/main/resources/typescript-angular/api.service.mustache
@@ -3,12 +3,15 @@
 
 import { Inject, Injectable, Optional }                      from '@angular/core';
 {{#useHttpClient}}
-import { HttpClient, HttpHeaders, HttpParams }               from '@angular/common/http';
+import { HttpClient, HttpHeaders, HttpParams,
+         HttpResponse, HttpEvent }                           from '@angular/common/http';
+import { CustomHttpUrlEncodingCodec }                        from '../encoder';
 {{/useHttpClient}}
 {{^useHttpClient}}
 import { Http, Headers, URLSearchParams }                    from '@angular/http';
 import { RequestMethod, RequestOptions, RequestOptionsArgs } from '@angular/http';
 import { Response, ResponseContentType }                     from '@angular/http';
+import { CustomQueryEncoderHelper }                          from '../encoder';
 {{/useHttpClient}}
 
 import { Observable }                                        from 'rxjs/Observable';
@@ -20,12 +23,6 @@ import { {{classname}} } from '../{{filename}}';
 
 import { BASE_PATH, COLLECTION_FORMATS }                     from '../variables';
 import { Configuration }                                     from '../configuration';
-{{#useHttpClient}}
-import { CustomHttpUrlEncodingCodec }                        from '../encoder';
-{{/useHttpClient}}
-{{^useHttpClient}}
-import { CustomQueryEncoderHelper }                          from '../encoder';
-{{/useHttpClient}}
 {{#withInterfaces}}
 import { {{classname}}Interface }                            from './{{classname}}Interface';
 {{/withInterfaces}}
@@ -74,8 +71,8 @@ export class {{classname}} {
     }
 
 {{^useHttpClient}}
-{{! not sure why we used to generate a second method here rather than inlining those few lines of code, 
-    but let's keep it for now for the sake of backwards compatiblity. }}  
+{{! not sure why we used to generate a second method here rather than inlining those few lines of code,
+    but let's keep it for now for the sake of backwards compatiblity. }}
 {{#operation}}
     /**
      * {{&notes}}
@@ -109,8 +106,18 @@ export class {{classname}} {
      * {{summary}}
      * {{notes}}
      {{#allParams}}* @param {{paramName}} {{description}}
-     {{/allParams}}*/
-    public {{nickname}}{{^useHttpClient}}WithHttpInfo{{/useHttpClient}}({{#allParams}}{{paramName}}{{^required}}?{{/required}}: {{{dataType}}}{{#hasMore}}, {{/hasMore}}{{/allParams}}{{^useHttpClient}}{{#hasParams}}, {{/hasParams}}extraHttpRequestParams?: RequestOptionsArgs{{/useHttpClient}}): Observable<{{#useHttpClient}}{{#returnType}}{{{returnType}}}{{#isResponseTypeFile}}|undefined{{/isResponseTypeFile}}{{/returnType}}{{^returnType}}{}{{/returnType}}{{/useHttpClient}}{{^useHttpClient}}Response{{/useHttpClient}}> {
+     {{/allParams}}{{#useHttpClient}}* @param observe set whether or not to return the data Observable as the body, response or events. defaults to returning the body.
+     * @param reportProgress flag to report request and response progress.{{/useHttpClient}}
+     */
+    {{#useHttpClient}}
+    public {{nickname}}({{#allParams}}{{paramName}}{{^required}}?{{/required}}: {{{dataType}}}{{#hasMore}}, {{/hasMore}}{{/allParams}}, observe?: 'body', reportProgress?: boolean): Observable<{{#returnType}}{{{returnType}}}{{#isResponseTypeFile}}|undefined{{/isResponseTypeFile}}{{/returnType}}{{^returnType}}any{{/returnType}}>;
+    public {{nickname}}({{#allParams}}{{paramName}}{{^required}}?{{/required}}: {{{dataType}}}{{#hasMore}}, {{/hasMore}}{{/allParams}}, observe?: 'response', reportProgress?: boolean): Observable<HttpResponse<{{#returnType}}{{{returnType}}}{{#isResponseTypeFile}}|undefined{{/isResponseTypeFile}}{{/returnType}}{{^returnType}}any{{/returnType}}>>;
+    public {{nickname}}({{#allParams}}{{paramName}}{{^required}}?{{/required}}: {{{dataType}}}{{#hasMore}}, {{/hasMore}}{{/allParams}}, observe?: 'events', reportProgress?: boolean): Observable<HttpEvent<{{#returnType}}{{{returnType}}}{{#isResponseTypeFile}}|undefined{{/isResponseTypeFile}}{{/returnType}}{{^returnType}}any{{/returnType}}>>;
+    public {{nickname}}({{#allParams}}{{paramName}}{{^required}}?{{/required}}: {{{dataType}}}{{#hasMore}}, {{/hasMore}}{{/allParams}}, observe: 'body' | 'response' | 'events' = 'body', reportProgress: boolean = false ): Observable<any> {
+    {{/useHttpClient}}
+    {{^useHttpClient}}
+    public {{nickname}}WithHttpInfo({{#allParams}}{{paramName}}{{^required}}?{{/required}}: {{{dataType}}}{{#hasMore}}, {{/hasMore}}{{/allParams}}{{#hasParams}}, {{/hasParams}}extraHttpRequestParams?: RequestOptionsArgs): Observable<Response> {
+    {{/useHttpClient}}
 {{#allParams}}
 {{#required}}
         if ({{paramName}} === null || {{paramName}} === undefined) {
@@ -151,7 +158,7 @@ export class {{classname}} {
         {{/isListContainer}}
 {{/queryParams}}
 
-{{/hasQueryParams}} 
+{{/hasQueryParams}}
         let headers = {{#useHttpClient}}this.defaultHeaders;{{/useHttpClient}}{{^useHttpClient}}new Headers(this.defaultHeaders.toJSON()); // https://github.com/angular/angular/issues/6845{{/useHttpClient}}
 {{#headerParams}}
         {{#isListContainer}}
@@ -282,24 +289,26 @@ export class {{classname}} {
 
 {{/hasFormParams}}
 {{#useHttpClient}}
-        return this.httpClient.{{httpMethod}}{{^isResponseFile}}<any>{{/isResponseFile}}(`${this.basePath}{{{path}}}`,{{#isBodyAllowed}}
+        return this.httpClient.{{httpMethod}}{{^isResponseFile}}<{{#returnType}}{{{returnType}}}{{#isResponseTypeFile}}|undefined{{/isResponseTypeFile}}{{/returnType}}{{^returnType}}any{{/returnType}}>{{/isResponseFile}}(`${this.basePath}{{{path}}}`,{{#isBodyAllowed}}
             {{#bodyParam}}{{paramName}}{{/bodyParam}}{{^bodyParam}}{{#hasFormParams}}convertFormParamsToString ? formParams.toString() : formParams{{/hasFormParams}}{{^hasFormParams}}null{{/hasFormParams}}{{/bodyParam}},{{/isBodyAllowed}}
             {
 {{#hasQueryParams}}
                 params: queryParameters,
 {{/hasQueryParams}}
-                headers: headers,
 {{#isResponseFile}}
                 responseType: "blob",
 {{/isResponseFile}}
                 withCredentials: this.configuration.withCredentials,
+                headers,
+                observe,
+                reportProgress
             }
         );
 {{/useHttpClient}}
 {{^useHttpClient}}
         let requestOptions: RequestOptionsArgs = new RequestOptions({
             method: {{httpMethod}},
-            headers: headers,
+            headers,
 {{#bodyParam}}
             body: {{paramName}} == null ? '' : JSON.stringify({{paramName}}), // https://github.com/angular/angular/issues/10612
 {{/bodyParam}}
@@ -320,7 +329,7 @@ export class {{classname}} {
         }
 
         return this.http.request(`${this.basePath}{{{path}}}`, requestOptions);
-{{/useHttpClient}}        
+{{/useHttpClient}}
     }
 
 {{/operation}}}

--- a/modules/swagger-codegen/src/main/resources/typescript-angular/api.service.mustache
+++ b/modules/swagger-codegen/src/main/resources/typescript-angular/api.service.mustache
@@ -71,8 +71,8 @@ export class {{classname}} {
     }
 
 {{^useHttpClient}}
-{{! not sure why we used to generate a second method here rather than inlining those few lines of code,
-    but let's keep it for now for the sake of backwards compatiblity. }}
+{{! Before HttpClient implementation or method overloading we relied on 2 functions, 1 to return the straight body as json
+    and another to get the full response.}}
 {{#operation}}
     /**
      * {{&notes}}
@@ -110,13 +110,13 @@ export class {{classname}} {
      * @param reportProgress flag to report request and response progress.{{/useHttpClient}}
      */
     {{#useHttpClient}}
-    public {{nickname}}({{#allParams}}{{paramName}}{{^required}}?{{/required}}: {{{dataType}}}{{#hasMore}}, {{/hasMore}}{{/allParams}}, observe?: 'body', reportProgress?: boolean): Observable<{{#returnType}}{{{returnType}}}{{#isResponseTypeFile}}|undefined{{/isResponseTypeFile}}{{/returnType}}{{^returnType}}any{{/returnType}}>;
-    public {{nickname}}({{#allParams}}{{paramName}}{{^required}}?{{/required}}: {{{dataType}}}{{#hasMore}}, {{/hasMore}}{{/allParams}}, observe?: 'response', reportProgress?: boolean): Observable<HttpResponse<{{#returnType}}{{{returnType}}}{{#isResponseTypeFile}}|undefined{{/isResponseTypeFile}}{{/returnType}}{{^returnType}}any{{/returnType}}>>;
-    public {{nickname}}({{#allParams}}{{paramName}}{{^required}}?{{/required}}: {{{dataType}}}{{#hasMore}}, {{/hasMore}}{{/allParams}}, observe?: 'events', reportProgress?: boolean): Observable<HttpEvent<{{#returnType}}{{{returnType}}}{{#isResponseTypeFile}}|undefined{{/isResponseTypeFile}}{{/returnType}}{{^returnType}}any{{/returnType}}>>;
-    public {{nickname}}({{#allParams}}{{paramName}}{{^required}}?{{/required}}: {{{dataType}}}{{#hasMore}}, {{/hasMore}}{{/allParams}}, observe: 'body' | 'response' | 'events' = 'body', reportProgress: boolean = false ): Observable<any> {
+    public {{nickname}}({{#allParams}}{{paramName}}{{^required}}?{{/required}}: {{{dataType}}}, {{/allParams}}observe?: 'body', reportProgress?: boolean): Observable<{{#returnType}}{{{returnType}}}{{#isResponseTypeFile}}|undefined{{/isResponseTypeFile}}{{/returnType}}{{^returnType}}any{{/returnType}}>;
+    public {{nickname}}({{#allParams}}{{paramName}}{{^required}}?{{/required}}: {{{dataType}}}, {{/allParams}}observe?: 'response', reportProgress?: boolean): Observable<HttpResponse<{{#returnType}}{{{returnType}}}{{#isResponseTypeFile}}|undefined{{/isResponseTypeFile}}{{/returnType}}{{^returnType}}any{{/returnType}}>>;
+    public {{nickname}}({{#allParams}}{{paramName}}{{^required}}?{{/required}}: {{{dataType}}}, {{/allParams}}observe?: 'events', reportProgress?: boolean): Observable<HttpEvent<{{#returnType}}{{{returnType}}}{{#isResponseTypeFile}}|undefined{{/isResponseTypeFile}}{{/returnType}}{{^returnType}}any{{/returnType}}>>;
+    public {{nickname}}({{#allParams}}{{paramName}}{{^required}}?{{/required}}: {{{dataType}}}, {{/allParams}}observe: 'body' | 'response' | 'events' = 'body', reportProgress: boolean = false ): Observable<any> {
     {{/useHttpClient}}
     {{^useHttpClient}}
-    public {{nickname}}WithHttpInfo({{#allParams}}{{paramName}}{{^required}}?{{/required}}: {{{dataType}}}{{#hasMore}}, {{/hasMore}}{{/allParams}}{{#hasParams}}, {{/hasParams}}extraHttpRequestParams?: RequestOptionsArgs): Observable<Response> {
+    public {{nickname}}WithHttpInfo({{#allParams}}{{paramName}}{{^required}}?{{/required}}: {{{dataType}}}, {{/allParams}}extraHttpRequestParams?: RequestOptionsArgs): Observable<Response> {
     {{/useHttpClient}}
 {{#allParams}}
 {{#required}}

--- a/modules/swagger-codegen/src/main/resources/typescript-angular/api.service.mustache
+++ b/modules/swagger-codegen/src/main/resources/typescript-angular/api.service.mustache
@@ -113,7 +113,7 @@ export class {{classname}} {
     public {{nickname}}({{#allParams}}{{paramName}}{{^required}}?{{/required}}: {{{dataType}}}, {{/allParams}}observe?: 'body', reportProgress?: boolean): Observable<{{#returnType}}{{{returnType}}}{{#isResponseTypeFile}}|undefined{{/isResponseTypeFile}}{{/returnType}}{{^returnType}}any{{/returnType}}>;
     public {{nickname}}({{#allParams}}{{paramName}}{{^required}}?{{/required}}: {{{dataType}}}, {{/allParams}}observe?: 'response', reportProgress?: boolean): Observable<HttpResponse<{{#returnType}}{{{returnType}}}{{#isResponseTypeFile}}|undefined{{/isResponseTypeFile}}{{/returnType}}{{^returnType}}any{{/returnType}}>>;
     public {{nickname}}({{#allParams}}{{paramName}}{{^required}}?{{/required}}: {{{dataType}}}, {{/allParams}}observe?: 'events', reportProgress?: boolean): Observable<HttpEvent<{{#returnType}}{{{returnType}}}{{#isResponseTypeFile}}|undefined{{/isResponseTypeFile}}{{/returnType}}{{^returnType}}any{{/returnType}}>>;
-    public {{nickname}}({{#allParams}}{{paramName}}{{^required}}?{{/required}}: {{{dataType}}}, {{/allParams}}observe: 'body' | 'response' | 'events' = 'body', reportProgress: boolean = false ): Observable<any> {
+    public {{nickname}}({{#allParams}}{{paramName}}{{^required}}?{{/required}}: {{{dataType}}}, {{/allParams}}observe: any = 'body', reportProgress: boolean = false ): Observable<any> {
     {{/useHttpClient}}
     {{^useHttpClient}}
     public {{nickname}}WithHttpInfo({{#allParams}}{{paramName}}{{^required}}?{{/required}}: {{{dataType}}}, {{/allParams}}extraHttpRequestParams?: RequestOptionsArgs): Observable<Response> {
@@ -299,16 +299,16 @@ export class {{classname}} {
                 responseType: "blob",
 {{/isResponseFile}}
                 withCredentials: this.configuration.withCredentials,
-                headers,
-                observe,
-                reportProgress
+                headers: headers,
+                observe: observe,
+                reportProgress: reportProgress
             }
         );
 {{/useHttpClient}}
 {{^useHttpClient}}
         let requestOptions: RequestOptionsArgs = new RequestOptions({
             method: {{httpMethod}},
-            headers,
+            headers: headers,
 {{#bodyParam}}
             body: {{paramName}} == null ? '' : JSON.stringify({{paramName}}), // https://github.com/angular/angular/issues/10612
 {{/bodyParam}}

--- a/modules/swagger-generator/pom.xml
+++ b/modules/swagger-generator/pom.xml
@@ -111,7 +111,7 @@
                             <goal>wget</goal>
                         </goals>
                         <configuration>
-                            <url>http://github.com/swagger-api/swagger-ui/archive/master.tar.gz</url>
+                            <url>https://github.com/swagger-api/swagger-ui/archive/master.tar.gz</url>
 
                             <unpack>true</unpack>
                             <skipCache>true</skipCache>

--- a/samples/client/petstore/typescript-angular-v2/default/api/pet.service.ts
+++ b/samples/client/petstore/typescript-angular-v2/default/api/pet.service.ts
@@ -235,7 +235,7 @@ export class PetService {
 
         let requestOptions: RequestOptionsArgs = new RequestOptions({
             method: RequestMethod.Post,
-            headers,
+            headers: headers,
             body: body == null ? '' : JSON.stringify(body), // https://github.com/angular/angular/issues/10612
             withCredentials:this.configuration.withCredentials
         });
@@ -288,7 +288,7 @@ export class PetService {
 
         let requestOptions: RequestOptionsArgs = new RequestOptions({
             method: RequestMethod.Delete,
-            headers,
+            headers: headers,
             withCredentials:this.configuration.withCredentials
         });
         // https://github.com/swagger-api/swagger-codegen/issues/4037
@@ -341,7 +341,7 @@ export class PetService {
 
         let requestOptions: RequestOptionsArgs = new RequestOptions({
             method: RequestMethod.Get,
-            headers,
+            headers: headers,
             search: queryParameters,
             withCredentials:this.configuration.withCredentials
         });
@@ -395,7 +395,7 @@ export class PetService {
 
         let requestOptions: RequestOptionsArgs = new RequestOptions({
             method: RequestMethod.Get,
-            headers,
+            headers: headers,
             search: queryParameters,
             withCredentials:this.configuration.withCredentials
         });
@@ -441,7 +441,7 @@ export class PetService {
 
         let requestOptions: RequestOptionsArgs = new RequestOptions({
             method: RequestMethod.Get,
-            headers,
+            headers: headers,
             withCredentials:this.configuration.withCredentials
         });
         // https://github.com/swagger-api/swagger-codegen/issues/4037
@@ -495,7 +495,7 @@ export class PetService {
 
         let requestOptions: RequestOptionsArgs = new RequestOptions({
             method: RequestMethod.Put,
-            headers,
+            headers: headers,
             body: body == null ? '' : JSON.stringify(body), // https://github.com/angular/angular/issues/10612
             withCredentials:this.configuration.withCredentials
         });
@@ -569,7 +569,7 @@ export class PetService {
 
         let requestOptions: RequestOptionsArgs = new RequestOptions({
             method: RequestMethod.Post,
-            headers,
+            headers: headers,
             body: convertFormParamsToString ? formParams.toString() : formParams,
             withCredentials:this.configuration.withCredentials
         });
@@ -645,7 +645,7 @@ export class PetService {
 
         let requestOptions: RequestOptionsArgs = new RequestOptions({
             method: RequestMethod.Post,
-            headers,
+            headers: headers,
             body: convertFormParamsToString ? formParams.toString() : formParams,
             withCredentials:this.configuration.withCredentials
         });

--- a/samples/client/petstore/typescript-angular-v2/default/api/pet.service.ts
+++ b/samples/client/petstore/typescript-angular-v2/default/api/pet.service.ts
@@ -15,6 +15,7 @@ import { Inject, Injectable, Optional }                      from '@angular/core
 import { Http, Headers, URLSearchParams }                    from '@angular/http';
 import { RequestMethod, RequestOptions, RequestOptionsArgs } from '@angular/http';
 import { Response, ResponseContentType }                     from '@angular/http';
+import { CustomQueryEncoderHelper }                          from '../encoder';
 
 import { Observable }                                        from 'rxjs/Observable';
 import '../rxjs-operators';
@@ -24,7 +25,6 @@ import { Pet } from '../model/pet';
 
 import { BASE_PATH, COLLECTION_FORMATS }                     from '../variables';
 import { Configuration }                                     from '../configuration';
-import { CustomQueryEncoderHelper }                          from '../encoder';
 
 
 @Injectable()
@@ -196,6 +196,7 @@ export class PetService {
      * Add a new pet to the store
      * 
      * @param body Pet object that needs to be added to the store
+     
      */
     public addPetWithHttpInfo(body: Pet, extraHttpRequestParams?: RequestOptionsArgs): Observable<Response> {
         if (body === null || body === undefined) {
@@ -234,7 +235,7 @@ export class PetService {
 
         let requestOptions: RequestOptionsArgs = new RequestOptions({
             method: RequestMethod.Post,
-            headers: headers,
+            headers,
             body: body == null ? '' : JSON.stringify(body), // https://github.com/angular/angular/issues/10612
             withCredentials:this.configuration.withCredentials
         });
@@ -251,6 +252,7 @@ export class PetService {
      * 
      * @param petId Pet id to delete
      * @param apiKey 
+     
      */
     public deletePetWithHttpInfo(petId: number, apiKey?: string, extraHttpRequestParams?: RequestOptionsArgs): Observable<Response> {
         if (petId === null || petId === undefined) {
@@ -286,7 +288,7 @@ export class PetService {
 
         let requestOptions: RequestOptionsArgs = new RequestOptions({
             method: RequestMethod.Delete,
-            headers: headers,
+            headers,
             withCredentials:this.configuration.withCredentials
         });
         // https://github.com/swagger-api/swagger-codegen/issues/4037
@@ -301,6 +303,7 @@ export class PetService {
      * Finds Pets by status
      * Multiple status values can be provided with comma separated strings
      * @param status Status values that need to be considered for filter
+     
      */
     public findPetsByStatusWithHttpInfo(status: Array<string>, extraHttpRequestParams?: RequestOptionsArgs): Observable<Response> {
         if (status === null || status === undefined) {
@@ -338,7 +341,7 @@ export class PetService {
 
         let requestOptions: RequestOptionsArgs = new RequestOptions({
             method: RequestMethod.Get,
-            headers: headers,
+            headers,
             search: queryParameters,
             withCredentials:this.configuration.withCredentials
         });
@@ -354,6 +357,7 @@ export class PetService {
      * Finds Pets by tags
      * Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
      * @param tags Tags to filter by
+     
      */
     public findPetsByTagsWithHttpInfo(tags: Array<string>, extraHttpRequestParams?: RequestOptionsArgs): Observable<Response> {
         if (tags === null || tags === undefined) {
@@ -391,7 +395,7 @@ export class PetService {
 
         let requestOptions: RequestOptionsArgs = new RequestOptions({
             method: RequestMethod.Get,
-            headers: headers,
+            headers,
             search: queryParameters,
             withCredentials:this.configuration.withCredentials
         });
@@ -407,6 +411,7 @@ export class PetService {
      * Find pet by ID
      * Returns a single pet
      * @param petId ID of pet to return
+     
      */
     public getPetByIdWithHttpInfo(petId: number, extraHttpRequestParams?: RequestOptionsArgs): Observable<Response> {
         if (petId === null || petId === undefined) {
@@ -436,7 +441,7 @@ export class PetService {
 
         let requestOptions: RequestOptionsArgs = new RequestOptions({
             method: RequestMethod.Get,
-            headers: headers,
+            headers,
             withCredentials:this.configuration.withCredentials
         });
         // https://github.com/swagger-api/swagger-codegen/issues/4037
@@ -451,6 +456,7 @@ export class PetService {
      * Update an existing pet
      * 
      * @param body Pet object that needs to be added to the store
+     
      */
     public updatePetWithHttpInfo(body: Pet, extraHttpRequestParams?: RequestOptionsArgs): Observable<Response> {
         if (body === null || body === undefined) {
@@ -489,7 +495,7 @@ export class PetService {
 
         let requestOptions: RequestOptionsArgs = new RequestOptions({
             method: RequestMethod.Put,
-            headers: headers,
+            headers,
             body: body == null ? '' : JSON.stringify(body), // https://github.com/angular/angular/issues/10612
             withCredentials:this.configuration.withCredentials
         });
@@ -507,6 +513,7 @@ export class PetService {
      * @param petId ID of pet that needs to be updated
      * @param name Updated name of the pet
      * @param status Updated status of the pet
+     
      */
     public updatePetWithFormWithHttpInfo(petId: number, name?: string, status?: string, extraHttpRequestParams?: RequestOptionsArgs): Observable<Response> {
         if (petId === null || petId === undefined) {
@@ -562,7 +569,7 @@ export class PetService {
 
         let requestOptions: RequestOptionsArgs = new RequestOptions({
             method: RequestMethod.Post,
-            headers: headers,
+            headers,
             body: convertFormParamsToString ? formParams.toString() : formParams,
             withCredentials:this.configuration.withCredentials
         });
@@ -580,6 +587,7 @@ export class PetService {
      * @param petId ID of pet to update
      * @param additionalMetadata Additional data to pass to server
      * @param file file to upload
+     
      */
     public uploadFileWithHttpInfo(petId: number, additionalMetadata?: string, file?: Blob, extraHttpRequestParams?: RequestOptionsArgs): Observable<Response> {
         if (petId === null || petId === undefined) {
@@ -637,7 +645,7 @@ export class PetService {
 
         let requestOptions: RequestOptionsArgs = new RequestOptions({
             method: RequestMethod.Post,
-            headers: headers,
+            headers,
             body: convertFormParamsToString ? formParams.toString() : formParams,
             withCredentials:this.configuration.withCredentials
         });

--- a/samples/client/petstore/typescript-angular-v2/default/api/store.service.ts
+++ b/samples/client/petstore/typescript-angular-v2/default/api/store.service.ts
@@ -15,6 +15,7 @@ import { Inject, Injectable, Optional }                      from '@angular/core
 import { Http, Headers, URLSearchParams }                    from '@angular/http';
 import { RequestMethod, RequestOptions, RequestOptionsArgs } from '@angular/http';
 import { Response, ResponseContentType }                     from '@angular/http';
+import { CustomQueryEncoderHelper }                          from '../encoder';
 
 import { Observable }                                        from 'rxjs/Observable';
 import '../rxjs-operators';
@@ -23,7 +24,6 @@ import { Order } from '../model/order';
 
 import { BASE_PATH, COLLECTION_FORMATS }                     from '../variables';
 import { Configuration }                                     from '../configuration';
-import { CustomQueryEncoderHelper }                          from '../encoder';
 
 
 @Injectable()
@@ -125,6 +125,7 @@ export class StoreService {
      * Delete purchase order by ID
      * For valid response try integer IDs with value &lt; 1000. Anything above 1000 or nonintegers will generate API errors
      * @param orderId ID of the order that needs to be deleted
+     
      */
     public deleteOrderWithHttpInfo(orderId: string, extraHttpRequestParams?: RequestOptionsArgs): Observable<Response> {
         if (orderId === null || orderId === undefined) {
@@ -149,7 +150,7 @@ export class StoreService {
 
         let requestOptions: RequestOptionsArgs = new RequestOptions({
             method: RequestMethod.Delete,
-            headers: headers,
+            headers,
             withCredentials:this.configuration.withCredentials
         });
         // https://github.com/swagger-api/swagger-codegen/issues/4037
@@ -163,6 +164,7 @@ export class StoreService {
     /**
      * Returns pet inventories by status
      * Returns a map of status codes to quantities
+     
      */
     public getInventoryWithHttpInfo(extraHttpRequestParams?: RequestOptionsArgs): Observable<Response> {
 
@@ -188,7 +190,7 @@ export class StoreService {
 
         let requestOptions: RequestOptionsArgs = new RequestOptions({
             method: RequestMethod.Get,
-            headers: headers,
+            headers,
             withCredentials:this.configuration.withCredentials
         });
         // https://github.com/swagger-api/swagger-codegen/issues/4037
@@ -203,6 +205,7 @@ export class StoreService {
      * Find purchase order by ID
      * For valid response try integer IDs with value &lt;&#x3D; 5 or &gt; 10. Other values will generated exceptions
      * @param orderId ID of pet that needs to be fetched
+     
      */
     public getOrderByIdWithHttpInfo(orderId: number, extraHttpRequestParams?: RequestOptionsArgs): Observable<Response> {
         if (orderId === null || orderId === undefined) {
@@ -227,7 +230,7 @@ export class StoreService {
 
         let requestOptions: RequestOptionsArgs = new RequestOptions({
             method: RequestMethod.Get,
-            headers: headers,
+            headers,
             withCredentials:this.configuration.withCredentials
         });
         // https://github.com/swagger-api/swagger-codegen/issues/4037
@@ -242,6 +245,7 @@ export class StoreService {
      * Place an order for a pet
      * 
      * @param body order placed for purchasing the pet
+     
      */
     public placeOrderWithHttpInfo(body: Order, extraHttpRequestParams?: RequestOptionsArgs): Observable<Response> {
         if (body === null || body === undefined) {
@@ -270,7 +274,7 @@ export class StoreService {
 
         let requestOptions: RequestOptionsArgs = new RequestOptions({
             method: RequestMethod.Post,
-            headers: headers,
+            headers,
             body: body == null ? '' : JSON.stringify(body), // https://github.com/angular/angular/issues/10612
             withCredentials:this.configuration.withCredentials
         });

--- a/samples/client/petstore/typescript-angular-v2/default/api/store.service.ts
+++ b/samples/client/petstore/typescript-angular-v2/default/api/store.service.ts
@@ -150,7 +150,7 @@ export class StoreService {
 
         let requestOptions: RequestOptionsArgs = new RequestOptions({
             method: RequestMethod.Delete,
-            headers,
+            headers: headers,
             withCredentials:this.configuration.withCredentials
         });
         // https://github.com/swagger-api/swagger-codegen/issues/4037
@@ -190,7 +190,7 @@ export class StoreService {
 
         let requestOptions: RequestOptionsArgs = new RequestOptions({
             method: RequestMethod.Get,
-            headers,
+            headers: headers,
             withCredentials:this.configuration.withCredentials
         });
         // https://github.com/swagger-api/swagger-codegen/issues/4037
@@ -230,7 +230,7 @@ export class StoreService {
 
         let requestOptions: RequestOptionsArgs = new RequestOptions({
             method: RequestMethod.Get,
-            headers,
+            headers: headers,
             withCredentials:this.configuration.withCredentials
         });
         // https://github.com/swagger-api/swagger-codegen/issues/4037
@@ -274,7 +274,7 @@ export class StoreService {
 
         let requestOptions: RequestOptionsArgs = new RequestOptions({
             method: RequestMethod.Post,
-            headers,
+            headers: headers,
             body: body == null ? '' : JSON.stringify(body), // https://github.com/angular/angular/issues/10612
             withCredentials:this.configuration.withCredentials
         });

--- a/samples/client/petstore/typescript-angular-v2/default/api/user.service.ts
+++ b/samples/client/petstore/typescript-angular-v2/default/api/user.service.ts
@@ -15,6 +15,7 @@ import { Inject, Injectable, Optional }                      from '@angular/core
 import { Http, Headers, URLSearchParams }                    from '@angular/http';
 import { RequestMethod, RequestOptions, RequestOptionsArgs } from '@angular/http';
 import { Response, ResponseContentType }                     from '@angular/http';
+import { CustomQueryEncoderHelper }                          from '../encoder';
 
 import { Observable }                                        from 'rxjs/Observable';
 import '../rxjs-operators';
@@ -23,7 +24,6 @@ import { User } from '../model/user';
 
 import { BASE_PATH, COLLECTION_FORMATS }                     from '../variables';
 import { Configuration }                                     from '../configuration';
-import { CustomQueryEncoderHelper }                          from '../encoder';
 
 
 @Injectable()
@@ -191,6 +191,7 @@ export class UserService {
      * Create user
      * This can only be done by the logged in user.
      * @param body Created user object
+     
      */
     public createUserWithHttpInfo(body: User, extraHttpRequestParams?: RequestOptionsArgs): Observable<Response> {
         if (body === null || body === undefined) {
@@ -219,7 +220,7 @@ export class UserService {
 
         let requestOptions: RequestOptionsArgs = new RequestOptions({
             method: RequestMethod.Post,
-            headers: headers,
+            headers,
             body: body == null ? '' : JSON.stringify(body), // https://github.com/angular/angular/issues/10612
             withCredentials:this.configuration.withCredentials
         });
@@ -235,6 +236,7 @@ export class UserService {
      * Creates list of users with given input array
      * 
      * @param body List of user object
+     
      */
     public createUsersWithArrayInputWithHttpInfo(body: Array<User>, extraHttpRequestParams?: RequestOptionsArgs): Observable<Response> {
         if (body === null || body === undefined) {
@@ -263,7 +265,7 @@ export class UserService {
 
         let requestOptions: RequestOptionsArgs = new RequestOptions({
             method: RequestMethod.Post,
-            headers: headers,
+            headers,
             body: body == null ? '' : JSON.stringify(body), // https://github.com/angular/angular/issues/10612
             withCredentials:this.configuration.withCredentials
         });
@@ -279,6 +281,7 @@ export class UserService {
      * Creates list of users with given input array
      * 
      * @param body List of user object
+     
      */
     public createUsersWithListInputWithHttpInfo(body: Array<User>, extraHttpRequestParams?: RequestOptionsArgs): Observable<Response> {
         if (body === null || body === undefined) {
@@ -307,7 +310,7 @@ export class UserService {
 
         let requestOptions: RequestOptionsArgs = new RequestOptions({
             method: RequestMethod.Post,
-            headers: headers,
+            headers,
             body: body == null ? '' : JSON.stringify(body), // https://github.com/angular/angular/issues/10612
             withCredentials:this.configuration.withCredentials
         });
@@ -323,6 +326,7 @@ export class UserService {
      * Delete user
      * This can only be done by the logged in user.
      * @param username The name that needs to be deleted
+     
      */
     public deleteUserWithHttpInfo(username: string, extraHttpRequestParams?: RequestOptionsArgs): Observable<Response> {
         if (username === null || username === undefined) {
@@ -347,7 +351,7 @@ export class UserService {
 
         let requestOptions: RequestOptionsArgs = new RequestOptions({
             method: RequestMethod.Delete,
-            headers: headers,
+            headers,
             withCredentials:this.configuration.withCredentials
         });
         // https://github.com/swagger-api/swagger-codegen/issues/4037
@@ -362,6 +366,7 @@ export class UserService {
      * Get user by user name
      * 
      * @param username The name that needs to be fetched. Use user1 for testing. 
+     
      */
     public getUserByNameWithHttpInfo(username: string, extraHttpRequestParams?: RequestOptionsArgs): Observable<Response> {
         if (username === null || username === undefined) {
@@ -386,7 +391,7 @@ export class UserService {
 
         let requestOptions: RequestOptionsArgs = new RequestOptions({
             method: RequestMethod.Get,
-            headers: headers,
+            headers,
             withCredentials:this.configuration.withCredentials
         });
         // https://github.com/swagger-api/swagger-codegen/issues/4037
@@ -402,6 +407,7 @@ export class UserService {
      * 
      * @param username The user name for login
      * @param password The password for login in clear text
+     
      */
     public loginUserWithHttpInfo(username: string, password: string, extraHttpRequestParams?: RequestOptionsArgs): Observable<Response> {
         if (username === null || username === undefined) {
@@ -437,7 +443,7 @@ export class UserService {
 
         let requestOptions: RequestOptionsArgs = new RequestOptions({
             method: RequestMethod.Get,
-            headers: headers,
+            headers,
             search: queryParameters,
             withCredentials:this.configuration.withCredentials
         });
@@ -452,6 +458,7 @@ export class UserService {
     /**
      * Logs out current logged in user session
      * 
+     
      */
     public logoutUserWithHttpInfo(extraHttpRequestParams?: RequestOptionsArgs): Observable<Response> {
 
@@ -473,7 +480,7 @@ export class UserService {
 
         let requestOptions: RequestOptionsArgs = new RequestOptions({
             method: RequestMethod.Get,
-            headers: headers,
+            headers,
             withCredentials:this.configuration.withCredentials
         });
         // https://github.com/swagger-api/swagger-codegen/issues/4037
@@ -489,6 +496,7 @@ export class UserService {
      * This can only be done by the logged in user.
      * @param username name that need to be deleted
      * @param body Updated user object
+     
      */
     public updateUserWithHttpInfo(username: string, body: User, extraHttpRequestParams?: RequestOptionsArgs): Observable<Response> {
         if (username === null || username === undefined) {
@@ -520,7 +528,7 @@ export class UserService {
 
         let requestOptions: RequestOptionsArgs = new RequestOptions({
             method: RequestMethod.Put,
-            headers: headers,
+            headers,
             body: body == null ? '' : JSON.stringify(body), // https://github.com/angular/angular/issues/10612
             withCredentials:this.configuration.withCredentials
         });

--- a/samples/client/petstore/typescript-angular-v2/default/api/user.service.ts
+++ b/samples/client/petstore/typescript-angular-v2/default/api/user.service.ts
@@ -220,7 +220,7 @@ export class UserService {
 
         let requestOptions: RequestOptionsArgs = new RequestOptions({
             method: RequestMethod.Post,
-            headers,
+            headers: headers,
             body: body == null ? '' : JSON.stringify(body), // https://github.com/angular/angular/issues/10612
             withCredentials:this.configuration.withCredentials
         });
@@ -265,7 +265,7 @@ export class UserService {
 
         let requestOptions: RequestOptionsArgs = new RequestOptions({
             method: RequestMethod.Post,
-            headers,
+            headers: headers,
             body: body == null ? '' : JSON.stringify(body), // https://github.com/angular/angular/issues/10612
             withCredentials:this.configuration.withCredentials
         });
@@ -310,7 +310,7 @@ export class UserService {
 
         let requestOptions: RequestOptionsArgs = new RequestOptions({
             method: RequestMethod.Post,
-            headers,
+            headers: headers,
             body: body == null ? '' : JSON.stringify(body), // https://github.com/angular/angular/issues/10612
             withCredentials:this.configuration.withCredentials
         });
@@ -351,7 +351,7 @@ export class UserService {
 
         let requestOptions: RequestOptionsArgs = new RequestOptions({
             method: RequestMethod.Delete,
-            headers,
+            headers: headers,
             withCredentials:this.configuration.withCredentials
         });
         // https://github.com/swagger-api/swagger-codegen/issues/4037
@@ -391,7 +391,7 @@ export class UserService {
 
         let requestOptions: RequestOptionsArgs = new RequestOptions({
             method: RequestMethod.Get,
-            headers,
+            headers: headers,
             withCredentials:this.configuration.withCredentials
         });
         // https://github.com/swagger-api/swagger-codegen/issues/4037
@@ -443,7 +443,7 @@ export class UserService {
 
         let requestOptions: RequestOptionsArgs = new RequestOptions({
             method: RequestMethod.Get,
-            headers,
+            headers: headers,
             search: queryParameters,
             withCredentials:this.configuration.withCredentials
         });
@@ -480,7 +480,7 @@ export class UserService {
 
         let requestOptions: RequestOptionsArgs = new RequestOptions({
             method: RequestMethod.Get,
-            headers,
+            headers: headers,
             withCredentials:this.configuration.withCredentials
         });
         // https://github.com/swagger-api/swagger-codegen/issues/4037
@@ -528,7 +528,7 @@ export class UserService {
 
         let requestOptions: RequestOptionsArgs = new RequestOptions({
             method: RequestMethod.Put,
-            headers,
+            headers: headers,
             body: body == null ? '' : JSON.stringify(body), // https://github.com/angular/angular/issues/10612
             withCredentials:this.configuration.withCredentials
         });

--- a/samples/client/petstore/typescript-angular-v2/default/git_push.sh
+++ b/samples/client/petstore/typescript-angular-v2/default/git_push.sh
@@ -36,7 +36,7 @@ git_remote=`git remote`
 if [ "$git_remote" = "" ]; then # git remote not defined
 
     if [ "$GIT_TOKEN" = "" ]; then
-        echo "[INFO] \$GIT_TOKEN (environment variable) is not set. Using the git crediential in your environment."
+        echo "[INFO] \$GIT_TOKEN (environment variable) is not set. Using the git credential in your environment."
         git remote add origin https://github.com/${git_user_id}/${git_repo_id}.git
     else
         git remote add origin https://${git_user_id}:${GIT_TOKEN}@github.com/${git_user_id}/${git_repo_id}.git

--- a/samples/client/petstore/typescript-angular-v2/npm/api/pet.service.ts
+++ b/samples/client/petstore/typescript-angular-v2/npm/api/pet.service.ts
@@ -235,7 +235,7 @@ export class PetService {
 
         let requestOptions: RequestOptionsArgs = new RequestOptions({
             method: RequestMethod.Post,
-            headers,
+            headers: headers,
             body: body == null ? '' : JSON.stringify(body), // https://github.com/angular/angular/issues/10612
             withCredentials:this.configuration.withCredentials
         });
@@ -288,7 +288,7 @@ export class PetService {
 
         let requestOptions: RequestOptionsArgs = new RequestOptions({
             method: RequestMethod.Delete,
-            headers,
+            headers: headers,
             withCredentials:this.configuration.withCredentials
         });
         // https://github.com/swagger-api/swagger-codegen/issues/4037
@@ -341,7 +341,7 @@ export class PetService {
 
         let requestOptions: RequestOptionsArgs = new RequestOptions({
             method: RequestMethod.Get,
-            headers,
+            headers: headers,
             search: queryParameters,
             withCredentials:this.configuration.withCredentials
         });
@@ -395,7 +395,7 @@ export class PetService {
 
         let requestOptions: RequestOptionsArgs = new RequestOptions({
             method: RequestMethod.Get,
-            headers,
+            headers: headers,
             search: queryParameters,
             withCredentials:this.configuration.withCredentials
         });
@@ -441,7 +441,7 @@ export class PetService {
 
         let requestOptions: RequestOptionsArgs = new RequestOptions({
             method: RequestMethod.Get,
-            headers,
+            headers: headers,
             withCredentials:this.configuration.withCredentials
         });
         // https://github.com/swagger-api/swagger-codegen/issues/4037
@@ -495,7 +495,7 @@ export class PetService {
 
         let requestOptions: RequestOptionsArgs = new RequestOptions({
             method: RequestMethod.Put,
-            headers,
+            headers: headers,
             body: body == null ? '' : JSON.stringify(body), // https://github.com/angular/angular/issues/10612
             withCredentials:this.configuration.withCredentials
         });
@@ -569,7 +569,7 @@ export class PetService {
 
         let requestOptions: RequestOptionsArgs = new RequestOptions({
             method: RequestMethod.Post,
-            headers,
+            headers: headers,
             body: convertFormParamsToString ? formParams.toString() : formParams,
             withCredentials:this.configuration.withCredentials
         });
@@ -645,7 +645,7 @@ export class PetService {
 
         let requestOptions: RequestOptionsArgs = new RequestOptions({
             method: RequestMethod.Post,
-            headers,
+            headers: headers,
             body: convertFormParamsToString ? formParams.toString() : formParams,
             withCredentials:this.configuration.withCredentials
         });

--- a/samples/client/petstore/typescript-angular-v2/npm/api/pet.service.ts
+++ b/samples/client/petstore/typescript-angular-v2/npm/api/pet.service.ts
@@ -15,6 +15,7 @@ import { Inject, Injectable, Optional }                      from '@angular/core
 import { Http, Headers, URLSearchParams }                    from '@angular/http';
 import { RequestMethod, RequestOptions, RequestOptionsArgs } from '@angular/http';
 import { Response, ResponseContentType }                     from '@angular/http';
+import { CustomQueryEncoderHelper }                          from '../encoder';
 
 import { Observable }                                        from 'rxjs/Observable';
 import '../rxjs-operators';
@@ -24,7 +25,6 @@ import { Pet } from '../model/pet';
 
 import { BASE_PATH, COLLECTION_FORMATS }                     from '../variables';
 import { Configuration }                                     from '../configuration';
-import { CustomQueryEncoderHelper }                          from '../encoder';
 
 
 @Injectable()
@@ -196,6 +196,7 @@ export class PetService {
      * Add a new pet to the store
      * 
      * @param body Pet object that needs to be added to the store
+     
      */
     public addPetWithHttpInfo(body: Pet, extraHttpRequestParams?: RequestOptionsArgs): Observable<Response> {
         if (body === null || body === undefined) {
@@ -234,7 +235,7 @@ export class PetService {
 
         let requestOptions: RequestOptionsArgs = new RequestOptions({
             method: RequestMethod.Post,
-            headers: headers,
+            headers,
             body: body == null ? '' : JSON.stringify(body), // https://github.com/angular/angular/issues/10612
             withCredentials:this.configuration.withCredentials
         });
@@ -251,6 +252,7 @@ export class PetService {
      * 
      * @param petId Pet id to delete
      * @param apiKey 
+     
      */
     public deletePetWithHttpInfo(petId: number, apiKey?: string, extraHttpRequestParams?: RequestOptionsArgs): Observable<Response> {
         if (petId === null || petId === undefined) {
@@ -286,7 +288,7 @@ export class PetService {
 
         let requestOptions: RequestOptionsArgs = new RequestOptions({
             method: RequestMethod.Delete,
-            headers: headers,
+            headers,
             withCredentials:this.configuration.withCredentials
         });
         // https://github.com/swagger-api/swagger-codegen/issues/4037
@@ -301,6 +303,7 @@ export class PetService {
      * Finds Pets by status
      * Multiple status values can be provided with comma separated strings
      * @param status Status values that need to be considered for filter
+     
      */
     public findPetsByStatusWithHttpInfo(status: Array<string>, extraHttpRequestParams?: RequestOptionsArgs): Observable<Response> {
         if (status === null || status === undefined) {
@@ -338,7 +341,7 @@ export class PetService {
 
         let requestOptions: RequestOptionsArgs = new RequestOptions({
             method: RequestMethod.Get,
-            headers: headers,
+            headers,
             search: queryParameters,
             withCredentials:this.configuration.withCredentials
         });
@@ -354,6 +357,7 @@ export class PetService {
      * Finds Pets by tags
      * Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
      * @param tags Tags to filter by
+     
      */
     public findPetsByTagsWithHttpInfo(tags: Array<string>, extraHttpRequestParams?: RequestOptionsArgs): Observable<Response> {
         if (tags === null || tags === undefined) {
@@ -391,7 +395,7 @@ export class PetService {
 
         let requestOptions: RequestOptionsArgs = new RequestOptions({
             method: RequestMethod.Get,
-            headers: headers,
+            headers,
             search: queryParameters,
             withCredentials:this.configuration.withCredentials
         });
@@ -407,6 +411,7 @@ export class PetService {
      * Find pet by ID
      * Returns a single pet
      * @param petId ID of pet to return
+     
      */
     public getPetByIdWithHttpInfo(petId: number, extraHttpRequestParams?: RequestOptionsArgs): Observable<Response> {
         if (petId === null || petId === undefined) {
@@ -436,7 +441,7 @@ export class PetService {
 
         let requestOptions: RequestOptionsArgs = new RequestOptions({
             method: RequestMethod.Get,
-            headers: headers,
+            headers,
             withCredentials:this.configuration.withCredentials
         });
         // https://github.com/swagger-api/swagger-codegen/issues/4037
@@ -451,6 +456,7 @@ export class PetService {
      * Update an existing pet
      * 
      * @param body Pet object that needs to be added to the store
+     
      */
     public updatePetWithHttpInfo(body: Pet, extraHttpRequestParams?: RequestOptionsArgs): Observable<Response> {
         if (body === null || body === undefined) {
@@ -489,7 +495,7 @@ export class PetService {
 
         let requestOptions: RequestOptionsArgs = new RequestOptions({
             method: RequestMethod.Put,
-            headers: headers,
+            headers,
             body: body == null ? '' : JSON.stringify(body), // https://github.com/angular/angular/issues/10612
             withCredentials:this.configuration.withCredentials
         });
@@ -507,6 +513,7 @@ export class PetService {
      * @param petId ID of pet that needs to be updated
      * @param name Updated name of the pet
      * @param status Updated status of the pet
+     
      */
     public updatePetWithFormWithHttpInfo(petId: number, name?: string, status?: string, extraHttpRequestParams?: RequestOptionsArgs): Observable<Response> {
         if (petId === null || petId === undefined) {
@@ -562,7 +569,7 @@ export class PetService {
 
         let requestOptions: RequestOptionsArgs = new RequestOptions({
             method: RequestMethod.Post,
-            headers: headers,
+            headers,
             body: convertFormParamsToString ? formParams.toString() : formParams,
             withCredentials:this.configuration.withCredentials
         });
@@ -580,6 +587,7 @@ export class PetService {
      * @param petId ID of pet to update
      * @param additionalMetadata Additional data to pass to server
      * @param file file to upload
+     
      */
     public uploadFileWithHttpInfo(petId: number, additionalMetadata?: string, file?: Blob, extraHttpRequestParams?: RequestOptionsArgs): Observable<Response> {
         if (petId === null || petId === undefined) {
@@ -637,7 +645,7 @@ export class PetService {
 
         let requestOptions: RequestOptionsArgs = new RequestOptions({
             method: RequestMethod.Post,
-            headers: headers,
+            headers,
             body: convertFormParamsToString ? formParams.toString() : formParams,
             withCredentials:this.configuration.withCredentials
         });

--- a/samples/client/petstore/typescript-angular-v2/npm/api/store.service.ts
+++ b/samples/client/petstore/typescript-angular-v2/npm/api/store.service.ts
@@ -15,6 +15,7 @@ import { Inject, Injectable, Optional }                      from '@angular/core
 import { Http, Headers, URLSearchParams }                    from '@angular/http';
 import { RequestMethod, RequestOptions, RequestOptionsArgs } from '@angular/http';
 import { Response, ResponseContentType }                     from '@angular/http';
+import { CustomQueryEncoderHelper }                          from '../encoder';
 
 import { Observable }                                        from 'rxjs/Observable';
 import '../rxjs-operators';
@@ -23,7 +24,6 @@ import { Order } from '../model/order';
 
 import { BASE_PATH, COLLECTION_FORMATS }                     from '../variables';
 import { Configuration }                                     from '../configuration';
-import { CustomQueryEncoderHelper }                          from '../encoder';
 
 
 @Injectable()
@@ -125,6 +125,7 @@ export class StoreService {
      * Delete purchase order by ID
      * For valid response try integer IDs with value &lt; 1000. Anything above 1000 or nonintegers will generate API errors
      * @param orderId ID of the order that needs to be deleted
+     
      */
     public deleteOrderWithHttpInfo(orderId: string, extraHttpRequestParams?: RequestOptionsArgs): Observable<Response> {
         if (orderId === null || orderId === undefined) {
@@ -149,7 +150,7 @@ export class StoreService {
 
         let requestOptions: RequestOptionsArgs = new RequestOptions({
             method: RequestMethod.Delete,
-            headers: headers,
+            headers,
             withCredentials:this.configuration.withCredentials
         });
         // https://github.com/swagger-api/swagger-codegen/issues/4037
@@ -163,6 +164,7 @@ export class StoreService {
     /**
      * Returns pet inventories by status
      * Returns a map of status codes to quantities
+     
      */
     public getInventoryWithHttpInfo(extraHttpRequestParams?: RequestOptionsArgs): Observable<Response> {
 
@@ -188,7 +190,7 @@ export class StoreService {
 
         let requestOptions: RequestOptionsArgs = new RequestOptions({
             method: RequestMethod.Get,
-            headers: headers,
+            headers,
             withCredentials:this.configuration.withCredentials
         });
         // https://github.com/swagger-api/swagger-codegen/issues/4037
@@ -203,6 +205,7 @@ export class StoreService {
      * Find purchase order by ID
      * For valid response try integer IDs with value &lt;&#x3D; 5 or &gt; 10. Other values will generated exceptions
      * @param orderId ID of pet that needs to be fetched
+     
      */
     public getOrderByIdWithHttpInfo(orderId: number, extraHttpRequestParams?: RequestOptionsArgs): Observable<Response> {
         if (orderId === null || orderId === undefined) {
@@ -227,7 +230,7 @@ export class StoreService {
 
         let requestOptions: RequestOptionsArgs = new RequestOptions({
             method: RequestMethod.Get,
-            headers: headers,
+            headers,
             withCredentials:this.configuration.withCredentials
         });
         // https://github.com/swagger-api/swagger-codegen/issues/4037
@@ -242,6 +245,7 @@ export class StoreService {
      * Place an order for a pet
      * 
      * @param body order placed for purchasing the pet
+     
      */
     public placeOrderWithHttpInfo(body: Order, extraHttpRequestParams?: RequestOptionsArgs): Observable<Response> {
         if (body === null || body === undefined) {
@@ -270,7 +274,7 @@ export class StoreService {
 
         let requestOptions: RequestOptionsArgs = new RequestOptions({
             method: RequestMethod.Post,
-            headers: headers,
+            headers,
             body: body == null ? '' : JSON.stringify(body), // https://github.com/angular/angular/issues/10612
             withCredentials:this.configuration.withCredentials
         });

--- a/samples/client/petstore/typescript-angular-v2/npm/api/store.service.ts
+++ b/samples/client/petstore/typescript-angular-v2/npm/api/store.service.ts
@@ -150,7 +150,7 @@ export class StoreService {
 
         let requestOptions: RequestOptionsArgs = new RequestOptions({
             method: RequestMethod.Delete,
-            headers,
+            headers: headers,
             withCredentials:this.configuration.withCredentials
         });
         // https://github.com/swagger-api/swagger-codegen/issues/4037
@@ -190,7 +190,7 @@ export class StoreService {
 
         let requestOptions: RequestOptionsArgs = new RequestOptions({
             method: RequestMethod.Get,
-            headers,
+            headers: headers,
             withCredentials:this.configuration.withCredentials
         });
         // https://github.com/swagger-api/swagger-codegen/issues/4037
@@ -230,7 +230,7 @@ export class StoreService {
 
         let requestOptions: RequestOptionsArgs = new RequestOptions({
             method: RequestMethod.Get,
-            headers,
+            headers: headers,
             withCredentials:this.configuration.withCredentials
         });
         // https://github.com/swagger-api/swagger-codegen/issues/4037
@@ -274,7 +274,7 @@ export class StoreService {
 
         let requestOptions: RequestOptionsArgs = new RequestOptions({
             method: RequestMethod.Post,
-            headers,
+            headers: headers,
             body: body == null ? '' : JSON.stringify(body), // https://github.com/angular/angular/issues/10612
             withCredentials:this.configuration.withCredentials
         });

--- a/samples/client/petstore/typescript-angular-v2/npm/api/user.service.ts
+++ b/samples/client/petstore/typescript-angular-v2/npm/api/user.service.ts
@@ -15,6 +15,7 @@ import { Inject, Injectable, Optional }                      from '@angular/core
 import { Http, Headers, URLSearchParams }                    from '@angular/http';
 import { RequestMethod, RequestOptions, RequestOptionsArgs } from '@angular/http';
 import { Response, ResponseContentType }                     from '@angular/http';
+import { CustomQueryEncoderHelper }                          from '../encoder';
 
 import { Observable }                                        from 'rxjs/Observable';
 import '../rxjs-operators';
@@ -23,7 +24,6 @@ import { User } from '../model/user';
 
 import { BASE_PATH, COLLECTION_FORMATS }                     from '../variables';
 import { Configuration }                                     from '../configuration';
-import { CustomQueryEncoderHelper }                          from '../encoder';
 
 
 @Injectable()
@@ -191,6 +191,7 @@ export class UserService {
      * Create user
      * This can only be done by the logged in user.
      * @param body Created user object
+     
      */
     public createUserWithHttpInfo(body: User, extraHttpRequestParams?: RequestOptionsArgs): Observable<Response> {
         if (body === null || body === undefined) {
@@ -219,7 +220,7 @@ export class UserService {
 
         let requestOptions: RequestOptionsArgs = new RequestOptions({
             method: RequestMethod.Post,
-            headers: headers,
+            headers,
             body: body == null ? '' : JSON.stringify(body), // https://github.com/angular/angular/issues/10612
             withCredentials:this.configuration.withCredentials
         });
@@ -235,6 +236,7 @@ export class UserService {
      * Creates list of users with given input array
      * 
      * @param body List of user object
+     
      */
     public createUsersWithArrayInputWithHttpInfo(body: Array<User>, extraHttpRequestParams?: RequestOptionsArgs): Observable<Response> {
         if (body === null || body === undefined) {
@@ -263,7 +265,7 @@ export class UserService {
 
         let requestOptions: RequestOptionsArgs = new RequestOptions({
             method: RequestMethod.Post,
-            headers: headers,
+            headers,
             body: body == null ? '' : JSON.stringify(body), // https://github.com/angular/angular/issues/10612
             withCredentials:this.configuration.withCredentials
         });
@@ -279,6 +281,7 @@ export class UserService {
      * Creates list of users with given input array
      * 
      * @param body List of user object
+     
      */
     public createUsersWithListInputWithHttpInfo(body: Array<User>, extraHttpRequestParams?: RequestOptionsArgs): Observable<Response> {
         if (body === null || body === undefined) {
@@ -307,7 +310,7 @@ export class UserService {
 
         let requestOptions: RequestOptionsArgs = new RequestOptions({
             method: RequestMethod.Post,
-            headers: headers,
+            headers,
             body: body == null ? '' : JSON.stringify(body), // https://github.com/angular/angular/issues/10612
             withCredentials:this.configuration.withCredentials
         });
@@ -323,6 +326,7 @@ export class UserService {
      * Delete user
      * This can only be done by the logged in user.
      * @param username The name that needs to be deleted
+     
      */
     public deleteUserWithHttpInfo(username: string, extraHttpRequestParams?: RequestOptionsArgs): Observable<Response> {
         if (username === null || username === undefined) {
@@ -347,7 +351,7 @@ export class UserService {
 
         let requestOptions: RequestOptionsArgs = new RequestOptions({
             method: RequestMethod.Delete,
-            headers: headers,
+            headers,
             withCredentials:this.configuration.withCredentials
         });
         // https://github.com/swagger-api/swagger-codegen/issues/4037
@@ -362,6 +366,7 @@ export class UserService {
      * Get user by user name
      * 
      * @param username The name that needs to be fetched. Use user1 for testing. 
+     
      */
     public getUserByNameWithHttpInfo(username: string, extraHttpRequestParams?: RequestOptionsArgs): Observable<Response> {
         if (username === null || username === undefined) {
@@ -386,7 +391,7 @@ export class UserService {
 
         let requestOptions: RequestOptionsArgs = new RequestOptions({
             method: RequestMethod.Get,
-            headers: headers,
+            headers,
             withCredentials:this.configuration.withCredentials
         });
         // https://github.com/swagger-api/swagger-codegen/issues/4037
@@ -402,6 +407,7 @@ export class UserService {
      * 
      * @param username The user name for login
      * @param password The password for login in clear text
+     
      */
     public loginUserWithHttpInfo(username: string, password: string, extraHttpRequestParams?: RequestOptionsArgs): Observable<Response> {
         if (username === null || username === undefined) {
@@ -437,7 +443,7 @@ export class UserService {
 
         let requestOptions: RequestOptionsArgs = new RequestOptions({
             method: RequestMethod.Get,
-            headers: headers,
+            headers,
             search: queryParameters,
             withCredentials:this.configuration.withCredentials
         });
@@ -452,6 +458,7 @@ export class UserService {
     /**
      * Logs out current logged in user session
      * 
+     
      */
     public logoutUserWithHttpInfo(extraHttpRequestParams?: RequestOptionsArgs): Observable<Response> {
 
@@ -473,7 +480,7 @@ export class UserService {
 
         let requestOptions: RequestOptionsArgs = new RequestOptions({
             method: RequestMethod.Get,
-            headers: headers,
+            headers,
             withCredentials:this.configuration.withCredentials
         });
         // https://github.com/swagger-api/swagger-codegen/issues/4037
@@ -489,6 +496,7 @@ export class UserService {
      * This can only be done by the logged in user.
      * @param username name that need to be deleted
      * @param body Updated user object
+     
      */
     public updateUserWithHttpInfo(username: string, body: User, extraHttpRequestParams?: RequestOptionsArgs): Observable<Response> {
         if (username === null || username === undefined) {
@@ -520,7 +528,7 @@ export class UserService {
 
         let requestOptions: RequestOptionsArgs = new RequestOptions({
             method: RequestMethod.Put,
-            headers: headers,
+            headers,
             body: body == null ? '' : JSON.stringify(body), // https://github.com/angular/angular/issues/10612
             withCredentials:this.configuration.withCredentials
         });

--- a/samples/client/petstore/typescript-angular-v2/npm/api/user.service.ts
+++ b/samples/client/petstore/typescript-angular-v2/npm/api/user.service.ts
@@ -220,7 +220,7 @@ export class UserService {
 
         let requestOptions: RequestOptionsArgs = new RequestOptions({
             method: RequestMethod.Post,
-            headers,
+            headers: headers,
             body: body == null ? '' : JSON.stringify(body), // https://github.com/angular/angular/issues/10612
             withCredentials:this.configuration.withCredentials
         });
@@ -265,7 +265,7 @@ export class UserService {
 
         let requestOptions: RequestOptionsArgs = new RequestOptions({
             method: RequestMethod.Post,
-            headers,
+            headers: headers,
             body: body == null ? '' : JSON.stringify(body), // https://github.com/angular/angular/issues/10612
             withCredentials:this.configuration.withCredentials
         });
@@ -310,7 +310,7 @@ export class UserService {
 
         let requestOptions: RequestOptionsArgs = new RequestOptions({
             method: RequestMethod.Post,
-            headers,
+            headers: headers,
             body: body == null ? '' : JSON.stringify(body), // https://github.com/angular/angular/issues/10612
             withCredentials:this.configuration.withCredentials
         });
@@ -351,7 +351,7 @@ export class UserService {
 
         let requestOptions: RequestOptionsArgs = new RequestOptions({
             method: RequestMethod.Delete,
-            headers,
+            headers: headers,
             withCredentials:this.configuration.withCredentials
         });
         // https://github.com/swagger-api/swagger-codegen/issues/4037
@@ -391,7 +391,7 @@ export class UserService {
 
         let requestOptions: RequestOptionsArgs = new RequestOptions({
             method: RequestMethod.Get,
-            headers,
+            headers: headers,
             withCredentials:this.configuration.withCredentials
         });
         // https://github.com/swagger-api/swagger-codegen/issues/4037
@@ -443,7 +443,7 @@ export class UserService {
 
         let requestOptions: RequestOptionsArgs = new RequestOptions({
             method: RequestMethod.Get,
-            headers,
+            headers: headers,
             search: queryParameters,
             withCredentials:this.configuration.withCredentials
         });
@@ -480,7 +480,7 @@ export class UserService {
 
         let requestOptions: RequestOptionsArgs = new RequestOptions({
             method: RequestMethod.Get,
-            headers,
+            headers: headers,
             withCredentials:this.configuration.withCredentials
         });
         // https://github.com/swagger-api/swagger-codegen/issues/4037
@@ -528,7 +528,7 @@ export class UserService {
 
         let requestOptions: RequestOptionsArgs = new RequestOptions({
             method: RequestMethod.Put,
-            headers,
+            headers: headers,
             body: body == null ? '' : JSON.stringify(body), // https://github.com/angular/angular/issues/10612
             withCredentials:this.configuration.withCredentials
         });

--- a/samples/client/petstore/typescript-angular-v2/npm/git_push.sh
+++ b/samples/client/petstore/typescript-angular-v2/npm/git_push.sh
@@ -36,7 +36,7 @@ git_remote=`git remote`
 if [ "$git_remote" = "" ]; then # git remote not defined
 
     if [ "$GIT_TOKEN" = "" ]; then
-        echo "[INFO] \$GIT_TOKEN (environment variable) is not set. Using the git crediential in your environment."
+        echo "[INFO] \$GIT_TOKEN (environment variable) is not set. Using the git credential in your environment."
         git remote add origin https://github.com/${git_user_id}/${git_repo_id}.git
     else
         git remote add origin https://${git_user_id}:${GIT_TOKEN}@github.com/${git_user_id}/${git_repo_id}.git

--- a/samples/client/petstore/typescript-angular-v2/with-interfaces/api/pet.service.ts
+++ b/samples/client/petstore/typescript-angular-v2/with-interfaces/api/pet.service.ts
@@ -15,6 +15,7 @@ import { Inject, Injectable, Optional }                      from '@angular/core
 import { Http, Headers, URLSearchParams }                    from '@angular/http';
 import { RequestMethod, RequestOptions, RequestOptionsArgs } from '@angular/http';
 import { Response, ResponseContentType }                     from '@angular/http';
+import { CustomQueryEncoderHelper }                          from '../encoder';
 
 import { Observable }                                        from 'rxjs/Observable';
 import '../rxjs-operators';
@@ -24,7 +25,6 @@ import { Pet } from '../model/pet';
 
 import { BASE_PATH, COLLECTION_FORMATS }                     from '../variables';
 import { Configuration }                                     from '../configuration';
-import { CustomQueryEncoderHelper }                          from '../encoder';
 import { PetServiceInterface }                            from './PetServiceInterface';
 
 
@@ -197,6 +197,7 @@ export class PetService implements PetServiceInterface {
      * Add a new pet to the store
      * 
      * @param body Pet object that needs to be added to the store
+     
      */
     public addPetWithHttpInfo(body: Pet, extraHttpRequestParams?: RequestOptionsArgs): Observable<Response> {
         if (body === null || body === undefined) {
@@ -235,7 +236,7 @@ export class PetService implements PetServiceInterface {
 
         let requestOptions: RequestOptionsArgs = new RequestOptions({
             method: RequestMethod.Post,
-            headers: headers,
+            headers,
             body: body == null ? '' : JSON.stringify(body), // https://github.com/angular/angular/issues/10612
             withCredentials:this.configuration.withCredentials
         });
@@ -252,6 +253,7 @@ export class PetService implements PetServiceInterface {
      * 
      * @param petId Pet id to delete
      * @param apiKey 
+     
      */
     public deletePetWithHttpInfo(petId: number, apiKey?: string, extraHttpRequestParams?: RequestOptionsArgs): Observable<Response> {
         if (petId === null || petId === undefined) {
@@ -287,7 +289,7 @@ export class PetService implements PetServiceInterface {
 
         let requestOptions: RequestOptionsArgs = new RequestOptions({
             method: RequestMethod.Delete,
-            headers: headers,
+            headers,
             withCredentials:this.configuration.withCredentials
         });
         // https://github.com/swagger-api/swagger-codegen/issues/4037
@@ -302,6 +304,7 @@ export class PetService implements PetServiceInterface {
      * Finds Pets by status
      * Multiple status values can be provided with comma separated strings
      * @param status Status values that need to be considered for filter
+     
      */
     public findPetsByStatusWithHttpInfo(status: Array<string>, extraHttpRequestParams?: RequestOptionsArgs): Observable<Response> {
         if (status === null || status === undefined) {
@@ -339,7 +342,7 @@ export class PetService implements PetServiceInterface {
 
         let requestOptions: RequestOptionsArgs = new RequestOptions({
             method: RequestMethod.Get,
-            headers: headers,
+            headers,
             search: queryParameters,
             withCredentials:this.configuration.withCredentials
         });
@@ -355,6 +358,7 @@ export class PetService implements PetServiceInterface {
      * Finds Pets by tags
      * Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
      * @param tags Tags to filter by
+     
      */
     public findPetsByTagsWithHttpInfo(tags: Array<string>, extraHttpRequestParams?: RequestOptionsArgs): Observable<Response> {
         if (tags === null || tags === undefined) {
@@ -392,7 +396,7 @@ export class PetService implements PetServiceInterface {
 
         let requestOptions: RequestOptionsArgs = new RequestOptions({
             method: RequestMethod.Get,
-            headers: headers,
+            headers,
             search: queryParameters,
             withCredentials:this.configuration.withCredentials
         });
@@ -408,6 +412,7 @@ export class PetService implements PetServiceInterface {
      * Find pet by ID
      * Returns a single pet
      * @param petId ID of pet to return
+     
      */
     public getPetByIdWithHttpInfo(petId: number, extraHttpRequestParams?: RequestOptionsArgs): Observable<Response> {
         if (petId === null || petId === undefined) {
@@ -437,7 +442,7 @@ export class PetService implements PetServiceInterface {
 
         let requestOptions: RequestOptionsArgs = new RequestOptions({
             method: RequestMethod.Get,
-            headers: headers,
+            headers,
             withCredentials:this.configuration.withCredentials
         });
         // https://github.com/swagger-api/swagger-codegen/issues/4037
@@ -452,6 +457,7 @@ export class PetService implements PetServiceInterface {
      * Update an existing pet
      * 
      * @param body Pet object that needs to be added to the store
+     
      */
     public updatePetWithHttpInfo(body: Pet, extraHttpRequestParams?: RequestOptionsArgs): Observable<Response> {
         if (body === null || body === undefined) {
@@ -490,7 +496,7 @@ export class PetService implements PetServiceInterface {
 
         let requestOptions: RequestOptionsArgs = new RequestOptions({
             method: RequestMethod.Put,
-            headers: headers,
+            headers,
             body: body == null ? '' : JSON.stringify(body), // https://github.com/angular/angular/issues/10612
             withCredentials:this.configuration.withCredentials
         });
@@ -508,6 +514,7 @@ export class PetService implements PetServiceInterface {
      * @param petId ID of pet that needs to be updated
      * @param name Updated name of the pet
      * @param status Updated status of the pet
+     
      */
     public updatePetWithFormWithHttpInfo(petId: number, name?: string, status?: string, extraHttpRequestParams?: RequestOptionsArgs): Observable<Response> {
         if (petId === null || petId === undefined) {
@@ -563,7 +570,7 @@ export class PetService implements PetServiceInterface {
 
         let requestOptions: RequestOptionsArgs = new RequestOptions({
             method: RequestMethod.Post,
-            headers: headers,
+            headers,
             body: convertFormParamsToString ? formParams.toString() : formParams,
             withCredentials:this.configuration.withCredentials
         });
@@ -581,6 +588,7 @@ export class PetService implements PetServiceInterface {
      * @param petId ID of pet to update
      * @param additionalMetadata Additional data to pass to server
      * @param file file to upload
+     
      */
     public uploadFileWithHttpInfo(petId: number, additionalMetadata?: string, file?: Blob, extraHttpRequestParams?: RequestOptionsArgs): Observable<Response> {
         if (petId === null || petId === undefined) {
@@ -638,7 +646,7 @@ export class PetService implements PetServiceInterface {
 
         let requestOptions: RequestOptionsArgs = new RequestOptions({
             method: RequestMethod.Post,
-            headers: headers,
+            headers,
             body: convertFormParamsToString ? formParams.toString() : formParams,
             withCredentials:this.configuration.withCredentials
         });

--- a/samples/client/petstore/typescript-angular-v2/with-interfaces/api/pet.service.ts
+++ b/samples/client/petstore/typescript-angular-v2/with-interfaces/api/pet.service.ts
@@ -236,7 +236,7 @@ export class PetService implements PetServiceInterface {
 
         let requestOptions: RequestOptionsArgs = new RequestOptions({
             method: RequestMethod.Post,
-            headers,
+            headers: headers,
             body: body == null ? '' : JSON.stringify(body), // https://github.com/angular/angular/issues/10612
             withCredentials:this.configuration.withCredentials
         });
@@ -289,7 +289,7 @@ export class PetService implements PetServiceInterface {
 
         let requestOptions: RequestOptionsArgs = new RequestOptions({
             method: RequestMethod.Delete,
-            headers,
+            headers: headers,
             withCredentials:this.configuration.withCredentials
         });
         // https://github.com/swagger-api/swagger-codegen/issues/4037
@@ -342,7 +342,7 @@ export class PetService implements PetServiceInterface {
 
         let requestOptions: RequestOptionsArgs = new RequestOptions({
             method: RequestMethod.Get,
-            headers,
+            headers: headers,
             search: queryParameters,
             withCredentials:this.configuration.withCredentials
         });
@@ -396,7 +396,7 @@ export class PetService implements PetServiceInterface {
 
         let requestOptions: RequestOptionsArgs = new RequestOptions({
             method: RequestMethod.Get,
-            headers,
+            headers: headers,
             search: queryParameters,
             withCredentials:this.configuration.withCredentials
         });
@@ -442,7 +442,7 @@ export class PetService implements PetServiceInterface {
 
         let requestOptions: RequestOptionsArgs = new RequestOptions({
             method: RequestMethod.Get,
-            headers,
+            headers: headers,
             withCredentials:this.configuration.withCredentials
         });
         // https://github.com/swagger-api/swagger-codegen/issues/4037
@@ -496,7 +496,7 @@ export class PetService implements PetServiceInterface {
 
         let requestOptions: RequestOptionsArgs = new RequestOptions({
             method: RequestMethod.Put,
-            headers,
+            headers: headers,
             body: body == null ? '' : JSON.stringify(body), // https://github.com/angular/angular/issues/10612
             withCredentials:this.configuration.withCredentials
         });
@@ -570,7 +570,7 @@ export class PetService implements PetServiceInterface {
 
         let requestOptions: RequestOptionsArgs = new RequestOptions({
             method: RequestMethod.Post,
-            headers,
+            headers: headers,
             body: convertFormParamsToString ? formParams.toString() : formParams,
             withCredentials:this.configuration.withCredentials
         });
@@ -646,7 +646,7 @@ export class PetService implements PetServiceInterface {
 
         let requestOptions: RequestOptionsArgs = new RequestOptions({
             method: RequestMethod.Post,
-            headers,
+            headers: headers,
             body: convertFormParamsToString ? formParams.toString() : formParams,
             withCredentials:this.configuration.withCredentials
         });

--- a/samples/client/petstore/typescript-angular-v2/with-interfaces/api/store.service.ts
+++ b/samples/client/petstore/typescript-angular-v2/with-interfaces/api/store.service.ts
@@ -15,6 +15,7 @@ import { Inject, Injectable, Optional }                      from '@angular/core
 import { Http, Headers, URLSearchParams }                    from '@angular/http';
 import { RequestMethod, RequestOptions, RequestOptionsArgs } from '@angular/http';
 import { Response, ResponseContentType }                     from '@angular/http';
+import { CustomQueryEncoderHelper }                          from '../encoder';
 
 import { Observable }                                        from 'rxjs/Observable';
 import '../rxjs-operators';
@@ -23,7 +24,6 @@ import { Order } from '../model/order';
 
 import { BASE_PATH, COLLECTION_FORMATS }                     from '../variables';
 import { Configuration }                                     from '../configuration';
-import { CustomQueryEncoderHelper }                          from '../encoder';
 import { StoreServiceInterface }                            from './StoreServiceInterface';
 
 
@@ -126,6 +126,7 @@ export class StoreService implements StoreServiceInterface {
      * Delete purchase order by ID
      * For valid response try integer IDs with value &lt; 1000. Anything above 1000 or nonintegers will generate API errors
      * @param orderId ID of the order that needs to be deleted
+     
      */
     public deleteOrderWithHttpInfo(orderId: string, extraHttpRequestParams?: RequestOptionsArgs): Observable<Response> {
         if (orderId === null || orderId === undefined) {
@@ -150,7 +151,7 @@ export class StoreService implements StoreServiceInterface {
 
         let requestOptions: RequestOptionsArgs = new RequestOptions({
             method: RequestMethod.Delete,
-            headers: headers,
+            headers,
             withCredentials:this.configuration.withCredentials
         });
         // https://github.com/swagger-api/swagger-codegen/issues/4037
@@ -164,6 +165,7 @@ export class StoreService implements StoreServiceInterface {
     /**
      * Returns pet inventories by status
      * Returns a map of status codes to quantities
+     
      */
     public getInventoryWithHttpInfo(extraHttpRequestParams?: RequestOptionsArgs): Observable<Response> {
 
@@ -189,7 +191,7 @@ export class StoreService implements StoreServiceInterface {
 
         let requestOptions: RequestOptionsArgs = new RequestOptions({
             method: RequestMethod.Get,
-            headers: headers,
+            headers,
             withCredentials:this.configuration.withCredentials
         });
         // https://github.com/swagger-api/swagger-codegen/issues/4037
@@ -204,6 +206,7 @@ export class StoreService implements StoreServiceInterface {
      * Find purchase order by ID
      * For valid response try integer IDs with value &lt;&#x3D; 5 or &gt; 10. Other values will generated exceptions
      * @param orderId ID of pet that needs to be fetched
+     
      */
     public getOrderByIdWithHttpInfo(orderId: number, extraHttpRequestParams?: RequestOptionsArgs): Observable<Response> {
         if (orderId === null || orderId === undefined) {
@@ -228,7 +231,7 @@ export class StoreService implements StoreServiceInterface {
 
         let requestOptions: RequestOptionsArgs = new RequestOptions({
             method: RequestMethod.Get,
-            headers: headers,
+            headers,
             withCredentials:this.configuration.withCredentials
         });
         // https://github.com/swagger-api/swagger-codegen/issues/4037
@@ -243,6 +246,7 @@ export class StoreService implements StoreServiceInterface {
      * Place an order for a pet
      * 
      * @param body order placed for purchasing the pet
+     
      */
     public placeOrderWithHttpInfo(body: Order, extraHttpRequestParams?: RequestOptionsArgs): Observable<Response> {
         if (body === null || body === undefined) {
@@ -271,7 +275,7 @@ export class StoreService implements StoreServiceInterface {
 
         let requestOptions: RequestOptionsArgs = new RequestOptions({
             method: RequestMethod.Post,
-            headers: headers,
+            headers,
             body: body == null ? '' : JSON.stringify(body), // https://github.com/angular/angular/issues/10612
             withCredentials:this.configuration.withCredentials
         });

--- a/samples/client/petstore/typescript-angular-v2/with-interfaces/api/store.service.ts
+++ b/samples/client/petstore/typescript-angular-v2/with-interfaces/api/store.service.ts
@@ -151,7 +151,7 @@ export class StoreService implements StoreServiceInterface {
 
         let requestOptions: RequestOptionsArgs = new RequestOptions({
             method: RequestMethod.Delete,
-            headers,
+            headers: headers,
             withCredentials:this.configuration.withCredentials
         });
         // https://github.com/swagger-api/swagger-codegen/issues/4037
@@ -191,7 +191,7 @@ export class StoreService implements StoreServiceInterface {
 
         let requestOptions: RequestOptionsArgs = new RequestOptions({
             method: RequestMethod.Get,
-            headers,
+            headers: headers,
             withCredentials:this.configuration.withCredentials
         });
         // https://github.com/swagger-api/swagger-codegen/issues/4037
@@ -231,7 +231,7 @@ export class StoreService implements StoreServiceInterface {
 
         let requestOptions: RequestOptionsArgs = new RequestOptions({
             method: RequestMethod.Get,
-            headers,
+            headers: headers,
             withCredentials:this.configuration.withCredentials
         });
         // https://github.com/swagger-api/swagger-codegen/issues/4037
@@ -275,7 +275,7 @@ export class StoreService implements StoreServiceInterface {
 
         let requestOptions: RequestOptionsArgs = new RequestOptions({
             method: RequestMethod.Post,
-            headers,
+            headers: headers,
             body: body == null ? '' : JSON.stringify(body), // https://github.com/angular/angular/issues/10612
             withCredentials:this.configuration.withCredentials
         });

--- a/samples/client/petstore/typescript-angular-v2/with-interfaces/api/user.service.ts
+++ b/samples/client/petstore/typescript-angular-v2/with-interfaces/api/user.service.ts
@@ -221,7 +221,7 @@ export class UserService implements UserServiceInterface {
 
         let requestOptions: RequestOptionsArgs = new RequestOptions({
             method: RequestMethod.Post,
-            headers,
+            headers: headers,
             body: body == null ? '' : JSON.stringify(body), // https://github.com/angular/angular/issues/10612
             withCredentials:this.configuration.withCredentials
         });
@@ -266,7 +266,7 @@ export class UserService implements UserServiceInterface {
 
         let requestOptions: RequestOptionsArgs = new RequestOptions({
             method: RequestMethod.Post,
-            headers,
+            headers: headers,
             body: body == null ? '' : JSON.stringify(body), // https://github.com/angular/angular/issues/10612
             withCredentials:this.configuration.withCredentials
         });
@@ -311,7 +311,7 @@ export class UserService implements UserServiceInterface {
 
         let requestOptions: RequestOptionsArgs = new RequestOptions({
             method: RequestMethod.Post,
-            headers,
+            headers: headers,
             body: body == null ? '' : JSON.stringify(body), // https://github.com/angular/angular/issues/10612
             withCredentials:this.configuration.withCredentials
         });
@@ -352,7 +352,7 @@ export class UserService implements UserServiceInterface {
 
         let requestOptions: RequestOptionsArgs = new RequestOptions({
             method: RequestMethod.Delete,
-            headers,
+            headers: headers,
             withCredentials:this.configuration.withCredentials
         });
         // https://github.com/swagger-api/swagger-codegen/issues/4037
@@ -392,7 +392,7 @@ export class UserService implements UserServiceInterface {
 
         let requestOptions: RequestOptionsArgs = new RequestOptions({
             method: RequestMethod.Get,
-            headers,
+            headers: headers,
             withCredentials:this.configuration.withCredentials
         });
         // https://github.com/swagger-api/swagger-codegen/issues/4037
@@ -444,7 +444,7 @@ export class UserService implements UserServiceInterface {
 
         let requestOptions: RequestOptionsArgs = new RequestOptions({
             method: RequestMethod.Get,
-            headers,
+            headers: headers,
             search: queryParameters,
             withCredentials:this.configuration.withCredentials
         });
@@ -481,7 +481,7 @@ export class UserService implements UserServiceInterface {
 
         let requestOptions: RequestOptionsArgs = new RequestOptions({
             method: RequestMethod.Get,
-            headers,
+            headers: headers,
             withCredentials:this.configuration.withCredentials
         });
         // https://github.com/swagger-api/swagger-codegen/issues/4037
@@ -529,7 +529,7 @@ export class UserService implements UserServiceInterface {
 
         let requestOptions: RequestOptionsArgs = new RequestOptions({
             method: RequestMethod.Put,
-            headers,
+            headers: headers,
             body: body == null ? '' : JSON.stringify(body), // https://github.com/angular/angular/issues/10612
             withCredentials:this.configuration.withCredentials
         });

--- a/samples/client/petstore/typescript-angular-v2/with-interfaces/api/user.service.ts
+++ b/samples/client/petstore/typescript-angular-v2/with-interfaces/api/user.service.ts
@@ -15,6 +15,7 @@ import { Inject, Injectable, Optional }                      from '@angular/core
 import { Http, Headers, URLSearchParams }                    from '@angular/http';
 import { RequestMethod, RequestOptions, RequestOptionsArgs } from '@angular/http';
 import { Response, ResponseContentType }                     from '@angular/http';
+import { CustomQueryEncoderHelper }                          from '../encoder';
 
 import { Observable }                                        from 'rxjs/Observable';
 import '../rxjs-operators';
@@ -23,7 +24,6 @@ import { User } from '../model/user';
 
 import { BASE_PATH, COLLECTION_FORMATS }                     from '../variables';
 import { Configuration }                                     from '../configuration';
-import { CustomQueryEncoderHelper }                          from '../encoder';
 import { UserServiceInterface }                            from './UserServiceInterface';
 
 
@@ -192,6 +192,7 @@ export class UserService implements UserServiceInterface {
      * Create user
      * This can only be done by the logged in user.
      * @param body Created user object
+     
      */
     public createUserWithHttpInfo(body: User, extraHttpRequestParams?: RequestOptionsArgs): Observable<Response> {
         if (body === null || body === undefined) {
@@ -220,7 +221,7 @@ export class UserService implements UserServiceInterface {
 
         let requestOptions: RequestOptionsArgs = new RequestOptions({
             method: RequestMethod.Post,
-            headers: headers,
+            headers,
             body: body == null ? '' : JSON.stringify(body), // https://github.com/angular/angular/issues/10612
             withCredentials:this.configuration.withCredentials
         });
@@ -236,6 +237,7 @@ export class UserService implements UserServiceInterface {
      * Creates list of users with given input array
      * 
      * @param body List of user object
+     
      */
     public createUsersWithArrayInputWithHttpInfo(body: Array<User>, extraHttpRequestParams?: RequestOptionsArgs): Observable<Response> {
         if (body === null || body === undefined) {
@@ -264,7 +266,7 @@ export class UserService implements UserServiceInterface {
 
         let requestOptions: RequestOptionsArgs = new RequestOptions({
             method: RequestMethod.Post,
-            headers: headers,
+            headers,
             body: body == null ? '' : JSON.stringify(body), // https://github.com/angular/angular/issues/10612
             withCredentials:this.configuration.withCredentials
         });
@@ -280,6 +282,7 @@ export class UserService implements UserServiceInterface {
      * Creates list of users with given input array
      * 
      * @param body List of user object
+     
      */
     public createUsersWithListInputWithHttpInfo(body: Array<User>, extraHttpRequestParams?: RequestOptionsArgs): Observable<Response> {
         if (body === null || body === undefined) {
@@ -308,7 +311,7 @@ export class UserService implements UserServiceInterface {
 
         let requestOptions: RequestOptionsArgs = new RequestOptions({
             method: RequestMethod.Post,
-            headers: headers,
+            headers,
             body: body == null ? '' : JSON.stringify(body), // https://github.com/angular/angular/issues/10612
             withCredentials:this.configuration.withCredentials
         });
@@ -324,6 +327,7 @@ export class UserService implements UserServiceInterface {
      * Delete user
      * This can only be done by the logged in user.
      * @param username The name that needs to be deleted
+     
      */
     public deleteUserWithHttpInfo(username: string, extraHttpRequestParams?: RequestOptionsArgs): Observable<Response> {
         if (username === null || username === undefined) {
@@ -348,7 +352,7 @@ export class UserService implements UserServiceInterface {
 
         let requestOptions: RequestOptionsArgs = new RequestOptions({
             method: RequestMethod.Delete,
-            headers: headers,
+            headers,
             withCredentials:this.configuration.withCredentials
         });
         // https://github.com/swagger-api/swagger-codegen/issues/4037
@@ -363,6 +367,7 @@ export class UserService implements UserServiceInterface {
      * Get user by user name
      * 
      * @param username The name that needs to be fetched. Use user1 for testing. 
+     
      */
     public getUserByNameWithHttpInfo(username: string, extraHttpRequestParams?: RequestOptionsArgs): Observable<Response> {
         if (username === null || username === undefined) {
@@ -387,7 +392,7 @@ export class UserService implements UserServiceInterface {
 
         let requestOptions: RequestOptionsArgs = new RequestOptions({
             method: RequestMethod.Get,
-            headers: headers,
+            headers,
             withCredentials:this.configuration.withCredentials
         });
         // https://github.com/swagger-api/swagger-codegen/issues/4037
@@ -403,6 +408,7 @@ export class UserService implements UserServiceInterface {
      * 
      * @param username The user name for login
      * @param password The password for login in clear text
+     
      */
     public loginUserWithHttpInfo(username: string, password: string, extraHttpRequestParams?: RequestOptionsArgs): Observable<Response> {
         if (username === null || username === undefined) {
@@ -438,7 +444,7 @@ export class UserService implements UserServiceInterface {
 
         let requestOptions: RequestOptionsArgs = new RequestOptions({
             method: RequestMethod.Get,
-            headers: headers,
+            headers,
             search: queryParameters,
             withCredentials:this.configuration.withCredentials
         });
@@ -453,6 +459,7 @@ export class UserService implements UserServiceInterface {
     /**
      * Logs out current logged in user session
      * 
+     
      */
     public logoutUserWithHttpInfo(extraHttpRequestParams?: RequestOptionsArgs): Observable<Response> {
 
@@ -474,7 +481,7 @@ export class UserService implements UserServiceInterface {
 
         let requestOptions: RequestOptionsArgs = new RequestOptions({
             method: RequestMethod.Get,
-            headers: headers,
+            headers,
             withCredentials:this.configuration.withCredentials
         });
         // https://github.com/swagger-api/swagger-codegen/issues/4037
@@ -490,6 +497,7 @@ export class UserService implements UserServiceInterface {
      * This can only be done by the logged in user.
      * @param username name that need to be deleted
      * @param body Updated user object
+     
      */
     public updateUserWithHttpInfo(username: string, body: User, extraHttpRequestParams?: RequestOptionsArgs): Observable<Response> {
         if (username === null || username === undefined) {
@@ -521,7 +529,7 @@ export class UserService implements UserServiceInterface {
 
         let requestOptions: RequestOptionsArgs = new RequestOptions({
             method: RequestMethod.Put,
-            headers: headers,
+            headers,
             body: body == null ? '' : JSON.stringify(body), // https://github.com/angular/angular/issues/10612
             withCredentials:this.configuration.withCredentials
         });

--- a/samples/client/petstore/typescript-angular-v2/with-interfaces/git_push.sh
+++ b/samples/client/petstore/typescript-angular-v2/with-interfaces/git_push.sh
@@ -36,7 +36,7 @@ git_remote=`git remote`
 if [ "$git_remote" = "" ]; then # git remote not defined
 
     if [ "$GIT_TOKEN" = "" ]; then
-        echo "[INFO] \$GIT_TOKEN (environment variable) is not set. Using the git crediential in your environment."
+        echo "[INFO] \$GIT_TOKEN (environment variable) is not set. Using the git credential in your environment."
         git remote add origin https://github.com/${git_user_id}/${git_repo_id}.git
     else
         git remote add origin https://${git_user_id}:${GIT_TOKEN}@github.com/${git_user_id}/${git_repo_id}.git

--- a/samples/client/petstore/typescript-angular-v2/with-interfaces/package.json
+++ b/samples/client/petstore/typescript-angular-v2/with-interfaces/package.json
@@ -35,6 +35,6 @@
     "typescript": "^2.1.5"
   },
   "publishConfig": {
-    "registry":"https://skimdb.npmjs.com/registry"
+    "registry": "https://skimdb.npmjs.com/registry"
   }
 }

--- a/samples/client/petstore/typescript-angular-v4.3/npm/api/pet.service.ts
+++ b/samples/client/petstore/typescript-angular-v4.3/npm/api/pet.service.ts
@@ -68,7 +68,7 @@ export class PetService {
     public addPet(body: Pet, observe?: 'body', reportProgress?: boolean): Observable<any>;
     public addPet(body: Pet, observe?: 'response', reportProgress?: boolean): Observable<HttpResponse<any>>;
     public addPet(body: Pet, observe?: 'events', reportProgress?: boolean): Observable<HttpEvent<any>>;
-    public addPet(body: Pet, observe: 'body' | 'response' | 'events' = 'body', reportProgress: boolean = false ): Observable<any> {
+    public addPet(body: Pet, observe: any = 'body', reportProgress: boolean = false ): Observable<any> {
         if (body === null || body === undefined) {
             throw new Error('Required parameter body was null or undefined when calling addPet.');
         }
@@ -107,9 +107,9 @@ export class PetService {
             body,
             {
                 withCredentials: this.configuration.withCredentials,
-                headers,
-                observe,
-                reportProgress
+                headers: headers,
+                observe: observe,
+                reportProgress: reportProgress
             }
         );
     }
@@ -125,7 +125,7 @@ export class PetService {
     public deletePet(petId: number, apiKey?: string, observe?: 'body', reportProgress?: boolean): Observable<any>;
     public deletePet(petId: number, apiKey?: string, observe?: 'response', reportProgress?: boolean): Observable<HttpResponse<any>>;
     public deletePet(petId: number, apiKey?: string, observe?: 'events', reportProgress?: boolean): Observable<HttpEvent<any>>;
-    public deletePet(petId: number, apiKey?: string, observe: 'body' | 'response' | 'events' = 'body', reportProgress: boolean = false ): Observable<any> {
+    public deletePet(petId: number, apiKey?: string, observe: any = 'body', reportProgress: boolean = false ): Observable<any> {
         if (petId === null || petId === undefined) {
             throw new Error('Required parameter petId was null or undefined when calling deletePet.');
         }
@@ -160,9 +160,9 @@ export class PetService {
         return this.httpClient.delete<any>(`${this.basePath}/pet/${encodeURIComponent(String(petId))}`,
             {
                 withCredentials: this.configuration.withCredentials,
-                headers,
-                observe,
-                reportProgress
+                headers: headers,
+                observe: observe,
+                reportProgress: reportProgress
             }
         );
     }
@@ -177,7 +177,7 @@ export class PetService {
     public findPetsByStatus(status: Array<string>, observe?: 'body', reportProgress?: boolean): Observable<Array<Pet>>;
     public findPetsByStatus(status: Array<string>, observe?: 'response', reportProgress?: boolean): Observable<HttpResponse<Array<Pet>>>;
     public findPetsByStatus(status: Array<string>, observe?: 'events', reportProgress?: boolean): Observable<HttpEvent<Array<Pet>>>;
-    public findPetsByStatus(status: Array<string>, observe: 'body' | 'response' | 'events' = 'body', reportProgress: boolean = false ): Observable<any> {
+    public findPetsByStatus(status: Array<string>, observe: any = 'body', reportProgress: boolean = false ): Observable<any> {
         if (status === null || status === undefined) {
             throw new Error('Required parameter status was null or undefined when calling findPetsByStatus.');
         }
@@ -215,9 +215,9 @@ export class PetService {
             {
                 params: queryParameters,
                 withCredentials: this.configuration.withCredentials,
-                headers,
-                observe,
-                reportProgress
+                headers: headers,
+                observe: observe,
+                reportProgress: reportProgress
             }
         );
     }
@@ -232,7 +232,7 @@ export class PetService {
     public findPetsByTags(tags: Array<string>, observe?: 'body', reportProgress?: boolean): Observable<Array<Pet>>;
     public findPetsByTags(tags: Array<string>, observe?: 'response', reportProgress?: boolean): Observable<HttpResponse<Array<Pet>>>;
     public findPetsByTags(tags: Array<string>, observe?: 'events', reportProgress?: boolean): Observable<HttpEvent<Array<Pet>>>;
-    public findPetsByTags(tags: Array<string>, observe: 'body' | 'response' | 'events' = 'body', reportProgress: boolean = false ): Observable<any> {
+    public findPetsByTags(tags: Array<string>, observe: any = 'body', reportProgress: boolean = false ): Observable<any> {
         if (tags === null || tags === undefined) {
             throw new Error('Required parameter tags was null or undefined when calling findPetsByTags.');
         }
@@ -270,9 +270,9 @@ export class PetService {
             {
                 params: queryParameters,
                 withCredentials: this.configuration.withCredentials,
-                headers,
-                observe,
-                reportProgress
+                headers: headers,
+                observe: observe,
+                reportProgress: reportProgress
             }
         );
     }
@@ -287,7 +287,7 @@ export class PetService {
     public getPetById(petId: number, observe?: 'body', reportProgress?: boolean): Observable<Pet>;
     public getPetById(petId: number, observe?: 'response', reportProgress?: boolean): Observable<HttpResponse<Pet>>;
     public getPetById(petId: number, observe?: 'events', reportProgress?: boolean): Observable<HttpEvent<Pet>>;
-    public getPetById(petId: number, observe: 'body' | 'response' | 'events' = 'body', reportProgress: boolean = false ): Observable<any> {
+    public getPetById(petId: number, observe: any = 'body', reportProgress: boolean = false ): Observable<any> {
         if (petId === null || petId === undefined) {
             throw new Error('Required parameter petId was null or undefined when calling getPetById.');
         }
@@ -316,9 +316,9 @@ export class PetService {
         return this.httpClient.get<Pet>(`${this.basePath}/pet/${encodeURIComponent(String(petId))}`,
             {
                 withCredentials: this.configuration.withCredentials,
-                headers,
-                observe,
-                reportProgress
+                headers: headers,
+                observe: observe,
+                reportProgress: reportProgress
             }
         );
     }
@@ -333,7 +333,7 @@ export class PetService {
     public updatePet(body: Pet, observe?: 'body', reportProgress?: boolean): Observable<any>;
     public updatePet(body: Pet, observe?: 'response', reportProgress?: boolean): Observable<HttpResponse<any>>;
     public updatePet(body: Pet, observe?: 'events', reportProgress?: boolean): Observable<HttpEvent<any>>;
-    public updatePet(body: Pet, observe: 'body' | 'response' | 'events' = 'body', reportProgress: boolean = false ): Observable<any> {
+    public updatePet(body: Pet, observe: any = 'body', reportProgress: boolean = false ): Observable<any> {
         if (body === null || body === undefined) {
             throw new Error('Required parameter body was null or undefined when calling updatePet.');
         }
@@ -372,9 +372,9 @@ export class PetService {
             body,
             {
                 withCredentials: this.configuration.withCredentials,
-                headers,
-                observe,
-                reportProgress
+                headers: headers,
+                observe: observe,
+                reportProgress: reportProgress
             }
         );
     }
@@ -391,7 +391,7 @@ export class PetService {
     public updatePetWithForm(petId: number, name?: string, status?: string, observe?: 'body', reportProgress?: boolean): Observable<any>;
     public updatePetWithForm(petId: number, name?: string, status?: string, observe?: 'response', reportProgress?: boolean): Observable<HttpResponse<any>>;
     public updatePetWithForm(petId: number, name?: string, status?: string, observe?: 'events', reportProgress?: boolean): Observable<HttpEvent<any>>;
-    public updatePetWithForm(petId: number, name?: string, status?: string, observe: 'body' | 'response' | 'events' = 'body', reportProgress: boolean = false ): Observable<any> {
+    public updatePetWithForm(petId: number, name?: string, status?: string, observe: any = 'body', reportProgress: boolean = false ): Observable<any> {
         if (petId === null || petId === undefined) {
             throw new Error('Required parameter petId was null or undefined when calling updatePetWithForm.');
         }
@@ -443,9 +443,9 @@ export class PetService {
             convertFormParamsToString ? formParams.toString() : formParams,
             {
                 withCredentials: this.configuration.withCredentials,
-                headers,
-                observe,
-                reportProgress
+                headers: headers,
+                observe: observe,
+                reportProgress: reportProgress
             }
         );
     }
@@ -462,7 +462,7 @@ export class PetService {
     public uploadFile(petId: number, additionalMetadata?: string, file?: Blob, observe?: 'body', reportProgress?: boolean): Observable<ApiResponse>;
     public uploadFile(petId: number, additionalMetadata?: string, file?: Blob, observe?: 'response', reportProgress?: boolean): Observable<HttpResponse<ApiResponse>>;
     public uploadFile(petId: number, additionalMetadata?: string, file?: Blob, observe?: 'events', reportProgress?: boolean): Observable<HttpEvent<ApiResponse>>;
-    public uploadFile(petId: number, additionalMetadata?: string, file?: Blob, observe: 'body' | 'response' | 'events' = 'body', reportProgress: boolean = false ): Observable<any> {
+    public uploadFile(petId: number, additionalMetadata?: string, file?: Blob, observe: any = 'body', reportProgress: boolean = false ): Observable<any> {
         if (petId === null || petId === undefined) {
             throw new Error('Required parameter petId was null or undefined when calling uploadFile.');
         }
@@ -516,9 +516,9 @@ export class PetService {
             convertFormParamsToString ? formParams.toString() : formParams,
             {
                 withCredentials: this.configuration.withCredentials,
-                headers,
-                observe,
-                reportProgress
+                headers: headers,
+                observe: observe,
+                reportProgress: reportProgress
             }
         );
     }

--- a/samples/client/petstore/typescript-angular-v4.3/npm/api/pet.service.ts
+++ b/samples/client/petstore/typescript-angular-v4.3/npm/api/pet.service.ts
@@ -12,7 +12,9 @@
 /* tslint:disable:no-unused-variable member-ordering */
 
 import { Inject, Injectable, Optional }                      from '@angular/core';
-import { HttpClient, HttpHeaders, HttpParams }               from '@angular/common/http';
+import { HttpClient, HttpHeaders, HttpParams,
+         HttpResponse, HttpEvent }                           from '@angular/common/http';
+import { CustomHttpUrlEncodingCodec }                        from '../encoder';
 
 import { Observable }                                        from 'rxjs/Observable';
 import '../rxjs-operators';
@@ -22,7 +24,6 @@ import { Pet } from '../model/pet';
 
 import { BASE_PATH, COLLECTION_FORMATS }                     from '../variables';
 import { Configuration }                                     from '../configuration';
-import { CustomHttpUrlEncodingCodec }                        from '../encoder';
 
 
 @Injectable()
@@ -61,8 +62,13 @@ export class PetService {
      * Add a new pet to the store
      * 
      * @param body Pet object that needs to be added to the store
+     * @param observe set whether or not to return the data Observable as the body, response or events. defaults to returning the body.
+     * @param reportProgress flag to report request and response progress.
      */
-    public addPet(body: Pet): Observable<{}> {
+    public addPet(body: Pet, observe?: 'body', reportProgress?: boolean): Observable<any>;
+    public addPet(body: Pet, observe?: 'response', reportProgress?: boolean): Observable<HttpResponse<any>>;
+    public addPet(body: Pet, observe?: 'events', reportProgress?: boolean): Observable<HttpEvent<any>>;
+    public addPet(body: Pet, observe: 'body' | 'response' | 'events' = 'body', reportProgress: boolean = false ): Observable<any> {
         if (body === null || body === undefined) {
             throw new Error('Required parameter body was null or undefined when calling addPet.');
         }
@@ -100,8 +106,10 @@ export class PetService {
         return this.httpClient.post<any>(`${this.basePath}/pet`,
             body,
             {
-                headers: headers,
                 withCredentials: this.configuration.withCredentials,
+                headers,
+                observe,
+                reportProgress
             }
         );
     }
@@ -111,8 +119,13 @@ export class PetService {
      * 
      * @param petId Pet id to delete
      * @param apiKey 
+     * @param observe set whether or not to return the data Observable as the body, response or events. defaults to returning the body.
+     * @param reportProgress flag to report request and response progress.
      */
-    public deletePet(petId: number, apiKey?: string): Observable<{}> {
+    public deletePet(petId: number, apiKey?: string, observe?: 'body', reportProgress?: boolean): Observable<any>;
+    public deletePet(petId: number, apiKey?: string, observe?: 'response', reportProgress?: boolean): Observable<HttpResponse<any>>;
+    public deletePet(petId: number, apiKey?: string, observe?: 'events', reportProgress?: boolean): Observable<HttpEvent<any>>;
+    public deletePet(petId: number, apiKey?: string, observe: 'body' | 'response' | 'events' = 'body', reportProgress: boolean = false ): Observable<any> {
         if (petId === null || petId === undefined) {
             throw new Error('Required parameter petId was null or undefined when calling deletePet.');
         }
@@ -146,8 +159,10 @@ export class PetService {
 
         return this.httpClient.delete<any>(`${this.basePath}/pet/${encodeURIComponent(String(petId))}`,
             {
-                headers: headers,
                 withCredentials: this.configuration.withCredentials,
+                headers,
+                observe,
+                reportProgress
             }
         );
     }
@@ -156,8 +171,13 @@ export class PetService {
      * Finds Pets by status
      * Multiple status values can be provided with comma separated strings
      * @param status Status values that need to be considered for filter
+     * @param observe set whether or not to return the data Observable as the body, response or events. defaults to returning the body.
+     * @param reportProgress flag to report request and response progress.
      */
-    public findPetsByStatus(status: Array<string>): Observable<Array<Pet>> {
+    public findPetsByStatus(status: Array<string>, observe?: 'body', reportProgress?: boolean): Observable<Array<Pet>>;
+    public findPetsByStatus(status: Array<string>, observe?: 'response', reportProgress?: boolean): Observable<HttpResponse<Array<Pet>>>;
+    public findPetsByStatus(status: Array<string>, observe?: 'events', reportProgress?: boolean): Observable<HttpEvent<Array<Pet>>>;
+    public findPetsByStatus(status: Array<string>, observe: 'body' | 'response' | 'events' = 'body', reportProgress: boolean = false ): Observable<any> {
         if (status === null || status === undefined) {
             throw new Error('Required parameter status was null or undefined when calling findPetsByStatus.');
         }
@@ -191,11 +211,13 @@ export class PetService {
         let consumes: string[] = [
         ];
 
-        return this.httpClient.get<any>(`${this.basePath}/pet/findByStatus`,
+        return this.httpClient.get<Array<Pet>>(`${this.basePath}/pet/findByStatus`,
             {
                 params: queryParameters,
-                headers: headers,
                 withCredentials: this.configuration.withCredentials,
+                headers,
+                observe,
+                reportProgress
             }
         );
     }
@@ -204,8 +226,13 @@ export class PetService {
      * Finds Pets by tags
      * Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
      * @param tags Tags to filter by
+     * @param observe set whether or not to return the data Observable as the body, response or events. defaults to returning the body.
+     * @param reportProgress flag to report request and response progress.
      */
-    public findPetsByTags(tags: Array<string>): Observable<Array<Pet>> {
+    public findPetsByTags(tags: Array<string>, observe?: 'body', reportProgress?: boolean): Observable<Array<Pet>>;
+    public findPetsByTags(tags: Array<string>, observe?: 'response', reportProgress?: boolean): Observable<HttpResponse<Array<Pet>>>;
+    public findPetsByTags(tags: Array<string>, observe?: 'events', reportProgress?: boolean): Observable<HttpEvent<Array<Pet>>>;
+    public findPetsByTags(tags: Array<string>, observe: 'body' | 'response' | 'events' = 'body', reportProgress: boolean = false ): Observable<any> {
         if (tags === null || tags === undefined) {
             throw new Error('Required parameter tags was null or undefined when calling findPetsByTags.');
         }
@@ -239,11 +266,13 @@ export class PetService {
         let consumes: string[] = [
         ];
 
-        return this.httpClient.get<any>(`${this.basePath}/pet/findByTags`,
+        return this.httpClient.get<Array<Pet>>(`${this.basePath}/pet/findByTags`,
             {
                 params: queryParameters,
-                headers: headers,
                 withCredentials: this.configuration.withCredentials,
+                headers,
+                observe,
+                reportProgress
             }
         );
     }
@@ -252,8 +281,13 @@ export class PetService {
      * Find pet by ID
      * Returns a single pet
      * @param petId ID of pet to return
+     * @param observe set whether or not to return the data Observable as the body, response or events. defaults to returning the body.
+     * @param reportProgress flag to report request and response progress.
      */
-    public getPetById(petId: number): Observable<Pet> {
+    public getPetById(petId: number, observe?: 'body', reportProgress?: boolean): Observable<Pet>;
+    public getPetById(petId: number, observe?: 'response', reportProgress?: boolean): Observable<HttpResponse<Pet>>;
+    public getPetById(petId: number, observe?: 'events', reportProgress?: boolean): Observable<HttpEvent<Pet>>;
+    public getPetById(petId: number, observe: 'body' | 'response' | 'events' = 'body', reportProgress: boolean = false ): Observable<any> {
         if (petId === null || petId === undefined) {
             throw new Error('Required parameter petId was null or undefined when calling getPetById.');
         }
@@ -279,10 +313,12 @@ export class PetService {
         let consumes: string[] = [
         ];
 
-        return this.httpClient.get<any>(`${this.basePath}/pet/${encodeURIComponent(String(petId))}`,
+        return this.httpClient.get<Pet>(`${this.basePath}/pet/${encodeURIComponent(String(petId))}`,
             {
-                headers: headers,
                 withCredentials: this.configuration.withCredentials,
+                headers,
+                observe,
+                reportProgress
             }
         );
     }
@@ -291,8 +327,13 @@ export class PetService {
      * Update an existing pet
      * 
      * @param body Pet object that needs to be added to the store
+     * @param observe set whether or not to return the data Observable as the body, response or events. defaults to returning the body.
+     * @param reportProgress flag to report request and response progress.
      */
-    public updatePet(body: Pet): Observable<{}> {
+    public updatePet(body: Pet, observe?: 'body', reportProgress?: boolean): Observable<any>;
+    public updatePet(body: Pet, observe?: 'response', reportProgress?: boolean): Observable<HttpResponse<any>>;
+    public updatePet(body: Pet, observe?: 'events', reportProgress?: boolean): Observable<HttpEvent<any>>;
+    public updatePet(body: Pet, observe: 'body' | 'response' | 'events' = 'body', reportProgress: boolean = false ): Observable<any> {
         if (body === null || body === undefined) {
             throw new Error('Required parameter body was null or undefined when calling updatePet.');
         }
@@ -330,8 +371,10 @@ export class PetService {
         return this.httpClient.put<any>(`${this.basePath}/pet`,
             body,
             {
-                headers: headers,
                 withCredentials: this.configuration.withCredentials,
+                headers,
+                observe,
+                reportProgress
             }
         );
     }
@@ -342,8 +385,13 @@ export class PetService {
      * @param petId ID of pet that needs to be updated
      * @param name Updated name of the pet
      * @param status Updated status of the pet
+     * @param observe set whether or not to return the data Observable as the body, response or events. defaults to returning the body.
+     * @param reportProgress flag to report request and response progress.
      */
-    public updatePetWithForm(petId: number, name?: string, status?: string): Observable<{}> {
+    public updatePetWithForm(petId: number, name?: string, status?: string, observe?: 'body', reportProgress?: boolean): Observable<any>;
+    public updatePetWithForm(petId: number, name?: string, status?: string, observe?: 'response', reportProgress?: boolean): Observable<HttpResponse<any>>;
+    public updatePetWithForm(petId: number, name?: string, status?: string, observe?: 'events', reportProgress?: boolean): Observable<HttpEvent<any>>;
+    public updatePetWithForm(petId: number, name?: string, status?: string, observe: 'body' | 'response' | 'events' = 'body', reportProgress: boolean = false ): Observable<any> {
         if (petId === null || petId === undefined) {
             throw new Error('Required parameter petId was null or undefined when calling updatePetWithForm.');
         }
@@ -394,8 +442,10 @@ export class PetService {
         return this.httpClient.post<any>(`${this.basePath}/pet/${encodeURIComponent(String(petId))}`,
             convertFormParamsToString ? formParams.toString() : formParams,
             {
-                headers: headers,
                 withCredentials: this.configuration.withCredentials,
+                headers,
+                observe,
+                reportProgress
             }
         );
     }
@@ -406,8 +456,13 @@ export class PetService {
      * @param petId ID of pet to update
      * @param additionalMetadata Additional data to pass to server
      * @param file file to upload
+     * @param observe set whether or not to return the data Observable as the body, response or events. defaults to returning the body.
+     * @param reportProgress flag to report request and response progress.
      */
-    public uploadFile(petId: number, additionalMetadata?: string, file?: Blob): Observable<ApiResponse> {
+    public uploadFile(petId: number, additionalMetadata?: string, file?: Blob, observe?: 'body', reportProgress?: boolean): Observable<ApiResponse>;
+    public uploadFile(petId: number, additionalMetadata?: string, file?: Blob, observe?: 'response', reportProgress?: boolean): Observable<HttpResponse<ApiResponse>>;
+    public uploadFile(petId: number, additionalMetadata?: string, file?: Blob, observe?: 'events', reportProgress?: boolean): Observable<HttpEvent<ApiResponse>>;
+    public uploadFile(petId: number, additionalMetadata?: string, file?: Blob, observe: 'body' | 'response' | 'events' = 'body', reportProgress: boolean = false ): Observable<any> {
         if (petId === null || petId === undefined) {
             throw new Error('Required parameter petId was null or undefined when calling uploadFile.');
         }
@@ -457,11 +512,13 @@ export class PetService {
             formParams = formParams.append('file', <any>file) || formParams;
         }
 
-        return this.httpClient.post<any>(`${this.basePath}/pet/${encodeURIComponent(String(petId))}/uploadImage`,
+        return this.httpClient.post<ApiResponse>(`${this.basePath}/pet/${encodeURIComponent(String(petId))}/uploadImage`,
             convertFormParamsToString ? formParams.toString() : formParams,
             {
-                headers: headers,
                 withCredentials: this.configuration.withCredentials,
+                headers,
+                observe,
+                reportProgress
             }
         );
     }

--- a/samples/client/petstore/typescript-angular-v4.3/npm/api/store.service.ts
+++ b/samples/client/petstore/typescript-angular-v4.3/npm/api/store.service.ts
@@ -104,10 +104,10 @@ export class StoreService {
      * @param observe set whether or not to return the data Observable as the body, response or events. defaults to returning the body.
      * @param reportProgress flag to report request and response progress.
      */
-    public getInventory(, observe?: 'body', reportProgress?: boolean): Observable<{ [key: string]: number; }>;
-    public getInventory(, observe?: 'response', reportProgress?: boolean): Observable<HttpResponse<{ [key: string]: number; }>>;
-    public getInventory(, observe?: 'events', reportProgress?: boolean): Observable<HttpEvent<{ [key: string]: number; }>>;
-    public getInventory(, observe: 'body' | 'response' | 'events' = 'body', reportProgress: boolean = false ): Observable<any> {
+    public getInventory(observe?: 'body', reportProgress?: boolean): Observable<{ [key: string]: number; }>;
+    public getInventory(observe?: 'response', reportProgress?: boolean): Observable<HttpResponse<{ [key: string]: number; }>>;
+    public getInventory(observe?: 'events', reportProgress?: boolean): Observable<HttpEvent<{ [key: string]: number; }>>;
+    public getInventory(observe: 'body' | 'response' | 'events' = 'body', reportProgress: boolean = false ): Observable<any> {
 
         let headers = this.defaultHeaders;
 

--- a/samples/client/petstore/typescript-angular-v4.3/npm/api/store.service.ts
+++ b/samples/client/petstore/typescript-angular-v4.3/npm/api/store.service.ts
@@ -12,7 +12,9 @@
 /* tslint:disable:no-unused-variable member-ordering */
 
 import { Inject, Injectable, Optional }                      from '@angular/core';
-import { HttpClient, HttpHeaders, HttpParams }               from '@angular/common/http';
+import { HttpClient, HttpHeaders, HttpParams,
+         HttpResponse, HttpEvent }                           from '@angular/common/http';
+import { CustomHttpUrlEncodingCodec }                        from '../encoder';
 
 import { Observable }                                        from 'rxjs/Observable';
 import '../rxjs-operators';
@@ -21,7 +23,6 @@ import { Order } from '../model/order';
 
 import { BASE_PATH, COLLECTION_FORMATS }                     from '../variables';
 import { Configuration }                                     from '../configuration';
-import { CustomHttpUrlEncodingCodec }                        from '../encoder';
 
 
 @Injectable()
@@ -60,8 +61,13 @@ export class StoreService {
      * Delete purchase order by ID
      * For valid response try integer IDs with value &lt; 1000. Anything above 1000 or nonintegers will generate API errors
      * @param orderId ID of the order that needs to be deleted
+     * @param observe set whether or not to return the data Observable as the body, response or events. defaults to returning the body.
+     * @param reportProgress flag to report request and response progress.
      */
-    public deleteOrder(orderId: string): Observable<{}> {
+    public deleteOrder(orderId: string, observe?: 'body', reportProgress?: boolean): Observable<any>;
+    public deleteOrder(orderId: string, observe?: 'response', reportProgress?: boolean): Observable<HttpResponse<any>>;
+    public deleteOrder(orderId: string, observe?: 'events', reportProgress?: boolean): Observable<HttpEvent<any>>;
+    public deleteOrder(orderId: string, observe: 'body' | 'response' | 'events' = 'body', reportProgress: boolean = false ): Observable<any> {
         if (orderId === null || orderId === undefined) {
             throw new Error('Required parameter orderId was null or undefined when calling deleteOrder.');
         }
@@ -84,8 +90,10 @@ export class StoreService {
 
         return this.httpClient.delete<any>(`${this.basePath}/store/order/${encodeURIComponent(String(orderId))}`,
             {
-                headers: headers,
                 withCredentials: this.configuration.withCredentials,
+                headers,
+                observe,
+                reportProgress
             }
         );
     }
@@ -93,8 +101,13 @@ export class StoreService {
     /**
      * Returns pet inventories by status
      * Returns a map of status codes to quantities
+     * @param observe set whether or not to return the data Observable as the body, response or events. defaults to returning the body.
+     * @param reportProgress flag to report request and response progress.
      */
-    public getInventory(): Observable<{ [key: string]: number; }> {
+    public getInventory(, observe?: 'body', reportProgress?: boolean): Observable<{ [key: string]: number; }>;
+    public getInventory(, observe?: 'response', reportProgress?: boolean): Observable<HttpResponse<{ [key: string]: number; }>>;
+    public getInventory(, observe?: 'events', reportProgress?: boolean): Observable<HttpEvent<{ [key: string]: number; }>>;
+    public getInventory(, observe: 'body' | 'response' | 'events' = 'body', reportProgress: boolean = false ): Observable<any> {
 
         let headers = this.defaultHeaders;
 
@@ -116,10 +129,12 @@ export class StoreService {
         let consumes: string[] = [
         ];
 
-        return this.httpClient.get<any>(`${this.basePath}/store/inventory`,
+        return this.httpClient.get<{ [key: string]: number; }>(`${this.basePath}/store/inventory`,
             {
-                headers: headers,
                 withCredentials: this.configuration.withCredentials,
+                headers,
+                observe,
+                reportProgress
             }
         );
     }
@@ -128,8 +143,13 @@ export class StoreService {
      * Find purchase order by ID
      * For valid response try integer IDs with value &lt;&#x3D; 5 or &gt; 10. Other values will generated exceptions
      * @param orderId ID of pet that needs to be fetched
+     * @param observe set whether or not to return the data Observable as the body, response or events. defaults to returning the body.
+     * @param reportProgress flag to report request and response progress.
      */
-    public getOrderById(orderId: number): Observable<Order> {
+    public getOrderById(orderId: number, observe?: 'body', reportProgress?: boolean): Observable<Order>;
+    public getOrderById(orderId: number, observe?: 'response', reportProgress?: boolean): Observable<HttpResponse<Order>>;
+    public getOrderById(orderId: number, observe?: 'events', reportProgress?: boolean): Observable<HttpEvent<Order>>;
+    public getOrderById(orderId: number, observe: 'body' | 'response' | 'events' = 'body', reportProgress: boolean = false ): Observable<any> {
         if (orderId === null || orderId === undefined) {
             throw new Error('Required parameter orderId was null or undefined when calling getOrderById.');
         }
@@ -150,10 +170,12 @@ export class StoreService {
         let consumes: string[] = [
         ];
 
-        return this.httpClient.get<any>(`${this.basePath}/store/order/${encodeURIComponent(String(orderId))}`,
+        return this.httpClient.get<Order>(`${this.basePath}/store/order/${encodeURIComponent(String(orderId))}`,
             {
-                headers: headers,
                 withCredentials: this.configuration.withCredentials,
+                headers,
+                observe,
+                reportProgress
             }
         );
     }
@@ -162,8 +184,13 @@ export class StoreService {
      * Place an order for a pet
      * 
      * @param body order placed for purchasing the pet
+     * @param observe set whether or not to return the data Observable as the body, response or events. defaults to returning the body.
+     * @param reportProgress flag to report request and response progress.
      */
-    public placeOrder(body: Order): Observable<Order> {
+    public placeOrder(body: Order, observe?: 'body', reportProgress?: boolean): Observable<Order>;
+    public placeOrder(body: Order, observe?: 'response', reportProgress?: boolean): Observable<HttpResponse<Order>>;
+    public placeOrder(body: Order, observe?: 'events', reportProgress?: boolean): Observable<HttpEvent<Order>>;
+    public placeOrder(body: Order, observe: 'body' | 'response' | 'events' = 'body', reportProgress: boolean = false ): Observable<any> {
         if (body === null || body === undefined) {
             throw new Error('Required parameter body was null or undefined when calling placeOrder.');
         }
@@ -188,11 +215,13 @@ export class StoreService {
             headers = headers.set("Content-Type", httpContentTypeSelected);
         }
 
-        return this.httpClient.post<any>(`${this.basePath}/store/order`,
+        return this.httpClient.post<Order>(`${this.basePath}/store/order`,
             body,
             {
-                headers: headers,
                 withCredentials: this.configuration.withCredentials,
+                headers,
+                observe,
+                reportProgress
             }
         );
     }

--- a/samples/client/petstore/typescript-angular-v4.3/npm/api/store.service.ts
+++ b/samples/client/petstore/typescript-angular-v4.3/npm/api/store.service.ts
@@ -67,7 +67,7 @@ export class StoreService {
     public deleteOrder(orderId: string, observe?: 'body', reportProgress?: boolean): Observable<any>;
     public deleteOrder(orderId: string, observe?: 'response', reportProgress?: boolean): Observable<HttpResponse<any>>;
     public deleteOrder(orderId: string, observe?: 'events', reportProgress?: boolean): Observable<HttpEvent<any>>;
-    public deleteOrder(orderId: string, observe: 'body' | 'response' | 'events' = 'body', reportProgress: boolean = false ): Observable<any> {
+    public deleteOrder(orderId: string, observe: any = 'body', reportProgress: boolean = false ): Observable<any> {
         if (orderId === null || orderId === undefined) {
             throw new Error('Required parameter orderId was null or undefined when calling deleteOrder.');
         }
@@ -91,9 +91,9 @@ export class StoreService {
         return this.httpClient.delete<any>(`${this.basePath}/store/order/${encodeURIComponent(String(orderId))}`,
             {
                 withCredentials: this.configuration.withCredentials,
-                headers,
-                observe,
-                reportProgress
+                headers: headers,
+                observe: observe,
+                reportProgress: reportProgress
             }
         );
     }
@@ -107,7 +107,7 @@ export class StoreService {
     public getInventory(observe?: 'body', reportProgress?: boolean): Observable<{ [key: string]: number; }>;
     public getInventory(observe?: 'response', reportProgress?: boolean): Observable<HttpResponse<{ [key: string]: number; }>>;
     public getInventory(observe?: 'events', reportProgress?: boolean): Observable<HttpEvent<{ [key: string]: number; }>>;
-    public getInventory(observe: 'body' | 'response' | 'events' = 'body', reportProgress: boolean = false ): Observable<any> {
+    public getInventory(observe: any = 'body', reportProgress: boolean = false ): Observable<any> {
 
         let headers = this.defaultHeaders;
 
@@ -132,9 +132,9 @@ export class StoreService {
         return this.httpClient.get<{ [key: string]: number; }>(`${this.basePath}/store/inventory`,
             {
                 withCredentials: this.configuration.withCredentials,
-                headers,
-                observe,
-                reportProgress
+                headers: headers,
+                observe: observe,
+                reportProgress: reportProgress
             }
         );
     }
@@ -149,7 +149,7 @@ export class StoreService {
     public getOrderById(orderId: number, observe?: 'body', reportProgress?: boolean): Observable<Order>;
     public getOrderById(orderId: number, observe?: 'response', reportProgress?: boolean): Observable<HttpResponse<Order>>;
     public getOrderById(orderId: number, observe?: 'events', reportProgress?: boolean): Observable<HttpEvent<Order>>;
-    public getOrderById(orderId: number, observe: 'body' | 'response' | 'events' = 'body', reportProgress: boolean = false ): Observable<any> {
+    public getOrderById(orderId: number, observe: any = 'body', reportProgress: boolean = false ): Observable<any> {
         if (orderId === null || orderId === undefined) {
             throw new Error('Required parameter orderId was null or undefined when calling getOrderById.');
         }
@@ -173,9 +173,9 @@ export class StoreService {
         return this.httpClient.get<Order>(`${this.basePath}/store/order/${encodeURIComponent(String(orderId))}`,
             {
                 withCredentials: this.configuration.withCredentials,
-                headers,
-                observe,
-                reportProgress
+                headers: headers,
+                observe: observe,
+                reportProgress: reportProgress
             }
         );
     }
@@ -190,7 +190,7 @@ export class StoreService {
     public placeOrder(body: Order, observe?: 'body', reportProgress?: boolean): Observable<Order>;
     public placeOrder(body: Order, observe?: 'response', reportProgress?: boolean): Observable<HttpResponse<Order>>;
     public placeOrder(body: Order, observe?: 'events', reportProgress?: boolean): Observable<HttpEvent<Order>>;
-    public placeOrder(body: Order, observe: 'body' | 'response' | 'events' = 'body', reportProgress: boolean = false ): Observable<any> {
+    public placeOrder(body: Order, observe: any = 'body', reportProgress: boolean = false ): Observable<any> {
         if (body === null || body === undefined) {
             throw new Error('Required parameter body was null or undefined when calling placeOrder.');
         }
@@ -219,9 +219,9 @@ export class StoreService {
             body,
             {
                 withCredentials: this.configuration.withCredentials,
-                headers,
-                observe,
-                reportProgress
+                headers: headers,
+                observe: observe,
+                reportProgress: reportProgress
             }
         );
     }

--- a/samples/client/petstore/typescript-angular-v4.3/npm/api/user.service.ts
+++ b/samples/client/petstore/typescript-angular-v4.3/npm/api/user.service.ts
@@ -337,10 +337,10 @@ export class UserService {
      * @param observe set whether or not to return the data Observable as the body, response or events. defaults to returning the body.
      * @param reportProgress flag to report request and response progress.
      */
-    public logoutUser(, observe?: 'body', reportProgress?: boolean): Observable<any>;
-    public logoutUser(, observe?: 'response', reportProgress?: boolean): Observable<HttpResponse<any>>;
-    public logoutUser(, observe?: 'events', reportProgress?: boolean): Observable<HttpEvent<any>>;
-    public logoutUser(, observe: 'body' | 'response' | 'events' = 'body', reportProgress: boolean = false ): Observable<any> {
+    public logoutUser(observe?: 'body', reportProgress?: boolean): Observable<any>;
+    public logoutUser(observe?: 'response', reportProgress?: boolean): Observable<HttpResponse<any>>;
+    public logoutUser(observe?: 'events', reportProgress?: boolean): Observable<HttpEvent<any>>;
+    public logoutUser(observe: 'body' | 'response' | 'events' = 'body', reportProgress: boolean = false ): Observable<any> {
 
         let headers = this.defaultHeaders;
 

--- a/samples/client/petstore/typescript-angular-v4.3/npm/api/user.service.ts
+++ b/samples/client/petstore/typescript-angular-v4.3/npm/api/user.service.ts
@@ -12,7 +12,9 @@
 /* tslint:disable:no-unused-variable member-ordering */
 
 import { Inject, Injectable, Optional }                      from '@angular/core';
-import { HttpClient, HttpHeaders, HttpParams }               from '@angular/common/http';
+import { HttpClient, HttpHeaders, HttpParams,
+         HttpResponse, HttpEvent }                           from '@angular/common/http';
+import { CustomHttpUrlEncodingCodec }                        from '../encoder';
 
 import { Observable }                                        from 'rxjs/Observable';
 import '../rxjs-operators';
@@ -21,7 +23,6 @@ import { User } from '../model/user';
 
 import { BASE_PATH, COLLECTION_FORMATS }                     from '../variables';
 import { Configuration }                                     from '../configuration';
-import { CustomHttpUrlEncodingCodec }                        from '../encoder';
 
 
 @Injectable()
@@ -60,8 +61,13 @@ export class UserService {
      * Create user
      * This can only be done by the logged in user.
      * @param body Created user object
+     * @param observe set whether or not to return the data Observable as the body, response or events. defaults to returning the body.
+     * @param reportProgress flag to report request and response progress.
      */
-    public createUser(body: User): Observable<{}> {
+    public createUser(body: User, observe?: 'body', reportProgress?: boolean): Observable<any>;
+    public createUser(body: User, observe?: 'response', reportProgress?: boolean): Observable<HttpResponse<any>>;
+    public createUser(body: User, observe?: 'events', reportProgress?: boolean): Observable<HttpEvent<any>>;
+    public createUser(body: User, observe: 'body' | 'response' | 'events' = 'body', reportProgress: boolean = false ): Observable<any> {
         if (body === null || body === undefined) {
             throw new Error('Required parameter body was null or undefined when calling createUser.');
         }
@@ -89,8 +95,10 @@ export class UserService {
         return this.httpClient.post<any>(`${this.basePath}/user`,
             body,
             {
-                headers: headers,
                 withCredentials: this.configuration.withCredentials,
+                headers,
+                observe,
+                reportProgress
             }
         );
     }
@@ -99,8 +107,13 @@ export class UserService {
      * Creates list of users with given input array
      * 
      * @param body List of user object
+     * @param observe set whether or not to return the data Observable as the body, response or events. defaults to returning the body.
+     * @param reportProgress flag to report request and response progress.
      */
-    public createUsersWithArrayInput(body: Array<User>): Observable<{}> {
+    public createUsersWithArrayInput(body: Array<User>, observe?: 'body', reportProgress?: boolean): Observable<any>;
+    public createUsersWithArrayInput(body: Array<User>, observe?: 'response', reportProgress?: boolean): Observable<HttpResponse<any>>;
+    public createUsersWithArrayInput(body: Array<User>, observe?: 'events', reportProgress?: boolean): Observable<HttpEvent<any>>;
+    public createUsersWithArrayInput(body: Array<User>, observe: 'body' | 'response' | 'events' = 'body', reportProgress: boolean = false ): Observable<any> {
         if (body === null || body === undefined) {
             throw new Error('Required parameter body was null or undefined when calling createUsersWithArrayInput.');
         }
@@ -128,8 +141,10 @@ export class UserService {
         return this.httpClient.post<any>(`${this.basePath}/user/createWithArray`,
             body,
             {
-                headers: headers,
                 withCredentials: this.configuration.withCredentials,
+                headers,
+                observe,
+                reportProgress
             }
         );
     }
@@ -138,8 +153,13 @@ export class UserService {
      * Creates list of users with given input array
      * 
      * @param body List of user object
+     * @param observe set whether or not to return the data Observable as the body, response or events. defaults to returning the body.
+     * @param reportProgress flag to report request and response progress.
      */
-    public createUsersWithListInput(body: Array<User>): Observable<{}> {
+    public createUsersWithListInput(body: Array<User>, observe?: 'body', reportProgress?: boolean): Observable<any>;
+    public createUsersWithListInput(body: Array<User>, observe?: 'response', reportProgress?: boolean): Observable<HttpResponse<any>>;
+    public createUsersWithListInput(body: Array<User>, observe?: 'events', reportProgress?: boolean): Observable<HttpEvent<any>>;
+    public createUsersWithListInput(body: Array<User>, observe: 'body' | 'response' | 'events' = 'body', reportProgress: boolean = false ): Observable<any> {
         if (body === null || body === undefined) {
             throw new Error('Required parameter body was null or undefined when calling createUsersWithListInput.');
         }
@@ -167,8 +187,10 @@ export class UserService {
         return this.httpClient.post<any>(`${this.basePath}/user/createWithList`,
             body,
             {
-                headers: headers,
                 withCredentials: this.configuration.withCredentials,
+                headers,
+                observe,
+                reportProgress
             }
         );
     }
@@ -177,8 +199,13 @@ export class UserService {
      * Delete user
      * This can only be done by the logged in user.
      * @param username The name that needs to be deleted
+     * @param observe set whether or not to return the data Observable as the body, response or events. defaults to returning the body.
+     * @param reportProgress flag to report request and response progress.
      */
-    public deleteUser(username: string): Observable<{}> {
+    public deleteUser(username: string, observe?: 'body', reportProgress?: boolean): Observable<any>;
+    public deleteUser(username: string, observe?: 'response', reportProgress?: boolean): Observable<HttpResponse<any>>;
+    public deleteUser(username: string, observe?: 'events', reportProgress?: boolean): Observable<HttpEvent<any>>;
+    public deleteUser(username: string, observe: 'body' | 'response' | 'events' = 'body', reportProgress: boolean = false ): Observable<any> {
         if (username === null || username === undefined) {
             throw new Error('Required parameter username was null or undefined when calling deleteUser.');
         }
@@ -201,8 +228,10 @@ export class UserService {
 
         return this.httpClient.delete<any>(`${this.basePath}/user/${encodeURIComponent(String(username))}`,
             {
-                headers: headers,
                 withCredentials: this.configuration.withCredentials,
+                headers,
+                observe,
+                reportProgress
             }
         );
     }
@@ -211,8 +240,13 @@ export class UserService {
      * Get user by user name
      * 
      * @param username The name that needs to be fetched. Use user1 for testing. 
+     * @param observe set whether or not to return the data Observable as the body, response or events. defaults to returning the body.
+     * @param reportProgress flag to report request and response progress.
      */
-    public getUserByName(username: string): Observable<User> {
+    public getUserByName(username: string, observe?: 'body', reportProgress?: boolean): Observable<User>;
+    public getUserByName(username: string, observe?: 'response', reportProgress?: boolean): Observable<HttpResponse<User>>;
+    public getUserByName(username: string, observe?: 'events', reportProgress?: boolean): Observable<HttpEvent<User>>;
+    public getUserByName(username: string, observe: 'body' | 'response' | 'events' = 'body', reportProgress: boolean = false ): Observable<any> {
         if (username === null || username === undefined) {
             throw new Error('Required parameter username was null or undefined when calling getUserByName.');
         }
@@ -233,10 +267,12 @@ export class UserService {
         let consumes: string[] = [
         ];
 
-        return this.httpClient.get<any>(`${this.basePath}/user/${encodeURIComponent(String(username))}`,
+        return this.httpClient.get<User>(`${this.basePath}/user/${encodeURIComponent(String(username))}`,
             {
-                headers: headers,
                 withCredentials: this.configuration.withCredentials,
+                headers,
+                observe,
+                reportProgress
             }
         );
     }
@@ -246,8 +282,13 @@ export class UserService {
      * 
      * @param username The user name for login
      * @param password The password for login in clear text
+     * @param observe set whether or not to return the data Observable as the body, response or events. defaults to returning the body.
+     * @param reportProgress flag to report request and response progress.
      */
-    public loginUser(username: string, password: string): Observable<string> {
+    public loginUser(username: string, password: string, observe?: 'body', reportProgress?: boolean): Observable<string>;
+    public loginUser(username: string, password: string, observe?: 'response', reportProgress?: boolean): Observable<HttpResponse<string>>;
+    public loginUser(username: string, password: string, observe?: 'events', reportProgress?: boolean): Observable<HttpEvent<string>>;
+    public loginUser(username: string, password: string, observe: 'body' | 'response' | 'events' = 'body', reportProgress: boolean = false ): Observable<any> {
         if (username === null || username === undefined) {
             throw new Error('Required parameter username was null or undefined when calling loginUser.');
         }
@@ -279,11 +320,13 @@ export class UserService {
         let consumes: string[] = [
         ];
 
-        return this.httpClient.get<any>(`${this.basePath}/user/login`,
+        return this.httpClient.get<string>(`${this.basePath}/user/login`,
             {
                 params: queryParameters,
-                headers: headers,
                 withCredentials: this.configuration.withCredentials,
+                headers,
+                observe,
+                reportProgress
             }
         );
     }
@@ -291,8 +334,13 @@ export class UserService {
     /**
      * Logs out current logged in user session
      * 
+     * @param observe set whether or not to return the data Observable as the body, response or events. defaults to returning the body.
+     * @param reportProgress flag to report request and response progress.
      */
-    public logoutUser(): Observable<{}> {
+    public logoutUser(, observe?: 'body', reportProgress?: boolean): Observable<any>;
+    public logoutUser(, observe?: 'response', reportProgress?: boolean): Observable<HttpResponse<any>>;
+    public logoutUser(, observe?: 'events', reportProgress?: boolean): Observable<HttpEvent<any>>;
+    public logoutUser(, observe: 'body' | 'response' | 'events' = 'body', reportProgress: boolean = false ): Observable<any> {
 
         let headers = this.defaultHeaders;
 
@@ -312,8 +360,10 @@ export class UserService {
 
         return this.httpClient.get<any>(`${this.basePath}/user/logout`,
             {
-                headers: headers,
                 withCredentials: this.configuration.withCredentials,
+                headers,
+                observe,
+                reportProgress
             }
         );
     }
@@ -323,8 +373,13 @@ export class UserService {
      * This can only be done by the logged in user.
      * @param username name that need to be deleted
      * @param body Updated user object
+     * @param observe set whether or not to return the data Observable as the body, response or events. defaults to returning the body.
+     * @param reportProgress flag to report request and response progress.
      */
-    public updateUser(username: string, body: User): Observable<{}> {
+    public updateUser(username: string, body: User, observe?: 'body', reportProgress?: boolean): Observable<any>;
+    public updateUser(username: string, body: User, observe?: 'response', reportProgress?: boolean): Observable<HttpResponse<any>>;
+    public updateUser(username: string, body: User, observe?: 'events', reportProgress?: boolean): Observable<HttpEvent<any>>;
+    public updateUser(username: string, body: User, observe: 'body' | 'response' | 'events' = 'body', reportProgress: boolean = false ): Observable<any> {
         if (username === null || username === undefined) {
             throw new Error('Required parameter username was null or undefined when calling updateUser.');
         }
@@ -355,8 +410,10 @@ export class UserService {
         return this.httpClient.put<any>(`${this.basePath}/user/${encodeURIComponent(String(username))}`,
             body,
             {
-                headers: headers,
                 withCredentials: this.configuration.withCredentials,
+                headers,
+                observe,
+                reportProgress
             }
         );
     }

--- a/samples/client/petstore/typescript-angular-v4.3/npm/api/user.service.ts
+++ b/samples/client/petstore/typescript-angular-v4.3/npm/api/user.service.ts
@@ -67,7 +67,7 @@ export class UserService {
     public createUser(body: User, observe?: 'body', reportProgress?: boolean): Observable<any>;
     public createUser(body: User, observe?: 'response', reportProgress?: boolean): Observable<HttpResponse<any>>;
     public createUser(body: User, observe?: 'events', reportProgress?: boolean): Observable<HttpEvent<any>>;
-    public createUser(body: User, observe: 'body' | 'response' | 'events' = 'body', reportProgress: boolean = false ): Observable<any> {
+    public createUser(body: User, observe: any = 'body', reportProgress: boolean = false ): Observable<any> {
         if (body === null || body === undefined) {
             throw new Error('Required parameter body was null or undefined when calling createUser.');
         }
@@ -96,9 +96,9 @@ export class UserService {
             body,
             {
                 withCredentials: this.configuration.withCredentials,
-                headers,
-                observe,
-                reportProgress
+                headers: headers,
+                observe: observe,
+                reportProgress: reportProgress
             }
         );
     }
@@ -113,7 +113,7 @@ export class UserService {
     public createUsersWithArrayInput(body: Array<User>, observe?: 'body', reportProgress?: boolean): Observable<any>;
     public createUsersWithArrayInput(body: Array<User>, observe?: 'response', reportProgress?: boolean): Observable<HttpResponse<any>>;
     public createUsersWithArrayInput(body: Array<User>, observe?: 'events', reportProgress?: boolean): Observable<HttpEvent<any>>;
-    public createUsersWithArrayInput(body: Array<User>, observe: 'body' | 'response' | 'events' = 'body', reportProgress: boolean = false ): Observable<any> {
+    public createUsersWithArrayInput(body: Array<User>, observe: any = 'body', reportProgress: boolean = false ): Observable<any> {
         if (body === null || body === undefined) {
             throw new Error('Required parameter body was null or undefined when calling createUsersWithArrayInput.');
         }
@@ -142,9 +142,9 @@ export class UserService {
             body,
             {
                 withCredentials: this.configuration.withCredentials,
-                headers,
-                observe,
-                reportProgress
+                headers: headers,
+                observe: observe,
+                reportProgress: reportProgress
             }
         );
     }
@@ -159,7 +159,7 @@ export class UserService {
     public createUsersWithListInput(body: Array<User>, observe?: 'body', reportProgress?: boolean): Observable<any>;
     public createUsersWithListInput(body: Array<User>, observe?: 'response', reportProgress?: boolean): Observable<HttpResponse<any>>;
     public createUsersWithListInput(body: Array<User>, observe?: 'events', reportProgress?: boolean): Observable<HttpEvent<any>>;
-    public createUsersWithListInput(body: Array<User>, observe: 'body' | 'response' | 'events' = 'body', reportProgress: boolean = false ): Observable<any> {
+    public createUsersWithListInput(body: Array<User>, observe: any = 'body', reportProgress: boolean = false ): Observable<any> {
         if (body === null || body === undefined) {
             throw new Error('Required parameter body was null or undefined when calling createUsersWithListInput.');
         }
@@ -188,9 +188,9 @@ export class UserService {
             body,
             {
                 withCredentials: this.configuration.withCredentials,
-                headers,
-                observe,
-                reportProgress
+                headers: headers,
+                observe: observe,
+                reportProgress: reportProgress
             }
         );
     }
@@ -205,7 +205,7 @@ export class UserService {
     public deleteUser(username: string, observe?: 'body', reportProgress?: boolean): Observable<any>;
     public deleteUser(username: string, observe?: 'response', reportProgress?: boolean): Observable<HttpResponse<any>>;
     public deleteUser(username: string, observe?: 'events', reportProgress?: boolean): Observable<HttpEvent<any>>;
-    public deleteUser(username: string, observe: 'body' | 'response' | 'events' = 'body', reportProgress: boolean = false ): Observable<any> {
+    public deleteUser(username: string, observe: any = 'body', reportProgress: boolean = false ): Observable<any> {
         if (username === null || username === undefined) {
             throw new Error('Required parameter username was null or undefined when calling deleteUser.');
         }
@@ -229,9 +229,9 @@ export class UserService {
         return this.httpClient.delete<any>(`${this.basePath}/user/${encodeURIComponent(String(username))}`,
             {
                 withCredentials: this.configuration.withCredentials,
-                headers,
-                observe,
-                reportProgress
+                headers: headers,
+                observe: observe,
+                reportProgress: reportProgress
             }
         );
     }
@@ -246,7 +246,7 @@ export class UserService {
     public getUserByName(username: string, observe?: 'body', reportProgress?: boolean): Observable<User>;
     public getUserByName(username: string, observe?: 'response', reportProgress?: boolean): Observable<HttpResponse<User>>;
     public getUserByName(username: string, observe?: 'events', reportProgress?: boolean): Observable<HttpEvent<User>>;
-    public getUserByName(username: string, observe: 'body' | 'response' | 'events' = 'body', reportProgress: boolean = false ): Observable<any> {
+    public getUserByName(username: string, observe: any = 'body', reportProgress: boolean = false ): Observable<any> {
         if (username === null || username === undefined) {
             throw new Error('Required parameter username was null or undefined when calling getUserByName.');
         }
@@ -270,9 +270,9 @@ export class UserService {
         return this.httpClient.get<User>(`${this.basePath}/user/${encodeURIComponent(String(username))}`,
             {
                 withCredentials: this.configuration.withCredentials,
-                headers,
-                observe,
-                reportProgress
+                headers: headers,
+                observe: observe,
+                reportProgress: reportProgress
             }
         );
     }
@@ -288,7 +288,7 @@ export class UserService {
     public loginUser(username: string, password: string, observe?: 'body', reportProgress?: boolean): Observable<string>;
     public loginUser(username: string, password: string, observe?: 'response', reportProgress?: boolean): Observable<HttpResponse<string>>;
     public loginUser(username: string, password: string, observe?: 'events', reportProgress?: boolean): Observable<HttpEvent<string>>;
-    public loginUser(username: string, password: string, observe: 'body' | 'response' | 'events' = 'body', reportProgress: boolean = false ): Observable<any> {
+    public loginUser(username: string, password: string, observe: any = 'body', reportProgress: boolean = false ): Observable<any> {
         if (username === null || username === undefined) {
             throw new Error('Required parameter username was null or undefined when calling loginUser.');
         }
@@ -324,9 +324,9 @@ export class UserService {
             {
                 params: queryParameters,
                 withCredentials: this.configuration.withCredentials,
-                headers,
-                observe,
-                reportProgress
+                headers: headers,
+                observe: observe,
+                reportProgress: reportProgress
             }
         );
     }
@@ -340,7 +340,7 @@ export class UserService {
     public logoutUser(observe?: 'body', reportProgress?: boolean): Observable<any>;
     public logoutUser(observe?: 'response', reportProgress?: boolean): Observable<HttpResponse<any>>;
     public logoutUser(observe?: 'events', reportProgress?: boolean): Observable<HttpEvent<any>>;
-    public logoutUser(observe: 'body' | 'response' | 'events' = 'body', reportProgress: boolean = false ): Observable<any> {
+    public logoutUser(observe: any = 'body', reportProgress: boolean = false ): Observable<any> {
 
         let headers = this.defaultHeaders;
 
@@ -361,9 +361,9 @@ export class UserService {
         return this.httpClient.get<any>(`${this.basePath}/user/logout`,
             {
                 withCredentials: this.configuration.withCredentials,
-                headers,
-                observe,
-                reportProgress
+                headers: headers,
+                observe: observe,
+                reportProgress: reportProgress
             }
         );
     }
@@ -379,7 +379,7 @@ export class UserService {
     public updateUser(username: string, body: User, observe?: 'body', reportProgress?: boolean): Observable<any>;
     public updateUser(username: string, body: User, observe?: 'response', reportProgress?: boolean): Observable<HttpResponse<any>>;
     public updateUser(username: string, body: User, observe?: 'events', reportProgress?: boolean): Observable<HttpEvent<any>>;
-    public updateUser(username: string, body: User, observe: 'body' | 'response' | 'events' = 'body', reportProgress: boolean = false ): Observable<any> {
+    public updateUser(username: string, body: User, observe: any = 'body', reportProgress: boolean = false ): Observable<any> {
         if (username === null || username === undefined) {
             throw new Error('Required parameter username was null or undefined when calling updateUser.');
         }
@@ -411,9 +411,9 @@ export class UserService {
             body,
             {
                 withCredentials: this.configuration.withCredentials,
-                headers,
-                observe,
-                reportProgress
+                headers: headers,
+                observe: observe,
+                reportProgress: reportProgress
             }
         );
     }

--- a/samples/client/petstore/typescript-angular-v4.3/npm/git_push.sh
+++ b/samples/client/petstore/typescript-angular-v4.3/npm/git_push.sh
@@ -36,7 +36,7 @@ git_remote=`git remote`
 if [ "$git_remote" = "" ]; then # git remote not defined
 
     if [ "$GIT_TOKEN" = "" ]; then
-        echo "[INFO] \$GIT_TOKEN (environment variable) is not set. Using the git crediential in your environment."
+        echo "[INFO] \$GIT_TOKEN (environment variable) is not set. Using the git credential in your environment."
         git remote add origin https://github.com/${git_user_id}/${git_repo_id}.git
     else
         git remote add origin https://${git_user_id}:${GIT_TOKEN}@github.com/${git_user_id}/${git_repo_id}.git

--- a/samples/client/petstore/typescript-angular-v4/npm/api/pet.service.ts
+++ b/samples/client/petstore/typescript-angular-v4/npm/api/pet.service.ts
@@ -235,7 +235,7 @@ export class PetService {
 
         let requestOptions: RequestOptionsArgs = new RequestOptions({
             method: RequestMethod.Post,
-            headers,
+            headers: headers,
             body: body == null ? '' : JSON.stringify(body), // https://github.com/angular/angular/issues/10612
             withCredentials:this.configuration.withCredentials
         });
@@ -288,7 +288,7 @@ export class PetService {
 
         let requestOptions: RequestOptionsArgs = new RequestOptions({
             method: RequestMethod.Delete,
-            headers,
+            headers: headers,
             withCredentials:this.configuration.withCredentials
         });
         // https://github.com/swagger-api/swagger-codegen/issues/4037
@@ -341,7 +341,7 @@ export class PetService {
 
         let requestOptions: RequestOptionsArgs = new RequestOptions({
             method: RequestMethod.Get,
-            headers,
+            headers: headers,
             search: queryParameters,
             withCredentials:this.configuration.withCredentials
         });
@@ -395,7 +395,7 @@ export class PetService {
 
         let requestOptions: RequestOptionsArgs = new RequestOptions({
             method: RequestMethod.Get,
-            headers,
+            headers: headers,
             search: queryParameters,
             withCredentials:this.configuration.withCredentials
         });
@@ -441,7 +441,7 @@ export class PetService {
 
         let requestOptions: RequestOptionsArgs = new RequestOptions({
             method: RequestMethod.Get,
-            headers,
+            headers: headers,
             withCredentials:this.configuration.withCredentials
         });
         // https://github.com/swagger-api/swagger-codegen/issues/4037
@@ -495,7 +495,7 @@ export class PetService {
 
         let requestOptions: RequestOptionsArgs = new RequestOptions({
             method: RequestMethod.Put,
-            headers,
+            headers: headers,
             body: body == null ? '' : JSON.stringify(body), // https://github.com/angular/angular/issues/10612
             withCredentials:this.configuration.withCredentials
         });
@@ -569,7 +569,7 @@ export class PetService {
 
         let requestOptions: RequestOptionsArgs = new RequestOptions({
             method: RequestMethod.Post,
-            headers,
+            headers: headers,
             body: convertFormParamsToString ? formParams.toString() : formParams,
             withCredentials:this.configuration.withCredentials
         });
@@ -645,7 +645,7 @@ export class PetService {
 
         let requestOptions: RequestOptionsArgs = new RequestOptions({
             method: RequestMethod.Post,
-            headers,
+            headers: headers,
             body: convertFormParamsToString ? formParams.toString() : formParams,
             withCredentials:this.configuration.withCredentials
         });

--- a/samples/client/petstore/typescript-angular-v4/npm/api/pet.service.ts
+++ b/samples/client/petstore/typescript-angular-v4/npm/api/pet.service.ts
@@ -15,6 +15,7 @@ import { Inject, Injectable, Optional }                      from '@angular/core
 import { Http, Headers, URLSearchParams }                    from '@angular/http';
 import { RequestMethod, RequestOptions, RequestOptionsArgs } from '@angular/http';
 import { Response, ResponseContentType }                     from '@angular/http';
+import { CustomQueryEncoderHelper }                          from '../encoder';
 
 import { Observable }                                        from 'rxjs/Observable';
 import '../rxjs-operators';
@@ -24,7 +25,6 @@ import { Pet } from '../model/pet';
 
 import { BASE_PATH, COLLECTION_FORMATS }                     from '../variables';
 import { Configuration }                                     from '../configuration';
-import { CustomQueryEncoderHelper }                          from '../encoder';
 
 
 @Injectable()
@@ -196,6 +196,7 @@ export class PetService {
      * Add a new pet to the store
      * 
      * @param body Pet object that needs to be added to the store
+     
      */
     public addPetWithHttpInfo(body: Pet, extraHttpRequestParams?: RequestOptionsArgs): Observable<Response> {
         if (body === null || body === undefined) {
@@ -234,7 +235,7 @@ export class PetService {
 
         let requestOptions: RequestOptionsArgs = new RequestOptions({
             method: RequestMethod.Post,
-            headers: headers,
+            headers,
             body: body == null ? '' : JSON.stringify(body), // https://github.com/angular/angular/issues/10612
             withCredentials:this.configuration.withCredentials
         });
@@ -251,6 +252,7 @@ export class PetService {
      * 
      * @param petId Pet id to delete
      * @param apiKey 
+     
      */
     public deletePetWithHttpInfo(petId: number, apiKey?: string, extraHttpRequestParams?: RequestOptionsArgs): Observable<Response> {
         if (petId === null || petId === undefined) {
@@ -286,7 +288,7 @@ export class PetService {
 
         let requestOptions: RequestOptionsArgs = new RequestOptions({
             method: RequestMethod.Delete,
-            headers: headers,
+            headers,
             withCredentials:this.configuration.withCredentials
         });
         // https://github.com/swagger-api/swagger-codegen/issues/4037
@@ -301,6 +303,7 @@ export class PetService {
      * Finds Pets by status
      * Multiple status values can be provided with comma separated strings
      * @param status Status values that need to be considered for filter
+     
      */
     public findPetsByStatusWithHttpInfo(status: Array<string>, extraHttpRequestParams?: RequestOptionsArgs): Observable<Response> {
         if (status === null || status === undefined) {
@@ -338,7 +341,7 @@ export class PetService {
 
         let requestOptions: RequestOptionsArgs = new RequestOptions({
             method: RequestMethod.Get,
-            headers: headers,
+            headers,
             search: queryParameters,
             withCredentials:this.configuration.withCredentials
         });
@@ -354,6 +357,7 @@ export class PetService {
      * Finds Pets by tags
      * Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
      * @param tags Tags to filter by
+     
      */
     public findPetsByTagsWithHttpInfo(tags: Array<string>, extraHttpRequestParams?: RequestOptionsArgs): Observable<Response> {
         if (tags === null || tags === undefined) {
@@ -391,7 +395,7 @@ export class PetService {
 
         let requestOptions: RequestOptionsArgs = new RequestOptions({
             method: RequestMethod.Get,
-            headers: headers,
+            headers,
             search: queryParameters,
             withCredentials:this.configuration.withCredentials
         });
@@ -407,6 +411,7 @@ export class PetService {
      * Find pet by ID
      * Returns a single pet
      * @param petId ID of pet to return
+     
      */
     public getPetByIdWithHttpInfo(petId: number, extraHttpRequestParams?: RequestOptionsArgs): Observable<Response> {
         if (petId === null || petId === undefined) {
@@ -436,7 +441,7 @@ export class PetService {
 
         let requestOptions: RequestOptionsArgs = new RequestOptions({
             method: RequestMethod.Get,
-            headers: headers,
+            headers,
             withCredentials:this.configuration.withCredentials
         });
         // https://github.com/swagger-api/swagger-codegen/issues/4037
@@ -451,6 +456,7 @@ export class PetService {
      * Update an existing pet
      * 
      * @param body Pet object that needs to be added to the store
+     
      */
     public updatePetWithHttpInfo(body: Pet, extraHttpRequestParams?: RequestOptionsArgs): Observable<Response> {
         if (body === null || body === undefined) {
@@ -489,7 +495,7 @@ export class PetService {
 
         let requestOptions: RequestOptionsArgs = new RequestOptions({
             method: RequestMethod.Put,
-            headers: headers,
+            headers,
             body: body == null ? '' : JSON.stringify(body), // https://github.com/angular/angular/issues/10612
             withCredentials:this.configuration.withCredentials
         });
@@ -507,6 +513,7 @@ export class PetService {
      * @param petId ID of pet that needs to be updated
      * @param name Updated name of the pet
      * @param status Updated status of the pet
+     
      */
     public updatePetWithFormWithHttpInfo(petId: number, name?: string, status?: string, extraHttpRequestParams?: RequestOptionsArgs): Observable<Response> {
         if (petId === null || petId === undefined) {
@@ -562,7 +569,7 @@ export class PetService {
 
         let requestOptions: RequestOptionsArgs = new RequestOptions({
             method: RequestMethod.Post,
-            headers: headers,
+            headers,
             body: convertFormParamsToString ? formParams.toString() : formParams,
             withCredentials:this.configuration.withCredentials
         });
@@ -580,6 +587,7 @@ export class PetService {
      * @param petId ID of pet to update
      * @param additionalMetadata Additional data to pass to server
      * @param file file to upload
+     
      */
     public uploadFileWithHttpInfo(petId: number, additionalMetadata?: string, file?: Blob, extraHttpRequestParams?: RequestOptionsArgs): Observable<Response> {
         if (petId === null || petId === undefined) {
@@ -637,7 +645,7 @@ export class PetService {
 
         let requestOptions: RequestOptionsArgs = new RequestOptions({
             method: RequestMethod.Post,
-            headers: headers,
+            headers,
             body: convertFormParamsToString ? formParams.toString() : formParams,
             withCredentials:this.configuration.withCredentials
         });

--- a/samples/client/petstore/typescript-angular-v4/npm/api/store.service.ts
+++ b/samples/client/petstore/typescript-angular-v4/npm/api/store.service.ts
@@ -15,6 +15,7 @@ import { Inject, Injectable, Optional }                      from '@angular/core
 import { Http, Headers, URLSearchParams }                    from '@angular/http';
 import { RequestMethod, RequestOptions, RequestOptionsArgs } from '@angular/http';
 import { Response, ResponseContentType }                     from '@angular/http';
+import { CustomQueryEncoderHelper }                          from '../encoder';
 
 import { Observable }                                        from 'rxjs/Observable';
 import '../rxjs-operators';
@@ -23,7 +24,6 @@ import { Order } from '../model/order';
 
 import { BASE_PATH, COLLECTION_FORMATS }                     from '../variables';
 import { Configuration }                                     from '../configuration';
-import { CustomQueryEncoderHelper }                          from '../encoder';
 
 
 @Injectable()
@@ -125,6 +125,7 @@ export class StoreService {
      * Delete purchase order by ID
      * For valid response try integer IDs with value &lt; 1000. Anything above 1000 or nonintegers will generate API errors
      * @param orderId ID of the order that needs to be deleted
+     
      */
     public deleteOrderWithHttpInfo(orderId: string, extraHttpRequestParams?: RequestOptionsArgs): Observable<Response> {
         if (orderId === null || orderId === undefined) {
@@ -149,7 +150,7 @@ export class StoreService {
 
         let requestOptions: RequestOptionsArgs = new RequestOptions({
             method: RequestMethod.Delete,
-            headers: headers,
+            headers,
             withCredentials:this.configuration.withCredentials
         });
         // https://github.com/swagger-api/swagger-codegen/issues/4037
@@ -163,6 +164,7 @@ export class StoreService {
     /**
      * Returns pet inventories by status
      * Returns a map of status codes to quantities
+     
      */
     public getInventoryWithHttpInfo(extraHttpRequestParams?: RequestOptionsArgs): Observable<Response> {
 
@@ -188,7 +190,7 @@ export class StoreService {
 
         let requestOptions: RequestOptionsArgs = new RequestOptions({
             method: RequestMethod.Get,
-            headers: headers,
+            headers,
             withCredentials:this.configuration.withCredentials
         });
         // https://github.com/swagger-api/swagger-codegen/issues/4037
@@ -203,6 +205,7 @@ export class StoreService {
      * Find purchase order by ID
      * For valid response try integer IDs with value &lt;&#x3D; 5 or &gt; 10. Other values will generated exceptions
      * @param orderId ID of pet that needs to be fetched
+     
      */
     public getOrderByIdWithHttpInfo(orderId: number, extraHttpRequestParams?: RequestOptionsArgs): Observable<Response> {
         if (orderId === null || orderId === undefined) {
@@ -227,7 +230,7 @@ export class StoreService {
 
         let requestOptions: RequestOptionsArgs = new RequestOptions({
             method: RequestMethod.Get,
-            headers: headers,
+            headers,
             withCredentials:this.configuration.withCredentials
         });
         // https://github.com/swagger-api/swagger-codegen/issues/4037
@@ -242,6 +245,7 @@ export class StoreService {
      * Place an order for a pet
      * 
      * @param body order placed for purchasing the pet
+     
      */
     public placeOrderWithHttpInfo(body: Order, extraHttpRequestParams?: RequestOptionsArgs): Observable<Response> {
         if (body === null || body === undefined) {
@@ -270,7 +274,7 @@ export class StoreService {
 
         let requestOptions: RequestOptionsArgs = new RequestOptions({
             method: RequestMethod.Post,
-            headers: headers,
+            headers,
             body: body == null ? '' : JSON.stringify(body), // https://github.com/angular/angular/issues/10612
             withCredentials:this.configuration.withCredentials
         });

--- a/samples/client/petstore/typescript-angular-v4/npm/api/store.service.ts
+++ b/samples/client/petstore/typescript-angular-v4/npm/api/store.service.ts
@@ -150,7 +150,7 @@ export class StoreService {
 
         let requestOptions: RequestOptionsArgs = new RequestOptions({
             method: RequestMethod.Delete,
-            headers,
+            headers: headers,
             withCredentials:this.configuration.withCredentials
         });
         // https://github.com/swagger-api/swagger-codegen/issues/4037
@@ -190,7 +190,7 @@ export class StoreService {
 
         let requestOptions: RequestOptionsArgs = new RequestOptions({
             method: RequestMethod.Get,
-            headers,
+            headers: headers,
             withCredentials:this.configuration.withCredentials
         });
         // https://github.com/swagger-api/swagger-codegen/issues/4037
@@ -230,7 +230,7 @@ export class StoreService {
 
         let requestOptions: RequestOptionsArgs = new RequestOptions({
             method: RequestMethod.Get,
-            headers,
+            headers: headers,
             withCredentials:this.configuration.withCredentials
         });
         // https://github.com/swagger-api/swagger-codegen/issues/4037
@@ -274,7 +274,7 @@ export class StoreService {
 
         let requestOptions: RequestOptionsArgs = new RequestOptions({
             method: RequestMethod.Post,
-            headers,
+            headers: headers,
             body: body == null ? '' : JSON.stringify(body), // https://github.com/angular/angular/issues/10612
             withCredentials:this.configuration.withCredentials
         });

--- a/samples/client/petstore/typescript-angular-v4/npm/api/user.service.ts
+++ b/samples/client/petstore/typescript-angular-v4/npm/api/user.service.ts
@@ -15,6 +15,7 @@ import { Inject, Injectable, Optional }                      from '@angular/core
 import { Http, Headers, URLSearchParams }                    from '@angular/http';
 import { RequestMethod, RequestOptions, RequestOptionsArgs } from '@angular/http';
 import { Response, ResponseContentType }                     from '@angular/http';
+import { CustomQueryEncoderHelper }                          from '../encoder';
 
 import { Observable }                                        from 'rxjs/Observable';
 import '../rxjs-operators';
@@ -23,7 +24,6 @@ import { User } from '../model/user';
 
 import { BASE_PATH, COLLECTION_FORMATS }                     from '../variables';
 import { Configuration }                                     from '../configuration';
-import { CustomQueryEncoderHelper }                          from '../encoder';
 
 
 @Injectable()
@@ -191,6 +191,7 @@ export class UserService {
      * Create user
      * This can only be done by the logged in user.
      * @param body Created user object
+     
      */
     public createUserWithHttpInfo(body: User, extraHttpRequestParams?: RequestOptionsArgs): Observable<Response> {
         if (body === null || body === undefined) {
@@ -219,7 +220,7 @@ export class UserService {
 
         let requestOptions: RequestOptionsArgs = new RequestOptions({
             method: RequestMethod.Post,
-            headers: headers,
+            headers,
             body: body == null ? '' : JSON.stringify(body), // https://github.com/angular/angular/issues/10612
             withCredentials:this.configuration.withCredentials
         });
@@ -235,6 +236,7 @@ export class UserService {
      * Creates list of users with given input array
      * 
      * @param body List of user object
+     
      */
     public createUsersWithArrayInputWithHttpInfo(body: Array<User>, extraHttpRequestParams?: RequestOptionsArgs): Observable<Response> {
         if (body === null || body === undefined) {
@@ -263,7 +265,7 @@ export class UserService {
 
         let requestOptions: RequestOptionsArgs = new RequestOptions({
             method: RequestMethod.Post,
-            headers: headers,
+            headers,
             body: body == null ? '' : JSON.stringify(body), // https://github.com/angular/angular/issues/10612
             withCredentials:this.configuration.withCredentials
         });
@@ -279,6 +281,7 @@ export class UserService {
      * Creates list of users with given input array
      * 
      * @param body List of user object
+     
      */
     public createUsersWithListInputWithHttpInfo(body: Array<User>, extraHttpRequestParams?: RequestOptionsArgs): Observable<Response> {
         if (body === null || body === undefined) {
@@ -307,7 +310,7 @@ export class UserService {
 
         let requestOptions: RequestOptionsArgs = new RequestOptions({
             method: RequestMethod.Post,
-            headers: headers,
+            headers,
             body: body == null ? '' : JSON.stringify(body), // https://github.com/angular/angular/issues/10612
             withCredentials:this.configuration.withCredentials
         });
@@ -323,6 +326,7 @@ export class UserService {
      * Delete user
      * This can only be done by the logged in user.
      * @param username The name that needs to be deleted
+     
      */
     public deleteUserWithHttpInfo(username: string, extraHttpRequestParams?: RequestOptionsArgs): Observable<Response> {
         if (username === null || username === undefined) {
@@ -347,7 +351,7 @@ export class UserService {
 
         let requestOptions: RequestOptionsArgs = new RequestOptions({
             method: RequestMethod.Delete,
-            headers: headers,
+            headers,
             withCredentials:this.configuration.withCredentials
         });
         // https://github.com/swagger-api/swagger-codegen/issues/4037
@@ -362,6 +366,7 @@ export class UserService {
      * Get user by user name
      * 
      * @param username The name that needs to be fetched. Use user1 for testing. 
+     
      */
     public getUserByNameWithHttpInfo(username: string, extraHttpRequestParams?: RequestOptionsArgs): Observable<Response> {
         if (username === null || username === undefined) {
@@ -386,7 +391,7 @@ export class UserService {
 
         let requestOptions: RequestOptionsArgs = new RequestOptions({
             method: RequestMethod.Get,
-            headers: headers,
+            headers,
             withCredentials:this.configuration.withCredentials
         });
         // https://github.com/swagger-api/swagger-codegen/issues/4037
@@ -402,6 +407,7 @@ export class UserService {
      * 
      * @param username The user name for login
      * @param password The password for login in clear text
+     
      */
     public loginUserWithHttpInfo(username: string, password: string, extraHttpRequestParams?: RequestOptionsArgs): Observable<Response> {
         if (username === null || username === undefined) {
@@ -437,7 +443,7 @@ export class UserService {
 
         let requestOptions: RequestOptionsArgs = new RequestOptions({
             method: RequestMethod.Get,
-            headers: headers,
+            headers,
             search: queryParameters,
             withCredentials:this.configuration.withCredentials
         });
@@ -452,6 +458,7 @@ export class UserService {
     /**
      * Logs out current logged in user session
      * 
+     
      */
     public logoutUserWithHttpInfo(extraHttpRequestParams?: RequestOptionsArgs): Observable<Response> {
 
@@ -473,7 +480,7 @@ export class UserService {
 
         let requestOptions: RequestOptionsArgs = new RequestOptions({
             method: RequestMethod.Get,
-            headers: headers,
+            headers,
             withCredentials:this.configuration.withCredentials
         });
         // https://github.com/swagger-api/swagger-codegen/issues/4037
@@ -489,6 +496,7 @@ export class UserService {
      * This can only be done by the logged in user.
      * @param username name that need to be deleted
      * @param body Updated user object
+     
      */
     public updateUserWithHttpInfo(username: string, body: User, extraHttpRequestParams?: RequestOptionsArgs): Observable<Response> {
         if (username === null || username === undefined) {
@@ -520,7 +528,7 @@ export class UserService {
 
         let requestOptions: RequestOptionsArgs = new RequestOptions({
             method: RequestMethod.Put,
-            headers: headers,
+            headers,
             body: body == null ? '' : JSON.stringify(body), // https://github.com/angular/angular/issues/10612
             withCredentials:this.configuration.withCredentials
         });

--- a/samples/client/petstore/typescript-angular-v4/npm/api/user.service.ts
+++ b/samples/client/petstore/typescript-angular-v4/npm/api/user.service.ts
@@ -220,7 +220,7 @@ export class UserService {
 
         let requestOptions: RequestOptionsArgs = new RequestOptions({
             method: RequestMethod.Post,
-            headers,
+            headers: headers,
             body: body == null ? '' : JSON.stringify(body), // https://github.com/angular/angular/issues/10612
             withCredentials:this.configuration.withCredentials
         });
@@ -265,7 +265,7 @@ export class UserService {
 
         let requestOptions: RequestOptionsArgs = new RequestOptions({
             method: RequestMethod.Post,
-            headers,
+            headers: headers,
             body: body == null ? '' : JSON.stringify(body), // https://github.com/angular/angular/issues/10612
             withCredentials:this.configuration.withCredentials
         });
@@ -310,7 +310,7 @@ export class UserService {
 
         let requestOptions: RequestOptionsArgs = new RequestOptions({
             method: RequestMethod.Post,
-            headers,
+            headers: headers,
             body: body == null ? '' : JSON.stringify(body), // https://github.com/angular/angular/issues/10612
             withCredentials:this.configuration.withCredentials
         });
@@ -351,7 +351,7 @@ export class UserService {
 
         let requestOptions: RequestOptionsArgs = new RequestOptions({
             method: RequestMethod.Delete,
-            headers,
+            headers: headers,
             withCredentials:this.configuration.withCredentials
         });
         // https://github.com/swagger-api/swagger-codegen/issues/4037
@@ -391,7 +391,7 @@ export class UserService {
 
         let requestOptions: RequestOptionsArgs = new RequestOptions({
             method: RequestMethod.Get,
-            headers,
+            headers: headers,
             withCredentials:this.configuration.withCredentials
         });
         // https://github.com/swagger-api/swagger-codegen/issues/4037
@@ -443,7 +443,7 @@ export class UserService {
 
         let requestOptions: RequestOptionsArgs = new RequestOptions({
             method: RequestMethod.Get,
-            headers,
+            headers: headers,
             search: queryParameters,
             withCredentials:this.configuration.withCredentials
         });
@@ -480,7 +480,7 @@ export class UserService {
 
         let requestOptions: RequestOptionsArgs = new RequestOptions({
             method: RequestMethod.Get,
-            headers,
+            headers: headers,
             withCredentials:this.configuration.withCredentials
         });
         // https://github.com/swagger-api/swagger-codegen/issues/4037
@@ -528,7 +528,7 @@ export class UserService {
 
         let requestOptions: RequestOptionsArgs = new RequestOptions({
             method: RequestMethod.Put,
-            headers,
+            headers: headers,
             body: body == null ? '' : JSON.stringify(body), // https://github.com/angular/angular/issues/10612
             withCredentials:this.configuration.withCredentials
         });

--- a/samples/client/petstore/typescript-angular-v4/npm/git_push.sh
+++ b/samples/client/petstore/typescript-angular-v4/npm/git_push.sh
@@ -36,7 +36,7 @@ git_remote=`git remote`
 if [ "$git_remote" = "" ]; then # git remote not defined
 
     if [ "$GIT_TOKEN" = "" ]; then
-        echo "[INFO] \$GIT_TOKEN (environment variable) is not set. Using the git crediential in your environment."
+        echo "[INFO] \$GIT_TOKEN (environment variable) is not set. Using the git credential in your environment."
         git remote add origin https://github.com/${git_user_id}/${git_repo_id}.git
     else
         git remote add origin https://${git_user_id}:${GIT_TOKEN}@github.com/${git_user_id}/${git_repo_id}.git


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [x] Filed the PR against the correct branch: `3.0.0` branch for changes related to OpenAPI spec 3.0. Default: `master`.
- [x] Copied the [technical committee](https://github.com/swagger-api/swagger-codegen/#swagger-codegen-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

Fixes #6902 with some added bonuses
@bedag-moo @HermenOtter Gonna need you 2 to test this as i'm not currently running angular ^4.3 Will be upgrading to 5 very soon though.

Note: For overloads to work with proper intellisense the first overload must always be for 'body'.  if any changes are made to the overload that rearranges them intellisense will break and confuse consumers

### Techies!
@TiFu @taxpon  @sebastianhaas  @Vrolijkx 

