### PR TITLE
Expand Resource and PagedResources generics for Java Rest

### DIFF
--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/CodegenConfig.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/CodegenConfig.java
@@ -157,6 +157,8 @@ public interface CodegenConfig {
 
     Map<String, Object> postProcessSupportingFileData(Map<String, Object> objs);
 
+    String postProcessFileContents(String templateName, String fileContents);
+
     void postProcessModelProperty(CodegenModel model, CodegenProperty property);
 
     void postProcessParameter(CodegenParameter parameter);

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/DefaultCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/DefaultCodegen.java
@@ -263,6 +263,18 @@ public class DefaultCodegen {
     }
 
     /**
+     * post process the file contents before it gets pushed to the file to provide any
+     * final adjustments not captured by templating etc.
+     * @param templateName Template name that generated the file contents
+     * @param fileContents Template generated file contents
+     * @return Contents to be written to the file.
+     */
+    public String postProcessFileContents(String templateName, String fileContents) {
+        return fileContents;
+    }
+
+
+    /**
      * Returns the common prefix of variables for enum naming
      *
      * @param vars List of variable names

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/DefaultGenerator.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/DefaultGenerator.java
@@ -762,7 +762,9 @@ public class DefaultGenerator extends AbstractGenerator implements Generator {
                     .defaultValue("")
                     .compile(template);
 
-            writeToFile(adjustedOutputFilename, tmpl.execute(templateData));
+            String fileContents = tmpl.execute(templateData);
+            String adjustedFileContents = config.postProcessFileContents(templateName, fileContents);
+            writeToFile(adjustedOutputFilename, adjustedFileContents);
             return new File(adjustedOutputFilename);
         }
 

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/JavaClientCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/JavaClientCodegen.java
@@ -15,6 +15,7 @@ import org.slf4j.LoggerFactory;
 
 import java.io.File;
 import java.util.*;
+import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 public class JavaClientCodegen extends AbstractJavaCodegen
@@ -375,6 +376,66 @@ public class JavaClientCodegen extends AbstractJavaCodegen
         }
 
         return objs;
+    }
+
+    @Override
+    public String postProcessFileContents(String templateName, String fileContents) {
+        String updatedContents = fileContents;
+        // Apply to all the api templates: controller, doc, and controller test.
+        List<String> apiTemplates = new ArrayList<>(Arrays.asList("api.mustache", "api_doc.mustache", "api_test.mustache"));
+        if (apiTemplates.contains(templateName)
+                && getLibrary().equalsIgnoreCase("RestTemplate")) {
+            updatedContents = reconstituteHateoasGenerics(updatedContents);
+        }
+        return updatedContents;
+    }
+
+    /**
+     * Update the file contents to fix the mangled HATEOAS generics
+     * @param contents Current contents
+     * @return Contents updated to have the HATEOAS generics reconstituted.
+     */
+    private String reconstituteHateoasGenerics(String contents) {
+        // Rebuild PagedResources into a generic. Do this before Resource since
+        // PagedResources contain Resource.
+        String updatedContents = reconstituteGenericTypeReferences("PagedResources", contents);
+
+        // Replace all ResourceBlah with Resource<Blah>
+        updatedContents = reconstituteGenericTypeReferences("Resource", updatedContents);
+        return updatedContents;
+    }
+
+    /**
+     * Re-constitute references to the specified generic type.
+     * Also removes the import of the mangled type name.
+     * @param genericClassName Generic type name
+     * @param originalText Text to re-constituted
+     * @return Reconstituted text
+     */
+    private String reconstituteGenericTypeReferences(String genericClassName, String originalText) {
+        // Remove the includes for the mangled generics
+        // This regex finds all lines with import GenericClassBlah;
+        String importPattern = String.format("import.*\\b%s\\w+.*;", genericClassName);
+        String updatedText = originalText.replaceAll(importPattern, "");
+
+        // Find the mangled GenericClassBlah and convert to GenericClass<Blah>
+        // This regex finds GenericClassBlah and breaks it into
+        // 2 groups for GenericClass and Blah
+        String referencePattern = String.format("\\b(%s)([\\w]+)", genericClassName);
+        Pattern pagedResourcesPattern = Pattern.compile(referencePattern);
+        Matcher matcher = pagedResourcesPattern.matcher(updatedText);
+        StringBuffer updatedTextStringBuffer = new StringBuffer();
+        int numberOfReferences = 0;
+        while (matcher.find()) {
+            String genericReference = String.format("%s<%s>", matcher.group(1), matcher.group(2));
+            matcher.appendReplacement(updatedTextStringBuffer, genericReference);
+            numberOfReferences++;
+        }
+        LOGGER.debug("Updated {} references to {}", numberOfReferences, genericClassName);
+        matcher.appendTail(updatedTextStringBuffer);
+        updatedText = updatedTextStringBuffer.toString();
+
+        return updatedText;
     }
 
     @Override

--- a/modules/swagger-codegen/src/main/resources/Java/libraries/resttemplate/api.mustache
+++ b/modules/swagger-codegen/src/main/resources/Java/libraries/resttemplate/api.mustache
@@ -23,6 +23,8 @@ import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
+import org.springframework.hateoas.PagedResources;
+import org.springframework.hateoas.Resource;
 
 {{>generatedAnnotation}}
 @Component("{{package}}.{{classname}}")

--- a/modules/swagger-codegen/src/main/resources/Java/libraries/resttemplate/api_test.mustache
+++ b/modules/swagger-codegen/src/main/resources/Java/libraries/resttemplate/api_test.mustache
@@ -12,6 +12,8 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import org.springframework.hateoas.PagedResources;
+import org.springframework.hateoas.Resource;
 {{/fullJavaUtil}}
 
 /**


### PR DESCRIPTION
- add new hook to codegen config: postProcessFileContents that is invoked
	after the file contents are generated from the template but
	before they are written to the file. Default is to leave contents
	as found
- for java client code generator, if the library is resttemplate and
	template is for the api, expand all occurrences of
	PagedResourcesBlah into PagedResources<Blah> and
	ResourceBlah into Resource<Blah>

US203263

### PR checklist

- [X] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [ X] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [X ] Filed the PR against the correct branch: `3.0.0` branch for changes related to OpenAPI spec 3.0. Default: `master`.
- [? ] Copied the [technical committee](https://github.com/swagger-api/swagger-codegen/#swagger-codegen-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

(details of the change, additional tests that have been done, reference to the issue for tracking, etc)
Close #7081 
Add a step in the code generation after the templates are applied that turns references such as PagedResourcesResourceMyStuff back into PagedResources<Resource<MyStuff>>
Applied only to Java codegens using the resttemplate library.