### PR TITLE
Updated SwaggerResponse Attributes so they use the actual dataType instead of the common returnType

### DIFF
--- a/modules/swagger-codegen/src/main/resources/aspnetcore/controller.mustache
+++ b/modules/swagger-codegen/src/main/resources/aspnetcore/controller.mustache
@@ -32,8 +32,8 @@ namespace {{packageName}}.Controllers
         [{{httpMethod}}]
         [Route("{{{basePathWithoutHost}}}{{{path}}}")]
         [ValidateModelState]
-        [SwaggerOperation("{{operationId}}")]{{#responses}}{{#returnType}}
-        [SwaggerResponse({{code}}, typeof({{&returnType}}), "{{message}}")]{{/returnType}}{{/responses}}
+        [SwaggerOperation("{{operationId}}")]{{#responses}}{{#dataType}}
+        [SwaggerResponse(statusCode: {{code}}, type: typeof({{&dataType}}), description: "{{message}}")]{{/dataType}}{{^dataType}}{{/dataType}}{{/responses}}
         public virtual IActionResult {{operationId}}({{#allParams}}{{>pathParam}}{{>queryParam}}{{>bodyParam}}{{>formParam}}{{>headerParam}}{{#hasMore}}, {{/hasMore}}{{/allParams}})
         { {{#responses}}
 {{#dataType}}

--- a/samples/server/petstore/aspnetcore/src/IO.Swagger/Controllers/PetApi.cs
+++ b/samples/server/petstore/aspnetcore/src/IO.Swagger/Controllers/PetApi.cs
@@ -81,8 +81,7 @@ namespace IO.Swagger.Controllers
         [Route("/v2/pet/findByStatus")]
         [ValidateModelState]
         [SwaggerOperation("FindPetsByStatus")]
-        [SwaggerResponse(200, typeof(List<Pet>), "successful operation")]
-        [SwaggerResponse(400, typeof(List<Pet>), "Invalid status value")]
+        [SwaggerResponse(statusCode: 200, type: typeof(List<Pet>), description: "successful operation")]
         public virtual IActionResult FindPetsByStatus([FromQuery][Required()]List<string> status)
         { 
             //TODO: Uncomment the next line to return response 200 or use other options such as return this.NotFound(), return this.BadRequest(..), ...
@@ -111,8 +110,7 @@ namespace IO.Swagger.Controllers
         [Route("/v2/pet/findByTags")]
         [ValidateModelState]
         [SwaggerOperation("FindPetsByTags")]
-        [SwaggerResponse(200, typeof(List<Pet>), "successful operation")]
-        [SwaggerResponse(400, typeof(List<Pet>), "Invalid tag value")]
+        [SwaggerResponse(statusCode: 200, type: typeof(List<Pet>), description: "successful operation")]
         public virtual IActionResult FindPetsByTags([FromQuery][Required()]List<string> tags)
         { 
             //TODO: Uncomment the next line to return response 200 or use other options such as return this.NotFound(), return this.BadRequest(..), ...
@@ -142,9 +140,7 @@ namespace IO.Swagger.Controllers
         [Route("/v2/pet/{petId}")]
         [ValidateModelState]
         [SwaggerOperation("GetPetById")]
-        [SwaggerResponse(200, typeof(Pet), "successful operation")]
-        [SwaggerResponse(400, typeof(Pet), "Invalid ID supplied")]
-        [SwaggerResponse(404, typeof(Pet), "Pet not found")]
+        [SwaggerResponse(statusCode: 200, type: typeof(Pet), description: "successful operation")]
         public virtual IActionResult GetPetById([FromRoute][Required]long? petId)
         { 
             //TODO: Uncomment the next line to return response 200 or use other options such as return this.NotFound(), return this.BadRequest(..), ...
@@ -225,7 +221,7 @@ namespace IO.Swagger.Controllers
         [Route("/v2/pet/{petId}/uploadImage")]
         [ValidateModelState]
         [SwaggerOperation("UploadFile")]
-        [SwaggerResponse(200, typeof(ApiResponse), "successful operation")]
+        [SwaggerResponse(statusCode: 200, type: typeof(ApiResponse), description: "successful operation")]
         public virtual IActionResult UploadFile([FromRoute][Required]long? petId, [FromForm]string additionalMetadata, [FromForm]System.IO.Stream file)
         { 
             //TODO: Uncomment the next line to return response 200 or use other options such as return this.NotFound(), return this.BadRequest(..), ...

--- a/samples/server/petstore/aspnetcore/src/IO.Swagger/Controllers/StoreApi.cs
+++ b/samples/server/petstore/aspnetcore/src/IO.Swagger/Controllers/StoreApi.cs
@@ -63,7 +63,7 @@ namespace IO.Swagger.Controllers
         [Route("/v2/store/inventory")]
         [ValidateModelState]
         [SwaggerOperation("GetInventory")]
-        [SwaggerResponse(200, typeof(Dictionary<string, int?>), "successful operation")]
+        [SwaggerResponse(statusCode: 200, type: typeof(Dictionary<string, int?>), description: "successful operation")]
         public virtual IActionResult GetInventory()
         { 
             //TODO: Uncomment the next line to return response 200 or use other options such as return this.NotFound(), return this.BadRequest(..), ...
@@ -90,9 +90,7 @@ namespace IO.Swagger.Controllers
         [Route("/v2/store/order/{orderId}")]
         [ValidateModelState]
         [SwaggerOperation("GetOrderById")]
-        [SwaggerResponse(200, typeof(Order), "successful operation")]
-        [SwaggerResponse(400, typeof(Order), "Invalid ID supplied")]
-        [SwaggerResponse(404, typeof(Order), "Order not found")]
+        [SwaggerResponse(statusCode: 200, type: typeof(Order), description: "successful operation")]
         public virtual IActionResult GetOrderById([FromRoute][Required][Range(1, 5)]long? orderId)
         { 
             //TODO: Uncomment the next line to return response 200 or use other options such as return this.NotFound(), return this.BadRequest(..), ...
@@ -124,8 +122,7 @@ namespace IO.Swagger.Controllers
         [Route("/v2/store/order")]
         [ValidateModelState]
         [SwaggerOperation("PlaceOrder")]
-        [SwaggerResponse(200, typeof(Order), "successful operation")]
-        [SwaggerResponse(400, typeof(Order), "Invalid Order")]
+        [SwaggerResponse(statusCode: 200, type: typeof(Order), description: "successful operation")]
         public virtual IActionResult PlaceOrder([FromBody]Order body)
         { 
             //TODO: Uncomment the next line to return response 200 or use other options such as return this.NotFound(), return this.BadRequest(..), ...

--- a/samples/server/petstore/aspnetcore/src/IO.Swagger/Controllers/UserApi.cs
+++ b/samples/server/petstore/aspnetcore/src/IO.Swagger/Controllers/UserApi.cs
@@ -123,9 +123,7 @@ namespace IO.Swagger.Controllers
         [Route("/v2/user/{username}")]
         [ValidateModelState]
         [SwaggerOperation("GetUserByName")]
-        [SwaggerResponse(200, typeof(User), "successful operation")]
-        [SwaggerResponse(400, typeof(User), "Invalid username supplied")]
-        [SwaggerResponse(404, typeof(User), "User not found")]
+        [SwaggerResponse(statusCode: 200, type: typeof(User), description: "successful operation")]
         public virtual IActionResult GetUserByName([FromRoute][Required]string username)
         { 
             //TODO: Uncomment the next line to return response 200 or use other options such as return this.NotFound(), return this.BadRequest(..), ...
@@ -158,8 +156,7 @@ namespace IO.Swagger.Controllers
         [Route("/v2/user/login")]
         [ValidateModelState]
         [SwaggerOperation("LoginUser")]
-        [SwaggerResponse(200, typeof(string), "successful operation")]
-        [SwaggerResponse(400, typeof(string), "Invalid username/password supplied")]
+        [SwaggerResponse(statusCode: 200, type: typeof(string), description: "successful operation")]
         public virtual IActionResult LoginUser([FromQuery][Required()]string username, [FromQuery][Required()]string password)
         { 
             //TODO: Uncomment the next line to return response 200 or use other options such as return this.NotFound(), return this.BadRequest(..), ...


### PR DESCRIPTION
RE: Issue #7094
@mandrean @jimschubert

I've modified the server generator, so that responses with no data are excluded, but multiple responses with their dataType are honored..

```
        [Route("/api/parcel/{trackingId}")]
        [ValidateModelState]
        [SwaggerOperation("TrackParcel")]
        [SwaggerResponse(statusCode: 200, type: typeof(TrackingInformation), description: "Parcel exists.")]
        [SwaggerResponse(statusCode: 500, type: typeof(Error), description: "The operation failed due to an error.")]
        public virtual IActionResult TrackParcel([FromRoute]string trackingId)
```