### PR TITLE
[python/tornado] ssl improvements

### DIFF
--- a/modules/swagger-codegen/src/main/resources/python/tornado/rest.mustache
+++ b/modules/swagger-codegen/src/main/resources/python/tornado/rest.mustache
@@ -6,9 +6,7 @@ import io
 import json
 import logging
 import re
-import ssl
 
-import certifi
 # python 2 and python 3 compatibility library
 import six
 from six.moves.urllib.parse import urlencode
@@ -41,30 +39,10 @@ class RESTClientObject(object):
 
     def __init__(self, configuration, pools_size=4, maxsize=4):
         # maxsize is number of requests to host that are allowed in parallel
-        # ca_certs vs cert_file vs key_file
-        # http://stackoverflow.com/a/23957365/2985775
 
-        # ca_certs
-        if configuration.ssl_ca_cert:
-            ca_certs = configuration.ssl_ca_cert
-        else:
-            # if not set certificate file, use Mozilla's root certificates.
-            ca_certs = certifi.where()
-
-        if hasattr(ssl, 'create_default_context'):
-            # require Python 2.7.9+, 3.4+
-            self.ssl_context = ssl.create_default_context()
-            self.ssl_context.load_verify_locations(cafile=ca_certs)
-            if configuration.cert_file:
-                self.ssl_context.load_cert_chain(
-                    configuration.cert_file, keyfile=configuration.key_file
-                )
-
-        elif configuration.cert_file or configuration.ssl_ca_cert:
-            raise NotImplementedError('SSL requires Python 2.7.9+, 3.4+')
-
-        else:
-            self.ssl_context = None
+        self.ca_certs = configuration.ssl_ca_cert
+        self.client_key = configuration.key_file
+        self.client_cert = configuration.cert_file
 
         self.proxy_port = self.proxy_host = None
 
@@ -106,7 +84,9 @@ class RESTClientObject(object):
             )
 
         request = httpclient.HTTPRequest(url)
-        request.ssl_context = self.ssl_context
+        request.ca_certs = self.ca_certs
+        request.client_key = self.client_key
+        request.client_cert = self.client_cert
         request.proxy_host = self.proxy_host
         request.proxy_port = self.proxy_port
         request.method = method


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [x] Filed the PR against the correct branch: `3.0.0` branch for changes related to OpenAPI spec 3.0. Default: `master`.
- [x] Copied the [technical committee](https://github.com/swagger-api/swagger-codegen/#swagger-codegen-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

In my last PR (https://github.com/swagger-api/swagger-codegen/pull/6968) I had to add some hack to disable SSL in older versions of Python. I looked into the implementation and I found that Tornado also didn't support older version of SSL in Python for security reasons (https://github.com/tornadoweb/tornado/pull/2177). Moreover it implements everything we need and also there is a notice about pycurl which doesn't work with SSLContext. Finally I switched to their implementation and it's simple and works correctly with SimpleAsyncHTTPClient and CurlAsyncHTTPClient.

Question: Do we have something to test SSL in CI pipeline ?

Please take a look: @wing328 @taxpon @frol @mbohlool @cbornet @kenjones-cisco @toumorokoshi 