### PR TITLE
Use {{{mediaType}} instead of {{mediaType}}

### DIFF
--- a/modules/swagger-codegen/src/main/resources/Java/libraries/resttemplate/api.mustache
+++ b/modules/swagger-codegen/src/main/resources/Java/libraries/resttemplate/api.mustache
@@ -89,11 +89,11 @@ public class {{classname}} {
         {{/hasMore}}{{/formParams}}{{/hasFormParams}}
 
         final String[] {{localVariablePrefix}}accepts = { {{#hasProduces}}
-            {{#produces}}"{{mediaType}}"{{#hasMore}}, {{/hasMore}}{{/produces}}
+            {{#produces}}"{{{mediaType}}}"{{#hasMore}}, {{/hasMore}}{{/produces}}
         {{/hasProduces}}};
         final List<MediaType> {{localVariablePrefix}}accept = {{localVariablePrefix}}apiClient.selectHeaderAccept({{localVariablePrefix}}accepts);
         final String[] {{localVariablePrefix}}contentTypes = { {{#hasConsumes}}
-            {{#consumes}}"{{mediaType}}"{{#hasMore}}, {{/hasMore}}{{/consumes}}
+            {{#consumes}}"{{{mediaType}}}"{{#hasMore}}, {{/hasMore}}{{/consumes}}
         {{/hasConsumes}}};
         final MediaType {{localVariablePrefix}}contentType = {{localVariablePrefix}}apiClient.selectHeaderContentType({{localVariablePrefix}}contentTypes);
 

--- a/modules/swagger-codegen/src/main/resources/Java/libraries/retrofit2/api.mustache
+++ b/modules/swagger-codegen/src/main/resources/Java/libraries/retrofit2/api.mustache
@@ -50,7 +50,7 @@ public interface {{classname}} {
   {{#prioritizedContentTypes}}
   {{#-first}}
   @Headers({
-    "Content-Type:{{mediaType}}"
+    "Content-Type:{{{mediaType}}}"
   })
   {{/-first}}
   {{/prioritizedContentTypes}}

--- a/modules/swagger-codegen/src/main/resources/Java/libraries/retrofit2/play24/api.mustache
+++ b/modules/swagger-codegen/src/main/resources/Java/libraries/retrofit2/play24/api.mustache
@@ -42,7 +42,7 @@ public interface {{classname}} {
   {{#prioritizedContentTypes}}
   {{#-first}}
   @Headers({
-    "Content-Type:{{mediaType}}"
+    "Content-Type:{{{mediaType}}}"
   })
   {{/-first}}
   {{/prioritizedContentTypes}}

--- a/modules/swagger-codegen/src/main/resources/Java/libraries/retrofit2/play25/api.mustache
+++ b/modules/swagger-codegen/src/main/resources/Java/libraries/retrofit2/play25/api.mustache
@@ -42,7 +42,7 @@ public interface {{classname}} {
   {{#prioritizedContentTypes}}
   {{#-first}}
   @Headers({
-    "Content-Type:{{mediaType}}"
+    "Content-Type:{{{mediaType}}}"
   })
   {{/-first}}
   {{/prioritizedContentTypes}}

--- a/modules/swagger-codegen/src/main/resources/JavaJaxRS/cxf-cdi/api.mustache
+++ b/modules/swagger-codegen/src/main/resources/JavaJaxRS/cxf-cdi/api.mustache
@@ -41,8 +41,8 @@ public class {{classname}}  {
 
     @{{httpMethod}}
     {{#subresourceOperation}}@Path("{{{path}}}"){{/subresourceOperation}}
-    {{#hasConsumes}}@Consumes({ {{#consumes}}"{{mediaType}}"{{#hasMore}}, {{/hasMore}}{{/consumes}} }){{/hasConsumes}}
-    {{#hasProduces}}@Produces({ {{#produces}}"{{mediaType}}"{{#hasMore}}, {{/hasMore}}{{/produces}} }){{/hasProduces}}
+    {{#hasConsumes}}@Consumes({ {{#consumes}}"{{{mediaType}}}"{{#hasMore}}, {{/hasMore}}{{/consumes}} }){{/hasConsumes}}
+    {{#hasProduces}}@Produces({ {{#produces}}"{{{mediaType}}}"{{#hasMore}}, {{/hasMore}}{{/produces}} }){{/hasProduces}}
     @ApiOperation(value = "{{{summary}}}", notes = "{{{notes}}}", response = {{{returnBaseType}}}.class{{#returnContainer}}, responseContainer = "{{{returnContainer}}}"{{/returnContainer}}{{#hasAuthMethods}}, authorizations = {
         {{#authMethods}}@Authorization(value = "{{name}}"{{#isOAuth}}, scopes = {
             {{#scopes}}@AuthorizationScope(scope = "{{scope}}", description = "{{description}}"){{#hasMore}},

--- a/modules/swagger-codegen/src/main/resources/apex/api.mustache
+++ b/modules/swagger-codegen/src/main/resources/apex/api.mustache
@@ -88,13 +88,13 @@ public class {{classname}} {
               {{/headerParams}}
             }{{/hasHeaderParams}}{{^hasHeaderParams}}(){{/hasHeaderParams}},
           {{#hasProduces}}
-            new List<String>{ {{#produces}}'{{mediaType}}'{{#hasMore}}, {{/hasMore}}{{/produces}} },
+            new List<String>{ {{#produces}}'{{{mediaType}}}'{{#hasMore}}, {{/hasMore}}{{/produces}} },
           {{/hasProduces}}
           {{^hasProduces}}
             new List<String>(),
           {{/hasProduces}}
           {{#hasConsumes}}
-            new List<String>{ {{#consumes}}'{{mediaType}}'{{#hasMore}}, {{/hasMore}}{{/consumes}} },
+            new List<String>{ {{#consumes}}'{{{mediaType}}}'{{#hasMore}}, {{/hasMore}}{{/consumes}} },
           {{/hasConsumes}}
           {{^hasConsumes}}
             new List<String>(),

--- a/modules/swagger-codegen/src/main/resources/bash/client.mustache
+++ b/modules/swagger-codegen/src/main/resources/bash/client.mustache
@@ -706,7 +706,7 @@ print_{{operationId}}_help() {
 {{/allParams}}
 {{#allParams}}
 {{#isBodyParam}}
-    echo -e "  * ${GREEN}body${OFF} ${BLUE}[{{#consumes}}{{mediaType}}{{#hasMore}},{{/hasMore}}{{/consumes}}]${OFF}{{#required}} ${RED}(required)${OFF}{{/required}}${OFF} - {{{description}}}" | paste -sd' ' | fold -sw 80 | sed '2,$s/^/    /'
+    echo -e "  * ${GREEN}body${OFF} ${BLUE}[{{#consumes}}{{{mediaType}}}{{#hasMore}},{{/hasMore}}{{/consumes}}]${OFF}{{#required}} ${RED}(required)${OFF}{{/required}}${OFF} - {{{description}}}" | paste -sd' ' | fold -sw 80 | sed '2,$s/^/    /'
     echo -e ""
 {{#vendorExtensions}}
 {{#x-codegen-body-example}}
@@ -791,7 +791,7 @@ call_{{operationId}}() {
 {{#-first}}
 {{^hasMore}}
     if [[ -z $header_content_type ]]; then
-        header_content_type="{{mediaType}}"
+        header_content_type="{{{mediaType}}}"
     fi
 {{/hasMore}}
 {{/-first}}
@@ -805,7 +805,7 @@ call_{{operationId}}() {
         echo "ERROR: Request's content-type not specified!!!"
         echo "This operation expects content-type in one of the following formats:"
 {{#consumes}}
-        echo -e "\\t- {{mediaType}}"
+        echo -e "\\t- {{{mediaType}}}"
 {{/consumes}}
         echo ""
         echo "Use '--content-type' to set proper content type"

--- a/modules/swagger-codegen/src/main/resources/cpprest/api-source.mustache
+++ b/modules/swagger-codegen/src/main/resources/cpprest/api-source.mustache
@@ -48,7 +48,7 @@ pplx::task<{{#returnType}}{{{returnType}}}{{/returnType}}{{^returnType}}void{{/r
 
     std::unordered_set<utility::string_t> responseHttpContentTypes;
     {{#produces}}
-    responseHttpContentTypes.insert( utility::conversions::to_string_t("{{mediaType}}") );
+    responseHttpContentTypes.insert( utility::conversions::to_string_t("{{{mediaType}}}") );
     {{/produces}}
 
     utility::string_t responseHttpContentType;
@@ -98,7 +98,7 @@ pplx::task<{{#returnType}}{{{returnType}}}{{/returnType}}{{^returnType}}void{{/r
 
     std::unordered_set<utility::string_t> consumeHttpContentTypes;
     {{#consumes}}
-    consumeHttpContentTypes.insert( utility::conversions::to_string_t("{{mediaType}}") );
+    consumeHttpContentTypes.insert( utility::conversions::to_string_t("{{{mediaType}}}") );
     {{/consumes}}
 
     {{#allParams}}

--- a/modules/swagger-codegen/src/main/resources/php-symfony/api_controller.mustache
+++ b/modules/swagger-codegen/src/main/resources/php-symfony/api_controller.mustache
@@ -58,7 +58,7 @@ class {{controllerName}} extends Controller
     {
         {{#bodyParams}}
         // Make sure that the client is providing something that we can consume
-        $consumes = [{{#consumes}}'{{mediaType}}'{{#hasMore}}, {{/hasMore}}{{/consumes}}];
+        $consumes = [{{#consumes}}'{{{mediaType}}}'{{#hasMore}}, {{/hasMore}}{{/consumes}}];
         $inputFormat = $request->headers->has('Content-Type')?$request->headers->get('Content-Type'):$consumes[0];
         if (!in_array($inputFormat, $consumes)) {
             // We can't consume the content that the client is sending us
@@ -67,7 +67,7 @@ class {{controllerName}} extends Controller
 
         {{/bodyParams}}
         // Figure out what data format to return to the client
-        $produces = [{{#produces}}'{{mediaType}}'{{#hasMore}}, {{/hasMore}}{{/produces}}];
+        $produces = [{{#produces}}'{{{mediaType}}}'{{#hasMore}}, {{/hasMore}}{{/produces}}];
         // Figure out what the client accepts
         $clientAccepts = $request->headers->has('Accept')?$request->headers->get('Accept'):'*/*';
         $responseFormat = $this->getOutputFormat($clientAccepts, $produces);

--- a/modules/swagger-codegen/src/main/resources/tizen/api-body.mustache
+++ b/modules/swagger-codegen/src/main/resources/tizen/api-body.mustache
@@ -169,7 +169,7 @@ static bool {{nickname}}Helper(char * accessToken,
 	headerList = curl_slist_append(headerList, accessHeader.c_str());
 	{{#hasConsumes}}
 	{{#consumes}}
-	headerList = curl_slist_append(headerList, "Content-Type: {{mediaType}}");
+	headerList = curl_slist_append(headerList, "Content-Type: {{{mediaType}}}");
 	{{/consumes}}
 	{{/hasConsumes}}
 	{{^hasConsumes}}

--- a/modules/swagger-codegen/src/main/resources/ze-ph/api.mustache
+++ b/modules/swagger-codegen/src/main/resources/ze-ph/api.mustache
@@ -29,7 +29,7 @@ class {{classname}} implements {{interfacesToImplement}}
 {{#bodyParam}}
 {{#consumes}}
      * TODO check if consumer is valid, if it has correct priority and if it can be moved to class annotation
-     * @PHA\Consumer(name=PHConsumer\Json::class, mediaType="{{mediaType}}")
+     * @PHA\Consumer(name=PHConsumer\Json::class, mediaType="{{{mediaType}}}")
 {{/consumes}}
 {{^isPrimitiveType}}
      * @PHA\Attribute(name=PHAttribute\Transfer::class, options={"type":{{dataType}}::class,"objectAttr":"{{paramName}}"})
@@ -37,7 +37,7 @@ class {{classname}} implements {{interfacesToImplement}}
 {{/bodyParam}}
 {{#produces}}
      * TODO check if producer is valid, if it has correct priority and if it can be moved to class annotation
-     * @PHA\Producer(name=PHProducer\Transfer::class, mediaType="{{mediaType}}")
+     * @PHA\Producer(name=PHProducer\Transfer::class, mediaType="{{{mediaType}}}")
 {{/produces}}
      * @param ServerRequestInterface $request
      *


### PR DESCRIPTION
### PR checklist

- [ ] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [ ] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [ ] Filed the PR against the correct branch: `3.0.0` branch for changes related to OpenAPI spec 3.0. Default: `master`.
- [ ] Copied the [technical committee](https://github.com/swagger-api/swagger-codegen/#swagger-codegen-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

To avoid issue with HTML-escaped characters in the `consumes`, `produces`
