### PR TITLE
#7047 - Added Bash syntax check to tests

### DIFF
--- a/modules/swagger-codegen/src/main/resources/bash/client.mustache
+++ b/modules/swagger-codegen/src/main/resources/bash/client.mustache
@@ -978,7 +978,7 @@ case $key in
         body_parameters[${body_key}]=${body_value}
     fi
     ;;
-    +([^=]):*)
+    +\([^=]\):*)
     # Parse header arguments and convert them into curl
     # only after the operation argument
     if [[ "$operation" ]]; then

--- a/samples/client/petstore/bash/README.md
+++ b/samples/client/petstore/bash/README.md
@@ -105,6 +105,7 @@ Class | Method | HTTP request | Description
 偽のエンドポイント
 가짜 엔드 포인트
 *FakeApi* | [**testEnumParameters**](docs/FakeApi.md#testenumparameters) | **GET** /fake | To test enum parameters
+*FakeApi* | [**testInlineAdditionalProperties**](docs/FakeApi.md#testinlineadditionalproperties) | **POST** /fake/inline-additionalProperties | test inline additionalProperties
 *FakeApi* | [**testJsonFormData**](docs/FakeApi.md#testjsonformdata) | **GET** /fake/jsonFormData | test json serialization of form data
 *FakeClassnameTags123Api* | [**testClassname**](docs/FakeClassnameTags123Api.md#testclassname) | **PATCH** /fake_classname_test | To test class name in snake case
 *PetApi* | [**addPet**](docs/PetApi.md#addpet) | **POST** /pet | Add a new pet to the store

--- a/samples/client/petstore/bash/_petstore-cli
+++ b/samples/client/petstore/bash/_petstore-cli
@@ -306,6 +306,7 @@ case $state in
 偽のエンドポイント
 가짜 엔드 포인트]" \
             "testEnumParameters[To test enum parameters]" \
+            "testInlineAdditionalProperties[test inline additionalProperties]" \
             "testJsonFormData[test json serialization of form data]"             "testClassname[To test class name in snake case]"             "addPet[Add a new pet to the store]" \
             "deletePet[Deletes a pet]" \
             "findPetsByStatus[Finds Pets by status]" \
@@ -381,6 +382,12 @@ case $state in
           "enum_header_string_array\::[HEADER] Header parameter enum test (string array)"
 "enum_header_string\::[HEADER] Header parameter enum test (string)"
 )
+        _describe -t actions 'operations' _op_arguments -S '' && ret=0
+        ;;
+      testInlineAdditionalProperties)
+        local -a _op_arguments
+        _op_arguments=(
+                              )
         _describe -t actions 'operations' _op_arguments -S '' && ret=0
         ;;
       testJsonFormData)

--- a/samples/client/petstore/bash/docs/FakeApi.md
+++ b/samples/client/petstore/bash/docs/FakeApi.md
@@ -14,6 +14,7 @@ Method | HTTP request | Description
 偽のエンドポイント
 가짜 엔드 포인트
 [**testEnumParameters**](FakeApi.md#testEnumParameters) | **GET** /fake | To test enum parameters
+[**testInlineAdditionalProperties**](FakeApi.md#testInlineAdditionalProperties) | **POST** /fake/inline-additionalProperties | test inline additionalProperties
 [**testJsonFormData**](FakeApi.md#testJsonFormData) | **GET** /fake/jsonFormData | test json serialization of form data
 
 
@@ -264,6 +265,38 @@ No authorization required
 
  - **Content-Type**: */*
  - **Accept**: */*
+
+[[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
+
+## **testInlineAdditionalProperties**
+
+test inline additionalProperties
+
+
+
+### Example
+```bash
+petstore-cli testInlineAdditionalProperties
+```
+
+### Parameters
+
+Name | Type | Description  | Notes
+------------- | ------------- | ------------- | -------------
+ **param** | **map** | request body |
+
+### Return type
+
+(empty response body)
+
+### Authorization
+
+No authorization required
+
+### HTTP request headers
+
+ - **Content-Type**: application/json
+ - **Accept**: Not Applicable
 
 [[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
 

--- a/samples/client/petstore/bash/petstore-cli
+++ b/samples/client/petstore/bash/petstore-cli
@@ -250,6 +250,7 @@ operation_parameters_collection_type["testEnumParameters:::enum_query_string_arr
 operation_parameters_collection_type["testEnumParameters:::enum_query_string"]=""
 operation_parameters_collection_type["testEnumParameters:::enum_query_integer"]=""
 operation_parameters_collection_type["testEnumParameters:::enum_query_double"]=""
+operation_parameters_collection_type["testInlineAdditionalProperties:::param"]=""
 operation_parameters_collection_type["testJsonFormData:::param"]=""
 operation_parameters_collection_type["testJsonFormData:::param2"]=""
 operation_parameters_collection_type["testClassname:::body"]=""
@@ -696,6 +697,7 @@ read -r -d '' ops <<EOF
 偽のエンドポイント
 가짜 엔드 포인트 (AUTH)
   ${CYAN}testEnumParameters${OFF};To test enum parameters
+  ${CYAN}testInlineAdditionalProperties${OFF};test inline additionalProperties
   ${CYAN}testJsonFormData${OFF};test json serialization of form data
 EOF
 echo "  $ops" | column -t -s ';'
@@ -769,7 +771,7 @@ print_about() {
     echo ""
     echo -e "${BOLD}${WHITE}Swagger Petstore command line client (API version 1.0.0)${OFF}"
     echo ""
-    echo -e "License: Apache 2.0"
+    echo -e "License: Apache-2.0"
     echo -e "Contact: apiteam@swagger.io"
     echo ""
 read -r -d '' appdescription <<EOF
@@ -956,6 +958,25 @@ print_testEnumParameters_help() {
     echo -e "${result_color_table[${code:0:1}]}  400;Invalid request${OFF}" | paste -sd' ' | column -t -s ';' | fold -sw 80 | sed '2,$s/^/       /'
     code=404
     echo -e "${result_color_table[${code:0:1}]}  404;Not found${OFF}" | paste -sd' ' | column -t -s ';' | fold -sw 80 | sed '2,$s/^/       /'
+}
+##############################################################################
+#
+# Print help for testInlineAdditionalProperties operation
+#
+##############################################################################
+print_testInlineAdditionalProperties_help() {
+    echo ""
+    echo -e "${BOLD}${WHITE}testInlineAdditionalProperties - test inline additionalProperties${OFF}" | paste -sd' ' | fold -sw 80 | sed '2,$s/^/    /'
+    echo -e ""
+    echo -e "" | paste -sd' ' | fold -sw 80
+    echo -e ""
+    echo -e "${BOLD}${WHITE}Parameters${OFF}"
+    echo -e "  * ${GREEN}body${OFF} ${BLUE}[application/json]${OFF} ${RED}(required)${OFF}${OFF} - request body" | paste -sd' ' | fold -sw 80 | sed '2,$s/^/    /'
+    echo -e ""
+    echo ""
+    echo -e "${BOLD}${WHITE}Responses${OFF}"
+    code=200
+    echo -e "${result_color_table[${code:0:1}]}  200;successful operation${OFF}" | paste -sd' ' | column -t -s ';' | fold -sw 80 | sed '2,$s/^/       /'
 }
 ##############################################################################
 #
@@ -1897,6 +1918,84 @@ call_testEnumParameters() {
         echo "curl ${basic_auth_option} ${curl_arguments} ${headers_curl} -X ${method} \"${host}${path}\""
     else
         eval "curl ${basic_auth_option} ${curl_arguments} ${headers_curl} -X ${method} \"${host}${path}\""
+    fi
+}
+
+##############################################################################
+#
+# Call testInlineAdditionalProperties operation
+#
+##############################################################################
+call_testInlineAdditionalProperties() {
+    # ignore error about 'path_parameter_names' being unused; passed by reference
+    # shellcheck disable=SC2034
+    local path_parameter_names=()
+    # ignore error about 'query_parameter_names' being unused; passed by reference
+    # shellcheck disable=SC2034
+    local query_parameter_names=()
+    local path
+
+    if ! path=$(build_request_path "/v2/fake/inline-additionalProperties" path_parameter_names query_parameter_names); then
+        ERROR_MSG=$path
+        exit 1
+    fi
+    local method="POST"
+    local headers_curl
+    headers_curl=$(header_arguments_to_curl)
+    if [[ -n $header_accept ]]; then
+        headers_curl="${headers_curl} -H 'Accept: ${header_accept}'"
+    fi
+
+    local basic_auth_option=""
+    if [[ -n $basic_auth_credential ]]; then
+        basic_auth_option="-u ${basic_auth_credential}"
+    fi
+    local body_json_curl=""
+
+    #
+    # Check if the user provided 'Content-type' headers in the
+    # command line. If not try to set them based on the Swagger specification
+    # if values produces and consumes are defined unambigously
+    #
+    if [[ -z $header_content_type ]]; then
+        header_content_type="application/json"
+    fi
+
+
+    if [[ -z $header_content_type && "$force" = false ]]; then
+        :
+        echo "ERROR: Request's content-type not specified!!!"
+        echo "This operation expects content-type in one of the following formats:"
+        echo -e "\\t- application/json"
+        echo ""
+        echo "Use '--content-type' to set proper content type"
+        exit 1
+    else
+        headers_curl="${headers_curl} -H 'Content-type: ${header_content_type}'"
+    fi
+
+
+    #
+    # If we have received some body content over pipe, pass it from the
+    # temporary file to cURL
+    #
+    if [[ -n $body_content_temp_file ]]; then
+        if [[ "$print_curl" = true ]]; then
+            echo "cat ${body_content_temp_file} | curl ${basic_auth_option} ${curl_arguments} ${headers_curl} -X ${method} \"${host}${path}\" -d @-"
+        else
+            eval "cat ${body_content_temp_file} | curl ${basic_auth_option} ${curl_arguments} ${headers_curl} -X ${method} \"${host}${path}\" -d @-"
+        fi
+        rm "${body_content_temp_file}"
+    #
+    # If not, try to build the content body from arguments KEY==VALUE and KEY:=VALUE
+    #
+    else
+        body_json_curl=$(body_parameters_to_json)
+        if [[ "$print_curl" = true ]]; then
+            echo "curl ${basic_auth_option} ${curl_arguments} ${headers_curl} -X ${method} ${body_json_curl} \"${host}${path}\""
+        else
+            eval "curl ${basic_auth_option} ${curl_arguments} ${headers_curl} -X ${method} ${body_json_curl} \"${host}${path}\""
+        fi
     fi
 }
 
@@ -3100,6 +3199,9 @@ case $key in
     testEnumParameters)
     operation="testEnumParameters"
     ;;
+    testInlineAdditionalProperties)
+    operation="testInlineAdditionalProperties"
+    ;;
     testJsonFormData)
     operation="testJsonFormData"
     ;;
@@ -3184,7 +3286,7 @@ case $key in
         body_parameters[${body_key}]=${body_value}
     fi
     ;;
-    +([^=]):*)
+    +\([^=]\):*)
     # Parse header arguments and convert them into curl
     # only after the operation argument
     if [[ "$operation" ]]; then
@@ -3273,6 +3375,9 @@ case $operation in
     ;;
     testEnumParameters)
     call_testEnumParameters
+    ;;
+    testInlineAdditionalProperties)
+    call_testInlineAdditionalProperties
     ;;
     testJsonFormData)
     call_testJsonFormData

--- a/samples/client/petstore/bash/petstore-cli.bash-completion
+++ b/samples/client/petstore/bash/petstore-cli.bash-completion
@@ -76,6 +76,7 @@ _petstore-cli()
     operations["testClientModel"]=1
     operations["testEndpointParameters"]=1
     operations["testEnumParameters"]=1
+    operations["testInlineAdditionalProperties"]=1
     operations["testJsonFormData"]=1
     operations["testClassname"]=1
     operations["addPet"]=1
@@ -110,6 +111,7 @@ _petstore-cli()
     operation_parameters["testClientModel"]=""
     operation_parameters["testEndpointParameters"]=""
     operation_parameters["testEnumParameters"]="enum_query_string_array= enum_query_string= enum_query_integer= enum_header_string_array: enum_header_string: "
+    operation_parameters["testInlineAdditionalProperties"]=""
     operation_parameters["testJsonFormData"]=""
     operation_parameters["testClassname"]=""
     operation_parameters["addPet"]=""

--- a/samples/client/petstore/bash/tests/petstore_test.sh
+++ b/samples/client/petstore/bash/tests/petstore_test.sh
@@ -5,6 +5,13 @@ export PETSTORE_CLI="petstore-cli"
 
 export PETSTORE_HOST="http://petstore.swagger.io"
 
+#
+# Bash syntax check
+#
+@test "Generated script should pass Bash syntax check" {
+    result="$(bash -n $PETSTORE_CLI)"
+    [ "$result" -eq 0 ]
+}
 
 #
 # Tests for parameter handling and validation


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [x] Filed the PR against the correct branch: `3.0.0` branch for changes related to OpenAPI spec 3.0. Default: `master`.
- [x] Copied the [technical committee](https://github.com/swagger-api/swagger-codegen/#swagger-codegen-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

Fixes #7047

Also added an automated test for checking syntax of generated Bash clients.

@MikeRalphson @wing328