### PR TITLE
Added apiNameSuffix parameter for JaxRsSpec code generator

### DIFF
--- a/modules/swagger-codegen-cli/src/main/java/io/swagger/codegen/cmd/Generate.java
+++ b/modules/swagger-codegen-cli/src/main/java/io/swagger/codegen/cmd/Generate.java
@@ -74,6 +74,10 @@ public class Generate implements Runnable {
             description = CodegenConstants.API_PACKAGE_DESC)
     private String apiPackage;
 
+    @Option(name = {"--api-name-suffix"}, title = "api name suffix",
+            description = CodegenConstants.API_NAME_SUFFIX_DESC)
+    private String apiNameSuffix;
+
     @Option(name = {"--model-package"}, title = "model package",
             description = CodegenConstants.MODEL_PACKAGE_DESC)
     private String modelPackage;
@@ -215,6 +219,10 @@ public class Generate implements Runnable {
 
         if (isNotEmpty(apiPackage)) {
             configurator.setApiPackage(apiPackage);
+        }
+
+        if (isNotEmpty(apiNameSuffix)) {
+            configurator.setApiNameSuffix(apiNameSuffix);
         }
 
         if (isNotEmpty(modelPackage)) {

--- a/modules/swagger-codegen-maven-plugin/src/main/java/io/swagger/codegen/plugin/CodeGenMojo.java
+++ b/modules/swagger-codegen-maven-plugin/src/main/java/io/swagger/codegen/plugin/CodeGenMojo.java
@@ -161,6 +161,12 @@ public class CodeGenMojo extends AbstractMojo {
     private String library;
 
     /**
+     * Sets the suffix for api classes
+     */
+    @Parameter(name = "apiNameSuffix", required = false)
+    private String apiNameSuffix;
+
+    /**
      * Sets the prefix for model enums and classes
      */
     @Parameter(name = "modelNamePrefix", required = false)
@@ -389,6 +395,10 @@ public class CodeGenMojo extends AbstractMojo {
 
         if (isNotEmpty(library)) {
             configurator.setLibrary(library);
+        }
+
+        if (isNotEmpty(apiNameSuffix)) {
+            configurator.setApiNameSuffix(apiNameSuffix);
         }
 
         if (isNotEmpty(modelNamePrefix)) {

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/CodegenConstants.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/CodegenConstants.java
@@ -159,6 +159,9 @@ public class CodegenConstants {
     public static final String ENUM_PROPERTY_NAMING = "enumPropertyNaming";
     public static final String ENUM_PROPERTY_NAMING_DESC = "Naming convention for enum properties: 'camelCase', 'PascalCase', 'snake_case', 'UPPERCASE', and 'original'";
 
+    public static final String API_NAME_SUFFIX = "apiNameSuffix";
+    public static final String API_NAME_SUFFIX_DESC = "Suffix that will be appended to all api names. Default is \"Api\".";
+
     public static final String MODEL_NAME_PREFIX = "modelNamePrefix";
     public static final String MODEL_NAME_PREFIX_DESC = "Prefix that will be prepended to all model names. Default is the empty string.";
 

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/DefaultCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/DefaultCodegen.java
@@ -74,6 +74,7 @@ public class DefaultCodegen {
     protected Set<String> languageSpecificPrimitives = new HashSet<String>();
     protected Map<String, String> importMapping = new HashMap<String, String>();
     protected String modelPackage = "", apiPackage = "", fileSuffix;
+    protected String apiNameSuffix = "Api";
     protected String modelNamePrefix = "", modelNameSuffix = "";
     protected String testPackage = "";
     protected Map<String, String> apiTemplateFiles = new HashMap<String, String>();
@@ -141,6 +142,10 @@ public class DefaultCodegen {
         if (additionalProperties.containsKey(CodegenConstants.ALLOW_UNICODE_IDENTIFIERS)) {
             this.setAllowUnicodeIdentifiers(Boolean.valueOf(additionalProperties
                     .get(CodegenConstants.ALLOW_UNICODE_IDENTIFIERS).toString()));
+        }
+
+        if (additionalProperties.containsKey(CodegenConstants.API_NAME_SUFFIX)) {
+            this.setApiNameSuffix((String) additionalProperties.get(CodegenConstants.API_NAME_SUFFIX));
         }
 
         if(additionalProperties.containsKey(CodegenConstants.MODEL_NAME_PREFIX)){
@@ -565,6 +570,10 @@ public class DefaultCodegen {
 
     public void setTemplateDir(String templateDir) {
         this.templateDir = templateDir;
+    }
+
+    public void setApiNameSuffix(String apiNameSuffix) {
+        this.apiNameSuffix = apiNameSuffix;
     }
 
     public void setModelPackage(String modelPackage) {
@@ -1266,7 +1275,7 @@ public class DefaultCodegen {
         if (name.length() == 0) {
             return "DefaultApi";
         }
-        return initialCaps(name) + "Api";
+        return initialCaps(name) + apiNameSuffix;
     }
 
     /**

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/config/CodegenConfigurator.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/config/CodegenConfigurator.java
@@ -48,6 +48,7 @@ public class CodegenConfigurator implements Serializable {
     private String templateDir;
     private String auth;
     private String apiPackage;
+    private String apiNameSuffix;
     private String modelPackage;
     private String invokerPackage;
     private String modelNamePrefix;
@@ -96,6 +97,15 @@ public class CodegenConfigurator implements Serializable {
 
     public CodegenConfigurator setOutputDir(String outputDir) {
         this.outputDir = toAbsolutePathStr(outputDir);
+        return this;
+    }
+
+    public String getApiNameSuffix() {
+        return apiNameSuffix;
+    }
+
+    public CodegenConfigurator setApiNameSuffix(String apiNameSuffix) {
+        this.apiNameSuffix = apiNameSuffix;
         return this;
     }
 
@@ -402,6 +412,7 @@ public class CodegenConfigurator implements Serializable {
         config.reservedWordsMappings().putAll(reservedWordMappings);
 
         checkAndSetAdditionalProperty(apiPackage, CodegenConstants.API_PACKAGE);
+        checkAndSetAdditionalProperty(apiNameSuffix, CodegenConstants.API_NAME_SUFFIX);
         checkAndSetAdditionalProperty(modelPackage, CodegenConstants.MODEL_PACKAGE);
         checkAndSetAdditionalProperty(invokerPackage, CodegenConstants.INVOKER_PACKAGE);
         checkAndSetAdditionalProperty(groupId, CodegenConstants.GROUP_ID);

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/AbstractJavaCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/AbstractJavaCodegen.java
@@ -502,7 +502,7 @@ public abstract class AbstractJavaCodegen extends DefaultCodegen implements Code
         if (name.length() == 0) {
             return "DefaultApi";
         }
-        return camelize(name) + "Api";
+        return camelize(name) + apiNameSuffix;
     }
 
     @Override

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/AbstractJavaJAXRSServerCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/AbstractJavaJAXRSServerCodegen.java
@@ -214,7 +214,7 @@ public abstract class AbstractJavaJAXRSServerCodegen extends AbstractJavaCodegen
             return "DefaultApi";
         }
         computed = sanitizeName(computed);
-        return camelize(computed) + "Api";
+        return camelize(computed) + apiNameSuffix;
     }
 
     @Override


### PR DESCRIPTION
### PR checklist

- [X] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [ ] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be fold .und in `.\bin\windows\`.
- [X] Filed the PR against the correct branch: `3.0.0` branch for changes related to OpenAPI spec 3.0. Default: `master`.
- [X] Copied the [technical committee](https://github.com/swagger-api/swagger-codegen/#swagger-codegen-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

I added an additional property to specify an api name suffix instead of always using "Api".
I only changed the JaxRsSpec generator but it will also affect generator that are not reimplementing "toApiName()".

I did run the script as mentioned but I didn't include to change as it changed unrelated stuff. 
You might want to run all the script on master.

@bbdouglas @JFCote @sreeshas @jfiala @lukoyanov @cbornet