### PR TITLE
[rust-server] End use of deprecated openssl method

### DIFF
--- a/modules/swagger-codegen/src/main/resources/rust-server/client.mustache
+++ b/modules/swagger-codegen/src/main/resources/rust-server/client.mustache
@@ -96,7 +96,7 @@ impl Client {
             let mut ssl = openssl::ssl::SslConnectorBuilder::new(openssl::ssl::SslMethod::tls()).unwrap();
 
             // Server authentication
-            ssl.builder_mut().set_ca_file(ca_certificate.clone()).unwrap();
+            ssl.set_ca_file(ca_certificate.clone()).unwrap();
 
             let ssl = hyper_openssl::OpensslClient::from(ssl.build());
             let connector = hyper::net::HttpsConnector::new(ssl);
@@ -128,12 +128,12 @@ impl Client {
             let mut ssl = openssl::ssl::SslConnectorBuilder::new(openssl::ssl::SslMethod::tls()).unwrap();
 
             // Server authentication
-            ssl.builder_mut().set_ca_file(ca_certificate.clone()).unwrap();
+            ssl.set_ca_file(ca_certificate.clone()).unwrap();
 
             // Client authentication
-            ssl.builder_mut().set_private_key_file(client_key.clone(), openssl::x509::X509_FILETYPE_PEM).unwrap();
-            ssl.builder_mut().set_certificate_chain_file(client_certificate.clone()).unwrap();
-            ssl.builder_mut().check_private_key().unwrap();
+            ssl.set_private_key_file(client_key.clone(), openssl::x509::X509_FILETYPE_PEM).unwrap();
+            ssl.set_certificate_chain_file(client_certificate.clone()).unwrap();
+            ssl.check_private_key().unwrap();
 
             let ssl = hyper_openssl::OpensslClient::from(ssl.build());
             let connector = hyper::net::HttpsConnector::new(ssl);

--- a/modules/swagger-codegen/src/main/resources/rust-server/example-server.mustache
+++ b/modules/swagger-codegen/src/main/resources/rust-server/example-server.mustache
@@ -33,9 +33,9 @@ fn ssl() -> Result<OpensslServer, ErrorStack> {
     let mut ssl = SslAcceptorBuilder::mozilla_intermediate_raw(SslMethod::tls())?;
 
     // Server authentication
-    ssl.builder_mut().set_private_key_file("examples/server-key.pem", X509_FILETYPE_PEM)?;
-    ssl.builder_mut().set_certificate_chain_file("examples/server-chain.pem")?;
-    ssl.builder_mut().check_private_key()?;
+    ssl.set_private_key_file("examples/server-key.pem", X509_FILETYPE_PEM)?;
+    ssl.set_certificate_chain_file("examples/server-chain.pem")?;
+    ssl.check_private_key()?;
 
     Ok(OpensslServer::from(ssl.build()))
 }

--- a/samples/server/petstore/rust-server/examples/server.rs
+++ b/samples/server/petstore/rust-server/examples/server.rs
@@ -33,9 +33,9 @@ fn ssl() -> Result<OpensslServer, ErrorStack> {
     let mut ssl = SslAcceptorBuilder::mozilla_intermediate_raw(SslMethod::tls())?;
 
     // Server authentication
-    ssl.builder_mut().set_private_key_file("examples/server-key.pem", X509_FILETYPE_PEM)?;
-    ssl.builder_mut().set_certificate_chain_file("examples/server-chain.pem")?;
-    ssl.builder_mut().check_private_key()?;
+    ssl.set_private_key_file("examples/server-key.pem", X509_FILETYPE_PEM)?;
+    ssl.set_certificate_chain_file("examples/server-chain.pem")?;
+    ssl.check_private_key()?;
 
     Ok(OpensslServer::from(ssl.build()))
 }

--- a/samples/server/petstore/rust-server/src/client.rs
+++ b/samples/server/petstore/rust-server/src/client.rs
@@ -126,7 +126,7 @@ impl Client {
             let mut ssl = openssl::ssl::SslConnectorBuilder::new(openssl::ssl::SslMethod::tls()).unwrap();
 
             // Server authentication
-            ssl.builder_mut().set_ca_file(ca_certificate.clone()).unwrap();
+            ssl.set_ca_file(ca_certificate.clone()).unwrap();
 
             let ssl = hyper_openssl::OpensslClient::from(ssl.build());
             let connector = hyper::net::HttpsConnector::new(ssl);
@@ -158,12 +158,12 @@ impl Client {
             let mut ssl = openssl::ssl::SslConnectorBuilder::new(openssl::ssl::SslMethod::tls()).unwrap();
 
             // Server authentication
-            ssl.builder_mut().set_ca_file(ca_certificate.clone()).unwrap();
+            ssl.set_ca_file(ca_certificate.clone()).unwrap();
 
             // Client authentication
-            ssl.builder_mut().set_private_key_file(client_key.clone(), openssl::x509::X509_FILETYPE_PEM).unwrap();
-            ssl.builder_mut().set_certificate_chain_file(client_certificate.clone()).unwrap();
-            ssl.builder_mut().check_private_key().unwrap();
+            ssl.set_private_key_file(client_key.clone(), openssl::x509::X509_FILETYPE_PEM).unwrap();
+            ssl.set_certificate_chain_file(client_certificate.clone()).unwrap();
+            ssl.check_private_key().unwrap();
 
             let ssl = hyper_openssl::OpensslClient::from(ssl.build());
             let connector = hyper::net::HttpsConnector::new(ssl);


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [x] Filed the PR against the correct branch: `3.0.0` branch for changes related to OpenAPI spec 3.0. Default: `master`.
- [x] Copied the [technical committee](https://github.com/swagger-api/swagger-codegen/#swagger-codegen-technical-committee) to review the pull request if your PR is targeting a particular programming language. @frol @farcaller 

### Description of the PR

The latest version of openssl deprecates some methods, leading to a bunch of warnings appearing. This PR performs the simple fix to use the new API.

Fixes #7133 
