### PR TITLE
Add missing go-server petstore batch script

### DIFF
--- a/bin/windows/go-petstore-server.bat
+++ b/bin/windows/go-petstore-server.bat
@@ -1,0 +1,10 @@
+set executable=.\modules\swagger-codegen-cli\target\swagger-codegen-cli.jar
+
+If Not Exist %executable% (
+  mvn clean package
+)
+
+REM set JAVA_OPTS=%JAVA_OPTS% -Xmx1024M -DloggerPath=conf/log4j.properties
+set ags=generate -i modules\swagger-codegen\src\test\resources\2_0\petstore.yaml -l go-server -o samples\server\petstore\go-api-server
+
+java %JAVA_OPTS% -jar %executable% %ags%


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [x] Filed the PR against the correct branch: `3.0.0` branch for changes related to OpenAPI spec 3.0. Default: `master`.
- [x] Copied the [technical committee](https://github.com/swagger-api/swagger-codegen/#swagger-codegen-technical-committee) to review the pull request if your PR is targeting a particular programming language.
 @antihax

### Description of the PR

Add missing go-server petstore Windows batch script to address issue #7144
