### PR TITLE
[CppRest] Support optional parameters

### DIFF
--- a/modules/swagger-codegen/src/main/resources/cpprest/api-header.mustache
+++ b/modules/swagger-codegen/src/main/resources/cpprest/api-header.mustache
@@ -14,6 +14,8 @@
 {{#imports}}{{{import}}}
 {{/imports}}
 
+#include <boost/optional.hpp>
+
 {{#apiNamespaceDeclarations}}
 namespace {{this}} {
 {{/apiNamespaceDeclarations}}
@@ -32,8 +34,14 @@ public:
     /// <remarks>
     /// {{notes}}
     /// </remarks>
-    {{#allParams}}/// <param name="{{paramName}}">{{description}}{{^required}} (optional{{#defaultValue}}, default to {{.}}{{/defaultValue}}){{/required}}</param>{{/allParams}}
-    pplx::task<{{#returnType}}{{{returnType}}}{{/returnType}}{{^returnType}}void{{/returnType}}> {{operationId}}({{#allParams}}{{{dataType}}} {{paramName}}{{^required}}{{/required}}{{#hasMore}}, {{/hasMore}}{{/allParams}});
+    {{#allParams}}
+    /// <param name="{{paramName}}">{{description}}{{^required}} (optional{{#defaultValue}}, default to {{.}}{{/defaultValue}}){{/required}}</param>
+    {{/allParams}}
+    pplx::task<{{#returnType}}{{{returnType}}}{{/returnType}}{{^returnType}}void{{/returnType}}> {{operationId}}(
+        {{#allParams}}
+        {{^required}}boost::optional<{{/required}}{{{dataType}}}{{^required}}>{{/required}} {{paramName}}{{#hasMore}},{{/hasMore}}
+        {{/allParams}}
+    );
     {{/operation}}
 
 protected:

--- a/modules/swagger-codegen/src/main/resources/cpprest/api-source.mustache
+++ b/modules/swagger-codegen/src/main/resources/cpprest/api-source.mustache
@@ -26,7 +26,7 @@ using namespace {{modelNamespace}};
 }
 
 {{#operation}}
-pplx::task<{{#returnType}}{{{returnType}}}{{/returnType}}{{^returnType}}void{{/returnType}}> {{classname}}::{{operationId}}({{#allParams}}{{{dataType}}} {{paramName}}{{^required}}{{/required}}{{#hasMore}}, {{/hasMore}}{{/allParams}})
+pplx::task<{{#returnType}}{{{returnType}}}{{/returnType}}{{^returnType}}void{{/returnType}}> {{classname}}::{{operationId}}({{#allParams}}{{^required}}boost::optional<{{/required}}{{{dataType}}}{{^required}}>{{/required}} {{paramName}}{{#hasMore}}, {{/hasMore}}{{/allParams}})
 {
 {{#allParams}}{{#required}}{{^isPrimitiveType}}{{^isContainer}}
     // verify the required parameter '{{paramName}}' is set
@@ -104,34 +104,53 @@ pplx::task<{{#returnType}}{{{returnType}}}{{/returnType}}{{^returnType}}void{{/r
     {{#allParams}}
     {{^isBodyParam}}
     {{^isPathParam}}
-    {{^isPrimitiveType}}{{^isContainer}}if ({{paramName}} != nullptr){{/isContainer}}{{/isPrimitiveType}}
+    {{#required}}
+        {{^isPrimitiveType}}
+        {{^isContainer}}
+    if ({{paramName}} != nullptr)
+        {{/isContainer}}
+        {{/isPrimitiveType}}
+    {{/required}}
+    {{^required}}
+        {{^isPrimitiveType}}
+        {{^isContainer}}
+    if ({{paramName}} && *{{paramName}} != nullptr)
+        {{/isContainer}}
+        {{/isPrimitiveType}}
+        {{#isPrimitiveType}}
+    if ({{paramName}})
+        {{/isPrimitiveType}}
+        {{#isContainer}}
+    if ({{paramName}})
+        {{/isContainer}}
+    {{/required}}
     {
         {{#isContainer}}
         {{#isQueryParam}}
-        queryParams[utility::conversions::to_string_t("{{baseName}}")] = ApiClient::parameterToArrayString<{{items.datatype}}>({{paramName}});
+        queryParams[utility::conversions::to_string_t("{{baseName}}")] = ApiClient::parameterToArrayString<{{items.datatype}}>({{^required}}*{{/required}}{{paramName}});
         {{/isQueryParam}}
         {{#isHeaderParam}}
-        headerParams[utility::conversions::to_string_t("{{baseName}}")] = ApiClient::parameterToArrayString<{{items.datatype}}>({{paramName}});
+        headerParams[utility::conversions::to_string_t("{{baseName}}")] = ApiClient::parameterToArrayString<{{items.datatype}}>({{^required}}*{{/required}}{{paramName}});
         {{/isHeaderParam}}
         {{#isFormParam}}
         {{^isFile}}
-        formParams[ utility::conversions::to_string_t("{{baseName}}") ] = ApiClient::parameterToArrayString<{{items.datatype}}>({{paramName}});
+        formParams[ utility::conversions::to_string_t("{{baseName}}") ] = ApiClient::parameterToArrayString<{{items.datatype}}>({{^required}}*{{/required}}{{paramName}});
         {{/isFile}}
         {{/isFormParam}}
         {{/isContainer}}
         {{^isContainer}}
         {{#isQueryParam}}
-        queryParams[utility::conversions::to_string_t("{{baseName}}")] = ApiClient::parameterToString({{paramName}});
+        queryParams[utility::conversions::to_string_t("{{baseName}}")] = ApiClient::parameterToString({{^required}}*{{/required}}{{paramName}});
         {{/isQueryParam}}
         {{#isHeaderParam}}
-        headerParams[utility::conversions::to_string_t("{{baseName}}")] = ApiClient::parameterToString({{paramName}});
+        headerParams[utility::conversions::to_string_t("{{baseName}}")] = ApiClient::parameterToString({{^required}}*{{/required}}{{paramName}});
         {{/isHeaderParam}}
         {{#isFormParam}}
         {{#isFile}}
-        fileParams[ utility::conversions::to_string_t("{{baseName}}") ] = {{paramName}};
+        fileParams[ utility::conversions::to_string_t("{{baseName}}") ] = {{^required}}*{{/required}}{{paramName}};
         {{/isFile}}
         {{^isFile}}
-        formParams[ utility::conversions::to_string_t("{{baseName}}") ] = ApiClient::parameterToString({{paramName}});
+        formParams[ utility::conversions::to_string_t("{{baseName}}") ] = ApiClient::parameterToString({{^required}}*{{/required}}{{paramName}});
         {{/isFile}}
         {{/isFormParam}}
         {{/isContainer}}

--- a/samples/client/petstore/cpprest/api/PetApi.cpp
+++ b/samples/client/petstore/cpprest/api/PetApi.cpp
@@ -155,7 +155,7 @@ pplx::task<void> PetApi::addPet(std::shared_ptr<Pet> body)
         return void();
     });
 }
-pplx::task<void> PetApi::deletePet(int64_t petId, utility::string_t apiKey)
+pplx::task<void> PetApi::deletePet(int64_t petId, boost::optional<utility::string_t> apiKey)
 {
 
 
@@ -198,9 +198,9 @@ pplx::task<void> PetApi::deletePet(int64_t petId, utility::string_t apiKey)
 
     std::unordered_set<utility::string_t> consumeHttpContentTypes;
 
-    
+    if (apiKey)
     {
-        headerParams[utility::conversions::to_string_t("api_key")] = ApiClient::parameterToString(apiKey);
+        headerParams[utility::conversions::to_string_t("api_key")] = ApiClient::parameterToString(*apiKey);
     }
 
     std::shared_ptr<IHttpBody> httpBody;
@@ -300,7 +300,6 @@ pplx::task<std::vector<std::shared_ptr<Pet>>> PetApi::findPetsByStatus(std::vect
 
     std::unordered_set<utility::string_t> consumeHttpContentTypes;
 
-    
     {
         queryParams[utility::conversions::to_string_t("status")] = ApiClient::parameterToArrayString<utility::string_t>(status);
     }
@@ -427,7 +426,6 @@ pplx::task<std::vector<std::shared_ptr<Pet>>> PetApi::findPetsByTags(std::vector
 
     std::unordered_set<utility::string_t> consumeHttpContentTypes;
 
-    
     {
         queryParams[utility::conversions::to_string_t("tags")] = ApiClient::parameterToArrayString<utility::string_t>(tags);
     }
@@ -754,7 +752,7 @@ pplx::task<void> PetApi::updatePet(std::shared_ptr<Pet> body)
         return void();
     });
 }
-pplx::task<void> PetApi::updatePetWithForm(int64_t petId, utility::string_t name, utility::string_t status)
+pplx::task<void> PetApi::updatePetWithForm(int64_t petId, boost::optional<utility::string_t> name, boost::optional<utility::string_t> status)
 {
 
 
@@ -798,13 +796,13 @@ pplx::task<void> PetApi::updatePetWithForm(int64_t petId, utility::string_t name
     std::unordered_set<utility::string_t> consumeHttpContentTypes;
     consumeHttpContentTypes.insert( utility::conversions::to_string_t("application/x-www-form-urlencoded") );
 
-    
+    if (name)
     {
-        formParams[ utility::conversions::to_string_t("name") ] = ApiClient::parameterToString(name);
+        formParams[ utility::conversions::to_string_t("name") ] = ApiClient::parameterToString(*name);
     }
-    
+    if (status)
     {
-        formParams[ utility::conversions::to_string_t("status") ] = ApiClient::parameterToString(status);
+        formParams[ utility::conversions::to_string_t("status") ] = ApiClient::parameterToString(*status);
     }
 
     std::shared_ptr<IHttpBody> httpBody;
@@ -862,7 +860,7 @@ pplx::task<void> PetApi::updatePetWithForm(int64_t petId, utility::string_t name
         return void();
     });
 }
-pplx::task<std::shared_ptr<ApiResponse>> PetApi::uploadFile(int64_t petId, utility::string_t additionalMetadata, std::shared_ptr<HttpContent> file)
+pplx::task<std::shared_ptr<ApiResponse>> PetApi::uploadFile(int64_t petId, boost::optional<utility::string_t> additionalMetadata, boost::optional<std::shared_ptr<HttpContent>> file)
 {
 
 
@@ -905,13 +903,13 @@ pplx::task<std::shared_ptr<ApiResponse>> PetApi::uploadFile(int64_t petId, utili
     std::unordered_set<utility::string_t> consumeHttpContentTypes;
     consumeHttpContentTypes.insert( utility::conversions::to_string_t("multipart/form-data") );
 
-    
+    if (additionalMetadata)
     {
-        formParams[ utility::conversions::to_string_t("additionalMetadata") ] = ApiClient::parameterToString(additionalMetadata);
+        formParams[ utility::conversions::to_string_t("additionalMetadata") ] = ApiClient::parameterToString(*additionalMetadata);
     }
-    if (file != nullptr)
+    if (file && *file != nullptr)
     {
-        fileParams[ utility::conversions::to_string_t("file") ] = file;
+        fileParams[ utility::conversions::to_string_t("file") ] = *file;
     }
 
     std::shared_ptr<IHttpBody> httpBody;

--- a/samples/client/petstore/cpprest/api/PetApi.h
+++ b/samples/client/petstore/cpprest/api/PetApi.h
@@ -27,6 +27,8 @@
 #include "Pet.h"
 #include <cpprest/details/basic_types.h>
 
+#include <boost/optional.hpp>
+
 namespace io {
 namespace swagger {
 namespace client {
@@ -46,15 +48,21 @@ public:
     /// 
     /// </remarks>
     /// <param name="body">Pet object that needs to be added to the store</param>
-    pplx::task<void> addPet(std::shared_ptr<Pet> body);
+    pplx::task<void> addPet(
+        std::shared_ptr<Pet> body
+    );
     /// <summary>
     /// Deletes a pet
     /// </summary>
     /// <remarks>
     /// 
     /// </remarks>
-    /// <param name="petId">Pet id to delete</param>/// <param name="apiKey"> (optional)</param>
-    pplx::task<void> deletePet(int64_t petId, utility::string_t apiKey);
+    /// <param name="petId">Pet id to delete</param>
+    /// <param name="apiKey"> (optional)</param>
+    pplx::task<void> deletePet(
+        int64_t petId,
+        boost::optional<utility::string_t> apiKey
+    );
     /// <summary>
     /// Finds Pets by status
     /// </summary>
@@ -62,7 +70,9 @@ public:
     /// Multiple status values can be provided with comma separated strings
     /// </remarks>
     /// <param name="status">Status values that need to be considered for filter</param>
-    pplx::task<std::vector<std::shared_ptr<Pet>>> findPetsByStatus(std::vector<utility::string_t> status);
+    pplx::task<std::vector<std::shared_ptr<Pet>>> findPetsByStatus(
+        std::vector<utility::string_t> status
+    );
     /// <summary>
     /// Finds Pets by tags
     /// </summary>
@@ -70,7 +80,9 @@ public:
     /// Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
     /// </remarks>
     /// <param name="tags">Tags to filter by</param>
-    pplx::task<std::vector<std::shared_ptr<Pet>>> findPetsByTags(std::vector<utility::string_t> tags);
+    pplx::task<std::vector<std::shared_ptr<Pet>>> findPetsByTags(
+        std::vector<utility::string_t> tags
+    );
     /// <summary>
     /// Find pet by ID
     /// </summary>
@@ -78,7 +90,9 @@ public:
     /// Returns a single pet
     /// </remarks>
     /// <param name="petId">ID of pet to return</param>
-    pplx::task<std::shared_ptr<Pet>> getPetById(int64_t petId);
+    pplx::task<std::shared_ptr<Pet>> getPetById(
+        int64_t petId
+    );
     /// <summary>
     /// Update an existing pet
     /// </summary>
@@ -86,23 +100,37 @@ public:
     /// 
     /// </remarks>
     /// <param name="body">Pet object that needs to be added to the store</param>
-    pplx::task<void> updatePet(std::shared_ptr<Pet> body);
+    pplx::task<void> updatePet(
+        std::shared_ptr<Pet> body
+    );
     /// <summary>
     /// Updates a pet in the store with form data
     /// </summary>
     /// <remarks>
     /// 
     /// </remarks>
-    /// <param name="petId">ID of pet that needs to be updated</param>/// <param name="name">Updated name of the pet (optional)</param>/// <param name="status">Updated status of the pet (optional)</param>
-    pplx::task<void> updatePetWithForm(int64_t petId, utility::string_t name, utility::string_t status);
+    /// <param name="petId">ID of pet that needs to be updated</param>
+    /// <param name="name">Updated name of the pet (optional)</param>
+    /// <param name="status">Updated status of the pet (optional)</param>
+    pplx::task<void> updatePetWithForm(
+        int64_t petId,
+        boost::optional<utility::string_t> name,
+        boost::optional<utility::string_t> status
+    );
     /// <summary>
     /// uploads an image
     /// </summary>
     /// <remarks>
     /// 
     /// </remarks>
-    /// <param name="petId">ID of pet to update</param>/// <param name="additionalMetadata">Additional data to pass to server (optional)</param>/// <param name="file">file to upload (optional)</param>
-    pplx::task<std::shared_ptr<ApiResponse>> uploadFile(int64_t petId, utility::string_t additionalMetadata, std::shared_ptr<HttpContent> file);
+    /// <param name="petId">ID of pet to update</param>
+    /// <param name="additionalMetadata">Additional data to pass to server (optional)</param>
+    /// <param name="file">file to upload (optional)</param>
+    pplx::task<std::shared_ptr<ApiResponse>> uploadFile(
+        int64_t petId,
+        boost::optional<utility::string_t> additionalMetadata,
+        boost::optional<std::shared_ptr<HttpContent>> file
+    );
 
 protected:
     std::shared_ptr<ApiClient> m_ApiClient;

--- a/samples/client/petstore/cpprest/api/StoreApi.h
+++ b/samples/client/petstore/cpprest/api/StoreApi.h
@@ -26,6 +26,8 @@
 #include <map>
 #include <cpprest/details/basic_types.h>
 
+#include <boost/optional.hpp>
+
 namespace io {
 namespace swagger {
 namespace client {
@@ -45,15 +47,17 @@ public:
     /// For valid response try integer IDs with value &lt; 1000. Anything above 1000 or nonintegers will generate API errors
     /// </remarks>
     /// <param name="orderId">ID of the order that needs to be deleted</param>
-    pplx::task<void> deleteOrder(utility::string_t orderId);
+    pplx::task<void> deleteOrder(
+        utility::string_t orderId
+    );
     /// <summary>
     /// Returns pet inventories by status
     /// </summary>
     /// <remarks>
     /// Returns a map of status codes to quantities
     /// </remarks>
-    
-    pplx::task<std::map<utility::string_t, int32_t>> getInventory();
+    pplx::task<std::map<utility::string_t, int32_t>> getInventory(
+    );
     /// <summary>
     /// Find purchase order by ID
     /// </summary>
@@ -61,7 +65,9 @@ public:
     /// For valid response try integer IDs with value &lt;&#x3D; 5 or &gt; 10. Other values will generated exceptions
     /// </remarks>
     /// <param name="orderId">ID of pet that needs to be fetched</param>
-    pplx::task<std::shared_ptr<Order>> getOrderById(int64_t orderId);
+    pplx::task<std::shared_ptr<Order>> getOrderById(
+        int64_t orderId
+    );
     /// <summary>
     /// Place an order for a pet
     /// </summary>
@@ -69,7 +75,9 @@ public:
     /// 
     /// </remarks>
     /// <param name="body">order placed for purchasing the pet</param>
-    pplx::task<std::shared_ptr<Order>> placeOrder(std::shared_ptr<Order> body);
+    pplx::task<std::shared_ptr<Order>> placeOrder(
+        std::shared_ptr<Order> body
+    );
 
 protected:
     std::shared_ptr<ApiClient> m_ApiClient;

--- a/samples/client/petstore/cpprest/api/UserApi.cpp
+++ b/samples/client/petstore/cpprest/api/UserApi.cpp
@@ -654,11 +654,9 @@ pplx::task<utility::string_t> UserApi::loginUser(utility::string_t username, uti
 
     std::unordered_set<utility::string_t> consumeHttpContentTypes;
 
-    
     {
         queryParams[utility::conversions::to_string_t("username")] = ApiClient::parameterToString(username);
     }
-    
     {
         queryParams[utility::conversions::to_string_t("password")] = ApiClient::parameterToString(password);
     }

--- a/samples/client/petstore/cpprest/api/UserApi.h
+++ b/samples/client/petstore/cpprest/api/UserApi.h
@@ -26,6 +26,8 @@
 #include <vector>
 #include <cpprest/details/basic_types.h>
 
+#include <boost/optional.hpp>
+
 namespace io {
 namespace swagger {
 namespace client {
@@ -45,7 +47,9 @@ public:
     /// This can only be done by the logged in user.
     /// </remarks>
     /// <param name="body">Created user object</param>
-    pplx::task<void> createUser(std::shared_ptr<User> body);
+    pplx::task<void> createUser(
+        std::shared_ptr<User> body
+    );
     /// <summary>
     /// Creates list of users with given input array
     /// </summary>
@@ -53,7 +57,9 @@ public:
     /// 
     /// </remarks>
     /// <param name="body">List of user object</param>
-    pplx::task<void> createUsersWithArrayInput(std::vector<std::shared_ptr<User>> body);
+    pplx::task<void> createUsersWithArrayInput(
+        std::vector<std::shared_ptr<User>> body
+    );
     /// <summary>
     /// Creates list of users with given input array
     /// </summary>
@@ -61,7 +67,9 @@ public:
     /// 
     /// </remarks>
     /// <param name="body">List of user object</param>
-    pplx::task<void> createUsersWithListInput(std::vector<std::shared_ptr<User>> body);
+    pplx::task<void> createUsersWithListInput(
+        std::vector<std::shared_ptr<User>> body
+    );
     /// <summary>
     /// Delete user
     /// </summary>
@@ -69,7 +77,9 @@ public:
     /// This can only be done by the logged in user.
     /// </remarks>
     /// <param name="username">The name that needs to be deleted</param>
-    pplx::task<void> deleteUser(utility::string_t username);
+    pplx::task<void> deleteUser(
+        utility::string_t username
+    );
     /// <summary>
     /// Get user by user name
     /// </summary>
@@ -77,31 +87,41 @@ public:
     /// 
     /// </remarks>
     /// <param name="username">The name that needs to be fetched. Use user1 for testing. </param>
-    pplx::task<std::shared_ptr<User>> getUserByName(utility::string_t username);
+    pplx::task<std::shared_ptr<User>> getUserByName(
+        utility::string_t username
+    );
     /// <summary>
     /// Logs user into the system
     /// </summary>
     /// <remarks>
     /// 
     /// </remarks>
-    /// <param name="username">The user name for login</param>/// <param name="password">The password for login in clear text</param>
-    pplx::task<utility::string_t> loginUser(utility::string_t username, utility::string_t password);
+    /// <param name="username">The user name for login</param>
+    /// <param name="password">The password for login in clear text</param>
+    pplx::task<utility::string_t> loginUser(
+        utility::string_t username,
+        utility::string_t password
+    );
     /// <summary>
     /// Logs out current logged in user session
     /// </summary>
     /// <remarks>
     /// 
     /// </remarks>
-    
-    pplx::task<void> logoutUser();
+    pplx::task<void> logoutUser(
+    );
     /// <summary>
     /// Updated user
     /// </summary>
     /// <remarks>
     /// This can only be done by the logged in user.
     /// </remarks>
-    /// <param name="username">name that need to be deleted</param>/// <param name="body">Updated user object</param>
-    pplx::task<void> updateUser(utility::string_t username, std::shared_ptr<User> body);
+    /// <param name="username">name that need to be deleted</param>
+    /// <param name="body">Updated user object</param>
+    pplx::task<void> updateUser(
+        utility::string_t username,
+        std::shared_ptr<User> body
+    );
 
 protected:
     std::shared_ptr<ApiClient> m_ApiClient;


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [x] Filed the PR against the correct branch: `3.0.0` branch for changes related to OpenAPI spec 3.0. Default: `master`.
- [x] Copied the [technical committee](https://github.com/swagger-api/swagger-codegen/#swagger-codegen-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

This PR adds support for optional parameters (those marked as `required: false` in a swagger spec) using `boost::optional`.
Users of the client code can now pass `boost::none` to API calls for any optional parameters they are not interested in using.

Notes:
- `in: path` params are not covered because they cannot be optional (see [OpenAPI spec](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md#parameterObject)).
- `in: body` params are also not covered, as the implementation would be less trivial. The current behaviour for those params doesn't change, i.e. they are always required to make a call.
- This doesn't add any new linking dependencies as `boost::optional` is header-only, and `boost` itself is already required to compile the generated client code.