### PR TITLE
[kotlin] support selection of datelibrary

### DIFF
--- a/bin/kotlin-client-petstore.sh
+++ b/bin/kotlin-client-petstore.sh
@@ -26,6 +26,6 @@ fi
 
 # if you've executed sbt assembly previously it will use that instead.
 export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
-ags="generate -t modules/swagger-codegen/src/main/resources/kotlin-client -i modules/swagger-codegen/src/test/resources/2_0/petstore.yaml -l kotlin --artifact-id kotlin-petstore-client -o samples/client/petstore/kotlin $@"
+ags="generate -t modules/swagger-codegen/src/main/resources/kotlin-client -i modules/swagger-codegen/src/test/resources/2_0/petstore.yaml -l kotlin --artifact-id kotlin-petstore-client -D dateLibrary=java8 -o samples/client/petstore/kotlin $@"
 
 java ${JAVA_OPTS} -jar ${executable} ${ags}

--- a/modules/swagger-codegen/src/test/java/io/swagger/codegen/kotlin/KotlinClientCodegenModelTest.java
+++ b/modules/swagger-codegen/src/test/java/io/swagger/codegen/kotlin/KotlinClientCodegenModelTest.java
@@ -89,6 +89,66 @@ public class KotlinClientCodegenModelTest {
         Assert.assertTrue(property3.isNotContainer);
     }
 
+    @Test(description = "convert a simple model: threetenbp")
+    public void selectDateLibraryAsThreetenbp() {
+        final Model model = getSimpleModel();
+        final KotlinClientCodegen codegen = new KotlinClientCodegen();
+        codegen.setDateLibrary(KotlinClientCodegen.DateLibrary.THREETENBP.value);
+        codegen.processOpts();
+
+        final CodegenModel cm = codegen.fromModel("sample", model);
+
+        final CodegenProperty property3 = cm.vars.get(2);
+        Assert.assertEquals(property3.baseName, "createdAt");
+        Assert.assertEquals(property3.datatype, "org.threeten.bp.LocalDateTime");
+        Assert.assertEquals(property3.name, "createdAt");
+        Assert.assertEquals(property3.defaultValue, "null");
+        Assert.assertEquals(property3.baseType, "org.threeten.bp.LocalDateTime");
+        Assert.assertFalse(property3.hasMore);
+        Assert.assertFalse(property3.required);
+        Assert.assertTrue(property3.isNotContainer);
+    }
+
+    @Test(description = "convert a simple model: date string")
+    public void selectDateLibraryAsString() {
+        final Model model = getSimpleModel();
+        final KotlinClientCodegen codegen = new KotlinClientCodegen();
+        codegen.setDateLibrary(KotlinClientCodegen.DateLibrary.STRING.value);
+        codegen.processOpts();
+
+        final CodegenModel cm = codegen.fromModel("sample", model);
+
+        final CodegenProperty property3 = cm.vars.get(2);
+        Assert.assertEquals(property3.baseName, "createdAt");
+        Assert.assertEquals(property3.datatype, "kotlin.String");
+        Assert.assertEquals(property3.name, "createdAt");
+        Assert.assertEquals(property3.defaultValue, "null");
+        Assert.assertEquals(property3.baseType, "kotlin.String");
+        Assert.assertFalse(property3.hasMore);
+        Assert.assertFalse(property3.required);
+        Assert.assertTrue(property3.isNotContainer);
+    }
+
+    @Test(description = "convert a simple model: date java8")
+    public void selectDateLibraryAsJava8() {
+        final Model model = getSimpleModel();
+        final KotlinClientCodegen codegen = new KotlinClientCodegen();
+        codegen.setDateLibrary(KotlinClientCodegen.DateLibrary.JAVA8.value);
+        codegen.processOpts();
+
+        final CodegenModel cm = codegen.fromModel("sample", model);
+
+        final CodegenProperty property3 = cm.vars.get(2);
+        Assert.assertEquals(property3.baseName, "createdAt");
+        Assert.assertEquals(property3.datatype, "java.time.LocalDateTime");
+        Assert.assertEquals(property3.name, "createdAt");
+        Assert.assertEquals(property3.defaultValue, "null");
+        Assert.assertEquals(property3.baseType, "java.time.LocalDateTime");
+        Assert.assertFalse(property3.hasMore);
+        Assert.assertFalse(property3.required);
+        Assert.assertTrue(property3.isNotContainer);
+    }
+
     @Test(description = "convert a model with array property to default kotlin.Array")
     public void arrayPropertyTest() {
         final Model model = getArrayTestModel();
@@ -113,6 +173,7 @@ public class KotlinClientCodegenModelTest {
         Assert.assertFalse(property.required);
         Assert.assertTrue(property.isContainer);
     }
+
     @Test(description = "convert a model with a map property")
     public void mapPropertyTest() {
         final Model model = getMapModel();
@@ -156,13 +217,13 @@ public class KotlinClientCodegenModelTest {
     }
 
     @DataProvider(name = "modelNames")
-    public static Object[][] modelNames(){
-        return new Object[][] {
-                { "TestNs.TestClass" , new ModelNameTest("TestNs.TestClass", "TestNsTestClass") },
-                { "$", new ModelNameTest("$", "Dollar") },
-                { "for", new ModelNameTest("`for`","`for`")},
-                { "One<Two", new ModelNameTest("One<Two", "OneLess_ThanTwo")},
-                { "this is a test", new ModelNameTest("this is a test", "This_is_a_test")}
+    public static Object[][] modelNames() {
+        return new Object[][]{
+                {"TestNs.TestClass", new ModelNameTest("TestNs.TestClass", "TestNsTestClass")},
+                {"$", new ModelNameTest("$", "Dollar")},
+                {"for", new ModelNameTest("`for`", "`for`")},
+                {"One<Two", new ModelNameTest("One<Two", "OneLess_ThanTwo")},
+                {"this is a test", new ModelNameTest("this is a test", "This_is_a_test")}
         };
     }
 

--- a/modules/swagger-codegen/src/test/java/io/swagger/codegen/kotlin/KotlinClientCodegenOptionsTest.java
+++ b/modules/swagger-codegen/src/test/java/io/swagger/codegen/kotlin/KotlinClientCodegenOptionsTest.java
@@ -38,6 +38,7 @@ public class KotlinClientCodegenOptionsTest extends AbstractOptionsTest {
             times = 1;
             codegen.setEnumPropertyNaming(KotlinClientCodegenOptionsProvider.ENUM_PROPERTY_NAMING);
             times = 1;
+            codegen.setDateLibrary(KotlinClientCodegenOptionsProvider.DATE_LIBRARY);
         }};
     }
 }

--- a/modules/swagger-codegen/src/test/java/io/swagger/codegen/options/KotlinClientCodegenOptionsProvider.java
+++ b/modules/swagger-codegen/src/test/java/io/swagger/codegen/options/KotlinClientCodegenOptionsProvider.java
@@ -3,6 +3,7 @@ package io.swagger.codegen.options;
 import io.swagger.codegen.CodegenConstants;
 
 import com.google.common.collect.ImmutableMap;
+import io.swagger.codegen.languages.KotlinClientCodegen;
 
 import java.util.Map;
 
@@ -13,6 +14,7 @@ public class KotlinClientCodegenOptionsProvider implements OptionsProvider {
     public static final String GROUP_ID = "io.swagger.tests";
     public static final String SOURCE_FOLDER = "./generated/kotlin";
     public static final String ENUM_PROPERTY_NAMING = "camelCase";
+    public static final String DATE_LIBRARY = KotlinClientCodegen.DateLibrary.JAVA8.value;
 
     @Override
     public String getLanguage() {
@@ -29,6 +31,7 @@ public class KotlinClientCodegenOptionsProvider implements OptionsProvider {
                 .put(CodegenConstants.GROUP_ID, GROUP_ID)
                 .put(CodegenConstants.SOURCE_FOLDER, SOURCE_FOLDER)
                 .put(CodegenConstants.ENUM_PROPERTY_NAMING, ENUM_PROPERTY_NAMING)
+                .put(KotlinClientCodegen.DATE_LIBRARY, DATE_LIBRARY)
                 .build();
     }
 


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [x] Filed the PR against the correct branch: `3.0.0` branch for changes related to OpenAPI spec 3.0. Default: `master`.
- [ ] Copied the [technical committee](https://github.com/swagger-api/swagger-codegen/#swagger-codegen-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

support selection of date library. (`java8`, `threetenbp`, `string`)

```bash
# no option
ags="generate -t modules/swagger-codegen/src/main/resources/kotlin-client -i modules/swagger-codegen/src/test/resources/2_0/petstore.yaml -l kotlin --artifact-id kotlin-petstore-client -D -o samples/client/petstore/kotlin $@"

# java8
ags="generate -t modules/swagger-codegen/src/main/resources/kotlin-client -i modules/swagger-codegen/src/test/resources/2_0/petstore.yaml -l kotlin --artifact-id kotlin-petstore-client -D dateLibrary=java8 -o samples/client/petstore/kotlin $@"

# no option
ags="generate -t modules/swagger-codegen/src/main/resources/kotlin-client -i modules/swagger-codegen/src/test/resources/2_0/petstore.yaml -l kotlin --artifact-id kotlin-petstore-client -D dateLibrary=string -o samples/client/petstore/kotlin $@"

# no option
ags="generate -t modules/swagger-codegen/src/main/resources/kotlin-client -i modules/swagger-codegen/src/test/resources/2_0/petstore.yaml -l kotlin --artifact-id kotlin-petstore-client -D dateLibrary=threetenbp -o samples/client/petstore/kotlin $@"
```

related Issue: https://github.com/swagger-api/swagger-codegen/issues/6892
(details of the change, additional tests that have been done, reference to the issue for tracking, etc)

