### PR TITLE
[PHP] Improve StoreApiTest

### DIFF
--- a/samples/client/petstore/php/SwaggerClient-php/tests/PetApiTest.php
+++ b/samples/client/petstore/php/SwaggerClient-php/tests/PetApiTest.php
@@ -374,25 +374,14 @@ class PetApiTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * test empty array response
+     * test invalid argument
      *
-     * Make sure empty arrays from a producer is actually returned as
-     * an empty array and not some other value. At some point it was
-     * returned as null because the code stumbled on PHP loose type
-     * checking (not on empty array is true, same thing could happen
-     * with careless use of empty()).
+     * @expectedException \InvalidArgumentException
      */
-    public function testEmptyArrayResponse()
+    public function testInvalidArgument()
     {
-        // this call returns and empty array
-        $response = $this->api->findPetsByStatus(array());
-
-        // make sure this is an array as we want it to be
-        $this->assertInternalType("array", $response);
-
-        // make sure the array is empty just in case the petstore
-        // server changes its output
-        $this->assertEmpty($response);
+        // the argument is required, and we must specify one or some from 'available', 'pending', 'sold'
+        $this->api->findPetsByStatus([]);
     }
 
 //    Disabled as currently we don't have any endpoint that would return file

--- a/samples/client/petstore/php/SwaggerClient-php/tests/PetApiTest.php
+++ b/samples/client/petstore/php/SwaggerClient-php/tests/PetApiTest.php
@@ -373,6 +373,28 @@ class PetApiTest extends \PHPUnit_Framework_TestCase
         $this->assertSame('red', $animal->getColor());
     }
 
+    /**
+     * test empty array response
+     *
+     * Make sure empty arrays from a producer is actually returned as
+     * an empty array and not some other value. At some point it was
+     * returned as null because the code stumbled on PHP loose type
+     * checking (not on empty array is true, same thing could happen
+     * with careless use of empty()).
+     */
+    public function testEmptyArrayResponse()
+    {
+        // this call returns and empty array
+        $response = $this->api->findPetsByStatus(array());
+
+        // make sure this is an array as we want it to be
+        $this->assertInternalType("array", $response);
+
+        // make sure the array is empty just in case the petstore
+        // server changes its output
+        $this->assertEmpty($response);
+    }
+
 //    Disabled as currently we don't have any endpoint that would return file
 //    For testing I just replaced url and return type in Api method.
 //    public function testDownloadingLargeFile()

--- a/samples/client/petstore/php/SwaggerClient-php/tests/StoreApiTest.php
+++ b/samples/client/petstore/php/SwaggerClient-php/tests/StoreApiTest.php
@@ -21,18 +21,4 @@ class StoreApiTest extends \PHPUnit_Framework_TestCase
         $this->assertInternalType("array", $result);
         $this->assertInternalType("int", $result['available']);
     }
-
-    /*
-     * comment out as we've removed invalid endpoints from the spec, we'll introduce something
-     * similar in the future when we've time to update the petstore server
-     *
-    // test get inventory
-    public function testGetInventoryInObject()
-    {
-        $result = $this->api->getInventoryInObject();
-
-        $this->assertInternalType("array", $result);
-        $this->assertInternalType("int", $result['available']);
-    }
-     */
 }

--- a/samples/client/petstore/php/SwaggerClient-php/tests/StoreApiTest.php
+++ b/samples/client/petstore/php/SwaggerClient-php/tests/StoreApiTest.php
@@ -35,26 +35,4 @@ class StoreApiTest extends \PHPUnit_Framework_TestCase
         $this->assertInternalType("int", $result['available']);
     }
      */
-
-    /**
-     * test empty array response
-     *
-     * Make sure empty arrays from a producer is actually returned as
-     * an empty array and not some other value. At some point it was
-     * returned as null because the code stumbled on PHP loose type
-     * checking (not on empty array is true, same thing could happen
-     * with careless use of empty()).
-     */
-//    public function testEmptyArrayResponse()
-//    {
-//        // this call returns and empty array
-//        $response = $this->api->findPetsByStatus(array());
-//
-//        // make sure this is an array as we want it to be
-//        $this->assertInternalType("array", $response);
-//
-//        // make sure the array is empty just in case the petstore
-//        // server changes its output
-//        $this->assertEmpty($response);
-//    }
 }

--- a/samples/client/petstore/php/SwaggerClient-php/tests/StoreApiTest.php
+++ b/samples/client/petstore/php/SwaggerClient-php/tests/StoreApiTest.php
@@ -18,7 +18,7 @@ class StoreApiTest extends \PHPUnit_Framework_TestCase
     {
         $result = $this->api->getInventory();
 
-        $this->assertInternalType("array", $result);
-        $this->assertInternalType("int", $result['available']);
+        $this->assertInternalType('array', $result);
+        $this->assertInternalType('int', $result['available']);
     }
 }


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [x] Filed the PR against the correct branch: `3.0.0` branch for changes related to OpenAPI spec 3.0. Default: `master`.
- [x] Copied the [technical committee](https://github.com/swagger-api/swagger-codegen/#swagger-codegen-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

This PR improves the disabled test code in StoreApiTest.
