### PR TITLE
Fixes segmentation faults for arrays of primitive types #6984

### DIFF
--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/Qt5CPPGenerator.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/Qt5CPPGenerator.java
@@ -315,19 +315,13 @@ public class Qt5CPPGenerator extends AbstractCppCodegen implements CodegenConfig
         } else if (p instanceof DecimalProperty) {
             return "0.0";
         } else if (p instanceof MapProperty) {
-            MapProperty ap = (MapProperty) p;
-            String inner = getSwaggerType(ap.getAdditionalProperties());
-            if (!languageSpecificPrimitives.contains(inner)) {
-                inner += "*";
-            }
-            return "new QMap<QString, " + inner + ">()";
+            MapProperty mp = (MapProperty) p;
+            Property inner = mp.getAdditionalProperties();
+            return "new QMap<QString, " + getTypeDeclaration(inner) + ">()";
         } else if (p instanceof ArrayProperty) {
             ArrayProperty ap = (ArrayProperty) p;
-            String inner = getSwaggerType(ap.getItems());
-            if (!languageSpecificPrimitives.contains(inner)) {
-                inner += "*";
-            }
-            return "new QList<" + inner + ">()";
+            Property inner = ap.getItems();
+            return "new QList<" + getTypeDeclaration(inner) + ">()";
         }
         // else
         if (p instanceof RefProperty) {

--- a/modules/swagger-codegen/src/main/resources/qt5cpp/helpers-body.mustache
+++ b/modules/swagger-codegen/src/main/resources/qt5cpp/helpers-body.mustache
@@ -132,10 +132,10 @@ setValue(void* value, QJsonValue obj, QString type, QString complexType) {
     }
     else if(type.startsWith("QList") && QString("").compare(complexType) != 0 && obj.isArray()) {
         // list of values
-        QList<void*>* output = new QList<void*>();
-        QJsonArray arr = obj.toArray();
-        foreach (const QJsonValue & jval, arr) {
-            if(complexType.startsWith("SWG")) {
+        if(complexType.startsWith("SWG")) {
+            QList<SWGObject*>* output = new QList<SWGObject*>();
+            QJsonArray arr = obj.toArray();
+            foreach (const QJsonValue & jval, arr) {
                 // it's an object
                 SWGObject * val = (SWGObject*)create(complexType);
                 QJsonObject t = jval.toObject();
@@ -143,53 +143,102 @@ setValue(void* value, QJsonValue obj, QString type, QString complexType) {
                 val->fromJsonObject(t);
                 output->append(val);
             }
-            else {
-                // primitives
-                if(QStringLiteral("qint32").compare(complexType) == 0) {
-                    qint32 val;
-                    setValue(&val, jval, QStringLiteral("qint32"), QStringLiteral(""));
-                    output->append((void*)&val);
-                }
-                else if(QStringLiteral("qint64").compare(complexType) == 0) {
-                    qint64 val;
-                    setValue(&val, jval, QStringLiteral("qint64"), QStringLiteral(""));
-                    output->append((void*)&val);
-                }
-                else if(QStringLiteral("bool").compare(complexType) == 0) {
-                    bool val;
-                    setValue(&val, jval, QStringLiteral("bool"), QStringLiteral(""));
-                    output->append((void*)&val);
-                }
-                else if(QStringLiteral("float").compare(complexType) == 0) {
-                    float val;
-                    setValue(&val, jval, QStringLiteral("float"), QStringLiteral(""));
-                    output->append((void*)&val);
-                }
-                else if(QStringLiteral("double").compare(complexType) == 0) {
-                    double val;
-                    setValue(&val, jval, QStringLiteral("double"), QStringLiteral(""));
-                    output->append((void*)&val);
-                }
-                else if(QStringLiteral("QString").compare(complexType) == 0) {
-                    QString * val = new QString();
-                    setValue(&val, jval, QStringLiteral("QString"), QStringLiteral(""));
-                    output->append((void*)val);
-                }
-                else if(QStringLiteral("QDate").compare(complexType) == 0) {
-                    QDate * val = new QDate();
-                    setValue(&val, jval, QStringLiteral("QDate"), QStringLiteral(""));
-                    output->append((void*)val);
-                }
-                else if(QStringLiteral("QDateTime").compare(complexType) == 0) {
-                    QDateTime * val = new QDateTime();
-                    setValue(&val, jval, QStringLiteral("QDateTime"), QStringLiteral(""));
-                    output->append((void*)val);
-                }
+            QList<SWGObject*> **val = static_cast<QList<SWGObject*>**>(value);
+            foreach (auto item, **val) {
+                delete item;
+            }
+            delete *val;
+            *val = output;
+        }
+        else if(QStringLiteral("qint32").compare(complexType) == 0) {
+            QList<qint32> **output = reinterpret_cast<QList<qint32> **> (value);
+            (*output)->clear();
+            QJsonArray arr = obj.toArray();
+            foreach (const QJsonValue & jval, arr){
+                qint32 val;
+                setValue(&val, jval, QStringLiteral("qint32"), QStringLiteral(""));
+                (*output)->push_back(val);
             }
         }
-        QList<void*> **val = static_cast<QList<void*>**>(value);
-        delete *val;
-        *val = output;
+        else if(QStringLiteral("qint64").compare(complexType) == 0) {
+            QList<qint64> **output = reinterpret_cast<QList<qint64> **> (value);
+            (*output)->clear();
+            QJsonArray arr = obj.toArray();
+            foreach (const QJsonValue & jval, arr){
+                qint64 val;
+                setValue(&val, jval, QStringLiteral("qint64"), QStringLiteral(""));
+                (*output)->push_back(val);
+            }
+        }
+        else if(QStringLiteral("bool").compare(complexType) == 0) {
+            QList<bool> **output = reinterpret_cast<QList<bool> **> (value);
+            (*output)->clear();
+            QJsonArray arr = obj.toArray();
+            foreach (const QJsonValue & jval, arr){
+                bool val;
+                setValue(&val, jval, QStringLiteral("bool"), QStringLiteral(""));
+                (*output)->push_back(val);
+            }
+        }
+        else if(QStringLiteral("float").compare(complexType) == 0) {
+            QList<float> **output = reinterpret_cast<QList<float> **> (value);
+            (*output)->clear();
+            QJsonArray arr = obj.toArray();
+            foreach (const QJsonValue & jval, arr){
+                float val;
+                setValue(&val, jval, QStringLiteral("float"), QStringLiteral(""));
+                (*output)->push_back(val);
+            }
+        }
+        else if(QStringLiteral("double").compare(complexType) == 0) {
+            QList<double> **output = reinterpret_cast<QList<double> **> (value);
+            (*output)->clear();
+            QJsonArray arr = obj.toArray();
+            foreach (const QJsonValue & jval, arr){
+                double val;
+                setValue(&val, jval, QStringLiteral("double"), QStringLiteral(""));
+                (*output)->push_back(val);
+            }
+        }
+        else if(QStringLiteral("QString").compare(complexType) == 0) {
+            QList<QString*> **output = reinterpret_cast<QList<QString*> **> (value);
+            foreach (auto item, **output) {
+                delete item;
+            }
+            (*output)->clear();
+            QJsonArray arr = obj.toArray();
+            foreach (const QJsonValue & jval, arr){
+                QString * val = new QString();
+                setValue(&val, jval, QStringLiteral("QString"), QStringLiteral(""));
+                (*output)->push_back(val);
+            }
+        }
+        else if(QStringLiteral("QDate").compare(complexType) == 0) {
+            QList<QDate*> **output = reinterpret_cast<QList<QDate*> **> (value);
+            foreach (auto item, **output) {
+                delete item;
+            }
+            (*output)->clear();
+            QJsonArray arr = obj.toArray();
+            foreach (const QJsonValue & jval, arr){
+                QDate * val = new QDate();
+                setValue(&val, jval, QStringLiteral("QDate"), QStringLiteral(""));
+                (*output)->push_back(val);
+            }
+        }
+        else if(QStringLiteral("QDateTime").compare(complexType) == 0) {
+            QList<QDateTime*> **output = reinterpret_cast<QList<QDateTime*> **> (value);
+            foreach (auto item, **output) {
+                delete item;
+            }
+            (*output)->clear();
+            QJsonArray arr = obj.toArray();
+            foreach (const QJsonValue & jval, arr){
+                QDateTime * val = new QDateTime();
+                setValue(&val, jval, QStringLiteral("QDateTime"), QStringLiteral(""));
+                (*output)->push_back(val);
+            }
+        }
     }
 }
 
@@ -254,11 +303,52 @@ toJsonValue(QString name, void* value, QJsonObject* output, QString type) {
 
 void
 toJsonArray(QList<void*>* value, QJsonArray* output, QString innerName, QString innerType) {
-    foreach(void* obj, *value) {
-        QJsonObject element;
-
-        toJsonValue(nullptr, obj, &element, innerType);
-        output->append(element);
+    if(innerType.startsWith("SWG")){
+        foreach(void* obj, *value) {
+            SWGObject *swgObject = reinterpret_cast<SWGObject *>(obj);
+            if(swgObject != nullptr) {
+                output->append(*(swgObject->asJsonObject()));
+            }
+        }
+    }
+    else if(QStringLiteral("QString").compare(innerType) == 0) {
+        foreach(QString* obj, *(reinterpret_cast<QList<QString*>*>(value))){
+            output->append(QJsonValue(*obj));
+        }
+    }
+    else if(QStringLiteral("QDate").compare(innerType) == 0) {
+        foreach(QDate* obj, *(reinterpret_cast<QList<QDate*>*>(value))){
+            output->append(QJsonValue(obj->toString(Qt::ISODate)));
+        }
+    }
+    else if(QStringLiteral("QDateTime").compare(innerType) == 0) {
+        foreach(QDateTime* obj, *(reinterpret_cast<QList<QDateTime*>*>(value))){
+            output->append(QJsonValue(obj->toString(Qt::ISODate)));        }
+    }
+    else if(QStringLiteral("QByteArray").compare(innerType) == 0) {
+        foreach(QByteArray* obj, *(reinterpret_cast<QList<QByteArray*>*>(value))){
+            output->append(QJsonValue(QString(obj->toBase64())));
+        }
+    }
+    else if(QStringLiteral("qint32").compare(innerType) == 0) {
+        foreach(qint32 obj, *(reinterpret_cast<QList<qint32>*>(value)))
+            output->append(QJsonValue(obj));
+    }
+    else if(QStringLiteral("qint64").compare(innerType) == 0) {
+        foreach(qint64 obj, *(reinterpret_cast<QList<qint64>*>(value)))
+            output->append(QJsonValue(obj));
+    }
+    else if(QStringLiteral("bool").compare(innerType) == 0) {
+        foreach(bool obj, *(reinterpret_cast<QList<bool>*>(value)))
+            output->append(QJsonValue(obj));
+    }
+    else if(QStringLiteral("float").compare(innerType) == 0) {
+        foreach(float obj, *(reinterpret_cast<QList<float>*>(value)))
+            output->append(QJsonValue(obj));
+    }
+    else if(QStringLiteral("double").compare(innerType) == 0) {
+        foreach(double obj, *(reinterpret_cast<QList<double>*>(value)))
+            output->append(QJsonValue(obj));
     }
 }
 


### PR DESCRIPTION
### PR checklist

- [X] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [X] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [X] Filed the PR against the correct branch: `3.0.0` branch for changes related to OpenAPI spec 3.0. Default: `master`.
- [x] Copied the [technical committee](https://github.com/swagger-api/swagger-codegen/#swagger-codegen-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

(details of the change, additional tests that have been done, reference to the issue for tracking, etc)

Fixes for #6984
