### PR TITLE
Make efficient use of entrySet iterator.

### DIFF
--- a/modules/swagger-codegen/src/main/resources/Java/libraries/resteasy/ApiClient.mustache
+++ b/modules/swagger-codegen/src/main/resources/Java/libraries/resteasy/ApiClient.mustache
@@ -589,18 +589,18 @@ public class ApiClient {
 
     Invocation.Builder invocationBuilder = target.request().accept(accept);
 
-    for (String key : headerParams.keySet()) {
-      String value = headerParams.get(key);
+    for (Entry<String, String> headerParamsEnrty : headerParams.entrySet()) {
+      String value = headerParamsEnrty.getValue();
       if (value != null) {
-        invocationBuilder = invocationBuilder.header(key, value);
+        invocationBuilder = invocationBuilder.header(headerParamsEnrty.getKey(), value);
       }
     }
 
-    for (String key : defaultHeaderMap.keySet()) {
-      if (!headerParams.containsKey(key)) {
-        String value = defaultHeaderMap.get(key);
+    for (Entry<String, String> defaultHeaderEnrty: defaultHeaderMap.entrySet()) {
+      if (!headerParams.containsKey(defaultHeaderEnrty.getKey())) {
+        String value = defaultHeaderEnrty.getKey();
         if (value != null) {
-          invocationBuilder = invocationBuilder.header(key, value);
+          invocationBuilder = invocationBuilder.header(defaultHeaderEnrty.getKey(), value);
         }
       }
     }

--- a/samples/client/petstore/java/resteasy/src/main/java/io/swagger/client/ApiClient.java
+++ b/samples/client/petstore/java/resteasy/src/main/java/io/swagger/client/ApiClient.java
@@ -584,18 +584,18 @@ public class ApiClient {
 
     Invocation.Builder invocationBuilder = target.request().accept(accept);
 
-    for (String key : headerParams.keySet()) {
-      String value = headerParams.get(key);
+    for (Entry<String, String> headerParamsEnrty : headerParams.entrySet()) {
+      String value = headerParamsEnrty.getValue();
       if (value != null) {
-        invocationBuilder = invocationBuilder.header(key, value);
+        invocationBuilder = invocationBuilder.header(headerParamsEnrty.getKey(), value);
       }
     }
 
-    for (String key : defaultHeaderMap.keySet()) {
-      if (!headerParams.containsKey(key)) {
-        String value = defaultHeaderMap.get(key);
+    for (Entry<String, String> defaultHeaderEnrty: defaultHeaderMap.entrySet()) {
+      if (!headerParams.containsKey(defaultHeaderEnrty.getKey())) {
+        String value = defaultHeaderEnrty.getKey();
         if (value != null) {
-          invocationBuilder = invocationBuilder.header(key, value);
+          invocationBuilder = invocationBuilder.header(defaultHeaderEnrty.getKey(), value);
         }
       }
     }


### PR DESCRIPTION
@bbdouglas 
@JFCote 
@sreeshas 
@jfiala 
@lukoyanov 
@cbornet

### PR checklist

- [x] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [x] Filed the PR against the correct branch: `3.0.0` branch for changes related to OpenAPI spec 3.0. Default: `master`.
- [x] Copied the [technical committee](https://github.com/swagger-api/swagger-codegen/#swagger-codegen-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

The original method accesses the value of a Map entry, using a key that was retrieved from a keySet iterator. It is more efficient to use an iterator on the entrySet of the map, to avoid the Map.get(key) lookup.

http://findbugs.sourceforge.net/bugDescriptions.html#WMI_WRONG_MAP_ITERATOR
