### PR TITLE
Fixed generating class for properties with empty properties

### DIFF
--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/InlineModelResolver.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/InlineModelResolver.java
@@ -48,7 +48,7 @@ public class InlineModelResolver {
                                     if (model instanceof ModelImpl) {
                                         ModelImpl obj = (ModelImpl) model;
                                         if (obj.getType() == null || "object".equals(obj.getType())) {
-                                            if (obj.getProperties() != null && obj.getProperties().size() > 0) {
+                                            if (obj.getProperties() != null) {
                                                 flattenProperties(obj.getProperties(), pathname);
                                                 String modelName = resolveModelName(obj.getTitle(), bp.getName());
                                                 bp.setSchema(new RefModel(modelName));
@@ -62,7 +62,7 @@ public class InlineModelResolver {
 
                                         if (inner instanceof ObjectProperty) {
                                             ObjectProperty op = (ObjectProperty) inner;
-                                            if (op.getProperties() != null && op.getProperties().size() > 0) {
+                                            if (op.getProperties() != null) {
                                                 flattenProperties(op.getProperties(), pathname);
                                                 String modelName = resolveModelName(op.getTitle(), bp.getName());
                                                 Model innerModel = modelFromProperty(op, modelName);
@@ -93,7 +93,7 @@ public class InlineModelResolver {
                                 Property property = response.getSchema();
                                 if (property instanceof ObjectProperty) {
                                     ObjectProperty op = (ObjectProperty) property;
-                                    if (op.getProperties() != null && op.getProperties().size() > 0) {
+                                    if (op.getProperties() != null) {
                                         String modelName = resolveModelName(op.getTitle(), "inline_response_" + key);
                                         Model model = modelFromProperty(op, modelName);
                                         String existing = matchGenerated(model);
@@ -115,7 +115,7 @@ public class InlineModelResolver {
 
                                     if (inner instanceof ObjectProperty) {
                                         ObjectProperty op = (ObjectProperty) inner;
-                                        if (op.getProperties() != null && op.getProperties().size() > 0) {
+                                        if (op.getProperties() != null) {
                                             flattenProperties(op.getProperties(), pathname);
                                             String modelName = resolveModelName(op.getTitle(),
                                                     "inline_response_" + key);
@@ -140,7 +140,7 @@ public class InlineModelResolver {
                                     Property innerProperty = mp.getAdditionalProperties();
                                     if (innerProperty instanceof ObjectProperty) {
                                         ObjectProperty op = (ObjectProperty) innerProperty;
-                                        if (op.getProperties() != null && op.getProperties().size() > 0) {
+                                        if (op.getProperties() != null) {
                                             flattenProperties(op.getProperties(), pathname);
                                             String modelName = resolveModelName(op.getTitle(),
                                                     "inline_response_" + key);
@@ -183,7 +183,7 @@ public class InlineModelResolver {
                     Property inner = m.getItems();
                     if (inner instanceof ObjectProperty) {
                         ObjectProperty op = (ObjectProperty) inner;
-                        if (op.getProperties() != null && op.getProperties().size() > 0) {
+                        if (op.getProperties() != null) {
                             String innerModelName = resolveModelName(op.getTitle(), modelName + "_inner");
                             Model innerModel = modelFromProperty(op, innerModelName);
                             String existing = matchGenerated(innerModel);
@@ -280,8 +280,7 @@ public class InlineModelResolver {
         Map<String, Model> modelsToAdd = new HashMap<String, Model>();
         for (String key : properties.keySet()) {
             Property property = properties.get(key);
-            if (property instanceof ObjectProperty && ((ObjectProperty) property).getProperties() != null
-                    && ((ObjectProperty) property).getProperties().size() > 0) {
+            if (property instanceof ObjectProperty && ((ObjectProperty) property).getProperties() != null) {
 
                 ObjectProperty op = (ObjectProperty) property;
 
@@ -308,7 +307,7 @@ public class InlineModelResolver {
 
                 if (inner instanceof ObjectProperty) {
                     ObjectProperty op = (ObjectProperty) inner;
-                    if (op.getProperties() != null && op.getProperties().size() > 0) {
+                    if (op.getProperties() != null) {
                         flattenProperties(op.getProperties(), path);
                         String modelName = resolveModelName(op.getTitle(), path + "_" + key);
                         Model innerModel = modelFromProperty(op, modelName);
@@ -332,7 +331,7 @@ public class InlineModelResolver {
 
                 if (inner instanceof ObjectProperty) {
                     ObjectProperty op = (ObjectProperty) inner;
-                    if (op.getProperties() != null && op.getProperties().size() > 0) {
+                    if (op.getProperties() != null) {
                         flattenProperties(op.getProperties(), path);
                         String modelName = resolveModelName(op.getTitle(), path + "_" + key);
                         Model innerModel = modelFromProperty(op, modelName);


### PR DESCRIPTION
Codegen doesn't generate class when an object defined with an empty
properties list. When an object named risk property defined with empty properties list generator defines it as java.lang.Object. But when reading the object with ObjectMapper it doesn't read `risk : {}`.

### PR checklist

- [ ] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [ ] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [ ] Filed the PR against the correct branch: `3.0.0` branch for changes related to OpenAPI spec 3.0. Default: `master`.
- [ ] Copied the [technical committee](https://github.com/swagger-api/swagger-codegen/#swagger-codegen-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

(details of the change, additional tests that have been done, reference to the issue for tracking, etc)

