### PR TITLE
[Go] Add context to all requests for tracing, logging, cancellations, etc.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1082,7 +1082,7 @@ If you want to join the committee, please kindly apply by sending an email to wi
 | Dart      | @ircecho (2017/07) |
 | Eiffel    | @jvelilla (2017/09) |
 | Elixir    |  |
-| Erlang    |  |
+| Erlang    | @tsloughter (2017/11) |
 | Groovy    |  |
 | Go        |  |
 | Haskell   |  |

--- a/modules/swagger-codegen/src/main/resources/go/README.mustache
+++ b/modules/swagger-codegen/src/main/resources/go/README.mustache
@@ -46,7 +46,7 @@ Class | Method | HTTP request | Description
 
 Example
 ```
-	auth := context.WithValue(context.TODO(), sw.ContextAPIKey, sw.APIKey{
+	auth := context.WithValue(context.Background(), sw.ContextAPIKey, sw.APIKey{
 		Key: "APIKEY",
 		Prefix: "Bearer", // Omit if not necessary.
 	})
@@ -57,7 +57,7 @@ Example
 
 Example
 ```
-	auth := context.WithValue(context.TODO(), sw.ContextBasicAuth, sw.BasicAuth{
+	auth := context.WithValue(context.Background(), sw.ContextBasicAuth, sw.BasicAuth{
 		UserName: "username",
 		Password: "password",
 	})
@@ -73,7 +73,7 @@ Example
 
 Example
 ```
-	auth := context.WithValue(context.TODO(), sw.ContextAccessToken, "ACCESSTOKENSTRING")
+	auth := context.WithValue(context.Background(), sw.ContextAccessToken, "ACCESSTOKENSTRING")
     r, err := client.Service.Operation(auth, args)
 ```
 

--- a/modules/swagger-codegen/src/main/resources/go/api.mustache
+++ b/modules/swagger-codegen/src/main/resources/go/api.mustache
@@ -22,12 +22,12 @@ type {{classname}}Service service
 
 /* {{{classname}}}Service {{summary}}{{#notes}}
  {{notes}}{{/notes}}
-{{#hasAuthMethods}} * @param ctx context.Context Authentication Context {{/hasAuthMethods}}
+ * @param ctx context.Context for authentication, logging, tracing, etc.
 {{#allParams}}{{#required}} @param {{paramName}} {{description}}
 {{/required}}{{/allParams}}{{#hasOptionalParams}} @param optional (nil or map[string]interface{}) with one or more of:
 {{#allParams}}{{^required}}     @param "{{paramName}}" ({{dataType}}) {{description}}
 {{/required}}{{/allParams}}{{/hasOptionalParams}} @return {{#returnType}}{{{returnType}}}{{/returnType}}*/
-func (a *{{{classname}}}Service) {{{nickname}}}({{#hasAuthMethods}}ctx context.Context, {{/hasAuthMethods}}{{#allParams}}{{#required}}{{paramName}} {{{dataType}}}{{#hasMore}}, {{/hasMore}}{{/required}}{{/allParams}}{{#hasOptionalParams}}localVarOptionals map[string]interface{}{{/hasOptionalParams}}) ({{#returnType}}{{{returnType}}}, {{/returnType}} *http.Response, error) {
+func (a *{{{classname}}}Service) {{{nickname}}}(ctx context.Context, {{#allParams}}{{#required}}{{paramName}} {{{dataType}}}{{#hasMore}}, {{/hasMore}}{{/required}}{{/allParams}}{{#hasOptionalParams}}localVarOptionals map[string]interface{}{{/hasOptionalParams}}) ({{#returnType}}{{{returnType}}}, {{/returnType}} *http.Response, error) {
 	var (
 		localVarHttpMethod = strings.ToUpper("{{httpMethod}}")
 		localVarPostBody interface{}
@@ -201,7 +201,7 @@ func (a *{{{classname}}}Service) {{{nickname}}}({{#hasAuthMethods}}ctx context.C
 	}
 {{/isApiKey}}
 {{/authMethods}}
-	r, err := a.client.prepareRequest({{#hasAuthMethods}}ctx, {{/hasAuthMethods}}{{^hasAuthMethods}}nil, {{/hasAuthMethods}}localVarPath, localVarHttpMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFileName, localVarFileBytes)
+	r, err := a.client.prepareRequest(ctx, localVarPath, localVarHttpMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFileName, localVarFileBytes)
 	if err != nil {
 		return {{#returnType}}successPayload, {{/returnType}}nil, err
 	}

--- a/modules/swagger-codegen/src/main/resources/go/api.mustache
+++ b/modules/swagger-codegen/src/main/resources/go/api.mustache
@@ -27,7 +27,7 @@ type {{classname}}Service service
 {{/required}}{{/allParams}}{{#hasOptionalParams}} @param optional (nil or map[string]interface{}) with one or more of:
 {{#allParams}}{{^required}}     @param "{{paramName}}" ({{dataType}}) {{description}}
 {{/required}}{{/allParams}}{{/hasOptionalParams}} @return {{#returnType}}{{{returnType}}}{{/returnType}}*/
-func (a *{{{classname}}}Service) {{{nickname}}}(ctx context.Context, {{#allParams}}{{#required}}{{paramName}} {{{dataType}}}{{#hasMore}}, {{/hasMore}}{{/required}}{{/allParams}}{{#hasOptionalParams}}localVarOptionals map[string]interface{}{{/hasOptionalParams}}) ({{#returnType}}{{{returnType}}}, {{/returnType}} *http.Response, error) {
+func (a *{{{classname}}}Service) {{{nickname}}}(ctx context.Context{{#hasParams}}, {{/hasParams}}{{#allParams}}{{#required}}{{paramName}} {{{dataType}}}{{#hasMore}}, {{/hasMore}}{{/required}}{{/allParams}}{{#hasOptionalParams}}localVarOptionals map[string]interface{}{{/hasOptionalParams}}) ({{#returnType}}{{{returnType}}}, {{/returnType}} *http.Response, error) {
 	var (
 		localVarHttpMethod = strings.ToUpper("{{httpMethod}}")
 		localVarPostBody interface{}

--- a/modules/swagger-codegen/src/main/resources/go/api_client.mustache
+++ b/modules/swagger-codegen/src/main/resources/go/api_client.mustache
@@ -267,8 +267,13 @@ func (c *APIClient) prepareRequest (
 	// Add the user agent to the request.
 	localVarRequest.Header.Add("User-Agent", c.cfg.UserAgent)
 	
-	// Walk through any authentication.
+
 	if ctx != nil {
+		// add context to the request
+		localVarRequest = localVarRequest.WithContext(ctx)
+
+		// Walk through any authentication.
+
 		// OAuth2 authentication
 		if tok, ok := ctx.Value(ContextOAuth2).(oauth2.TokenSource); ok {
 			// We were able to grab an oauth2 token from the context

--- a/modules/swagger-codegen/src/main/resources/go/api_doc.mustache
+++ b/modules/swagger-codegen/src/main/resources/go/api_doc.mustache
@@ -11,7 +11,7 @@ Method | HTTP request | Description
 {{#operations}}
 {{#operation}}
 # **{{{operationId}}}**
-> {{#returnType}}{{{returnType}}} {{/returnType}}{{{operationId}}}({{#authMethods}}ctx, {{/authMethods}}{{#allParams}}{{#required}}{{paramName}}{{#hasMore}}, {{/hasMore}}{{/required}}{{/allParams}}{{#hasOptionalParams}}optional{{/hasOptionalParams}})
+> {{#returnType}}{{{returnType}}} {{/returnType}}{{{operationId}}}(ctx, {{#allParams}}{{#required}}{{paramName}}{{#hasMore}}, {{/hasMore}}{{/required}}{{/allParams}}{{#hasOptionalParams}}optional{{/hasOptionalParams}})
 {{{summary}}}{{#notes}}
 
 {{{notes}}}{{/notes}}
@@ -19,8 +19,8 @@ Method | HTTP request | Description
 ### Required Parameters
 {{^allParams}}This endpoint does not need any parameter.{{/allParams}}{{#allParams}}{{#-last}}
 Name | Type | Description  | Notes
-------------- | ------------- | ------------- | -------------{{#authMethods}}
- **ctx** | **context.Context** | context containing the authentication | nil if no authentication{{/authMethods}}{{/-last}}{{/allParams}}{{#allParams}}{{#required}}
+------------- | ------------- | ------------- | -------------
+ **ctx** | **context.Context** | context for logging, tracing, authentication, etc.{{/-last}}{{/allParams}}{{#allParams}}{{#required}}
   **{{paramName}}** | {{#isFile}}**{{dataType}}**{{/isFile}}{{#isPrimitiveType}}**{{dataType}}**{{/isPrimitiveType}}{{^isPrimitiveType}}{{^isFile}}[**{{dataType}}**]({{baseType}}.md){{/isFile}}{{/isPrimitiveType}}| {{description}} | {{#defaultValue}}[default to {{defaultValue}}]{{/defaultValue}}{{/required}}{{/allParams}}{{#hasOptionalParams}}
  **optional** | **map[string]interface{}** | optional parameters | nil if no parameters
 

--- a/modules/swagger-codegen/src/main/resources/go/configuration.mustache
+++ b/modules/swagger-codegen/src/main/resources/go/configuration.mustache
@@ -5,16 +5,37 @@ import (
 	"net/http"
 )
 
-const ContextOAuth2 		int = 1
-const ContextBasicAuth 		int = 2
-const ContextAccessToken 	int = 3
-const ContextAPIKey 		int = 4 
+// contextKeys are used to identify the type of value in the context.
+// Since these are string, it is possible to get a short description of the
+// context key for logging and debugging using key.String().
 
+type contextKey string
+
+func (c contextKey) String() string {
+	return "auth " + string(c)
+}
+
+var (
+	// ContextOAuth2 takes a oauth2.TokenSource as authentication for the request.
+	ContextOAuth2    	= contextKey("token")
+
+	// ContextBasicAuth takes BasicAuth as authentication for the request.
+	ContextBasicAuth 	= contextKey("basic")
+
+	// ContextAccessToken takes a string oauth2 access token as authentication for the request.
+	ContextAccessToken 	= contextKey("accesstoken")
+
+	// ContextAPIKey takes an APIKey as authentication for the request
+ 	ContextAPIKey 		= contextKey("apikey")
+)
+
+// BasicAuth provides basic http authentication to a request passed via context using ContextBasicAuth 
 type BasicAuth struct {
 	UserName      string            `json:"userName,omitempty"`
 	Password      string            `json:"password,omitempty"`	
 }
 
+// APIKey provides API key based authentication to a request passed via context using ContextAPIKey
 type APIKey struct {
 	Key 	string
 	Prefix	string

--- a/samples/client/petstore-security-test/go/README.md
+++ b/samples/client/petstore-security-test/go/README.md
@@ -36,7 +36,7 @@ Class | Method | HTTP request | Description
 
 Example
 ```
-	auth := context.WithValue(context.TODO(), sw.ContextAPIKey, sw.APIKey{
+	auth := context.WithValue(context.Background(), sw.ContextAPIKey, sw.APIKey{
 		Key: "APIKEY",
 		Prefix: "Bearer", // Omit if not necessary.
 	})
@@ -52,7 +52,7 @@ Example
 
 Example
 ```
-	auth := context.WithValue(context.TODO(), sw.ContextAccessToken, "ACCESSTOKENSTRING")
+	auth := context.WithValue(context.Background(), sw.ContextAccessToken, "ACCESSTOKENSTRING")
     r, err := client.Service.Operation(auth, args)
 ```
 

--- a/samples/client/petstore-security-test/go/api_client.go
+++ b/samples/client/petstore-security-test/go/api_client.go
@@ -264,8 +264,13 @@ func (c *APIClient) prepareRequest (
 	// Add the user agent to the request.
 	localVarRequest.Header.Add("User-Agent", c.cfg.UserAgent)
 	
-	// Walk through any authentication.
+
 	if ctx != nil {
+		// add context to the request
+		localVarRequest = localVarRequest.WithContext(ctx)
+
+		// Walk through any authentication.
+
 		// OAuth2 authentication
 		if tok, ok := ctx.Value(ContextOAuth2).(oauth2.TokenSource); ok {
 			// We were able to grab an oauth2 token from the context

--- a/samples/client/petstore-security-test/go/configuration.go
+++ b/samples/client/petstore-security-test/go/configuration.go
@@ -14,16 +14,37 @@ import (
 	"net/http"
 )
 
-const ContextOAuth2 		int = 1
-const ContextBasicAuth 		int = 2
-const ContextAccessToken 	int = 3
-const ContextAPIKey 		int = 4 
+// contextKeys are used to identify the type of value in the context.
+// Since these are string, it is possible to get a short description of the
+// context key for logging and debugging using key.String().
 
+type contextKey string
+
+func (c contextKey) String() string {
+	return "auth " + string(c)
+}
+
+var (
+	// ContextOAuth2 takes a oauth2.TokenSource as authentication for the request.
+	ContextOAuth2    	= contextKey("token")
+
+	// ContextBasicAuth takes BasicAuth as authentication for the request.
+	ContextBasicAuth 	= contextKey("basic")
+
+	// ContextAccessToken takes a string oauth2 access token as authentication for the request.
+	ContextAccessToken 	= contextKey("accesstoken")
+
+	// ContextAPIKey takes an APIKey as authentication for the request
+ 	ContextAPIKey 		= contextKey("apikey")
+)
+
+// BasicAuth provides basic http authentication to a request passed via context using ContextBasicAuth 
 type BasicAuth struct {
 	UserName      string            `json:"userName,omitempty"`
 	Password      string            `json:"password,omitempty"`	
 }
 
+// APIKey provides API key based authentication to a request passed via context using ContextAPIKey
 type APIKey struct {
 	Key 	string
 	Prefix	string

--- a/samples/client/petstore-security-test/go/docs/FakeApi.md
+++ b/samples/client/petstore-security-test/go/docs/FakeApi.md
@@ -8,13 +8,14 @@ Method | HTTP request | Description
 
 
 # **TestCodeInjectEndRnNR**
-> TestCodeInjectEndRnNR(optional)
+> TestCodeInjectEndRnNR(ctx, optional)
 To test code injection *_/ ' \" =end -- \\r\\n \\n \\r
 
 ### Required Parameters
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
+ **ctx** | **context.Context** | context for logging, tracing, authentication, etc.
  **optional** | **map[string]interface{}** | optional parameters | nil if no parameters
 
 ### Optional Parameters

--- a/samples/client/petstore-security-test/go/fake_api.go
+++ b/samples/client/petstore-security-test/go/fake_api.go
@@ -26,11 +26,11 @@ type FakeApiService service
 
 
 /* FakeApiService To test code injection *_/ &#39; \&quot; &#x3D;end -- \\r\\n \\n \\r
-
+ * @param ctx context.Context for authentication, logging, tracing, etc.
  @param optional (nil or map[string]interface{}) with one or more of:
      @param "testCodeInjectEndRnNR" (string) To test code injection *_/ &#39; \&quot; &#x3D;end -- \\r\\n \\n \\r
  @return */
-func (a *FakeApiService) TestCodeInjectEndRnNR(localVarOptionals map[string]interface{}) ( *http.Response, error) {
+func (a *FakeApiService) TestCodeInjectEndRnNR(ctx context.Context, localVarOptionals map[string]interface{}) ( *http.Response, error) {
 	var (
 		localVarHttpMethod = strings.ToUpper("Put")
 		localVarPostBody interface{}
@@ -72,7 +72,7 @@ func (a *FakeApiService) TestCodeInjectEndRnNR(localVarOptionals map[string]inte
 	if localVarTempParam, localVarOk := localVarOptionals["testCodeInjectEndRnNR"].(string); localVarOk {
 		localVarFormParams.Add("test code inject */ &#39; &quot; &#x3D;end -- \r\n \n \r", parameterToString(localVarTempParam, ""))
 	}
-	r, err := a.client.prepareRequest(nil, localVarPath, localVarHttpMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFileName, localVarFileBytes)
+	r, err := a.client.prepareRequest(ctx, localVarPath, localVarHttpMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFileName, localVarFileBytes)
 	if err != nil {
 		return nil, err
 	}

--- a/samples/client/petstore-security-test/go/git_push.sh
+++ b/samples/client/petstore-security-test/go/git_push.sh
@@ -36,7 +36,7 @@ git_remote=`git remote`
 if [ "$git_remote" = "" ]; then # git remote not defined
 
     if [ "$GIT_TOKEN" = "" ]; then
-        echo "[INFO] \$GIT_TOKEN (environment variable) is not set. Using the git crediential in your environment."
+        echo "[INFO] \$GIT_TOKEN (environment variable) is not set. Using the git credential in your environment."
         git remote add origin https://github.com/${git_user_id}/${git_repo_id}.git
     else
         git remote add origin https://${git_user_id}:${GIT_TOKEN}@github.com/${git_user_id}/${git_repo_id}.git

--- a/samples/client/petstore/go/auth_test.go
+++ b/samples/client/petstore/go/auth_test.go
@@ -36,12 +36,12 @@ func TestOAuth2(t *testing.T) {
 
 	// then a fake tokenSource
 	tokenSource := cfg.TokenSource(createContext(nil), &tok)
-	auth := context.WithValue(oauth2.NoContext, sw.ContextOAuth2, tokenSource)
+	auth := context.WithValue(context.Background(), sw.ContextOAuth2, tokenSource)
 
 	newPet := (sw.Pet{Id: 12992, Name: "gopher",
 		PhotoUrls: []string{"http://1.com", "http://2.com"}, Status: "pending", Tags: []sw.Tag{sw.Tag{Id: 1, Name: "tag2"}}})
 
-	r, err := client.PetApi.AddPet(nil, newPet)
+	r, err := client.PetApi.AddPet(context.Background(), newPet)
 
 	if err != nil {
 		t.Errorf("Error while adding pet")
@@ -60,7 +60,7 @@ func TestOAuth2(t *testing.T) {
 	if r.StatusCode != 200 {
 		t.Log(r)
 	}
-	reqb, err := httputil.DumpRequest(r.Request, true)
+	reqb, _ := httputil.DumpRequest(r.Request, true)
 
 	if !strings.Contains((string)(reqb), "Authorization: Bearer FAKE") {
 		t.Errorf("OAuth2 Authentication is missing")
@@ -69,7 +69,7 @@ func TestOAuth2(t *testing.T) {
 
 func TestBasicAuth(t *testing.T) {
 
-	auth := context.WithValue(context.TODO(), sw.ContextBasicAuth, sw.BasicAuth{
+	auth := context.WithValue(context.Background(), sw.ContextBasicAuth, sw.BasicAuth{
 		UserName: "fakeUser",
 		Password: "f4k3p455",
 	})
@@ -96,14 +96,14 @@ func TestBasicAuth(t *testing.T) {
 	if r.StatusCode != 200 {
 		t.Log(r)
 	}
-	reqb, err := httputil.DumpRequest(r.Request, true)
+	reqb, _ := httputil.DumpRequest(r.Request, true)
 	if !strings.Contains((string)(reqb), "Authorization: Basic ZmFrZVVzZXI6ZjRrM3A0NTU") {
 		t.Errorf("Basic Authentication is missing")
 	}
 }
 
 func TestAccessToken(t *testing.T) {
-	auth := context.WithValue(context.TODO(), sw.ContextAccessToken, "TESTFAKEACCESSTOKENISFAKE")
+	auth := context.WithValue(context.Background(), sw.ContextAccessToken, "TESTFAKEACCESSTOKENISFAKE")
 
 	newPet := (sw.Pet{Id: 12992, Name: "gopher",
 		PhotoUrls: []string{"http://1.com", "http://2.com"}, Status: "pending", Tags: []sw.Tag{sw.Tag{Id: 1, Name: "tag2"}}})
@@ -127,19 +127,19 @@ func TestAccessToken(t *testing.T) {
 	if r.StatusCode != 200 {
 		t.Log(r)
 	}
-	reqb, err := httputil.DumpRequest(r.Request, true)
+	reqb, _ := httputil.DumpRequest(r.Request, true)
 	if !strings.Contains((string)(reqb), "Authorization: Bearer TESTFAKEACCESSTOKENISFAKE") {
 		t.Errorf("AccessToken Authentication is missing")
 	}
 }
 
 func TestAPIKeyNoPrefix(t *testing.T) {
-	auth := context.WithValue(context.TODO(), sw.ContextAPIKey, sw.APIKey{Key: "TEST123"})
+	auth := context.WithValue(context.Background(), sw.ContextAPIKey, sw.APIKey{Key: "TEST123"})
 
 	newPet := (sw.Pet{Id: 12992, Name: "gopher",
 		PhotoUrls: []string{"http://1.com", "http://2.com"}, Status: "pending", Tags: []sw.Tag{sw.Tag{Id: 1, Name: "tag2"}}})
 
-	r, err := client.PetApi.AddPet(nil, newPet)
+	r, err := client.PetApi.AddPet(context.Background(), newPet)
 
 	if err != nil {
 		t.Errorf("Error while adding pet")
@@ -155,7 +155,7 @@ func TestAPIKeyNoPrefix(t *testing.T) {
 		t.Log(err)
 	}
 
-	reqb, err := httputil.DumpRequest(r.Request, true)
+	reqb, _ := httputil.DumpRequest(r.Request, true)
 	if !strings.Contains((string)(reqb), "Api_key: TEST123") {
 		t.Errorf("APIKey Authentication is missing")
 	}
@@ -171,7 +171,7 @@ func TestAPIKeyNoPrefix(t *testing.T) {
 }
 
 func TestAPIKeyWithPrefix(t *testing.T) {
-	auth := context.WithValue(context.TODO(), sw.ContextAPIKey, sw.APIKey{Key: "TEST123", Prefix: "Bearer"})
+	auth := context.WithValue(context.Background(), sw.ContextAPIKey, sw.APIKey{Key: "TEST123", Prefix: "Bearer"})
 
 	newPet := (sw.Pet{Id: 12992, Name: "gopher",
 		PhotoUrls: []string{"http://1.com", "http://2.com"}, Status: "pending", Tags: []sw.Tag{sw.Tag{Id: 1, Name: "tag2"}}})
@@ -192,7 +192,7 @@ func TestAPIKeyWithPrefix(t *testing.T) {
 		t.Log(err)
 	}
 
-	reqb, err := httputil.DumpRequest(r.Request, true)
+	reqb, _ := httputil.DumpRequest(r.Request, true)
 	if !strings.Contains((string)(reqb), "Api_key: Bearer TEST123") {
 		t.Errorf("APIKey Authentication is missing")
 	}
@@ -212,7 +212,7 @@ func TestDefaultHeader(t *testing.T) {
 	newPet := (sw.Pet{Id: 12992, Name: "gopher",
 		PhotoUrls: []string{"http://1.com", "http://2.com"}, Status: "pending", Tags: []sw.Tag{sw.Tag{Id: 1, Name: "tag2"}}})
 
-	r, err := client.PetApi.AddPet(nil, newPet)
+	r, err := client.PetApi.AddPet(context.Background(), newPet)
 
 	if err != nil {
 		t.Errorf("Error while adding pet")
@@ -222,7 +222,7 @@ func TestDefaultHeader(t *testing.T) {
 		t.Log(r)
 	}
 
-	r, err = client.PetApi.DeletePet(nil, 12992, nil)
+	r, err = client.PetApi.DeletePet(context.Background(), 12992, nil)
 
 	if err != nil {
 		t.Errorf("Error while deleting pet by id")
@@ -231,14 +231,14 @@ func TestDefaultHeader(t *testing.T) {
 	if r.StatusCode != 200 {
 		t.Log(r)
 	}
-	reqb, err := httputil.DumpRequest(r.Request, true)
+	reqb, _ := httputil.DumpRequest(r.Request, true)
 	if !strings.Contains((string)(reqb), "Testheader: testvalue") {
 		t.Errorf("Default Header is missing")
 	}
 }
 
 func TestHostOverride(t *testing.T) {
-	_, r, err := client.PetApi.FindPetsByStatus(nil, nil)
+	_, r, err := client.PetApi.FindPetsByStatus(context.Background(), nil)
 
 	if err != nil {
 		t.Errorf("Error while finding pets by status")

--- a/samples/client/petstore/go/go-petstore/README.md
+++ b/samples/client/petstore/go/go-petstore/README.md
@@ -29,6 +29,7 @@ Class | Method | HTTP request | Description
 *FakeApi* | [**TestClientModel**](docs/FakeApi.md#testclientmodel) | **Patch** /fake | To test \&quot;client\&quot; model
 *FakeApi* | [**TestEndpointParameters**](docs/FakeApi.md#testendpointparameters) | **Post** /fake | Fake endpoint for testing various parameters 假端點 偽のエンドポイント 가짜 엔드 포인트 
 *FakeApi* | [**TestEnumParameters**](docs/FakeApi.md#testenumparameters) | **Get** /fake | To test enum parameters
+*FakeApi* | [**TestInlineAdditionalProperties**](docs/FakeApi.md#testinlineadditionalproperties) | **Post** /fake/inline-additionalProperties | test inline additionalProperties
 *FakeApi* | [**TestJsonFormData**](docs/FakeApi.md#testjsonformdata) | **Get** /fake/jsonFormData | test json serialization of form data
 *FakeClassnameTags123Api* | [**TestClassname**](docs/FakeClassnameTags123Api.md#testclassname) | **Patch** /fake_classname_test | To test class name in snake case
 *PetApi* | [**AddPet**](docs/PetApi.md#addpet) | **Post** /pet | Add a new pet to the store
@@ -100,7 +101,7 @@ Class | Method | HTTP request | Description
 
 Example
 ```
-	auth := context.WithValue(context.TODO(), sw.ContextAPIKey, sw.APIKey{
+	auth := context.WithValue(context.Background(), sw.ContextAPIKey, sw.APIKey{
 		Key: "APIKEY",
 		Prefix: "Bearer", // Omit if not necessary.
 	})
@@ -111,7 +112,7 @@ Example
 
 Example
 ```
-	auth := context.WithValue(context.TODO(), sw.ContextAPIKey, sw.APIKey{
+	auth := context.WithValue(context.Background(), sw.ContextAPIKey, sw.APIKey{
 		Key: "APIKEY",
 		Prefix: "Bearer", // Omit if not necessary.
 	})
@@ -122,7 +123,7 @@ Example
 
 Example
 ```
-	auth := context.WithValue(context.TODO(), sw.ContextBasicAuth, sw.BasicAuth{
+	auth := context.WithValue(context.Background(), sw.ContextBasicAuth, sw.BasicAuth{
 		UserName: "username",
 		Password: "password",
 	})
@@ -138,7 +139,7 @@ Example
 
 Example
 ```
-	auth := context.WithValue(context.TODO(), sw.ContextAccessToken, "ACCESSTOKENSTRING")
+	auth := context.WithValue(context.Background(), sw.ContextAccessToken, "ACCESSTOKENSTRING")
     r, err := client.Service.Operation(auth, args)
 ```
 

--- a/samples/client/petstore/go/go-petstore/another_fake_api.go
+++ b/samples/client/petstore/go/go-petstore/another_fake_api.go
@@ -28,10 +28,10 @@ type AnotherFakeApiService service
 
 /* AnotherFakeApiService To test special tags
  To test special tags
-
+ * @param ctx context.Context for authentication, logging, tracing, etc.
  @param body client model
  @return Client*/
-func (a *AnotherFakeApiService) TestSpecialTags(body Client) (Client,  *http.Response, error) {
+func (a *AnotherFakeApiService) TestSpecialTags(ctx context.Context, body Client) (Client,  *http.Response, error) {
 	var (
 		localVarHttpMethod = strings.ToUpper("Patch")
 		localVarPostBody interface{}
@@ -69,7 +69,7 @@ func (a *AnotherFakeApiService) TestSpecialTags(body Client) (Client,  *http.Res
 	}
 	// body params
 	localVarPostBody = &body
-	r, err := a.client.prepareRequest(nil, localVarPath, localVarHttpMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFileName, localVarFileBytes)
+	r, err := a.client.prepareRequest(ctx, localVarPath, localVarHttpMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFileName, localVarFileBytes)
 	if err != nil {
 		return successPayload, nil, err
 	}

--- a/samples/client/petstore/go/go-petstore/api_client.go
+++ b/samples/client/petstore/go/go-petstore/api_client.go
@@ -274,8 +274,13 @@ func (c *APIClient) prepareRequest (
 	// Add the user agent to the request.
 	localVarRequest.Header.Add("User-Agent", c.cfg.UserAgent)
 	
-	// Walk through any authentication.
+
 	if ctx != nil {
+		// add context to the request
+		localVarRequest = localVarRequest.WithContext(ctx)
+
+		// Walk through any authentication.
+
 		// OAuth2 authentication
 		if tok, ok := ctx.Value(ContextOAuth2).(oauth2.TokenSource); ok {
 			// We were able to grab an oauth2 token from the context

--- a/samples/client/petstore/go/go-petstore/configuration.go
+++ b/samples/client/petstore/go/go-petstore/configuration.go
@@ -14,16 +14,37 @@ import (
 	"net/http"
 )
 
-const ContextOAuth2 		int = 1
-const ContextBasicAuth 		int = 2
-const ContextAccessToken 	int = 3
-const ContextAPIKey 		int = 4 
+// contextKeys are used to identify the type of value in the context.
+// Since these are string, it is possible to get a short description of the
+// context key for logging and debugging using key.String().
 
+type contextKey string
+
+func (c contextKey) String() string {
+	return "auth " + string(c)
+}
+
+var (
+	// ContextOAuth2 takes a oauth2.TokenSource as authentication for the request.
+	ContextOAuth2    	= contextKey("token")
+
+	// ContextBasicAuth takes BasicAuth as authentication for the request.
+	ContextBasicAuth 	= contextKey("basic")
+
+	// ContextAccessToken takes a string oauth2 access token as authentication for the request.
+	ContextAccessToken 	= contextKey("accesstoken")
+
+	// ContextAPIKey takes an APIKey as authentication for the request
+ 	ContextAPIKey 		= contextKey("apikey")
+)
+
+// BasicAuth provides basic http authentication to a request passed via context using ContextBasicAuth 
 type BasicAuth struct {
 	UserName      string            `json:"userName,omitempty"`
 	Password      string            `json:"password,omitempty"`	
 }
 
+// APIKey provides API key based authentication to a request passed via context using ContextAPIKey
 type APIKey struct {
 	Key 	string
 	Prefix	string

--- a/samples/client/petstore/go/go-petstore/docs/AnotherFakeApi.md
+++ b/samples/client/petstore/go/go-petstore/docs/AnotherFakeApi.md
@@ -8,7 +8,7 @@ Method | HTTP request | Description
 
 
 # **TestSpecialTags**
-> Client TestSpecialTags(body)
+> Client TestSpecialTags(ctx, body)
 To test special tags
 
 To test special tags
@@ -17,6 +17,7 @@ To test special tags
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
+ **ctx** | **context.Context** | context for logging, tracing, authentication, etc.
   **body** | [**Client**](Client.md)| client model | 
 
 ### Return type

--- a/samples/client/petstore/go/go-petstore/docs/FakeApi.md
+++ b/samples/client/petstore/go/go-petstore/docs/FakeApi.md
@@ -11,11 +11,12 @@ Method | HTTP request | Description
 [**TestClientModel**](FakeApi.md#TestClientModel) | **Patch** /fake | To test \&quot;client\&quot; model
 [**TestEndpointParameters**](FakeApi.md#TestEndpointParameters) | **Post** /fake | Fake endpoint for testing various parameters 假端點 偽のエンドポイント 가짜 엔드 포인트 
 [**TestEnumParameters**](FakeApi.md#TestEnumParameters) | **Get** /fake | To test enum parameters
+[**TestInlineAdditionalProperties**](FakeApi.md#TestInlineAdditionalProperties) | **Post** /fake/inline-additionalProperties | test inline additionalProperties
 [**TestJsonFormData**](FakeApi.md#TestJsonFormData) | **Get** /fake/jsonFormData | test json serialization of form data
 
 
 # **FakeOuterBooleanSerialize**
-> OuterBoolean FakeOuterBooleanSerialize(optional)
+> OuterBoolean FakeOuterBooleanSerialize(ctx, optional)
 
 
 Test serialization of outer boolean types
@@ -24,6 +25,7 @@ Test serialization of outer boolean types
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
+ **ctx** | **context.Context** | context for logging, tracing, authentication, etc.
  **optional** | **map[string]interface{}** | optional parameters | nil if no parameters
 
 ### Optional Parameters
@@ -49,7 +51,7 @@ No authorization required
 [[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
 
 # **FakeOuterCompositeSerialize**
-> OuterComposite FakeOuterCompositeSerialize(optional)
+> OuterComposite FakeOuterCompositeSerialize(ctx, optional)
 
 
 Test serialization of object with outer number type
@@ -58,6 +60,7 @@ Test serialization of object with outer number type
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
+ **ctx** | **context.Context** | context for logging, tracing, authentication, etc.
  **optional** | **map[string]interface{}** | optional parameters | nil if no parameters
 
 ### Optional Parameters
@@ -83,7 +86,7 @@ No authorization required
 [[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
 
 # **FakeOuterNumberSerialize**
-> OuterNumber FakeOuterNumberSerialize(optional)
+> OuterNumber FakeOuterNumberSerialize(ctx, optional)
 
 
 Test serialization of outer number types
@@ -92,6 +95,7 @@ Test serialization of outer number types
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
+ **ctx** | **context.Context** | context for logging, tracing, authentication, etc.
  **optional** | **map[string]interface{}** | optional parameters | nil if no parameters
 
 ### Optional Parameters
@@ -117,7 +121,7 @@ No authorization required
 [[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
 
 # **FakeOuterStringSerialize**
-> OuterString FakeOuterStringSerialize(optional)
+> OuterString FakeOuterStringSerialize(ctx, optional)
 
 
 Test serialization of outer string types
@@ -126,6 +130,7 @@ Test serialization of outer string types
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
+ **ctx** | **context.Context** | context for logging, tracing, authentication, etc.
  **optional** | **map[string]interface{}** | optional parameters | nil if no parameters
 
 ### Optional Parameters
@@ -151,7 +156,7 @@ No authorization required
 [[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
 
 # **TestClientModel**
-> Client TestClientModel(body)
+> Client TestClientModel(ctx, body)
 To test \"client\" model
 
 To test \"client\" model
@@ -160,6 +165,7 @@ To test \"client\" model
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
+ **ctx** | **context.Context** | context for logging, tracing, authentication, etc.
   **body** | [**Client**](Client.md)| client model | 
 
 ### Return type
@@ -187,7 +193,7 @@ Fake endpoint for testing various parameters 假端點 偽のエンドポイン�
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
- **ctx** | **context.Context** | context containing the authentication | nil if no authentication
+ **ctx** | **context.Context** | context for logging, tracing, authentication, etc.
   **number** | **float32**| None | 
   **double** | **float64**| None | 
   **patternWithoutDelimiter** | **string**| None | 
@@ -230,7 +236,7 @@ Name | Type | Description  | Notes
 [[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
 
 # **TestEnumParameters**
-> TestEnumParameters(optional)
+> TestEnumParameters(ctx, optional)
 To test enum parameters
 
 To test enum parameters
@@ -239,6 +245,7 @@ To test enum parameters
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
+ **ctx** | **context.Context** | context for logging, tracing, authentication, etc.
  **optional** | **map[string]interface{}** | optional parameters | nil if no parameters
 
 ### Optional Parameters
@@ -270,8 +277,36 @@ No authorization required
 
 [[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
 
+# **TestInlineAdditionalProperties**
+> TestInlineAdditionalProperties(ctx, param)
+test inline additionalProperties
+
+
+
+### Required Parameters
+
+Name | Type | Description  | Notes
+------------- | ------------- | ------------- | -------------
+ **ctx** | **context.Context** | context for logging, tracing, authentication, etc.
+  **param** | [**interface{}**](interface{}.md)| request body | 
+
+### Return type
+
+ (empty response body)
+
+### Authorization
+
+No authorization required
+
+### HTTP request headers
+
+ - **Content-Type**: application/json
+ - **Accept**: Not defined
+
+[[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
+
 # **TestJsonFormData**
-> TestJsonFormData(param, param2)
+> TestJsonFormData(ctx, param, param2)
 test json serialization of form data
 
 
@@ -280,6 +315,7 @@ test json serialization of form data
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
+ **ctx** | **context.Context** | context for logging, tracing, authentication, etc.
   **param** | **string**| field1 | 
   **param2** | **string**| field2 | 
 

--- a/samples/client/petstore/go/go-petstore/docs/FakeClassnameTags123Api.md
+++ b/samples/client/petstore/go/go-petstore/docs/FakeClassnameTags123Api.md
@@ -15,7 +15,7 @@ To test class name in snake case
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
- **ctx** | **context.Context** | context containing the authentication | nil if no authentication
+ **ctx** | **context.Context** | context for logging, tracing, authentication, etc.
   **body** | [**Client**](Client.md)| client model | 
 
 ### Return type

--- a/samples/client/petstore/go/go-petstore/docs/PetApi.md
+++ b/samples/client/petstore/go/go-petstore/docs/PetApi.md
@@ -24,7 +24,7 @@ Add a new pet to the store
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
- **ctx** | **context.Context** | context containing the authentication | nil if no authentication
+ **ctx** | **context.Context** | context for logging, tracing, authentication, etc.
   **body** | [**Pet**](Pet.md)| Pet object that needs to be added to the store | 
 
 ### Return type
@@ -52,7 +52,7 @@ Deletes a pet
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
- **ctx** | **context.Context** | context containing the authentication | nil if no authentication
+ **ctx** | **context.Context** | context for logging, tracing, authentication, etc.
   **petId** | **int64**| Pet id to delete | 
  **optional** | **map[string]interface{}** | optional parameters | nil if no parameters
 
@@ -89,7 +89,7 @@ Multiple status values can be provided with comma separated strings
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
- **ctx** | **context.Context** | context containing the authentication | nil if no authentication
+ **ctx** | **context.Context** | context for logging, tracing, authentication, etc.
   **status** | [**[]string**](string.md)| Status values that need to be considered for filter | 
 
 ### Return type
@@ -117,7 +117,7 @@ Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
- **ctx** | **context.Context** | context containing the authentication | nil if no authentication
+ **ctx** | **context.Context** | context for logging, tracing, authentication, etc.
   **tags** | [**[]string**](string.md)| Tags to filter by | 
 
 ### Return type
@@ -145,7 +145,7 @@ Returns a single pet
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
- **ctx** | **context.Context** | context containing the authentication | nil if no authentication
+ **ctx** | **context.Context** | context for logging, tracing, authentication, etc.
   **petId** | **int64**| ID of pet to return | 
 
 ### Return type
@@ -173,7 +173,7 @@ Update an existing pet
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
- **ctx** | **context.Context** | context containing the authentication | nil if no authentication
+ **ctx** | **context.Context** | context for logging, tracing, authentication, etc.
   **body** | [**Pet**](Pet.md)| Pet object that needs to be added to the store | 
 
 ### Return type
@@ -201,7 +201,7 @@ Updates a pet in the store with form data
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
- **ctx** | **context.Context** | context containing the authentication | nil if no authentication
+ **ctx** | **context.Context** | context for logging, tracing, authentication, etc.
   **petId** | **int64**| ID of pet that needs to be updated | 
  **optional** | **map[string]interface{}** | optional parameters | nil if no parameters
 
@@ -239,7 +239,7 @@ uploads an image
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
- **ctx** | **context.Context** | context containing the authentication | nil if no authentication
+ **ctx** | **context.Context** | context for logging, tracing, authentication, etc.
   **petId** | **int64**| ID of pet to update | 
  **optional** | **map[string]interface{}** | optional parameters | nil if no parameters
 

--- a/samples/client/petstore/go/go-petstore/docs/StoreApi.md
+++ b/samples/client/petstore/go/go-petstore/docs/StoreApi.md
@@ -11,7 +11,7 @@ Method | HTTP request | Description
 
 
 # **DeleteOrder**
-> DeleteOrder(orderId)
+> DeleteOrder(ctx, orderId)
 Delete purchase order by ID
 
 For valid response try integer IDs with value < 1000. Anything above 1000 or nonintegers will generate API errors
@@ -20,6 +20,7 @@ For valid response try integer IDs with value < 1000. Anything above 1000 or non
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
+ **ctx** | **context.Context** | context for logging, tracing, authentication, etc.
   **orderId** | **string**| ID of the order that needs to be deleted | 
 
 ### Return type
@@ -62,7 +63,7 @@ This endpoint does not need any parameter.
 [[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
 
 # **GetOrderById**
-> Order GetOrderById(orderId)
+> Order GetOrderById(ctx, orderId)
 Find purchase order by ID
 
 For valid response try integer IDs with value <= 5 or > 10. Other values will generated exceptions
@@ -71,6 +72,7 @@ For valid response try integer IDs with value <= 5 or > 10. Other values will ge
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
+ **ctx** | **context.Context** | context for logging, tracing, authentication, etc.
   **orderId** | **int64**| ID of pet that needs to be fetched | 
 
 ### Return type
@@ -89,7 +91,7 @@ No authorization required
 [[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
 
 # **PlaceOrder**
-> Order PlaceOrder(body)
+> Order PlaceOrder(ctx, body)
 Place an order for a pet
 
 
@@ -98,6 +100,7 @@ Place an order for a pet
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
+ **ctx** | **context.Context** | context for logging, tracing, authentication, etc.
   **body** | [**Order**](Order.md)| order placed for purchasing the pet | 
 
 ### Return type

--- a/samples/client/petstore/go/go-petstore/docs/UserApi.md
+++ b/samples/client/petstore/go/go-petstore/docs/UserApi.md
@@ -15,7 +15,7 @@ Method | HTTP request | Description
 
 
 # **CreateUser**
-> CreateUser(body)
+> CreateUser(ctx, body)
 Create user
 
 This can only be done by the logged in user.
@@ -24,6 +24,7 @@ This can only be done by the logged in user.
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
+ **ctx** | **context.Context** | context for logging, tracing, authentication, etc.
   **body** | [**User**](User.md)| Created user object | 
 
 ### Return type
@@ -42,7 +43,7 @@ No authorization required
 [[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
 
 # **CreateUsersWithArrayInput**
-> CreateUsersWithArrayInput(body)
+> CreateUsersWithArrayInput(ctx, body)
 Creates list of users with given input array
 
 
@@ -51,6 +52,7 @@ Creates list of users with given input array
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
+ **ctx** | **context.Context** | context for logging, tracing, authentication, etc.
   **body** | [**[]User**](User.md)| List of user object | 
 
 ### Return type
@@ -69,7 +71,7 @@ No authorization required
 [[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
 
 # **CreateUsersWithListInput**
-> CreateUsersWithListInput(body)
+> CreateUsersWithListInput(ctx, body)
 Creates list of users with given input array
 
 
@@ -78,6 +80,7 @@ Creates list of users with given input array
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
+ **ctx** | **context.Context** | context for logging, tracing, authentication, etc.
   **body** | [**[]User**](User.md)| List of user object | 
 
 ### Return type
@@ -96,7 +99,7 @@ No authorization required
 [[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
 
 # **DeleteUser**
-> DeleteUser(username)
+> DeleteUser(ctx, username)
 Delete user
 
 This can only be done by the logged in user.
@@ -105,6 +108,7 @@ This can only be done by the logged in user.
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
+ **ctx** | **context.Context** | context for logging, tracing, authentication, etc.
   **username** | **string**| The name that needs to be deleted | 
 
 ### Return type
@@ -123,7 +127,7 @@ No authorization required
 [[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
 
 # **GetUserByName**
-> User GetUserByName(username)
+> User GetUserByName(ctx, username)
 Get user by user name
 
 
@@ -132,6 +136,7 @@ Get user by user name
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
+ **ctx** | **context.Context** | context for logging, tracing, authentication, etc.
   **username** | **string**| The name that needs to be fetched. Use user1 for testing.  | 
 
 ### Return type
@@ -150,7 +155,7 @@ No authorization required
 [[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
 
 # **LoginUser**
-> string LoginUser(username, password)
+> string LoginUser(ctx, username, password)
 Logs user into the system
 
 
@@ -159,6 +164,7 @@ Logs user into the system
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
+ **ctx** | **context.Context** | context for logging, tracing, authentication, etc.
   **username** | **string**| The user name for login | 
   **password** | **string**| The password for login in clear text | 
 
@@ -178,7 +184,7 @@ No authorization required
 [[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
 
 # **LogoutUser**
-> LogoutUser()
+> LogoutUser(ctx, )
 Logs out current logged in user session
 
 
@@ -202,7 +208,7 @@ No authorization required
 [[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
 
 # **UpdateUser**
-> UpdateUser(username, body)
+> UpdateUser(ctx, username, body)
 Updated user
 
 This can only be done by the logged in user.
@@ -211,6 +217,7 @@ This can only be done by the logged in user.
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
+ **ctx** | **context.Context** | context for logging, tracing, authentication, etc.
   **username** | **string**| name that need to be deleted | 
   **body** | [**User**](User.md)| Updated user object | 
 

--- a/samples/client/petstore/go/go-petstore/fake_api.go
+++ b/samples/client/petstore/go/go-petstore/fake_api.go
@@ -29,11 +29,11 @@ type FakeApiService service
 
 /* FakeApiService 
  Test serialization of outer boolean types
-
+ * @param ctx context.Context for authentication, logging, tracing, etc.
  @param optional (nil or map[string]interface{}) with one or more of:
      @param "body" (OuterBoolean) Input boolean as post body
  @return OuterBoolean*/
-func (a *FakeApiService) FakeOuterBooleanSerialize(localVarOptionals map[string]interface{}) (OuterBoolean,  *http.Response, error) {
+func (a *FakeApiService) FakeOuterBooleanSerialize(ctx context.Context, localVarOptionals map[string]interface{}) (OuterBoolean,  *http.Response, error) {
 	var (
 		localVarHttpMethod = strings.ToUpper("Post")
 		localVarPostBody interface{}
@@ -72,7 +72,7 @@ func (a *FakeApiService) FakeOuterBooleanSerialize(localVarOptionals map[string]
 	if localVarTempParam, localVarOk := localVarOptionals["body"].(OuterBoolean); localVarOk {
 		localVarPostBody = &localVarTempParam
 	}
-	r, err := a.client.prepareRequest(nil, localVarPath, localVarHttpMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFileName, localVarFileBytes)
+	r, err := a.client.prepareRequest(ctx, localVarPath, localVarHttpMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFileName, localVarFileBytes)
 	if err != nil {
 		return successPayload, nil, err
 	}
@@ -96,11 +96,11 @@ func (a *FakeApiService) FakeOuterBooleanSerialize(localVarOptionals map[string]
 
 /* FakeApiService 
  Test serialization of object with outer number type
-
+ * @param ctx context.Context for authentication, logging, tracing, etc.
  @param optional (nil or map[string]interface{}) with one or more of:
      @param "body" (OuterComposite) Input composite as post body
  @return OuterComposite*/
-func (a *FakeApiService) FakeOuterCompositeSerialize(localVarOptionals map[string]interface{}) (OuterComposite,  *http.Response, error) {
+func (a *FakeApiService) FakeOuterCompositeSerialize(ctx context.Context, localVarOptionals map[string]interface{}) (OuterComposite,  *http.Response, error) {
 	var (
 		localVarHttpMethod = strings.ToUpper("Post")
 		localVarPostBody interface{}
@@ -139,7 +139,7 @@ func (a *FakeApiService) FakeOuterCompositeSerialize(localVarOptionals map[strin
 	if localVarTempParam, localVarOk := localVarOptionals["body"].(OuterComposite); localVarOk {
 		localVarPostBody = &localVarTempParam
 	}
-	r, err := a.client.prepareRequest(nil, localVarPath, localVarHttpMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFileName, localVarFileBytes)
+	r, err := a.client.prepareRequest(ctx, localVarPath, localVarHttpMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFileName, localVarFileBytes)
 	if err != nil {
 		return successPayload, nil, err
 	}
@@ -163,11 +163,11 @@ func (a *FakeApiService) FakeOuterCompositeSerialize(localVarOptionals map[strin
 
 /* FakeApiService 
  Test serialization of outer number types
-
+ * @param ctx context.Context for authentication, logging, tracing, etc.
  @param optional (nil or map[string]interface{}) with one or more of:
      @param "body" (OuterNumber) Input number as post body
  @return OuterNumber*/
-func (a *FakeApiService) FakeOuterNumberSerialize(localVarOptionals map[string]interface{}) (OuterNumber,  *http.Response, error) {
+func (a *FakeApiService) FakeOuterNumberSerialize(ctx context.Context, localVarOptionals map[string]interface{}) (OuterNumber,  *http.Response, error) {
 	var (
 		localVarHttpMethod = strings.ToUpper("Post")
 		localVarPostBody interface{}
@@ -206,7 +206,7 @@ func (a *FakeApiService) FakeOuterNumberSerialize(localVarOptionals map[string]i
 	if localVarTempParam, localVarOk := localVarOptionals["body"].(OuterNumber); localVarOk {
 		localVarPostBody = &localVarTempParam
 	}
-	r, err := a.client.prepareRequest(nil, localVarPath, localVarHttpMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFileName, localVarFileBytes)
+	r, err := a.client.prepareRequest(ctx, localVarPath, localVarHttpMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFileName, localVarFileBytes)
 	if err != nil {
 		return successPayload, nil, err
 	}
@@ -230,11 +230,11 @@ func (a *FakeApiService) FakeOuterNumberSerialize(localVarOptionals map[string]i
 
 /* FakeApiService 
  Test serialization of outer string types
-
+ * @param ctx context.Context for authentication, logging, tracing, etc.
  @param optional (nil or map[string]interface{}) with one or more of:
      @param "body" (OuterString) Input string as post body
  @return OuterString*/
-func (a *FakeApiService) FakeOuterStringSerialize(localVarOptionals map[string]interface{}) (OuterString,  *http.Response, error) {
+func (a *FakeApiService) FakeOuterStringSerialize(ctx context.Context, localVarOptionals map[string]interface{}) (OuterString,  *http.Response, error) {
 	var (
 		localVarHttpMethod = strings.ToUpper("Post")
 		localVarPostBody interface{}
@@ -273,7 +273,7 @@ func (a *FakeApiService) FakeOuterStringSerialize(localVarOptionals map[string]i
 	if localVarTempParam, localVarOk := localVarOptionals["body"].(OuterString); localVarOk {
 		localVarPostBody = &localVarTempParam
 	}
-	r, err := a.client.prepareRequest(nil, localVarPath, localVarHttpMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFileName, localVarFileBytes)
+	r, err := a.client.prepareRequest(ctx, localVarPath, localVarHttpMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFileName, localVarFileBytes)
 	if err != nil {
 		return successPayload, nil, err
 	}
@@ -297,10 +297,10 @@ func (a *FakeApiService) FakeOuterStringSerialize(localVarOptionals map[string]i
 
 /* FakeApiService To test \&quot;client\&quot; model
  To test \&quot;client\&quot; model
-
+ * @param ctx context.Context for authentication, logging, tracing, etc.
  @param body client model
  @return Client*/
-func (a *FakeApiService) TestClientModel(body Client) (Client,  *http.Response, error) {
+func (a *FakeApiService) TestClientModel(ctx context.Context, body Client) (Client,  *http.Response, error) {
 	var (
 		localVarHttpMethod = strings.ToUpper("Patch")
 		localVarPostBody interface{}
@@ -338,7 +338,7 @@ func (a *FakeApiService) TestClientModel(body Client) (Client,  *http.Response, 
 	}
 	// body params
 	localVarPostBody = &body
-	r, err := a.client.prepareRequest(nil, localVarPath, localVarHttpMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFileName, localVarFileBytes)
+	r, err := a.client.prepareRequest(ctx, localVarPath, localVarHttpMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFileName, localVarFileBytes)
 	if err != nil {
 		return successPayload, nil, err
 	}
@@ -362,7 +362,7 @@ func (a *FakeApiService) TestClientModel(body Client) (Client,  *http.Response, 
 
 /* FakeApiService Fake endpoint for testing various parameters 假端點 偽のエンドポイント 가짜 엔드 포인트 
  Fake endpoint for testing various parameters 假端點 偽のエンドポイント 가짜 엔드 포인트 
- * @param ctx context.Context Authentication Context 
+ * @param ctx context.Context for authentication, logging, tracing, etc.
  @param number None
  @param double None
  @param patternWithoutDelimiter None
@@ -510,7 +510,7 @@ func (a *FakeApiService) TestEndpointParameters(ctx context.Context, number floa
 
 /* FakeApiService To test enum parameters
  To test enum parameters
-
+ * @param ctx context.Context for authentication, logging, tracing, etc.
  @param optional (nil or map[string]interface{}) with one or more of:
      @param "enumFormStringArray" ([]string) Form parameter enum test (string array)
      @param "enumFormString" (string) Form parameter enum test (string)
@@ -521,7 +521,7 @@ func (a *FakeApiService) TestEndpointParameters(ctx context.Context, number floa
      @param "enumQueryInteger" (int32) Query parameter enum test (double)
      @param "enumQueryDouble" (float64) Query parameter enum test (double)
  @return */
-func (a *FakeApiService) TestEnumParameters(localVarOptionals map[string]interface{}) ( *http.Response, error) {
+func (a *FakeApiService) TestEnumParameters(ctx context.Context, localVarOptionals map[string]interface{}) ( *http.Response, error) {
 	var (
 		localVarHttpMethod = strings.ToUpper("Get")
 		localVarPostBody interface{}
@@ -595,7 +595,65 @@ func (a *FakeApiService) TestEnumParameters(localVarOptionals map[string]interfa
 	if localVarTempParam, localVarOk := localVarOptionals["enumQueryDouble"].(float64); localVarOk {
 		localVarFormParams.Add("enum_query_double", parameterToString(localVarTempParam, ""))
 	}
-	r, err := a.client.prepareRequest(nil, localVarPath, localVarHttpMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFileName, localVarFileBytes)
+	r, err := a.client.prepareRequest(ctx, localVarPath, localVarHttpMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFileName, localVarFileBytes)
+	if err != nil {
+		return nil, err
+	}
+
+	localVarHttpResponse, err := a.client.callAPI(r)
+	if err != nil || localVarHttpResponse == nil {
+		return localVarHttpResponse, err
+	}
+	defer localVarHttpResponse.Body.Close()
+	if localVarHttpResponse.StatusCode >= 300 {
+		return localVarHttpResponse, reportError(localVarHttpResponse.Status)
+	}
+
+	return localVarHttpResponse, err
+}
+
+/* FakeApiService test inline additionalProperties
+ 
+ * @param ctx context.Context for authentication, logging, tracing, etc.
+ @param param request body
+ @return */
+func (a *FakeApiService) TestInlineAdditionalProperties(ctx context.Context, param interface{}) ( *http.Response, error) {
+	var (
+		localVarHttpMethod = strings.ToUpper("Post")
+		localVarPostBody interface{}
+		localVarFileName string
+		localVarFileBytes []byte
+	)
+
+	// create path and map variables
+	localVarPath := a.client.cfg.BasePath + "/fake/inline-additionalProperties"
+
+	localVarHeaderParams := make(map[string]string)
+	localVarQueryParams := url.Values{}
+	localVarFormParams := url.Values{}
+
+
+	// to determine the Content-Type header
+	localVarHttpContentTypes := []string{ "application/json",  }
+
+	// set Content-Type header
+	localVarHttpContentType := selectHeaderContentType(localVarHttpContentTypes)
+	if localVarHttpContentType != "" {
+		localVarHeaderParams["Content-Type"] = localVarHttpContentType
+	}
+
+	// to determine the Accept header
+	localVarHttpHeaderAccepts := []string{
+		}
+
+	// set Accept header
+	localVarHttpHeaderAccept := selectHeaderAccept(localVarHttpHeaderAccepts)
+	if localVarHttpHeaderAccept != "" {
+		localVarHeaderParams["Accept"] = localVarHttpHeaderAccept
+	}
+	// body params
+	localVarPostBody = &param
+	r, err := a.client.prepareRequest(ctx, localVarPath, localVarHttpMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFileName, localVarFileBytes)
 	if err != nil {
 		return nil, err
 	}
@@ -614,11 +672,11 @@ func (a *FakeApiService) TestEnumParameters(localVarOptionals map[string]interfa
 
 /* FakeApiService test json serialization of form data
  
-
+ * @param ctx context.Context for authentication, logging, tracing, etc.
  @param param field1
  @param param2 field2
  @return */
-func (a *FakeApiService) TestJsonFormData(param string, param2 string) ( *http.Response, error) {
+func (a *FakeApiService) TestJsonFormData(ctx context.Context, param string, param2 string) ( *http.Response, error) {
 	var (
 		localVarHttpMethod = strings.ToUpper("Get")
 		localVarPostBody interface{}
@@ -654,7 +712,7 @@ func (a *FakeApiService) TestJsonFormData(param string, param2 string) ( *http.R
 	}
 	localVarFormParams.Add("param", parameterToString(param, ""))
 	localVarFormParams.Add("param2", parameterToString(param2, ""))
-	r, err := a.client.prepareRequest(nil, localVarPath, localVarHttpMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFileName, localVarFileBytes)
+	r, err := a.client.prepareRequest(ctx, localVarPath, localVarHttpMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFileName, localVarFileBytes)
 	if err != nil {
 		return nil, err
 	}

--- a/samples/client/petstore/go/go-petstore/fake_classname_tags123_api.go
+++ b/samples/client/petstore/go/go-petstore/fake_classname_tags123_api.go
@@ -27,7 +27,7 @@ type FakeClassnameTags123ApiService service
 
 
 /* FakeClassnameTags123ApiService To test class name in snake case
- * @param ctx context.Context Authentication Context 
+ * @param ctx context.Context for authentication, logging, tracing, etc.
  @param body client model
  @return Client*/
 func (a *FakeClassnameTags123ApiService) TestClassname(ctx context.Context, body Client) (Client,  *http.Response, error) {

--- a/samples/client/petstore/go/go-petstore/git_push.sh
+++ b/samples/client/petstore/go/go-petstore/git_push.sh
@@ -36,7 +36,7 @@ git_remote=`git remote`
 if [ "$git_remote" = "" ]; then # git remote not defined
 
     if [ "$GIT_TOKEN" = "" ]; then
-        echo "[INFO] \$GIT_TOKEN (environment variable) is not set. Using the git crediential in your environment."
+        echo "[INFO] \$GIT_TOKEN (environment variable) is not set. Using the git credential in your environment."
         git remote add origin https://github.com/${git_user_id}/${git_repo_id}.git
     else
         git remote add origin https://${git_user_id}:${GIT_TOKEN}@github.com/${git_user_id}/${git_repo_id}.git

--- a/samples/client/petstore/go/go-petstore/pet_api.go
+++ b/samples/client/petstore/go/go-petstore/pet_api.go
@@ -31,7 +31,7 @@ type PetApiService service
 
 /* PetApiService Add a new pet to the store
  
- * @param ctx context.Context Authentication Context 
+ * @param ctx context.Context for authentication, logging, tracing, etc.
  @param body Pet object that needs to be added to the store
  @return */
 func (a *PetApiService) AddPet(ctx context.Context, body Pet) ( *http.Response, error) {
@@ -91,7 +91,7 @@ func (a *PetApiService) AddPet(ctx context.Context, body Pet) ( *http.Response, 
 
 /* PetApiService Deletes a pet
  
- * @param ctx context.Context Authentication Context 
+ * @param ctx context.Context for authentication, logging, tracing, etc.
  @param petId Pet id to delete
  @param optional (nil or map[string]interface{}) with one or more of:
      @param "apiKey" (string) 
@@ -158,7 +158,7 @@ func (a *PetApiService) DeletePet(ctx context.Context, petId int64, localVarOpti
 
 /* PetApiService Finds Pets by status
  Multiple status values can be provided with comma separated strings
- * @param ctx context.Context Authentication Context 
+ * @param ctx context.Context for authentication, logging, tracing, etc.
  @param status Status values that need to be considered for filter
  @return []Pet*/
 func (a *PetApiService) FindPetsByStatus(ctx context.Context, status []string) ([]Pet,  *http.Response, error) {
@@ -223,7 +223,7 @@ func (a *PetApiService) FindPetsByStatus(ctx context.Context, status []string) (
 
 /* PetApiService Finds Pets by tags
  Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
- * @param ctx context.Context Authentication Context 
+ * @param ctx context.Context for authentication, logging, tracing, etc.
  @param tags Tags to filter by
  @return []Pet*/
 func (a *PetApiService) FindPetsByTags(ctx context.Context, tags []string) ([]Pet,  *http.Response, error) {
@@ -288,7 +288,7 @@ func (a *PetApiService) FindPetsByTags(ctx context.Context, tags []string) ([]Pe
 
 /* PetApiService Find pet by ID
  Returns a single pet
- * @param ctx context.Context Authentication Context 
+ * @param ctx context.Context for authentication, logging, tracing, etc.
  @param petId ID of pet to return
  @return Pet*/
 func (a *PetApiService) GetPetById(ctx context.Context, petId int64) (Pet,  *http.Response, error) {
@@ -365,7 +365,7 @@ func (a *PetApiService) GetPetById(ctx context.Context, petId int64) (Pet,  *htt
 
 /* PetApiService Update an existing pet
  
- * @param ctx context.Context Authentication Context 
+ * @param ctx context.Context for authentication, logging, tracing, etc.
  @param body Pet object that needs to be added to the store
  @return */
 func (a *PetApiService) UpdatePet(ctx context.Context, body Pet) ( *http.Response, error) {
@@ -425,7 +425,7 @@ func (a *PetApiService) UpdatePet(ctx context.Context, body Pet) ( *http.Respons
 
 /* PetApiService Updates a pet in the store with form data
  
- * @param ctx context.Context Authentication Context 
+ * @param ctx context.Context for authentication, logging, tracing, etc.
  @param petId ID of pet that needs to be updated
  @param optional (nil or map[string]interface{}) with one or more of:
      @param "name" (string) Updated name of the pet
@@ -499,7 +499,7 @@ func (a *PetApiService) UpdatePetWithForm(ctx context.Context, petId int64, loca
 
 /* PetApiService uploads an image
  
- * @param ctx context.Context Authentication Context 
+ * @param ctx context.Context for authentication, logging, tracing, etc.
  @param petId ID of pet to update
  @param optional (nil or map[string]interface{}) with one or more of:
      @param "additionalMetadata" (string) Additional data to pass to server

--- a/samples/client/petstore/go/go-petstore/store_api.go
+++ b/samples/client/petstore/go/go-petstore/store_api.go
@@ -29,10 +29,10 @@ type StoreApiService service
 
 /* StoreApiService Delete purchase order by ID
  For valid response try integer IDs with value &lt; 1000. Anything above 1000 or nonintegers will generate API errors
-
+ * @param ctx context.Context for authentication, logging, tracing, etc.
  @param orderId ID of the order that needs to be deleted
  @return */
-func (a *StoreApiService) DeleteOrder(orderId string) ( *http.Response, error) {
+func (a *StoreApiService) DeleteOrder(ctx context.Context, orderId string) ( *http.Response, error) {
 	var (
 		localVarHttpMethod = strings.ToUpper("Delete")
 		localVarPostBody interface{}
@@ -69,7 +69,7 @@ func (a *StoreApiService) DeleteOrder(orderId string) ( *http.Response, error) {
 	if localVarHttpHeaderAccept != "" {
 		localVarHeaderParams["Accept"] = localVarHttpHeaderAccept
 	}
-	r, err := a.client.prepareRequest(nil, localVarPath, localVarHttpMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFileName, localVarFileBytes)
+	r, err := a.client.prepareRequest(ctx, localVarPath, localVarHttpMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFileName, localVarFileBytes)
 	if err != nil {
 		return nil, err
 	}
@@ -88,7 +88,7 @@ func (a *StoreApiService) DeleteOrder(orderId string) ( *http.Response, error) {
 
 /* StoreApiService Returns pet inventories by status
  Returns a map of status codes to quantities
- * @param ctx context.Context Authentication Context 
+ * @param ctx context.Context for authentication, logging, tracing, etc.
  @return map[string]int32*/
 func (a *StoreApiService) GetInventory(ctx context.Context, ) (map[string]int32,  *http.Response, error) {
 	var (
@@ -162,10 +162,10 @@ func (a *StoreApiService) GetInventory(ctx context.Context, ) (map[string]int32,
 
 /* StoreApiService Find purchase order by ID
  For valid response try integer IDs with value &lt;&#x3D; 5 or &gt; 10. Other values will generated exceptions
-
+ * @param ctx context.Context for authentication, logging, tracing, etc.
  @param orderId ID of pet that needs to be fetched
  @return Order*/
-func (a *StoreApiService) GetOrderById(orderId int64) (Order,  *http.Response, error) {
+func (a *StoreApiService) GetOrderById(ctx context.Context, orderId int64) (Order,  *http.Response, error) {
 	var (
 		localVarHttpMethod = strings.ToUpper("Get")
 		localVarPostBody interface{}
@@ -209,7 +209,7 @@ func (a *StoreApiService) GetOrderById(orderId int64) (Order,  *http.Response, e
 	if localVarHttpHeaderAccept != "" {
 		localVarHeaderParams["Accept"] = localVarHttpHeaderAccept
 	}
-	r, err := a.client.prepareRequest(nil, localVarPath, localVarHttpMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFileName, localVarFileBytes)
+	r, err := a.client.prepareRequest(ctx, localVarPath, localVarHttpMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFileName, localVarFileBytes)
 	if err != nil {
 		return successPayload, nil, err
 	}
@@ -233,10 +233,10 @@ func (a *StoreApiService) GetOrderById(orderId int64) (Order,  *http.Response, e
 
 /* StoreApiService Place an order for a pet
  
-
+ * @param ctx context.Context for authentication, logging, tracing, etc.
  @param body order placed for purchasing the pet
  @return Order*/
-func (a *StoreApiService) PlaceOrder(body Order) (Order,  *http.Response, error) {
+func (a *StoreApiService) PlaceOrder(ctx context.Context, body Order) (Order,  *http.Response, error) {
 	var (
 		localVarHttpMethod = strings.ToUpper("Post")
 		localVarPostBody interface{}
@@ -275,7 +275,7 @@ func (a *StoreApiService) PlaceOrder(body Order) (Order,  *http.Response, error)
 	}
 	// body params
 	localVarPostBody = &body
-	r, err := a.client.prepareRequest(nil, localVarPath, localVarHttpMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFileName, localVarFileBytes)
+	r, err := a.client.prepareRequest(ctx, localVarPath, localVarHttpMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFileName, localVarFileBytes)
 	if err != nil {
 		return successPayload, nil, err
 	}

--- a/samples/client/petstore/go/go-petstore/store_api.go
+++ b/samples/client/petstore/go/go-petstore/store_api.go
@@ -90,7 +90,7 @@ func (a *StoreApiService) DeleteOrder(ctx context.Context, orderId string) ( *ht
  Returns a map of status codes to quantities
  * @param ctx context.Context for authentication, logging, tracing, etc.
  @return map[string]int32*/
-func (a *StoreApiService) GetInventory(ctx context.Context, ) (map[string]int32,  *http.Response, error) {
+func (a *StoreApiService) GetInventory(ctx context.Context) (map[string]int32,  *http.Response, error) {
 	var (
 		localVarHttpMethod = strings.ToUpper("Get")
 		localVarPostBody interface{}

--- a/samples/client/petstore/go/go-petstore/user_api.go
+++ b/samples/client/petstore/go/go-petstore/user_api.go
@@ -402,7 +402,7 @@ func (a *UserApiService) LoginUser(ctx context.Context, username string, passwor
  
  * @param ctx context.Context for authentication, logging, tracing, etc.
  @return */
-func (a *UserApiService) LogoutUser(ctx context.Context, ) ( *http.Response, error) {
+func (a *UserApiService) LogoutUser(ctx context.Context) ( *http.Response, error) {
 	var (
 		localVarHttpMethod = strings.ToUpper("Get")
 		localVarPostBody interface{}

--- a/samples/client/petstore/go/go-petstore/user_api.go
+++ b/samples/client/petstore/go/go-petstore/user_api.go
@@ -29,10 +29,10 @@ type UserApiService service
 
 /* UserApiService Create user
  This can only be done by the logged in user.
-
+ * @param ctx context.Context for authentication, logging, tracing, etc.
  @param body Created user object
  @return */
-func (a *UserApiService) CreateUser(body User) ( *http.Response, error) {
+func (a *UserApiService) CreateUser(ctx context.Context, body User) ( *http.Response, error) {
 	var (
 		localVarHttpMethod = strings.ToUpper("Post")
 		localVarPostBody interface{}
@@ -70,7 +70,7 @@ func (a *UserApiService) CreateUser(body User) ( *http.Response, error) {
 	}
 	// body params
 	localVarPostBody = &body
-	r, err := a.client.prepareRequest(nil, localVarPath, localVarHttpMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFileName, localVarFileBytes)
+	r, err := a.client.prepareRequest(ctx, localVarPath, localVarHttpMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFileName, localVarFileBytes)
 	if err != nil {
 		return nil, err
 	}
@@ -89,10 +89,10 @@ func (a *UserApiService) CreateUser(body User) ( *http.Response, error) {
 
 /* UserApiService Creates list of users with given input array
  
-
+ * @param ctx context.Context for authentication, logging, tracing, etc.
  @param body List of user object
  @return */
-func (a *UserApiService) CreateUsersWithArrayInput(body []User) ( *http.Response, error) {
+func (a *UserApiService) CreateUsersWithArrayInput(ctx context.Context, body []User) ( *http.Response, error) {
 	var (
 		localVarHttpMethod = strings.ToUpper("Post")
 		localVarPostBody interface{}
@@ -130,7 +130,7 @@ func (a *UserApiService) CreateUsersWithArrayInput(body []User) ( *http.Response
 	}
 	// body params
 	localVarPostBody = &body
-	r, err := a.client.prepareRequest(nil, localVarPath, localVarHttpMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFileName, localVarFileBytes)
+	r, err := a.client.prepareRequest(ctx, localVarPath, localVarHttpMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFileName, localVarFileBytes)
 	if err != nil {
 		return nil, err
 	}
@@ -149,10 +149,10 @@ func (a *UserApiService) CreateUsersWithArrayInput(body []User) ( *http.Response
 
 /* UserApiService Creates list of users with given input array
  
-
+ * @param ctx context.Context for authentication, logging, tracing, etc.
  @param body List of user object
  @return */
-func (a *UserApiService) CreateUsersWithListInput(body []User) ( *http.Response, error) {
+func (a *UserApiService) CreateUsersWithListInput(ctx context.Context, body []User) ( *http.Response, error) {
 	var (
 		localVarHttpMethod = strings.ToUpper("Post")
 		localVarPostBody interface{}
@@ -190,7 +190,7 @@ func (a *UserApiService) CreateUsersWithListInput(body []User) ( *http.Response,
 	}
 	// body params
 	localVarPostBody = &body
-	r, err := a.client.prepareRequest(nil, localVarPath, localVarHttpMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFileName, localVarFileBytes)
+	r, err := a.client.prepareRequest(ctx, localVarPath, localVarHttpMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFileName, localVarFileBytes)
 	if err != nil {
 		return nil, err
 	}
@@ -209,10 +209,10 @@ func (a *UserApiService) CreateUsersWithListInput(body []User) ( *http.Response,
 
 /* UserApiService Delete user
  This can only be done by the logged in user.
-
+ * @param ctx context.Context for authentication, logging, tracing, etc.
  @param username The name that needs to be deleted
  @return */
-func (a *UserApiService) DeleteUser(username string) ( *http.Response, error) {
+func (a *UserApiService) DeleteUser(ctx context.Context, username string) ( *http.Response, error) {
 	var (
 		localVarHttpMethod = strings.ToUpper("Delete")
 		localVarPostBody interface{}
@@ -249,7 +249,7 @@ func (a *UserApiService) DeleteUser(username string) ( *http.Response, error) {
 	if localVarHttpHeaderAccept != "" {
 		localVarHeaderParams["Accept"] = localVarHttpHeaderAccept
 	}
-	r, err := a.client.prepareRequest(nil, localVarPath, localVarHttpMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFileName, localVarFileBytes)
+	r, err := a.client.prepareRequest(ctx, localVarPath, localVarHttpMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFileName, localVarFileBytes)
 	if err != nil {
 		return nil, err
 	}
@@ -268,10 +268,10 @@ func (a *UserApiService) DeleteUser(username string) ( *http.Response, error) {
 
 /* UserApiService Get user by user name
  
-
+ * @param ctx context.Context for authentication, logging, tracing, etc.
  @param username The name that needs to be fetched. Use user1 for testing. 
  @return User*/
-func (a *UserApiService) GetUserByName(username string) (User,  *http.Response, error) {
+func (a *UserApiService) GetUserByName(ctx context.Context, username string) (User,  *http.Response, error) {
 	var (
 		localVarHttpMethod = strings.ToUpper("Get")
 		localVarPostBody interface{}
@@ -309,7 +309,7 @@ func (a *UserApiService) GetUserByName(username string) (User,  *http.Response, 
 	if localVarHttpHeaderAccept != "" {
 		localVarHeaderParams["Accept"] = localVarHttpHeaderAccept
 	}
-	r, err := a.client.prepareRequest(nil, localVarPath, localVarHttpMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFileName, localVarFileBytes)
+	r, err := a.client.prepareRequest(ctx, localVarPath, localVarHttpMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFileName, localVarFileBytes)
 	if err != nil {
 		return successPayload, nil, err
 	}
@@ -333,11 +333,11 @@ func (a *UserApiService) GetUserByName(username string) (User,  *http.Response, 
 
 /* UserApiService Logs user into the system
  
-
+ * @param ctx context.Context for authentication, logging, tracing, etc.
  @param username The user name for login
  @param password The password for login in clear text
  @return string*/
-func (a *UserApiService) LoginUser(username string, password string) (string,  *http.Response, error) {
+func (a *UserApiService) LoginUser(ctx context.Context, username string, password string) (string,  *http.Response, error) {
 	var (
 		localVarHttpMethod = strings.ToUpper("Get")
 		localVarPostBody interface{}
@@ -376,7 +376,7 @@ func (a *UserApiService) LoginUser(username string, password string) (string,  *
 	if localVarHttpHeaderAccept != "" {
 		localVarHeaderParams["Accept"] = localVarHttpHeaderAccept
 	}
-	r, err := a.client.prepareRequest(nil, localVarPath, localVarHttpMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFileName, localVarFileBytes)
+	r, err := a.client.prepareRequest(ctx, localVarPath, localVarHttpMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFileName, localVarFileBytes)
 	if err != nil {
 		return successPayload, nil, err
 	}
@@ -400,9 +400,9 @@ func (a *UserApiService) LoginUser(username string, password string) (string,  *
 
 /* UserApiService Logs out current logged in user session
  
-
+ * @param ctx context.Context for authentication, logging, tracing, etc.
  @return */
-func (a *UserApiService) LogoutUser() ( *http.Response, error) {
+func (a *UserApiService) LogoutUser(ctx context.Context, ) ( *http.Response, error) {
 	var (
 		localVarHttpMethod = strings.ToUpper("Get")
 		localVarPostBody interface{}
@@ -438,7 +438,7 @@ func (a *UserApiService) LogoutUser() ( *http.Response, error) {
 	if localVarHttpHeaderAccept != "" {
 		localVarHeaderParams["Accept"] = localVarHttpHeaderAccept
 	}
-	r, err := a.client.prepareRequest(nil, localVarPath, localVarHttpMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFileName, localVarFileBytes)
+	r, err := a.client.prepareRequest(ctx, localVarPath, localVarHttpMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFileName, localVarFileBytes)
 	if err != nil {
 		return nil, err
 	}
@@ -457,11 +457,11 @@ func (a *UserApiService) LogoutUser() ( *http.Response, error) {
 
 /* UserApiService Updated user
  This can only be done by the logged in user.
-
+ * @param ctx context.Context for authentication, logging, tracing, etc.
  @param username name that need to be deleted
  @param body Updated user object
  @return */
-func (a *UserApiService) UpdateUser(username string, body User) ( *http.Response, error) {
+func (a *UserApiService) UpdateUser(ctx context.Context, username string, body User) ( *http.Response, error) {
 	var (
 		localVarHttpMethod = strings.ToUpper("Put")
 		localVarPostBody interface{}
@@ -500,7 +500,7 @@ func (a *UserApiService) UpdateUser(username string, body User) ( *http.Response
 	}
 	// body params
 	localVarPostBody = &body
-	r, err := a.client.prepareRequest(nil, localVarPath, localVarHttpMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFileName, localVarFileBytes)
+	r, err := a.client.prepareRequest(ctx, localVarPath, localVarHttpMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFileName, localVarFileBytes)
 	if err != nil {
 		return nil, err
 	}

--- a/samples/client/petstore/go/pet_api_test.go
+++ b/samples/client/petstore/go/pet_api_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	sw "./go-petstore"
+	"golang.org/x/net/context"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -27,7 +28,7 @@ func TestAddPet(t *testing.T) {
 	newPet := (sw.Pet{Id: 12830, Name: "gopher",
 		PhotoUrls: []string{"http://1.com", "http://2.com"}, Status: "pending", Tags: []sw.Tag{sw.Tag{Id: 1, Name: "tag2"}}})
 
-	r, err := client.PetApi.AddPet(nil, newPet)
+	r, err := client.PetApi.AddPet(context.Background(), newPet)
 
 	if err != nil {
 		t.Errorf("Error while adding pet")
@@ -39,7 +40,7 @@ func TestAddPet(t *testing.T) {
 }
 
 func TestFindPetsByStatusWithMissingParam(t *testing.T) {
-	_, r, err := client.PetApi.FindPetsByStatus(nil, nil)
+	_, r, err := client.PetApi.FindPetsByStatus(context.Background(), nil)
 
 	if err != nil {
 		t.Errorf("Error while testing TestFindPetsByStatusWithMissingParam")
@@ -55,7 +56,7 @@ func TestGetPetById(t *testing.T) {
 }
 
 func TestGetPetByIdWithInvalidID(t *testing.T) {
-	resp, r, err := client.PetApi.GetPetById(nil, 999999999)
+	resp, r, err := client.PetApi.GetPetById(context.Background(), 999999999)
 	if r != nil && r.StatusCode == 404 {
 		return // This is a pass condition. API will return with a 404 error.
 	} else if err != nil {
@@ -68,7 +69,7 @@ func TestGetPetByIdWithInvalidID(t *testing.T) {
 }
 
 func TestUpdatePetWithForm(t *testing.T) {
-	r, err := client.PetApi.UpdatePetWithForm(nil, 12830, map[string]interface{}{"name": "golang", "status": "available"})
+	r, err := client.PetApi.UpdatePetWithForm(context.Background(), 12830, map[string]interface{}{"name": "golang", "status": "available"})
 
 	if err != nil {
 		t.Errorf("Error while updating pet by id")
@@ -82,7 +83,7 @@ func TestUpdatePetWithForm(t *testing.T) {
 
 func TestFindPetsByTag(t *testing.T) {
 	var found = false
-	resp, r, err := client.PetApi.FindPetsByTags(nil, []string{"tag2"})
+	resp, r, err := client.PetApi.FindPetsByTags(context.Background(), []string{"tag2"})
 	if err != nil {
 		t.Errorf("Error while getting pet by tag")
 		t.Log(err)
@@ -112,7 +113,7 @@ func TestFindPetsByTag(t *testing.T) {
 }
 
 func TestFindPetsByStatus(t *testing.T) {
-	resp, r, err := client.PetApi.FindPetsByStatus(nil, []string{"available"})
+	resp, r, err := client.PetApi.FindPetsByStatus(context.Background(), []string{"available"})
 	if err != nil {
 		t.Errorf("Error while getting pet by id")
 		t.Log(err)
@@ -136,7 +137,7 @@ func TestFindPetsByStatus(t *testing.T) {
 func TestUploadFile(t *testing.T) {
 	file, _ := os.Open("../python/testfiles/foo.png")
 
-	_, r, err := client.PetApi.UploadFile(nil, 12830, map[string]interface{}{"name": "golang", "file": file})
+	_, r, err := client.PetApi.UploadFile(context.Background(), 12830, map[string]interface{}{"name": "golang", "file": file})
 
 	if err != nil {
 		t.Errorf("Error while uploading file")
@@ -149,7 +150,7 @@ func TestUploadFile(t *testing.T) {
 }
 
 func TestDeletePet(t *testing.T) {
-	r, err := client.PetApi.DeletePet(nil, 12830, nil)
+	r, err := client.PetApi.DeletePet(context.Background(), 12830, nil)
 
 	if err != nil {
 		t.Errorf("Error while deleting pet by id")
@@ -241,7 +242,7 @@ func waitOnFunctions(t *testing.T, errc chan error, n int) {
 }
 
 func deletePet(t *testing.T, id int64) {
-	r, err := client.PetApi.DeletePet(nil, id, nil)
+	r, err := client.PetApi.DeletePet(context.Background(), id, nil)
 
 	if err != nil {
 		t.Errorf("Error while deleting pet by id")
@@ -254,7 +255,7 @@ func deletePet(t *testing.T, id int64) {
 
 func isPetCorrect(t *testing.T, id int64, name string, status string) {
 	assert := assert.New(t)
-	resp, r, err := client.PetApi.GetPetById(nil, id)
+	resp, r, err := client.PetApi.GetPetById(context.Background(), id)
 	if err != nil {
 		t.Errorf("Error while getting pet by id")
 		t.Log(err)

--- a/samples/client/petstore/go/pet_api_test.go
+++ b/samples/client/petstore/go/pet_api_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	sw "./go-petstore"
+
 	"github.com/stretchr/testify/assert"
 )
 
@@ -80,7 +81,7 @@ func TestUpdatePetWithForm(t *testing.T) {
 }
 
 func TestFindPetsByTag(t *testing.T) {
-	var found bool = false
+	var found = false
 	resp, r, err := client.PetApi.FindPetsByTags(nil, []string{"tag2"})
 	if err != nil {
 		t.Errorf("Error while getting pet by tag")

--- a/samples/client/petstore/go/user_api_test.go
+++ b/samples/client/petstore/go/user_api_test.go
@@ -4,6 +4,8 @@ import (
 	"testing"
 
 	sw "./go-petstore"
+	"golang.org/x/net/context"
+
 	"github.com/stretchr/testify/assert"
 )
 
@@ -18,7 +20,7 @@ func TestCreateUser(t *testing.T) {
 		Phone:      "5101112222",
 		UserStatus: 1}
 
-	apiResponse, err := client.UserApi.CreateUser(newUser)
+	apiResponse, err := client.UserApi.CreateUser(context.Background(), newUser)
 
 	if err != nil {
 		t.Errorf("Error while adding user")
@@ -54,7 +56,7 @@ func TestCreateUsersWithArrayInput(t *testing.T) {
 		},
 	}
 
-	apiResponse, err := client.UserApi.CreateUsersWithArrayInput(newUsers)
+	apiResponse, err := client.UserApi.CreateUsersWithArrayInput(context.Background(), newUsers)
 	if err != nil {
 		t.Errorf("Error while adding users")
 		t.Log(err)
@@ -64,13 +66,13 @@ func TestCreateUsersWithArrayInput(t *testing.T) {
 	}
 
 	//tear down
-	_, err1 := client.UserApi.DeleteUser("gopher1")
+	_, err1 := client.UserApi.DeleteUser(context.Background(), "gopher1")
 	if err1 != nil {
 		t.Errorf("Error while deleting user")
 		t.Log(err1)
 	}
 
-	_, err2 := client.UserApi.DeleteUser("gopher2")
+	_, err2 := client.UserApi.DeleteUser(context.Background(), "gopher2")
 	if err2 != nil {
 		t.Errorf("Error while deleting user")
 		t.Log(err2)
@@ -80,7 +82,7 @@ func TestCreateUsersWithArrayInput(t *testing.T) {
 func TestGetUserByName(t *testing.T) {
 	assert := assert.New(t)
 
-	resp, apiResponse, err := client.UserApi.GetUserByName("gopher")
+	resp, apiResponse, err := client.UserApi.GetUserByName(context.Background(), "gopher")
 	if err != nil {
 		t.Errorf("Error while getting user by id")
 		t.Log(err)
@@ -96,7 +98,7 @@ func TestGetUserByName(t *testing.T) {
 }
 
 func TestGetUserByNameWithInvalidID(t *testing.T) {
-	resp, apiResponse, err := client.UserApi.GetUserByName("999999999")
+	resp, apiResponse, err := client.UserApi.GetUserByName(context.Background(), "999999999")
 	if apiResponse != nil && apiResponse.StatusCode == 404 {
 		return // This is a pass condition. API will return with a 404 error.
 	} else if err != nil {
@@ -124,7 +126,7 @@ func TestUpdateUser(t *testing.T) {
 		Phone:      "5101112222",
 		UserStatus: 1}
 
-	apiResponse, err := client.UserApi.UpdateUser("gopher", newUser)
+	apiResponse, err := client.UserApi.UpdateUser(context.Background(), "gopher", newUser)
 	if err != nil {
 		t.Errorf("Error while deleting user by id")
 		t.Log(err)
@@ -134,7 +136,7 @@ func TestUpdateUser(t *testing.T) {
 	}
 
 	//verify changings are correct
-	resp, apiResponse, err := client.UserApi.GetUserByName("gopher")
+	resp, apiResponse, err := client.UserApi.GetUserByName(context.Background(), "gopher")
 	if err != nil {
 		t.Errorf("Error while getting user by id")
 		t.Log(err)
@@ -146,7 +148,7 @@ func TestUpdateUser(t *testing.T) {
 }
 
 func TestDeleteUser(t *testing.T) {
-	apiResponse, err := client.UserApi.DeleteUser("gopher")
+	apiResponse, err := client.UserApi.DeleteUser(context.Background(), "gopher")
 
 	if err != nil {
 		t.Errorf("Error while deleting user")


### PR DESCRIPTION
### PR checklist

- [X] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [X] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [X] Filed the PR against the correct branch: `3.0.0` branch for changes related to OpenAPI spec 3.0. Default: `master`.
- [X] Copied the [technical committee](https://github.com/swagger-api/swagger-codegen/#swagger-codegen-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Addition of Context to all requests
Added context.Context to all requests and tied to the request to be utilized for cancellations, deadlines, logging, tracing, as well as authentication or other value transfer.
Converted to text context keys. int will cause a linter warning.


