### PR TITLE
[Java/jersey2] Add readTimeout field

### DIFF
--- a/modules/swagger-codegen/src/main/resources/Java/libraries/jersey2/ApiClient.mustache
+++ b/modules/swagger-codegen/src/main/resources/Java/libraries/jersey2/ApiClient.mustache
@@ -61,6 +61,7 @@ public class ApiClient {
   protected String basePath = "{{{basePath}}}";
   protected boolean debugging = false;
   protected int connectionTimeout = 0;
+  private int readTimeout = 0;
 
   protected Client httpClient;
   protected JSON json;


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [x] Filed the PR against the correct branch: `3.0.0` branch for changes related to OpenAPI spec 3.0. Default: `master`.
- [x] Copied the [technical committee](https://github.com/swagger-api/swagger-codegen/#swagger-codegen-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

https://github.com/swagger-api/swagger-codegen/pull/6853 added a getter and setter for `readTimeout` in the ApiClient.mustache template for the jersey2 "sub-template". However, the `readTimeout` field does not exist in `ApiClient.java`, so the generated client cannot be compiled. This is a one-line change to add `readTimeout` to the template.

~The second commit (b04a360c5) is the result of `./bin/java-petstore-all.sh`, and contains many changes unrelated to the first commit.~ I backed out this change -- I'm pretty sure it's unrelated to the fix I'm trying to make, and deleting the google-api-client sample causes the CI tests to fail.

cc @bbdouglas @JFCote @sreeshas @jfiala @lukoyanov @cbornet @normana400 
