### PR TITLE
[python] fix tests, tornado ssl fix

### DIFF
--- a/modules/swagger-codegen/src/main/resources/python/tornado/rest.mustache
+++ b/modules/swagger-codegen/src/main/resources/python/tornado/rest.mustache
@@ -6,14 +6,7 @@ import io
 import json
 import logging
 import re
-
 import ssl
-try:
-    from ssl import create_default_context
-except ImportError:
-    # backward capability create_default_context is on Python 3.4+, 2.7.9+
-    def create_default_context():
-        return ssl.SSLContext(ssl.PROTOCOL_SSLv23)
 
 import certifi
 # python 2 and python 3 compatibility library
@@ -58,12 +51,20 @@ class RESTClientObject(object):
             # if not set certificate file, use Mozilla's root certificates.
             ca_certs = certifi.where()
 
-        self.ssl_context = create_default_context()
-        self.ssl_context.load_verify_locations(cafile=ca_certs)
-        if configuration.cert_file:
-            self.ssl_context.load_cert_chain(
-                configuration.cert_file, keyfile=configuration.key_file
-            )
+        if hasattr(ssl, 'create_default_context'):
+            # require Python 2.7.9+, 3.4+
+            self.ssl_context = ssl.create_default_context()
+            self.ssl_context.load_verify_locations(cafile=ca_certs)
+            if configuration.cert_file:
+                self.ssl_context.load_cert_chain(
+                    configuration.cert_file, keyfile=configuration.key_file
+                )
+
+        elif configuration.cert_file or configuration.ssl_ca_cert:
+            raise NotImplementedError('SSL requires Python 2.7.9+, 3.4+')
+
+        else:
+            self.ssl_context = None
 
         self.proxy_port = self.proxy_host = None
 

--- a/modules/swagger-codegen/src/main/resources/python/tornado/rest.mustache
+++ b/modules/swagger-codegen/src/main/resources/python/tornado/rest.mustache
@@ -6,7 +6,14 @@ import io
 import json
 import logging
 import re
+
 import ssl
+try:
+    from ssl import create_default_context
+except ImportError:
+    # backward capability create_default_context is on Python 3.4+, 2.7.9+
+    def create_default_context():
+        return ssl.SSLContext(ssl.PROTOCOL_SSLv23)
 
 import certifi
 # python 2 and python 3 compatibility library
@@ -51,7 +58,7 @@ class RESTClientObject(object):
             # if not set certificate file, use Mozilla's root certificates.
             ca_certs = certifi.where()
 
-        self.ssl_context = ssl.create_default_context(ssl.Purpose.CLIENT_AUTH)
+        self.ssl_context = create_default_context()
         self.ssl_context.load_verify_locations(cafile=ca_certs)
         if configuration.cert_file:
             self.ssl_context.load_cert_chain(

--- a/samples/client/petstore/python-tornado/Makefile
+++ b/samples/client/petstore/python-tornado/Makefile
@@ -14,8 +14,5 @@ clean:
 		find . -name "*.py[oc]" -delete
 		find . -name "__pycache__" -delete
 
-test: clean
-		bash ./test_python2.sh
-
 test-all: clean
 		bash ./test_python2_and_3.sh

--- a/samples/client/petstore/python-tornado/docs/FakeApi.md
+++ b/samples/client/petstore/python-tornado/docs/FakeApi.md
@@ -273,10 +273,10 @@ configuration.password = 'YOUR_PASSWORD'
 
 # create an instance of the API class
 api_instance = petstore_api.FakeApi(petstore_api.ApiClient(configuration))
-number = 8.14 # float | None
+number = 3.4 # float | None
 double = 1.2 # float | None
 pattern_without_delimiter = 'pattern_without_delimiter_example' # str | None
-byte = 'B' # str | None
+byte = 'byte_example' # str | None
 integer = 56 # int | None (optional)
 int32 = 56 # int | None (optional)
 int64 = 789 # int | None (optional)

--- a/samples/client/petstore/python-tornado/git_push.sh
+++ b/samples/client/petstore/python-tornado/git_push.sh
@@ -36,7 +36,7 @@ git_remote=`git remote`
 if [ "$git_remote" = "" ]; then # git remote not defined
 
     if [ "$GIT_TOKEN" = "" ]; then
-        echo "[INFO] \$GIT_TOKEN (environment variable) is not set. Using the git crediential in your environment."
+        echo "[INFO] \$GIT_TOKEN (environment variable) is not set. Using the git credential in your environment."
         git remote add origin https://github.com/${git_user_id}/${git_repo_id}.git
     else
         git remote add origin https://${git_user_id}:${GIT_TOKEN}@github.com/${git_user_id}/${git_repo_id}.git

--- a/samples/client/petstore/python-tornado/petstore_api/rest.py
+++ b/samples/client/petstore/python-tornado/petstore_api/rest.py
@@ -15,7 +15,14 @@ import io
 import json
 import logging
 import re
+
 import ssl
+try:
+    from ssl import create_default_context
+except ImportError:
+    # backward capability create_default_context is on Python 3.4+, 2.7.9+
+    def create_default_context():
+        return ssl.SSLContext(ssl.PROTOCOL_SSLv23)
 
 import certifi
 # python 2 and python 3 compatibility library
@@ -60,7 +67,7 @@ class RESTClientObject(object):
             # if not set certificate file, use Mozilla's root certificates.
             ca_certs = certifi.where()
 
-        self.ssl_context = ssl.create_default_context(ssl.Purpose.CLIENT_AUTH)
+        self.ssl_context = create_default_context()
         self.ssl_context.load_verify_locations(cafile=ca_certs)
         if configuration.cert_file:
             self.ssl_context.load_cert_chain(

--- a/samples/client/petstore/python-tornado/test_python2_and_3.sh
+++ b/samples/client/petstore/python-tornado/test_python2_and_3.sh
@@ -21,7 +21,7 @@ pip install -r $REQUIREMENTS_FILE | tee -a $REQUIREMENTS_OUT
 python setup.py develop
 
 ### run tests
-tox
+tox || exit 1
 
 ### static analysis of code
 flake8 --show-source petstore_api/

--- a/samples/client/petstore/python-tornado/tests/test_pet_api.py
+++ b/samples/client/petstore/python-tornado/tests/test_pet_api.py
@@ -4,6 +4,8 @@
 
 """
 Run the tests.
+$ docker pull swaggerapi/petstore
+$ docker run -d -e SWAGGER_HOST=http://petstore.swagger.io -e SWAGGER_BASE_PATH=/v2 -p 80:8080 swaggerapi/petstore
 $ pip install nose (optional)
 $ cd petstore_api-python
 $ nosetests -v
@@ -25,8 +27,7 @@ import json
 
 import urllib3
 
-HOST = 'http://petstore.swagger.io/v2'
-
+HOST = 'http://localhost/v2'
 
 class PetApiTests(AsyncTestCase):
 
@@ -152,7 +153,6 @@ class PetApiTests(AsyncTestCase):
         self.assertEqual(fetched.category.name, self.pet.category.name)
 
     @gen_test
-    @unittest.skip('skipping the test as the method sometimes invalid Petstore object with incorrect status')
     def test_find_pets_by_status(self):
         yield self.pet_api.add_pet(body=self.pet)
         pets = yield self.pet_api.find_pets_by_status(status=[self.pet.status])
@@ -162,7 +162,6 @@ class PetApiTests(AsyncTestCase):
         )
 
     @gen_test
-    @unittest.skip("skipping the test as the method sometimes invalid Petstore object with incorrect status")
     def test_find_pets_by_tags(self):
         yield self.pet_api.add_pet(body=self.pet)
         pets = yield self.pet_api.find_pets_by_tags(tags=[self.tag.name])

--- a/samples/client/petstore/python/docs/FakeApi.md
+++ b/samples/client/petstore/python/docs/FakeApi.md
@@ -273,10 +273,10 @@ configuration.password = 'YOUR_PASSWORD'
 
 # create an instance of the API class
 api_instance = petstore_api.FakeApi(petstore_api.ApiClient(configuration))
-number = 8.14 # float | None
+number = 3.4 # float | None
 double = 1.2 # float | None
 pattern_without_delimiter = 'pattern_without_delimiter_example' # str | None
-byte = 'B' # str | None
+byte = 'byte_example' # str | None
 integer = 56 # int | None (optional)
 int32 = 56 # int | None (optional)
 int64 = 789 # int | None (optional)

--- a/samples/client/petstore/python/git_push.sh
+++ b/samples/client/petstore/python/git_push.sh
@@ -36,7 +36,7 @@ git_remote=`git remote`
 if [ "$git_remote" = "" ]; then # git remote not defined
 
     if [ "$GIT_TOKEN" = "" ]; then
-        echo "[INFO] \$GIT_TOKEN (environment variable) is not set. Using the git crediential in your environment."
+        echo "[INFO] \$GIT_TOKEN (environment variable) is not set. Using the git credential in your environment."
         git remote add origin https://github.com/${git_user_id}/${git_repo_id}.git
     else
         git remote add origin https://${git_user_id}:${GIT_TOKEN}@github.com/${git_user_id}/${git_repo_id}.git

--- a/samples/client/petstore/python/test_python2.sh
+++ b/samples/client/petstore/python/test_python2.sh
@@ -21,7 +21,7 @@ pip install -r $REQUIREMENTS_FILE | tee -a $REQUIREMENTS_OUT
 python setup.py develop
 
 ### run tests
-nosetests
+nosetests || exit 1
 
 ### static analysis of code
 flake8 --show-source petstore_api/

--- a/samples/client/petstore/python/test_python2_and_3.sh
+++ b/samples/client/petstore/python/test_python2_and_3.sh
@@ -21,7 +21,7 @@ pip install -r $REQUIREMENTS_FILE | tee -a $REQUIREMENTS_OUT
 python setup.py develop
 
 ### run tests
-tox
+tox || exit 1
 
 ### static analysis of code
 flake8 --show-source petstore_api/

--- a/samples/client/petstore/python/tests/test_pet_api.py
+++ b/samples/client/petstore/python/tests/test_pet_api.py
@@ -4,6 +4,8 @@
 
 """
 Run the tests.
+$ docker pull swaggerapi/petstore
+$ docker run -d -e SWAGGER_HOST=http://petstore.swagger.io -e SWAGGER_BASE_PATH=/v2 -p 80:8080 swaggerapi/petstore
 $ pip install nose (optional)
 $ cd petstore_api-python
 $ nosetests -v
@@ -22,7 +24,7 @@ import json
 
 import urllib3
 
-HOST = 'http://petstore.swagger.io/v2'
+HOST = 'http://localhost/v2'
 
 
 class TimeoutWithEqual(urllib3.Timeout):
@@ -102,14 +104,14 @@ class PetApiTests(unittest.TestCase):
         mock_pool = MockPoolManager(self)
         self.api_client.rest_client.pool_manager = mock_pool
 
-        mock_pool.expect_request('POST', 'http://petstore.swagger.io/v2/pet',
+        mock_pool.expect_request('POST', 'http://localhost/v2/pet',
                                  body=json.dumps(self.api_client.sanitize_for_serialization(self.pet)),
                                  headers={'Content-Type': 'application/json',
                                           'Authorization': 'Bearer ',
                                           'Accept': 'application/json',
                                           'User-Agent': 'Swagger-Codegen/1.0.0/python'},
                                  preload_content=True, timeout=TimeoutWithEqual(total=5))
-        mock_pool.expect_request('POST', 'http://petstore.swagger.io/v2/pet',
+        mock_pool.expect_request('POST', 'http://localhost/v2/pet',
                                  body=json.dumps(self.api_client.sanitize_for_serialization(self.pet)),
                                  headers={'Content-Type': 'application/json',
                                           'Authorization': 'Bearer ',
@@ -220,7 +222,6 @@ class PetApiTests(unittest.TestCase):
             list(map(lambda x: getattr(x, 'id'), self.pet_api.find_pets_by_status(status=[self.pet.status])))
         )
 
-    @unittest.skip("skipping the test as the method sometimes invalid Petstore object with incorrect status")
     def test_find_pets_by_tags(self):
         self.pet_api.add_pet(body=self.pet)
 


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [x] Filed the PR against the correct branch: `3.0.0` branch for changes related to OpenAPI spec 3.0. Default: `master`.
- [x] Copied the [technical committee](https://github.com/swagger-api/swagger-codegen/#swagger-codegen-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

Fixes related to:

1. Travis doesn't know that tests fail because an exit codes from bash scripts are always zero - fixed
2. Tornado client doesn't work in python < 2.7.9 - fixed
3. Some tests are skipped because public PetStore endpoint has incorrect data. Travis use local instance of PetStore server and all test can run. I removed `@skip` and also force endpoint name to `localhost`. IMO it'll remind developers about starting a local instance. #6907 

Please take a look: @wing328 @taxpon @frol @mbohlool @cbornet @kenjones-cisco