### PR TITLE
[Ruby] Fix typo

### DIFF
--- a/modules/swagger-codegen/src/main/resources/ruby/partial_model_generic.mustache
+++ b/modules/swagger-codegen/src/main/resources/ruby/partial_model_generic.mustache
@@ -79,7 +79,7 @@
     end
 
     # Show invalid properties with the reasons. Usually used together with valid?
-    # @return Array for valid properies with the reasons
+    # @return Array for valid properties with the reasons
     def list_invalid_properties
       invalid_properties = Array.new
       {{#vars}}


### PR DESCRIPTION
### PR checklist

- [X] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [X] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [X] Filed the PR against the correct branch: `3.0.0` branch for changes related to OpenAPI spec 3.0. Default: `master`.
- [x] Copied the [technical committee](https://github.com/swagger-api/swagger-codegen/#swagger-codegen-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

Changes a typo, that's all.


### Mentioning the TC

@cliffano @zlx


### Notes

After running the `./bin/ruby-petshore.sh` and `./bin/security/ruby-petstore.sh` it generated diff in the samples which I'm not sure is correct/incorrect, therefore I didn't add it in the commit.

The diff is

```

diff --git a/samples/client/petstore-security-test/ruby/git_push.sh b/samples/client/petstore-security-test/ruby/git_push.sh
index 7cb1edb..89eb49e 100644
--- a/samples/client/petstore-security-test/ruby/git_push.sh
+++ b/samples/client/petstore-security-test/ruby/git_push.sh
@@ -39,7 +39,7 @@ git_remote=`git remote`
 if [ "$git_remote" = "" ]; then # git remote not defined
 
     if [ "$GIT_TOKEN" = "" ]; then
-        echo "[INFO] \$GIT_TOKEN (environment variable) is not set. Using the git crediential in your environment."
+        echo "[INFO] \$GIT_TOKEN (environment variable) is not set. Using the git credential in your environment."
         git remote add origin https://github.com/${git_user_id}/${git_repo_id}.git
     else
         git remote add origin https://${git_user_id}:${GIT_TOKEN}@github.com/${git_user_id}/${git_repo_id}.git
diff --git a/samples/client/petstore/ruby/docs/FakeApi.md b/samples/client/petstore/ruby/docs/FakeApi.md
index 72aaf84..382293c 100644
--- a/samples/client/petstore/ruby/docs/FakeApi.md
+++ b/samples/client/petstore/ruby/docs/FakeApi.md
@@ -270,13 +270,13 @@ end
 
 api_instance = Petstore::FakeApi.new
 
-number = 3.4 # Float | None
+number = 8.14 # Float | None
 
 double = 1.2 # Float | None
 
 pattern_without_delimiter = "pattern_without_delimiter_example" # String | None
 
-byte = "byte_example" # String | None
+byte = "B" # String | None
 
 opts = { 
   integer: 56, # Integer | None
diff --git a/samples/client/petstore/ruby/git_push.sh b/samples/client/petstore/ruby/git_push.sh
index 7cb1edb..89eb49e 100644
--- a/samples/client/petstore/ruby/git_push.sh
+++ b/samples/client/petstore/ruby/git_push.sh
@@ -39,7 +39,7 @@ git_remote=`git remote`
 if [ "$git_remote" = "" ]; then # git remote not defined
 
     if [ "$GIT_TOKEN" = "" ]; then
-        echo "[INFO] \$GIT_TOKEN (environment variable) is not set. Using the git crediential in your environment."
+        echo "[INFO] \$GIT_TOKEN (environment variable) is not set. Using the git credential in your environment."
         git remote add origin https://github.com/${git_user_id}/${git_repo_id}.git
     else
         git remote add origin https://${git_user_id}:${GIT_TOKEN}@github.com/${git_user_id}/${git_repo_id}.git

```