### PR TITLE
Upgrade to resteasy-jackson2-provider

### DIFF
--- a/modules/swagger-codegen/src/main/resources/Java/libraries/resteasy/pom.mustache
+++ b/modules/swagger-codegen/src/main/resources/Java/libraries/resteasy/pom.mustache
@@ -202,7 +202,7 @@
     {{/supportJava6}}
     <dependency>
       <groupId>org.jboss.resteasy</groupId>
-      <artifactId>resteasy-jackson-provider</artifactId>
+      <artifactId>resteasy-jackson2-provider</artifactId>
       <version>3.1.3.Final</version>
     </dependency>
     <dependency>


### PR DESCRIPTION
Since jackson-2.6.4 is used the dependency resteasy-jackson2-provider should be used to reflect that. 

### PR checklist

- [ ] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [ ] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [ ] Filed the PR against the correct branch: `3.0.0` branch for changes related to OpenAPI spec 3.0. Default: `master`.
- [ ] Copied the [technical committee](https://github.com/swagger-api/swagger-codegen/#swagger-codegen-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

(details of the change, additional tests that have been done, reference to the issue for tracking, etc)

