### PR TITLE
Remove rxjs operators

### DIFF
--- a/modules/swagger-codegen/src/main/resources/typescript-angular/api.service.mustache
+++ b/modules/swagger-codegen/src/main/resources/typescript-angular/api.service.mustache
@@ -12,7 +12,9 @@ import { Response, ResponseContentType }                     from '@angular/http
 {{/useHttpClient}}
 
 import { Observable }                                        from 'rxjs/Observable';
+{{^useHttpClient}}
 import '../rxjs-operators';
+{{/useHttpClient}}
 
 {{#imports}}
 import { {{classname}} } from '../{{filename}}';

--- a/modules/swagger-codegen/src/main/resources/typescript-angular/rxjs-operators.mustache
+++ b/modules/swagger-codegen/src/main/resources/typescript-angular/rxjs-operators.mustache
@@ -1,3 +1,8 @@
+{{#useHttpClient}}
+// RxJS imports are not needed for Angular 4.3 and later
+{{/useHttpClient}}
+
+{{^useHttpClient}}
 // RxJS imports according to https://angular.io/docs/ts/latest/guide/server-communication.html#!#rxjs
 
 // See node_module/rxjs/Rxjs.js
@@ -9,3 +14,4 @@ import 'rxjs/add/observable/throw';
 // Operators
 import 'rxjs/add/operator/catch';
 import 'rxjs/add/operator/map';
+{{/useHttpClient}}

--- a/samples/client/petstore/typescript-angular-v2/default/git_push.sh
+++ b/samples/client/petstore/typescript-angular-v2/default/git_push.sh
@@ -36,7 +36,7 @@ git_remote=`git remote`
 if [ "$git_remote" = "" ]; then # git remote not defined
 
     if [ "$GIT_TOKEN" = "" ]; then
-        echo "[INFO] \$GIT_TOKEN (environment variable) is not set. Using the git crediential in your environment."
+        echo "[INFO] \$GIT_TOKEN (environment variable) is not set. Using the git credential in your environment."
         git remote add origin https://github.com/${git_user_id}/${git_repo_id}.git
     else
         git remote add origin https://${git_user_id}:${GIT_TOKEN}@github.com/${git_user_id}/${git_repo_id}.git

--- a/samples/client/petstore/typescript-angular-v2/default/rxjs-operators.ts
+++ b/samples/client/petstore/typescript-angular-v2/default/rxjs-operators.ts
@@ -1,3 +1,4 @@
+
 // RxJS imports according to https://angular.io/docs/ts/latest/guide/server-communication.html#!#rxjs
 
 // See node_module/rxjs/Rxjs.js

--- a/samples/client/petstore/typescript-angular-v2/npm/git_push.sh
+++ b/samples/client/petstore/typescript-angular-v2/npm/git_push.sh
@@ -36,7 +36,7 @@ git_remote=`git remote`
 if [ "$git_remote" = "" ]; then # git remote not defined
 
     if [ "$GIT_TOKEN" = "" ]; then
-        echo "[INFO] \$GIT_TOKEN (environment variable) is not set. Using the git crediential in your environment."
+        echo "[INFO] \$GIT_TOKEN (environment variable) is not set. Using the git credential in your environment."
         git remote add origin https://github.com/${git_user_id}/${git_repo_id}.git
     else
         git remote add origin https://${git_user_id}:${GIT_TOKEN}@github.com/${git_user_id}/${git_repo_id}.git

--- a/samples/client/petstore/typescript-angular-v2/npm/rxjs-operators.ts
+++ b/samples/client/petstore/typescript-angular-v2/npm/rxjs-operators.ts
@@ -1,3 +1,4 @@
+
 // RxJS imports according to https://angular.io/docs/ts/latest/guide/server-communication.html#!#rxjs
 
 // See node_module/rxjs/Rxjs.js

--- a/samples/client/petstore/typescript-angular-v2/with-interfaces/git_push.sh
+++ b/samples/client/petstore/typescript-angular-v2/with-interfaces/git_push.sh
@@ -36,7 +36,7 @@ git_remote=`git remote`
 if [ "$git_remote" = "" ]; then # git remote not defined
 
     if [ "$GIT_TOKEN" = "" ]; then
-        echo "[INFO] \$GIT_TOKEN (environment variable) is not set. Using the git crediential in your environment."
+        echo "[INFO] \$GIT_TOKEN (environment variable) is not set. Using the git credential in your environment."
         git remote add origin https://github.com/${git_user_id}/${git_repo_id}.git
     else
         git remote add origin https://${git_user_id}:${GIT_TOKEN}@github.com/${git_user_id}/${git_repo_id}.git

--- a/samples/client/petstore/typescript-angular-v2/with-interfaces/package.json
+++ b/samples/client/petstore/typescript-angular-v2/with-interfaces/package.json
@@ -35,6 +35,6 @@
     "typescript": "^2.1.5"
   },
   "publishConfig": {
-    "registry":"https://skimdb.npmjs.com/registry"
+    "registry": "https://skimdb.npmjs.com/registry"
   }
 }

--- a/samples/client/petstore/typescript-angular-v2/with-interfaces/rxjs-operators.ts
+++ b/samples/client/petstore/typescript-angular-v2/with-interfaces/rxjs-operators.ts
@@ -1,3 +1,4 @@
+
 // RxJS imports according to https://angular.io/docs/ts/latest/guide/server-communication.html#!#rxjs
 
 // See node_module/rxjs/Rxjs.js

--- a/samples/client/petstore/typescript-angular-v4.3/npm/api/pet.service.ts
+++ b/samples/client/petstore/typescript-angular-v4.3/npm/api/pet.service.ts
@@ -15,7 +15,6 @@ import { Inject, Injectable, Optional }                      from '@angular/core
 import { HttpClient, HttpHeaders, HttpParams }               from '@angular/common/http';
 
 import { Observable }                                        from 'rxjs/Observable';
-import '../rxjs-operators';
 
 import { ApiResponse } from '../model/apiResponse';
 import { Pet } from '../model/pet';

--- a/samples/client/petstore/typescript-angular-v4.3/npm/api/store.service.ts
+++ b/samples/client/petstore/typescript-angular-v4.3/npm/api/store.service.ts
@@ -15,7 +15,6 @@ import { Inject, Injectable, Optional }                      from '@angular/core
 import { HttpClient, HttpHeaders, HttpParams }               from '@angular/common/http';
 
 import { Observable }                                        from 'rxjs/Observable';
-import '../rxjs-operators';
 
 import { Order } from '../model/order';
 

--- a/samples/client/petstore/typescript-angular-v4.3/npm/api/user.service.ts
+++ b/samples/client/petstore/typescript-angular-v4.3/npm/api/user.service.ts
@@ -15,7 +15,6 @@ import { Inject, Injectable, Optional }                      from '@angular/core
 import { HttpClient, HttpHeaders, HttpParams }               from '@angular/common/http';
 
 import { Observable }                                        from 'rxjs/Observable';
-import '../rxjs-operators';
 
 import { User } from '../model/user';
 

--- a/samples/client/petstore/typescript-angular-v4.3/npm/git_push.sh
+++ b/samples/client/petstore/typescript-angular-v4.3/npm/git_push.sh
@@ -36,7 +36,7 @@ git_remote=`git remote`
 if [ "$git_remote" = "" ]; then # git remote not defined
 
     if [ "$GIT_TOKEN" = "" ]; then
-        echo "[INFO] \$GIT_TOKEN (environment variable) is not set. Using the git crediential in your environment."
+        echo "[INFO] \$GIT_TOKEN (environment variable) is not set. Using the git credential in your environment."
         git remote add origin https://github.com/${git_user_id}/${git_repo_id}.git
     else
         git remote add origin https://${git_user_id}:${GIT_TOKEN}@github.com/${git_user_id}/${git_repo_id}.git

--- a/samples/client/petstore/typescript-angular-v4.3/npm/rxjs-operators.ts
+++ b/samples/client/petstore/typescript-angular-v4.3/npm/rxjs-operators.ts
@@ -1,11 +1,2 @@
-// RxJS imports according to https://angular.io/docs/ts/latest/guide/server-communication.html#!#rxjs
+// RxJS imports are not needed for Angular 4.3 and later
 
-// See node_module/rxjs/Rxjs.js
-// Import just the rxjs statics and operators we need for THIS app.
-
-// Statics
-import 'rxjs/add/observable/throw';
-
-// Operators
-import 'rxjs/add/operator/catch';
-import 'rxjs/add/operator/map';

--- a/samples/client/petstore/typescript-angular-v4/npm/git_push.sh
+++ b/samples/client/petstore/typescript-angular-v4/npm/git_push.sh
@@ -36,7 +36,7 @@ git_remote=`git remote`
 if [ "$git_remote" = "" ]; then # git remote not defined
 
     if [ "$GIT_TOKEN" = "" ]; then
-        echo "[INFO] \$GIT_TOKEN (environment variable) is not set. Using the git crediential in your environment."
+        echo "[INFO] \$GIT_TOKEN (environment variable) is not set. Using the git credential in your environment."
         git remote add origin https://github.com/${git_user_id}/${git_repo_id}.git
     else
         git remote add origin https://${git_user_id}:${GIT_TOKEN}@github.com/${git_user_id}/${git_repo_id}.git

--- a/samples/client/petstore/typescript-angular-v4/npm/rxjs-operators.ts
+++ b/samples/client/petstore/typescript-angular-v4/npm/rxjs-operators.ts
@@ -1,3 +1,4 @@
+
 // RxJS imports according to https://angular.io/docs/ts/latest/guide/server-communication.html#!#rxjs
 
 // See node_module/rxjs/Rxjs.js


### PR DESCRIPTION
### PR checklist

- [ x] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [x ] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [x ] Filed the PR against the correct branch: `3.0.0` branch for changes related to OpenAPI spec 3.0. Default: `master`.
- [x ] Copied the [technical committee](https://github.com/swagger-api/swagger-codegen/#swagger-codegen-technical-committee) to review the pull request if your PR is targeting a particular programming language.
@kenisteward @wing328  @sebastianhaas
### Description of the PR
It look like import '../rxjs-operators'; is not needed 
since angular 4.3


