### PR TITLE
[Java][Spring] One space too many before JavaDoc first line in model methods

### DIFF
--- a/modules/swagger-codegen/src/main/resources/JavaSpring/pojo.mustache
+++ b/modules/swagger-codegen/src/main/resources/JavaSpring/pojo.mustache
@@ -68,7 +68,7 @@ public class {{classname}} {{#parent}}extends {{{parent}}}{{/parent}} {{#seriali
   }
   {{/isMapContainer}}
 
-   /**
+  /**
   {{#description}}
    * {{{description}}}
   {{/description}}


### PR DESCRIPTION
Fixes issue #7167.