### PR TITLE
Fix issue 7134 Wrong "params" indentation

### DIFF
--- a/modules/swagger-codegen/src/main/resources/typescript-angularjs/api.mustache
+++ b/modules/swagger-codegen/src/main/resources/typescript-angularjs/api.mustache
@@ -73,9 +73,11 @@ export class {{classname}} {
         let httpRequestParams: ng.IRequestConfig = {
             method: '{{httpMethod}}',
             url: localVarPath,
-            {{#bodyParam}}data: {{paramName}},
+            {{#bodyParam}}
+            data: {{paramName}},
             {{/bodyParam}}
-            {{#hasFormParams}}data: this.$httpParamSerializer(formParams),
+            {{#hasFormParams}}
+            data: this.$httpParamSerializer(formParams),
             {{/hasFormParams}}
             params: queryParameters,
             headers: headerParams

--- a/samples/client/petstore/typescript-angularjs/git_push.sh
+++ b/samples/client/petstore/typescript-angularjs/git_push.sh
@@ -36,7 +36,7 @@ git_remote=`git remote`
 if [ "$git_remote" = "" ]; then # git remote not defined
 
     if [ "$GIT_TOKEN" = "" ]; then
-        echo "[INFO] \$GIT_TOKEN (environment variable) is not set. Using the git crediential in your environment."
+        echo "[INFO] \$GIT_TOKEN (environment variable) is not set. Using the git credential in your environment."
         git remote add origin https://github.com/${git_user_id}/${git_repo_id}.git
     else
         git remote add origin https://${git_user_id}:${GIT_TOKEN}@github.com/${git_user_id}/${git_repo_id}.git


### PR DESCRIPTION
### PR checklist

- [X] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [X] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [x] Filed the PR against the correct branch: `3.0.0` branch for changes related to OpenAPI spec 3.0. Default: `master`.
- [x] Copied the [technical committee](https://github.com/swagger-api/swagger-codegen/#swagger-codegen-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

Fixes issue #7134 Wrong "params" indentation

### Technical committee
@TiFu (2017/07) @taxpon (2017/07) @sebastianhaas (2017/07) @kenisteward (2017/07) @Vrolijkx (2017/09)