### PR TITLE
Match rust integer type to minimum and maximum constraints

### DIFF
--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/RustServerCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/RustServerCodegen.java
@@ -1,13 +1,6 @@
 package io.swagger.codegen.languages;
 
-import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.JsonSerializer;
-import com.fasterxml.jackson.databind.SerializerProvider;
-import com.fasterxml.jackson.databind.module.SimpleModule;
-import com.google.common.collect.ArrayListMultimap;
-import com.google.common.collect.Lists;
-import com.google.common.collect.Multimap;
 import io.swagger.codegen.*;
 import io.swagger.models.*;
 import io.swagger.models.parameters.BodyParameter;
@@ -21,8 +14,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.File;
-import java.io.IOException;
-import java.math.BigDecimal;
 import java.util.*;
 import java.util.Map.Entry;
 import org.apache.commons.lang3.StringUtils;
@@ -32,6 +23,8 @@ public class RustServerCodegen extends DefaultCodegen implements CodegenConfig {
     private static final Logger LOGGER = LoggerFactory.getLogger(RustServerCodegen.class);
 
     private HashMap<String, String> modelXmlNames = new HashMap<String, String>();
+
+    private static final String NO_FORMAT = "%%NO_FORMAT";
 
     protected String apiVersion = "1.0.0";
     protected int serverPort = 8080;
@@ -869,12 +862,47 @@ public class RustServerCodegen extends DefaultCodegen implements CodegenConfig {
             }
         }
 
-        // Handle custom unsigned integer formats.
         if ("integer".equals(property.baseType)) {
+            // custom integer formats (legacy)
             if ("uint32".equals(property.dataFormat)) {
                 property.datatype = "u32";
             } else if ("uint64".equals(property.dataFormat)) {
                 property.datatype = "u64";
+
+            } else {
+                // match int type to schema constraints
+                Long inclusiveMinimum = property.minimum != null ? Long.parseLong(property.minimum): null;
+                if (inclusiveMinimum != null && property.exclusiveMinimum) {
+                    inclusiveMinimum++;
+                }
+
+                // a signed int is required unless a minimum greater than zero is set
+                boolean unsigned = inclusiveMinimum != null && inclusiveMinimum >= 0;
+
+                Long inclusiveMaximum = property.maximum != null ? Long.parseLong(property.maximum): null;
+                if (inclusiveMaximum != null && property.exclusiveMaximum) {
+                    inclusiveMaximum--;
+                }
+
+                switch (property.dataFormat == null ? NO_FORMAT : property.dataFormat) {
+                    // standard swagger formats
+                    case "int32":
+                        property.datatype = unsigned ? "u32" : "i32";
+                        break;
+
+                    case "int64":
+                        property.datatype = unsigned ? "u64" : "i64";
+                        break;
+
+                    case NO_FORMAT:
+                        property.datatype = matchingIntType(unsigned, inclusiveMinimum, inclusiveMaximum);
+                        break;
+
+                    default:
+                        // unknown format
+                        LOGGER.warn("The integer format '{}' is not recognized and will be ignored.", property.dataFormat);
+                        property.datatype = matchingIntType(unsigned, inclusiveMinimum, inclusiveMaximum);
+                }
             }
         }
 
@@ -883,6 +911,46 @@ public class RustServerCodegen extends DefaultCodegen implements CodegenConfig {
         if (!property.required) {
             property.defaultValue = (property.defaultValue != null) ? "Some(" + property.defaultValue + ")" : "None";
         }
+    }
+
+    static long requiredBits(Long bound, boolean unsigned) {
+        if (bound == null) return 0;
+
+        if (unsigned) {
+            if (bound < 0) {
+                throw new RuntimeException("Unsigned bound is negative: " + bound);
+            }
+            return 65 - Long.numberOfLeadingZeros(bound >> 1);
+        }
+
+        return 65 - Long.numberOfLeadingZeros(
+                // signed bounds go from (-n) to (n - 1), i.e. i8 goes from -128 to 127
+                bound < 0 ? Math.abs(bound) - 1 : bound);
+    }
+
+    static String matchingIntType(boolean unsigned, Long inclusiveMin, Long inclusiveMax) {
+        long requiredMinBits = requiredBits(inclusiveMin, unsigned);
+        long requiredMaxBits = requiredBits(inclusiveMax, unsigned);
+        long requiredBits = Math.max(requiredMinBits, requiredMaxBits);
+
+        if (requiredMaxBits == 0 && requiredMinBits <= 16) {
+            // rust 'size' types are arch-specific and thus somewhat loose
+            // so they are used when no format or maximum are specified
+            // and as long as minimum stays within plausible smallest ptr size (16 bits)
+            // this way all rust types are obtainable without defining custom formats
+            // this behavior (default int size) could also follow a generator flag
+            return unsigned ? "usize" : "isize";
+
+        } else if (requiredBits <= 8) {
+            return unsigned ? "u8" : "i8";
+
+        } else if (requiredBits <= 16) {
+            return unsigned ? "u16" : "i16";
+
+        } else if (requiredBits <= 32) {
+            return unsigned ? "u32" : "i32";
+        }
+        return unsigned ? "u64" : "i64";
     }
 
     @Override

--- a/modules/swagger-codegen/src/test/java/io/swagger/codegen/languages/RustServerCodegenTest.java
+++ b/modules/swagger-codegen/src/test/java/io/swagger/codegen/languages/RustServerCodegenTest.java
@@ -1,0 +1,48 @@
+package io.swagger.codegen.languages;
+
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+
+public class RustServerCodegenTest {
+
+    @Test
+    public void testRustIntSize() {
+        assertEquals(RustServerCodegen.matchingIntType(true, null, null), "usize");
+        assertEquals(RustServerCodegen.matchingIntType(true, 0L, null), "usize");
+        assertEquals(RustServerCodegen.matchingIntType(true, 0xFFL, null), "usize");
+        assertEquals(RustServerCodegen.matchingIntType(true, 0xFFFFL, null), "usize");
+        assertEquals(RustServerCodegen.matchingIntType(true, 0x10000L, null), "u32");
+        assertEquals(RustServerCodegen.matchingIntType(true, 0xFFFFFFFFL, null), "u32");
+        assertEquals(RustServerCodegen.matchingIntType(true, 0x100000000L, null), "u64");
+        assertEquals(RustServerCodegen.matchingIntType(true, null, 0xFFL), "u8");
+        assertEquals(RustServerCodegen.matchingIntType(true, null, 0x100L), "u16");
+        assertEquals(RustServerCodegen.matchingIntType(true, null, 0xFFFFL), "u16");
+        assertEquals(RustServerCodegen.matchingIntType(true, null, 0x10000L), "u32");
+        assertEquals(RustServerCodegen.matchingIntType(true, null, 0xFFFFFFFFL), "u32");
+        assertEquals(RustServerCodegen.matchingIntType(true, null, 0x100000000L), "u64");
+        assertEquals(RustServerCodegen.matchingIntType(true, 0xFFL, 0xFFL), "u8");
+        assertEquals(RustServerCodegen.matchingIntType(true, 0x100L, 0x100L), "u16");
+        assertEquals(RustServerCodegen.matchingIntType(true, 0xFFFFL, 0xFFFFL), "u16");
+        assertEquals(RustServerCodegen.matchingIntType(true, 0x10000L, 0x10000L), "u32");
+        assertEquals(RustServerCodegen.matchingIntType(true, 0xFFFFFFFFL, 0xFFFFFFFFL), "u32");
+        assertEquals(RustServerCodegen.matchingIntType(true, 0x100000000L, 0x100000000L), "u64");
+
+        assertEquals(RustServerCodegen.matchingIntType(false, null, null), "isize");
+        assertEquals(RustServerCodegen.matchingIntType(false, -256L, null), "isize");
+        assertEquals(RustServerCodegen.matchingIntType(false, -257L, null), "isize");
+        assertEquals(RustServerCodegen.matchingIntType(false, -16385L, null), "isize");
+        assertEquals(RustServerCodegen.matchingIntType(false, ((long) Short.MIN_VALUE) - 1, null), "i32");
+        assertEquals(RustServerCodegen.matchingIntType(false, (long) Integer.MIN_VALUE, null), "i32");
+        assertEquals(RustServerCodegen.matchingIntType(false, ((long) Integer.MIN_VALUE) - 1, null), "i64");
+        assertEquals(RustServerCodegen.matchingIntType(false, Long.MIN_VALUE, null), "i64");
+        assertEquals(RustServerCodegen.matchingIntType(false, null, 127L), "i8");
+        assertEquals(RustServerCodegen.matchingIntType(false, null, 128L), "i16");
+        assertEquals(RustServerCodegen.matchingIntType(false, null, (long) Short.MAX_VALUE), "i16");
+        assertEquals(RustServerCodegen.matchingIntType(false, null, (long) Short.MAX_VALUE + 1), "i32");
+        assertEquals(RustServerCodegen.matchingIntType(false, null, (long) Integer.MAX_VALUE), "i32");
+        assertEquals(RustServerCodegen.matchingIntType(false, null, (long) Integer.MAX_VALUE + 1), "i64");
+        assertEquals(RustServerCodegen.matchingIntType(false, null, Long.MAX_VALUE), "i64");
+    }
+
+}

--- a/samples/client/petstore/rust/git_push.sh
+++ b/samples/client/petstore/rust/git_push.sh
@@ -36,7 +36,7 @@ git_remote=`git remote`
 if [ "$git_remote" = "" ]; then # git remote not defined
 
     if [ "$GIT_TOKEN" = "" ]; then
-        echo "[INFO] \$GIT_TOKEN (environment variable) is not set. Using the git crediential in your environment."
+        echo "[INFO] \$GIT_TOKEN (environment variable) is not set. Using the git credential in your environment."
         git remote add origin https://github.com/${git_user_id}/${git_repo_id}.git
     else
         git remote add origin https://${git_user_id}:${GIT_TOKEN}@github.com/${git_user_id}/${git_repo_id}.git


### PR DESCRIPTION
@frol @farcaller 

In rust-server, use rust integer types best matching the `format`, `minimum` and `maximum` schema constraints.

Matching rules cover all rust standard int size, from 8 to 64bits, signed and unsigned, including `size` types.

- `minimum` is used to determine if the int type should be signed. Default is signed.
- `maximum` is used to determine the int size. Default is `isize` or `usize`.
- Standard `formats` `int32` and `int64` can be used to force int size.
- Existing custom formats `uint32` and `uint64` have been preserved, even though they are superseded by new code.
- `minimum` and `maximum` constraints also respects their `exclusive` flags if specified.