### PR TITLE
[Java][MSF4J] fix return type annotation

### DIFF
--- a/modules/swagger-codegen/src/main/resources/MSF4J/api.mustache
+++ b/modules/swagger-codegen/src/main/resources/MSF4J/api.mustache
@@ -37,7 +37,7 @@ public class {{classname}}  {
     {{#subresourceOperation}}@Path("{{{path}}}"){{/subresourceOperation}}
     {{#hasConsumes}}@Consumes({ {{#consumes}}"{{{mediaType}}}"{{#hasMore}}, {{/hasMore}}{{/consumes}} }){{/hasConsumes}}
     {{#hasProduces}}@Produces({ {{#produces}}"{{{mediaType}}}"{{#hasMore}}, {{/hasMore}}{{/produces}} }){{/hasProduces}}
-    @io.swagger.annotations.ApiOperation(value = "{{{summary}}}", notes = "{{{notes}}}", response = {{{returnType}}}.class{{#returnContainer}}, responseContainer = "{{{returnContainer}}}"{{/returnContainer}}{{#hasAuthMethods}}, authorizations = {
+    @io.swagger.annotations.ApiOperation(value = "{{{summary}}}", notes = "{{{notes}}}", response = {{{returnBaseType}}}.class{{#returnContainer}}, responseContainer = "{{{returnContainer}}}"{{/returnContainer}}{{#hasAuthMethods}}, authorizations = {
         {{#authMethods}}@io.swagger.annotations.Authorization(value = "{{name}}"{{#isOAuth}}, scopes = {
             {{#scopes}}@io.swagger.annotations.AuthorizationScope(scope = "{{scope}}", description = "{{description}}"){{#hasMore}},
             {{/hasMore}}{{/scopes}}
@@ -45,7 +45,7 @@ public class {{classname}}  {
         {{/hasMore}}{{/authMethods}}
     }{{/hasAuthMethods}}, tags={ {{#vendorExtensions.x-tags}}"{{tag}}",{{/vendorExtensions.x-tags}} })
     @io.swagger.annotations.ApiResponses(value = { {{#responses}}
-        @io.swagger.annotations.ApiResponse(code = {{{code}}}, message = "{{{message}}}", response = {{{returnType}}}.class{{#returnContainer}}, responseContainer = "{{{returnContainer}}}"{{/returnContainer}}){{#hasMore}},
+        @io.swagger.annotations.ApiResponse(code = {{{code}}}, message = "{{{message}}}", response = {{{returnBaseType}}}.class{{#returnContainer}}, responseContainer = "{{{returnContainer}}}"{{/returnContainer}}){{#hasMore}},
         {{/hasMore}}{{/responses}} })
     public Response {{nickname}}({{#allParams}}{{>queryParams}}{{>pathParams}}{{>headerParams}}{{>bodyParams}}{{>formParams}}{{#hasMore}},{{/hasMore}}{{/allParams}})
     throws NotFoundException {

--- a/samples/server/petstore/java-msf4j/pom.xml
+++ b/samples/server/petstore/java-msf4j/pom.xml
@@ -89,7 +89,7 @@
     </repository>
   </repositories>
   <properties>
-    <java.version>1.7</java.version>
+    <java.version>1.8</java.version>
     <maven.compiler.source>${java.version}</maven.compiler.source>
     <maven.compiler.target>${java.version}</maven.compiler.target>
     <swagger-core-version>1.5.15</swagger-core-version>

--- a/samples/server/petstore/java-msf4j/src/gen/java/io/swagger/api/AnotherFakeApi.java
+++ b/samples/server/petstore/java-msf4j/src/gen/java/io/swagger/api/AnotherFakeApi.java
@@ -1,0 +1,45 @@
+package io.swagger.api;
+
+import io.swagger.model.*;
+import io.swagger.api.AnotherFakeApiService;
+import io.swagger.api.factories.AnotherFakeApiServiceFactory;
+
+import io.swagger.annotations.ApiParam;
+import io.swagger.jaxrs.*;
+
+import io.swagger.model.Client;
+
+import java.util.List;
+import io.swagger.api.NotFoundException;
+
+import java.io.InputStream;
+
+import org.wso2.msf4j.formparam.FormDataParam;
+import org.wso2.msf4j.formparam.FileInfo;
+
+import javax.ws.rs.core.Context;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.SecurityContext;
+import javax.ws.rs.*;
+
+@Path("/another-fake")
+
+
+@io.swagger.annotations.Api(description = "the another-fake API")
+
+public class AnotherFakeApi  {
+   private final AnotherFakeApiService delegate = AnotherFakeApiServiceFactory.getAnotherFakeApi();
+
+    @PATCH
+    @Path("/dummy")
+    @Consumes({ "application/json" })
+    @Produces({ "application/json" })
+    @io.swagger.annotations.ApiOperation(value = "To test special tags", notes = "To test special tags", response = Client.class, tags={ "$another-fake?", })
+    @io.swagger.annotations.ApiResponses(value = { 
+        @io.swagger.annotations.ApiResponse(code = 200, message = "successful operation", response = Client.class) })
+    public Response testSpecialTags(@ApiParam(value = "client model" ,required=true) Client body
+)
+    throws NotFoundException {
+        return delegate.testSpecialTags(body);
+    }
+}

--- a/samples/server/petstore/java-msf4j/src/gen/java/io/swagger/api/AnotherFakeApiService.java
+++ b/samples/server/petstore/java-msf4j/src/gen/java/io/swagger/api/AnotherFakeApiService.java
@@ -1,0 +1,23 @@
+package io.swagger.api;
+
+import io.swagger.api.*;
+import io.swagger.model.*;
+
+import org.wso2.msf4j.formparam.FormDataParam;
+import org.wso2.msf4j.formparam.FileInfo;
+
+import io.swagger.model.Client;
+
+import java.util.List;
+import io.swagger.api.NotFoundException;
+
+import java.io.InputStream;
+
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.SecurityContext;
+
+
+public abstract class AnotherFakeApiService {
+    public abstract Response testSpecialTags(Client body
+ ) throws NotFoundException;
+}

--- a/samples/server/petstore/java-msf4j/src/gen/java/io/swagger/api/FakeApi.java
+++ b/samples/server/petstore/java-msf4j/src/gen/java/io/swagger/api/FakeApi.java
@@ -97,13 +97,13 @@ public class FakeApi  {
     
     @Consumes({ "application/xml; charset=utf-8", "application/json; charset=utf-8" })
     @Produces({ "application/xml; charset=utf-8", "application/json; charset=utf-8" })
-    @io.swagger.annotations.ApiOperation(value = "Fake endpoint for testing various parameters 假端點 偽のエンドポイント 가짜 엔드 포인트 ", notes = "Fake endpoint for testing various parameters 假端點 偽のエンドポイント 가짜 엔드 포인트 ", response = void.class, authorizations = {
+    @io.swagger.annotations.ApiOperation(value = "Fake endpoint for testing various parameters 假端點 偽のエンドポイント 가짜 엔드 포인트 ", notes = "Fake endpoint for testing various parameters 假端點 偽のエンドポイント 가짜 엔드 포인트 ", response = Void.class, authorizations = {
         @io.swagger.annotations.Authorization(value = "http_basic_test")
     }, tags={ "fake", })
     @io.swagger.annotations.ApiResponses(value = { 
-        @io.swagger.annotations.ApiResponse(code = 400, message = "Invalid username supplied", response = void.class),
+        @io.swagger.annotations.ApiResponse(code = 400, message = "Invalid username supplied", response = Void.class),
         
-        @io.swagger.annotations.ApiResponse(code = 404, message = "User not found", response = void.class) })
+        @io.swagger.annotations.ApiResponse(code = 404, message = "User not found", response = Void.class) })
     public Response testEndpointParameters(@ApiParam(value = "None", required=true)  @FormParam("number")  BigDecimal number
 ,@ApiParam(value = "None", required=true)  @FormParam("double")  Double _double
 ,@ApiParam(value = "None", required=true)  @FormParam("pattern_without_delimiter")  String patternWithoutDelimiter
@@ -126,11 +126,11 @@ public class FakeApi  {
     
     @Consumes({ "*/*" })
     @Produces({ "*/*" })
-    @io.swagger.annotations.ApiOperation(value = "To test enum parameters", notes = "To test enum parameters", response = void.class, tags={ "fake", })
+    @io.swagger.annotations.ApiOperation(value = "To test enum parameters", notes = "To test enum parameters", response = Void.class, tags={ "fake", })
     @io.swagger.annotations.ApiResponses(value = { 
-        @io.swagger.annotations.ApiResponse(code = 400, message = "Invalid request", response = void.class),
+        @io.swagger.annotations.ApiResponse(code = 400, message = "Invalid request", response = Void.class),
         
-        @io.swagger.annotations.ApiResponse(code = 404, message = "Not found", response = void.class) })
+        @io.swagger.annotations.ApiResponse(code = 404, message = "Not found", response = Void.class) })
     public Response testEnumParameters(@ApiParam(value = "Form parameter enum test (string array)", allowableValues=">, $")  @FormParam("enum_form_string_array")  List<String> enumFormStringArray
 ,@ApiParam(value = "Form parameter enum test (string)", allowableValues="_abc, -efg, (xyz)", defaultValue="-efg")  @DefaultValue("-efg") @FormParam("enum_form_string")  String enumFormString
 ,@ApiParam(value = "Header parameter enum test (string array)" , allowableValues=">, $")@HeaderParam("enum_header_string_array") List<String> enumHeaderStringArray
@@ -142,5 +142,30 @@ public class FakeApi  {
 )
     throws NotFoundException {
         return delegate.testEnumParameters(enumFormStringArray,enumFormString,enumHeaderStringArray,enumHeaderString,enumQueryStringArray,enumQueryString,enumQueryInteger,enumQueryDouble);
+    }
+    @POST
+    @Path("/inline-additionalProperties")
+    @Consumes({ "application/json" })
+    
+    @io.swagger.annotations.ApiOperation(value = "test inline additionalProperties", notes = "", response = Void.class, tags={ "fake", })
+    @io.swagger.annotations.ApiResponses(value = { 
+        @io.swagger.annotations.ApiResponse(code = 200, message = "successful operation", response = Void.class) })
+    public Response testInlineAdditionalProperties(@ApiParam(value = "request body" ,required=true) Object param
+)
+    throws NotFoundException {
+        return delegate.testInlineAdditionalProperties(param);
+    }
+    @GET
+    @Path("/jsonFormData")
+    @Consumes({ "application/json" })
+    
+    @io.swagger.annotations.ApiOperation(value = "test json serialization of form data", notes = "", response = Void.class, tags={ "fake", })
+    @io.swagger.annotations.ApiResponses(value = { 
+        @io.swagger.annotations.ApiResponse(code = 200, message = "successful operation", response = Void.class) })
+    public Response testJsonFormData(@ApiParam(value = "field1", required=true)  @FormParam("param")  String param
+,@ApiParam(value = "field2", required=true)  @FormParam("param2")  String param2
+)
+    throws NotFoundException {
+        return delegate.testJsonFormData(param,param2);
     }
 }

--- a/samples/server/petstore/java-msf4j/src/gen/java/io/swagger/api/FakeApiService.java
+++ b/samples/server/petstore/java-msf4j/src/gen/java/io/swagger/api/FakeApiService.java
@@ -55,4 +55,9 @@ public abstract class FakeApiService {
  ,Integer enumQueryInteger
  ,Double enumQueryDouble
  ) throws NotFoundException;
+    public abstract Response testInlineAdditionalProperties(Object param
+ ) throws NotFoundException;
+    public abstract Response testJsonFormData(String param
+ ,String param2
+ ) throws NotFoundException;
 }

--- a/samples/server/petstore/java-msf4j/src/gen/java/io/swagger/api/FakeClassnameTestApi.java
+++ b/samples/server/petstore/java-msf4j/src/gen/java/io/swagger/api/FakeClassnameTestApi.java
@@ -34,7 +34,9 @@ public class FakeClassnameTestApi  {
     
     @Consumes({ "application/json" })
     @Produces({ "application/json" })
-    @io.swagger.annotations.ApiOperation(value = "To test class name in snake case", notes = "", response = Client.class, tags={ "fake_classname_tags 123#$%^", })
+    @io.swagger.annotations.ApiOperation(value = "To test class name in snake case", notes = "", response = Client.class, authorizations = {
+        @io.swagger.annotations.Authorization(value = "api_key_query")
+    }, tags={ "fake_classname_tags 123#$%^", })
     @io.swagger.annotations.ApiResponses(value = { 
         @io.swagger.annotations.ApiResponse(code = 200, message = "successful operation", response = Client.class) })
     public Response testClassname(@ApiParam(value = "client model" ,required=true) Client body

--- a/samples/server/petstore/java-msf4j/src/gen/java/io/swagger/api/PetApi.java
+++ b/samples/server/petstore/java-msf4j/src/gen/java/io/swagger/api/PetApi.java
@@ -36,14 +36,14 @@ public class PetApi  {
     
     @Consumes({ "application/json", "application/xml" })
     @Produces({ "application/xml", "application/json" })
-    @io.swagger.annotations.ApiOperation(value = "Add a new pet to the store", notes = "", response = void.class, authorizations = {
+    @io.swagger.annotations.ApiOperation(value = "Add a new pet to the store", notes = "", response = Void.class, authorizations = {
         @io.swagger.annotations.Authorization(value = "petstore_auth", scopes = {
             @io.swagger.annotations.AuthorizationScope(scope = "write:pets", description = "modify pets in your account"),
             @io.swagger.annotations.AuthorizationScope(scope = "read:pets", description = "read your pets")
         })
     }, tags={ "pet", })
     @io.swagger.annotations.ApiResponses(value = { 
-        @io.swagger.annotations.ApiResponse(code = 405, message = "Invalid input", response = void.class) })
+        @io.swagger.annotations.ApiResponse(code = 405, message = "Invalid input", response = Void.class) })
     public Response addPet(@ApiParam(value = "Pet object that needs to be added to the store" ,required=true) Pet body
 )
     throws NotFoundException {
@@ -53,14 +53,14 @@ public class PetApi  {
     @Path("/{petId}")
     
     @Produces({ "application/xml", "application/json" })
-    @io.swagger.annotations.ApiOperation(value = "Deletes a pet", notes = "", response = void.class, authorizations = {
+    @io.swagger.annotations.ApiOperation(value = "Deletes a pet", notes = "", response = Void.class, authorizations = {
         @io.swagger.annotations.Authorization(value = "petstore_auth", scopes = {
             @io.swagger.annotations.AuthorizationScope(scope = "write:pets", description = "modify pets in your account"),
             @io.swagger.annotations.AuthorizationScope(scope = "read:pets", description = "read your pets")
         })
     }, tags={ "pet", })
     @io.swagger.annotations.ApiResponses(value = { 
-        @io.swagger.annotations.ApiResponse(code = 400, message = "Invalid pet value", response = void.class) })
+        @io.swagger.annotations.ApiResponse(code = 400, message = "Invalid pet value", response = Void.class) })
     public Response deletePet(@ApiParam(value = "Pet id to delete",required=true) @PathParam("petId") Long petId
 ,@ApiParam(value = "" )@HeaderParam("api_key") String apiKey
 )
@@ -127,18 +127,18 @@ public class PetApi  {
     
     @Consumes({ "application/json", "application/xml" })
     @Produces({ "application/xml", "application/json" })
-    @io.swagger.annotations.ApiOperation(value = "Update an existing pet", notes = "", response = void.class, authorizations = {
+    @io.swagger.annotations.ApiOperation(value = "Update an existing pet", notes = "", response = Void.class, authorizations = {
         @io.swagger.annotations.Authorization(value = "petstore_auth", scopes = {
             @io.swagger.annotations.AuthorizationScope(scope = "write:pets", description = "modify pets in your account"),
             @io.swagger.annotations.AuthorizationScope(scope = "read:pets", description = "read your pets")
         })
     }, tags={ "pet", })
     @io.swagger.annotations.ApiResponses(value = { 
-        @io.swagger.annotations.ApiResponse(code = 400, message = "Invalid ID supplied", response = void.class),
+        @io.swagger.annotations.ApiResponse(code = 400, message = "Invalid ID supplied", response = Void.class),
         
-        @io.swagger.annotations.ApiResponse(code = 404, message = "Pet not found", response = void.class),
+        @io.swagger.annotations.ApiResponse(code = 404, message = "Pet not found", response = Void.class),
         
-        @io.swagger.annotations.ApiResponse(code = 405, message = "Validation exception", response = void.class) })
+        @io.swagger.annotations.ApiResponse(code = 405, message = "Validation exception", response = Void.class) })
     public Response updatePet(@ApiParam(value = "Pet object that needs to be added to the store" ,required=true) Pet body
 )
     throws NotFoundException {
@@ -148,14 +148,14 @@ public class PetApi  {
     @Path("/{petId}")
     @Consumes({ "application/x-www-form-urlencoded" })
     @Produces({ "application/xml", "application/json" })
-    @io.swagger.annotations.ApiOperation(value = "Updates a pet in the store with form data", notes = "", response = void.class, authorizations = {
+    @io.swagger.annotations.ApiOperation(value = "Updates a pet in the store with form data", notes = "", response = Void.class, authorizations = {
         @io.swagger.annotations.Authorization(value = "petstore_auth", scopes = {
             @io.swagger.annotations.AuthorizationScope(scope = "write:pets", description = "modify pets in your account"),
             @io.swagger.annotations.AuthorizationScope(scope = "read:pets", description = "read your pets")
         })
     }, tags={ "pet", })
     @io.swagger.annotations.ApiResponses(value = { 
-        @io.swagger.annotations.ApiResponse(code = 405, message = "Invalid input", response = void.class) })
+        @io.swagger.annotations.ApiResponse(code = 405, message = "Invalid input", response = Void.class) })
     public Response updatePetWithForm(@ApiParam(value = "ID of pet that needs to be updated",required=true) @PathParam("petId") Long petId
 ,@ApiParam(value = "Updated name of the pet")  @FormParam("name")  String name
 ,@ApiParam(value = "Updated status of the pet")  @FormParam("status")  String status

--- a/samples/server/petstore/java-msf4j/src/gen/java/io/swagger/api/StoreApi.java
+++ b/samples/server/petstore/java-msf4j/src/gen/java/io/swagger/api/StoreApi.java
@@ -35,11 +35,11 @@ public class StoreApi  {
     @Path("/order/{order_id}")
     
     @Produces({ "application/xml", "application/json" })
-    @io.swagger.annotations.ApiOperation(value = "Delete purchase order by ID", notes = "For valid response try integer IDs with value < 1000. Anything above 1000 or nonintegers will generate API errors", response = void.class, tags={ "store", })
+    @io.swagger.annotations.ApiOperation(value = "Delete purchase order by ID", notes = "For valid response try integer IDs with value < 1000. Anything above 1000 or nonintegers will generate API errors", response = Void.class, tags={ "store", })
     @io.swagger.annotations.ApiResponses(value = { 
-        @io.swagger.annotations.ApiResponse(code = 400, message = "Invalid ID supplied", response = void.class),
+        @io.swagger.annotations.ApiResponse(code = 400, message = "Invalid ID supplied", response = Void.class),
         
-        @io.swagger.annotations.ApiResponse(code = 404, message = "Order not found", response = void.class) })
+        @io.swagger.annotations.ApiResponse(code = 404, message = "Order not found", response = Void.class) })
     public Response deleteOrder(@ApiParam(value = "ID of the order that needs to be deleted",required=true) @PathParam("order_id") String orderId
 )
     throws NotFoundException {

--- a/samples/server/petstore/java-msf4j/src/gen/java/io/swagger/api/UserApi.java
+++ b/samples/server/petstore/java-msf4j/src/gen/java/io/swagger/api/UserApi.java
@@ -35,9 +35,9 @@ public class UserApi  {
     
     
     @Produces({ "application/xml", "application/json" })
-    @io.swagger.annotations.ApiOperation(value = "Create user", notes = "This can only be done by the logged in user.", response = void.class, tags={ "user", })
+    @io.swagger.annotations.ApiOperation(value = "Create user", notes = "This can only be done by the logged in user.", response = Void.class, tags={ "user", })
     @io.swagger.annotations.ApiResponses(value = { 
-        @io.swagger.annotations.ApiResponse(code = 200, message = "successful operation", response = void.class) })
+        @io.swagger.annotations.ApiResponse(code = 200, message = "successful operation", response = Void.class) })
     public Response createUser(@ApiParam(value = "Created user object" ,required=true) User body
 )
     throws NotFoundException {
@@ -47,9 +47,9 @@ public class UserApi  {
     @Path("/createWithArray")
     
     @Produces({ "application/xml", "application/json" })
-    @io.swagger.annotations.ApiOperation(value = "Creates list of users with given input array", notes = "", response = void.class, tags={ "user", })
+    @io.swagger.annotations.ApiOperation(value = "Creates list of users with given input array", notes = "", response = Void.class, tags={ "user", })
     @io.swagger.annotations.ApiResponses(value = { 
-        @io.swagger.annotations.ApiResponse(code = 200, message = "successful operation", response = void.class) })
+        @io.swagger.annotations.ApiResponse(code = 200, message = "successful operation", response = Void.class) })
     public Response createUsersWithArrayInput(@ApiParam(value = "List of user object" ,required=true) List<User> body
 )
     throws NotFoundException {
@@ -59,9 +59,9 @@ public class UserApi  {
     @Path("/createWithList")
     
     @Produces({ "application/xml", "application/json" })
-    @io.swagger.annotations.ApiOperation(value = "Creates list of users with given input array", notes = "", response = void.class, tags={ "user", })
+    @io.swagger.annotations.ApiOperation(value = "Creates list of users with given input array", notes = "", response = Void.class, tags={ "user", })
     @io.swagger.annotations.ApiResponses(value = { 
-        @io.swagger.annotations.ApiResponse(code = 200, message = "successful operation", response = void.class) })
+        @io.swagger.annotations.ApiResponse(code = 200, message = "successful operation", response = Void.class) })
     public Response createUsersWithListInput(@ApiParam(value = "List of user object" ,required=true) List<User> body
 )
     throws NotFoundException {
@@ -71,11 +71,11 @@ public class UserApi  {
     @Path("/{username}")
     
     @Produces({ "application/xml", "application/json" })
-    @io.swagger.annotations.ApiOperation(value = "Delete user", notes = "This can only be done by the logged in user.", response = void.class, tags={ "user", })
+    @io.swagger.annotations.ApiOperation(value = "Delete user", notes = "This can only be done by the logged in user.", response = Void.class, tags={ "user", })
     @io.swagger.annotations.ApiResponses(value = { 
-        @io.swagger.annotations.ApiResponse(code = 400, message = "Invalid username supplied", response = void.class),
+        @io.swagger.annotations.ApiResponse(code = 400, message = "Invalid username supplied", response = Void.class),
         
-        @io.swagger.annotations.ApiResponse(code = 404, message = "User not found", response = void.class) })
+        @io.swagger.annotations.ApiResponse(code = 404, message = "User not found", response = Void.class) })
     public Response deleteUser(@ApiParam(value = "The name that needs to be deleted",required=true) @PathParam("username") String username
 )
     throws NotFoundException {
@@ -116,9 +116,9 @@ public class UserApi  {
     @Path("/logout")
     
     @Produces({ "application/xml", "application/json" })
-    @io.swagger.annotations.ApiOperation(value = "Logs out current logged in user session", notes = "", response = void.class, tags={ "user", })
+    @io.swagger.annotations.ApiOperation(value = "Logs out current logged in user session", notes = "", response = Void.class, tags={ "user", })
     @io.swagger.annotations.ApiResponses(value = { 
-        @io.swagger.annotations.ApiResponse(code = 200, message = "successful operation", response = void.class) })
+        @io.swagger.annotations.ApiResponse(code = 200, message = "successful operation", response = Void.class) })
     public Response logoutUser()
     throws NotFoundException {
         return delegate.logoutUser();
@@ -127,11 +127,11 @@ public class UserApi  {
     @Path("/{username}")
     
     @Produces({ "application/xml", "application/json" })
-    @io.swagger.annotations.ApiOperation(value = "Updated user", notes = "This can only be done by the logged in user.", response = void.class, tags={ "user", })
+    @io.swagger.annotations.ApiOperation(value = "Updated user", notes = "This can only be done by the logged in user.", response = Void.class, tags={ "user", })
     @io.swagger.annotations.ApiResponses(value = { 
-        @io.swagger.annotations.ApiResponse(code = 400, message = "Invalid user supplied", response = void.class),
+        @io.swagger.annotations.ApiResponse(code = 400, message = "Invalid user supplied", response = Void.class),
         
-        @io.swagger.annotations.ApiResponse(code = 404, message = "User not found", response = void.class) })
+        @io.swagger.annotations.ApiResponse(code = 404, message = "User not found", response = Void.class) })
     public Response updateUser(@ApiParam(value = "name that need to be deleted",required=true) @PathParam("username") String username
 ,@ApiParam(value = "Updated user object" ,required=true) User body
 )

--- a/samples/server/petstore/java-msf4j/src/gen/java/io/swagger/model/Cat.java
+++ b/samples/server/petstore/java-msf4j/src/gen/java/io/swagger/model/Cat.java
@@ -25,7 +25,7 @@ public class Cat extends Animal  {
    * @return declawed
   **/
   @ApiModelProperty(value = "")
-  public Boolean getDeclawed() {
+  public Boolean isDeclawed() {
     return declawed;
   }
 

--- a/samples/server/petstore/java-msf4j/src/gen/java/io/swagger/model/Order.java
+++ b/samples/server/petstore/java-msf4j/src/gen/java/io/swagger/model/Order.java
@@ -164,7 +164,7 @@ public class Order   {
    * @return complete
   **/
   @ApiModelProperty(value = "")
-  public Boolean getComplete() {
+  public Boolean isComplete() {
     return complete;
   }
 

--- a/samples/server/petstore/java-msf4j/src/main/java/io/swagger/api/factories/AnotherFakeApiServiceFactory.java
+++ b/samples/server/petstore/java-msf4j/src/main/java/io/swagger/api/factories/AnotherFakeApiServiceFactory.java
@@ -1,0 +1,12 @@
+package io.swagger.api.factories;
+
+import io.swagger.api.AnotherFakeApiService;
+import io.swagger.api.impl.AnotherFakeApiServiceImpl;
+
+public class AnotherFakeApiServiceFactory {
+    private final static AnotherFakeApiService service = new AnotherFakeApiServiceImpl();
+
+    public static AnotherFakeApiService getAnotherFakeApi() {
+        return service;
+    }
+}

--- a/samples/server/petstore/java-msf4j/src/main/java/io/swagger/api/impl/AnotherFakeApiServiceImpl.java
+++ b/samples/server/petstore/java-msf4j/src/main/java/io/swagger/api/impl/AnotherFakeApiServiceImpl.java
@@ -1,0 +1,27 @@
+package io.swagger.api.impl;
+
+import io.swagger.api.*;
+import io.swagger.model.*;
+
+import io.swagger.model.Client;
+
+import java.util.List;
+import io.swagger.api.NotFoundException;
+
+import java.io.InputStream;
+
+import org.wso2.msf4j.formparam.FormDataParam;
+import org.wso2.msf4j.formparam.FileInfo;
+
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.SecurityContext;
+
+
+public class AnotherFakeApiServiceImpl extends AnotherFakeApiService {
+    @Override
+    public Response testSpecialTags(Client body
+ ) throws NotFoundException {
+        // do some magic!
+        return Response.ok().entity(new ApiResponseMessage(ApiResponseMessage.OK, "magic!")).build();
+    }
+}

--- a/samples/server/petstore/java-msf4j/src/main/java/io/swagger/api/impl/FakeApiServiceImpl.java
+++ b/samples/server/petstore/java-msf4j/src/main/java/io/swagger/api/impl/FakeApiServiceImpl.java
@@ -83,4 +83,17 @@ public class FakeApiServiceImpl extends FakeApiService {
         // do some magic!
         return Response.ok().entity(new ApiResponseMessage(ApiResponseMessage.OK, "magic!")).build();
     }
+    @Override
+    public Response testInlineAdditionalProperties(Object param
+ ) throws NotFoundException {
+        // do some magic!
+        return Response.ok().entity(new ApiResponseMessage(ApiResponseMessage.OK, "magic!")).build();
+    }
+    @Override
+    public Response testJsonFormData(String param
+, String param2
+ ) throws NotFoundException {
+        // do some magic!
+        return Response.ok().entity(new ApiResponseMessage(ApiResponseMessage.OK, "magic!")).build();
+    }
 }


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [x] Filed the PR against the correct branch: `3.0.0` branch for changes related to OpenAPI spec 3.0. Default: `master`.
- [ ] Copied the [technical committee](https://github.com/swagger-api/swagger-codegen/#swagger-codegen-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

Use {{returnBaseType}} to fix the annotation
