### PR TITLE
[Python][Flask] use python client's "toOperationId"

### DIFF
--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/FlaskConnexionCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/FlaskConnexionCodegen.java
@@ -473,13 +473,18 @@ public class FlaskConnexionCodegen extends DefaultCodegen implements CodegenConf
 
     @Override
     public String toOperationId(String operationId) {
-        operationId = super.toOperationId(operationId); // FIXME: a parameter should not be assigned. Also declare the methods parameters as 'final'.
-        // Use the part after the last dot, e.g.
-        //     controllers.defaultController.addPet => addPet
-        operationId = operationId.replaceAll(".*\\.", "");
-        // Need to underscore it since it has been processed via removeNonNameElementToCamelCase, e.g.
-        //     addPet => add_pet
-        return underscore(operationId);
+        // throw exception if method name is empty (should not occur as an auto-generated method name will be used)
+        if (StringUtils.isEmpty(operationId)) {
+            throw new RuntimeException("Empty method name (operationId) not allowed");
+        }
+
+        // method name cannot use reserved keyword, e.g. return
+        if (isReservedWord(operationId)) {
+            LOGGER.warn(operationId + " (reserved word) cannot be used as method name. Renamed to " + underscore(sanitizeName("call_" + operationId)));
+            operationId = "call_" + operationId;
+        }
+
+        return underscore(sanitizeName(operationId));
     }
 
     /**

--- a/samples/server/petstore/flaskConnexion-python2/git_push.sh
+++ b/samples/server/petstore/flaskConnexion-python2/git_push.sh
@@ -36,7 +36,7 @@ git_remote=`git remote`
 if [ "$git_remote" = "" ]; then # git remote not defined
 
     if [ "$GIT_TOKEN" = "" ]; then
-        echo "[INFO] \$GIT_TOKEN (environment variable) is not set. Using the git crediential in your environment."
+        echo "[INFO] \$GIT_TOKEN (environment variable) is not set. Using the git credential in your environment."
         git remote add origin https://github.com/${git_user_id}/${git_repo_id}.git
     else
         git remote add origin https://${git_user_id}:${GIT_TOKEN}@github.com/${git_user_id}/${git_repo_id}.git

--- a/samples/server/petstore/flaskConnexion-python2/swagger_server/swagger/swagger.yaml
+++ b/samples/server/petstore/flaskConnexion-python2/swagger_server/swagger/swagger.yaml
@@ -108,11 +108,11 @@ paths:
         type: "array"
         items:
           type: "string"
+          default: "available"
           enum:
           - "available"
           - "pending"
           - "sold"
-          default: "available"
         collectionFormat: "csv"
       responses:
         200:
@@ -627,12 +627,12 @@ definitions:
     title: "Pet Order"
     description: "An order for a pets from the pet store"
     example:
-      id: 0
       petId: 6
+      quantity: 1
+      id: 0
+      shipDate: "2000-01-23T04:56:07.000+00:00"
       complete: false
       status: "placed"
-      quantity: 1
-      shipDate: "2000-01-23T04:56:07.000+00:00"
     xml:
       name: "Order"
   Category:
@@ -646,8 +646,8 @@ definitions:
     title: "Pet catehgry"
     description: "A category for a pet"
     example:
-      id: 6
       name: "name"
+      id: 6
     xml:
       name: "Category"
   User:
@@ -675,14 +675,14 @@ definitions:
     title: "a User"
     description: "A User who is purchasing from the pet store"
     example:
-      id: 0
-      lastName: "lastName"
-      phone: "phone"
-      username: "username"
-      email: "email"
-      userStatus: 6
       firstName: "firstName"
+      lastName: "lastName"
       password: "password"
+      userStatus: 6
+      phone: "phone"
+      id: 0
+      email: "email"
+      username: "username"
     xml:
       name: "User"
   Tag:
@@ -696,8 +696,8 @@ definitions:
     title: "Pet Tag"
     description: "A tag for a pet"
     example:
-      id: 1
       name: "name"
+      id: 1
     xml:
       name: "Tag"
   Pet:
@@ -738,20 +738,20 @@ definitions:
     title: "a Pet"
     description: "A pet for sale in the pet store"
     example:
-      tags:
-      - id: 1
-        name: "name"
-      - id: 1
-        name: "name"
-      id: 0
-      category:
-        id: 6
-        name: "name"
-      status: "available"
-      name: "doggie"
       photoUrls:
       - "photoUrls"
       - "photoUrls"
+      name: "doggie"
+      id: 0
+      category:
+        name: "name"
+        id: 6
+      tags:
+      - name: "name"
+        id: 1
+      - name: "name"
+        id: 1
+      status: "available"
     xml:
       name: "Pet"
   ApiResponse:
@@ -767,9 +767,9 @@ definitions:
     title: "An uploaded response"
     description: "Describes the result of uploading an image resource"
     example:
-      message: "message"
       code: 0
       type: "type"
+      message: "message"
 externalDocs:
   description: "Find out more about Swagger"
   url: "http://swagger.io"

--- a/samples/server/petstore/flaskConnexion/git_push.sh
+++ b/samples/server/petstore/flaskConnexion/git_push.sh
@@ -36,7 +36,7 @@ git_remote=`git remote`
 if [ "$git_remote" = "" ]; then # git remote not defined
 
     if [ "$GIT_TOKEN" = "" ]; then
-        echo "[INFO] \$GIT_TOKEN (environment variable) is not set. Using the git crediential in your environment."
+        echo "[INFO] \$GIT_TOKEN (environment variable) is not set. Using the git credential in your environment."
         git remote add origin https://github.com/${git_user_id}/${git_repo_id}.git
     else
         git remote add origin https://${git_user_id}:${GIT_TOKEN}@github.com/${git_user_id}/${git_repo_id}.git

--- a/samples/server/petstore/flaskConnexion/swagger_server/swagger/swagger.yaml
+++ b/samples/server/petstore/flaskConnexion/swagger_server/swagger/swagger.yaml
@@ -108,11 +108,11 @@ paths:
         type: "array"
         items:
           type: "string"
+          default: "available"
           enum:
           - "available"
           - "pending"
           - "sold"
-          default: "available"
         collectionFormat: "csv"
       responses:
         200:
@@ -627,12 +627,12 @@ definitions:
     title: "Pet Order"
     description: "An order for a pets from the pet store"
     example:
-      id: 0
       petId: 6
+      quantity: 1
+      id: 0
+      shipDate: "2000-01-23T04:56:07.000+00:00"
       complete: false
       status: "placed"
-      quantity: 1
-      shipDate: "2000-01-23T04:56:07.000+00:00"
     xml:
       name: "Order"
   Category:
@@ -646,8 +646,8 @@ definitions:
     title: "Pet catehgry"
     description: "A category for a pet"
     example:
-      id: 6
       name: "name"
+      id: 6
     xml:
       name: "Category"
   User:
@@ -675,14 +675,14 @@ definitions:
     title: "a User"
     description: "A User who is purchasing from the pet store"
     example:
-      id: 0
-      lastName: "lastName"
-      phone: "phone"
-      username: "username"
-      email: "email"
-      userStatus: 6
       firstName: "firstName"
+      lastName: "lastName"
       password: "password"
+      userStatus: 6
+      phone: "phone"
+      id: 0
+      email: "email"
+      username: "username"
     xml:
       name: "User"
   Tag:
@@ -696,8 +696,8 @@ definitions:
     title: "Pet Tag"
     description: "A tag for a pet"
     example:
-      id: 1
       name: "name"
+      id: 1
     xml:
       name: "Tag"
   Pet:
@@ -738,20 +738,20 @@ definitions:
     title: "a Pet"
     description: "A pet for sale in the pet store"
     example:
-      tags:
-      - id: 1
-        name: "name"
-      - id: 1
-        name: "name"
-      id: 0
-      category:
-        id: 6
-        name: "name"
-      status: "available"
-      name: "doggie"
       photoUrls:
       - "photoUrls"
       - "photoUrls"
+      name: "doggie"
+      id: 0
+      category:
+        name: "name"
+        id: 6
+      tags:
+      - name: "name"
+        id: 1
+      - name: "name"
+        id: 1
+      status: "available"
     xml:
       name: "Pet"
   ApiResponse:
@@ -767,9 +767,9 @@ definitions:
     title: "An uploaded response"
     description: "Describes the result of uploading an image resource"
     example:
-      message: "message"
       code: 0
       type: "type"
+      message: "message"
 externalDocs:
   description: "Find out more about Swagger"
   url: "http://swagger.io"


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [x] Filed the PR against the correct branch: `3.0.0` branch for changes related to OpenAPI spec 3.0. Default: `master`.
- [x] Copied the [technical committee](https://github.com/swagger-api/swagger-codegen/#swagger-codegen-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

Removed the "special" logic to use the last part of the operationId (separated by dot)

Reused the same logic in python client's "toOperationId"

(this will help us more easily create a common abstract class "AbstractPythonCodegen" later. 

To close https://github.com/swagger-api/swagger-codegen/issues/7015
