### PR TITLE
[Qt5] plug mem-leaks

### DIFF
--- a/modules/swagger-codegen/src/main/resources/qt5cpp/HttpRequest.cpp.mustache
+++ b/modules/swagger-codegen/src/main/resources/qt5cpp/HttpRequest.cpp.mustache
@@ -47,7 +47,7 @@ void {{prefix}}HttpRequestInput::add_file(QString variable_name, QString local_f
     qsrand(QDateTime::currentDateTime().toTime_t());
 
     manager = new QNetworkAccessManager(this);
-    connect(manager, SIGNAL(finished(QNetworkReply*)), this, SLOT(on_manager_finished(QNetworkReply*)));
+    connect(manager, &QNetworkAccessManager::finished, this, &HttpRequestWorker::on_manager_finished);
 }
 
 {{prefix}}HttpRequestWorker::~{{prefix}}HttpRequestWorker() {

--- a/modules/swagger-codegen/src/main/resources/qt5cpp/api-body.mustache
+++ b/modules/swagger-codegen/src/main/resources/qt5cpp/api-body.mustache
@@ -98,10 +98,10 @@ void
 
     {{#bodyParams}}
     {{#isContainer}}
-    auto {{paramName}}_jobj = new QJsonObject();
-    toJsonArray((QList<void*>*){{paramName}}, {{paramName}}_jobj, QString("body"), QString("{{prefix}}User*"));
+    QJsonObject {{paramName}}_jobj;
+    toJsonArray((QList<void*>){{paramName}}, {{paramName}}_jobj, QString("body"), QString("{{prefix}}User*"));
 
-    QJsonDocument doc(*{{paramName}}_jobj);
+    QJsonDocument doc({{paramName}}_jobj);
     QByteArray bytes = doc.toJson();
 
     input.request_body.append(bytes);
@@ -174,9 +174,9 @@ void
     QJsonObject obj = doc.object();
 
     foreach(QString key, obj.keys()) {
-        qint32* val;
-        setValue(&val, obj[key], "{{returnBaseType}}", "");
-        output->insert(key, *val);
+        qint32 val;
+        setValue(&val, obj[key], "{{returnBaseType}}", QString());
+        output->insert(key, val);
     }
     {{/isMapContainer}}
     {{^isMapContainer}}

--- a/modules/swagger-codegen/src/main/resources/qt5cpp/helpers-body.mustache
+++ b/modules/swagger-codegen/src/main/resources/qt5cpp/helpers-body.mustache
@@ -366,7 +366,7 @@ toJsonArray(QList<void*> value, QJsonObject& output, QString innerName, QString 
         for(void* obj : value) {
             {{prefix}}Object *{{prefix}}object = reinterpret_cast<{{prefix}}Object *>(obj);
             if({{prefix}}object != nullptr) {
-                outputarray.append(*({{prefix}}object->asJsonObject()));
+                outputarray.append({{prefix}}object->asJsonObject());
             }
         }
     }
@@ -409,7 +409,7 @@ toJsonArray(QList<void*> value, QJsonObject& output, QString innerName, QString 
         for(double obj : *(reinterpret_cast<QList<double>*>(&value)))
             outputarray.append(QJsonValue(obj));
     }
-    output->insert(innerName, outputarray);
+    output.insert(innerName, outputarray);
 }
 
 void

--- a/modules/swagger-codegen/src/main/resources/qt5cpp/helpers-body.mustache
+++ b/modules/swagger-codegen/src/main/resources/qt5cpp/helpers-body.mustache
@@ -413,78 +413,12 @@ toJsonArray(QList<void*> value, QJsonObject& output, QString innerName, QString 
 }
 
 void
-toJsonMap(QMap<QString, void*>* value, QJsonObject* output, QString innerName, QString innerType) {
-    if((value == nullptr) || (output == nullptr)) {
-        return;
+toJsonMap(QMap<QString, void*> value, QJsonObject& output, QString innerName, QString innerType) {
+    for (auto itemkey: value.keys()) {
+        QJsonObject mapobj;
+        ::{{cppNamespace}}::toJsonValue(itemkey, value.value(itemkey), &mapobj, innerType);
+        output.insert(innerName, mapobj);
     }
-    QJsonObject mapobj;
-    if(innerType.startsWith("{{prefix}}")){
-        auto items = reinterpret_cast< QMap<QString, {{prefix}}Object*> *>(value);
-        for(auto itemkey: items->keys()) {
-            ::{{cppNamespace}}::toJsonValue(itemkey, items->value(itemkey), &mapobj, innerType);
-        }
-    }
-    else if(QStringLiteral("QString").compare(innerType) == 0) {
-        auto items = reinterpret_cast< QMap<QString, QString*> *>(value);
-        for(auto itemkey: items->keys()) {
-            ::{{cppNamespace}}::toJsonValue(itemkey, items->value(itemkey), &mapobj, innerType);
-        }
-    }
-    else if(QStringLiteral("QDate").compare(innerType) == 0) {
-        auto items = reinterpret_cast< QMap<QString, QDate*> *>(value);
-        for(auto itemkey: items->keys()) {
-            ::{{cppNamespace}}::toJsonValue(itemkey, items->value(itemkey), &mapobj, innerType);
-        }
-    }
-    else if(QStringLiteral("QDateTime").compare(innerType) == 0) {
-        auto items = reinterpret_cast< QMap<QString, QDateTime*> *>(value);
-        for(auto itemkey: items->keys()) {
-            ::{{cppNamespace}}::toJsonValue(itemkey, items->value(itemkey), &mapobj, innerType);
-        }
-    }
-    else if(QStringLiteral("QByteArray").compare(innerType) == 0) {
-        auto items = reinterpret_cast< QMap<QString, QByteArray*> *>(value);
-        for(auto itemkey: items->keys()) {
-            ::{{cppNamespace}}::toJsonValue(itemkey, items->value(itemkey), &mapobj, innerType);
-        }
-    }
-    else if(QStringLiteral("qint32").compare(innerType) == 0) {
-        auto items = reinterpret_cast< QMap<QString, qint32> *>(value);
-        for(auto itemkey: items->keys()) {
-            auto val = items->value(itemkey);
-            ::{{cppNamespace}}::toJsonValue(itemkey, &val, &mapobj, innerType);
-        }
-    }
-    else if(QStringLiteral("qint64").compare(innerType) == 0) {
-        auto items = reinterpret_cast< QMap<QString, qint64> *>(value);
-        for(auto itemkey: items->keys()) {
-            auto val = items->value(itemkey);
-            ::{{cppNamespace}}::toJsonValue(itemkey, &val, &mapobj, innerType);
-        }
-    }
-    else if(QStringLiteral("bool").compare(innerType) == 0) {
-        auto items = reinterpret_cast< QMap<QString, bool> *>(value);
-        for(auto itemkey: items->keys()) {
-            auto val = items->value(itemkey);
-            ::{{cppNamespace}}::toJsonValue(itemkey, &val, &mapobj, innerType);
-        }
-    }
-    else if(QStringLiteral("float").compare(innerType) == 0) {
-        auto items = reinterpret_cast< QMap<QString, float> *>(value);
-        for(auto itemkey: items->keys()) {
-            auto val = items->value(itemkey);
-            ::{{cppNamespace}}::toJsonValue(itemkey, &val, &mapobj, innerType);
-        }
-    }
-    else if(QStringLiteral("double").compare(innerType) == 0) {
-        auto items = reinterpret_cast< QMap<QString, double> *>(value);
-        for(auto itemkey: items->keys() ) {
-            auto val = items->value(itemkey);
-            ::{{cppNamespace}}::toJsonValue(itemkey, &val, &mapobj, innerType);
-        }
-    }
-    output->insert(innerName, mapobj);
-
 }
 
 QString

--- a/modules/swagger-codegen/src/main/resources/qt5cpp/helpers-body.mustache
+++ b/modules/swagger-codegen/src/main/resources/qt5cpp/helpers-body.mustache
@@ -32,91 +32,31 @@ setValue(void* value, QJsonValue obj, QString type, QString complexType) {
     }
     else if(QStringLiteral("float").compare(type) == 0) {
         float *val = static_cast<float*>(value);
-        *val = obj.toDouble();
+        *val = static_cast<float>(obj.toDouble());
     }
     else if(QStringLiteral("double").compare(type) == 0) {
         double *val = static_cast<double*>(value);
         *val = obj.toDouble();
     }
     else if (QStringLiteral("QString").compare(type) == 0) {
-        QString **val = static_cast<QString**>(value);
-        if(val != nullptr) {
-            if(!obj.isNull()) {
-                // create a new value and return
-                if(*val != nullptr) delete *val;
-                *val = new QString(obj.toString());
-                return;
-            }
-            else {
-                // set target to nullptr
-                if(*val != nullptr) delete *val;
-                *val = nullptr;
-            }
-        }
-        else {
-            qDebug() << "Can't set value because the target pointer is nullptr";
-        }
+        QString *val = static_cast<QString*>(value);
+        *val = obj.toString();
+        return;
     }
     else if (QStringLiteral("QDateTime").compare(type) == 0) {
-        QDateTime **val = static_cast<QDateTime**>(value);
-
-        if(val != nullptr) {
-            if(!obj.isNull()) {
-                // create a new value and return
-                if(*val != nullptr) delete *val;
-                *val = new QDateTime(QDateTime::fromString(obj.toString(), Qt::ISODate));
-                return;
-            }
-            else {
-                // set target to nullptr
-                if(*val != nullptr) delete *val;
-                *val = nullptr;
-            }
-        }
-        else {
-            qDebug() << "Can't set value because the target pointer is nullptr";
-        }
+        QDateTime *val = static_cast<QDateTime*>(value);
+        *val = QDateTime::fromString(obj.toString(), Qt::ISODate);
+        return;
     }
     else if (QStringLiteral("QDate").compare(type) == 0) {
-        QDate **val = static_cast<QDate**>(value);
-
-        if(val != nullptr) {
-            if(!obj.isNull()) {
-                // create a new value and return
-                if(*val != nullptr) delete *val;
-                *val = new QDate(QDate::fromString(obj.toString(), Qt::ISODate));
-                return;
-            }
-            else {
-                // set target to nullptr
-                if(*val != nullptr) delete *val;
-                *val = nullptr;
-            }
-        }
-        else {
-            qDebug() << "Can't set value because the target pointer is nullptr";
-        }
+        QDate *val = static_cast<QDate*>(value);
+        *val = QDate::fromString(obj.toString(), Qt::ISODate);
+        return;
     }
     else if (QStringLiteral("QByteArray").compare(type) == 0) {
-        QByteArray **val = static_cast<QByteArray**>(value);
-
-        if(val != nullptr) {
-            if(!obj.isNull()) {
-                // create a new value and return
-                if(*val != nullptr) delete *val;
-
-                *val = new QByteArray(QByteArray::fromBase64(QByteArray::fromStdString(obj.toString().toStdString())));
-                return;
-            }
-            else {
-                // set target to nullptr
-                if(*val != nullptr) delete *val;
-                *val = nullptr;
-            }
-        }
-        else {
-            qDebug() << "Can't set value because the target pointer is nullptr";
-        }
+        QByteArray *val = static_cast<QByteArray*>(value);
+        *val = QByteArray::fromBase64(QByteArray::fromStdString(obj.toString().toStdString()));
+        return;
     }
     else if(type.startsWith("{{prefix}}") && obj.isObject()) {
         // complex type
@@ -132,107 +72,97 @@ setValue(void* value, QJsonValue obj, QString type, QString complexType) {
     else if(type.startsWith("QList") && QString("").compare(complexType) != 0 && obj.isArray()) {
         // list of values
         if(complexType.startsWith("{{prefix}}")) {
-            auto output = reinterpret_cast<QList<{{prefix}}Object *> **> (value);
-            for (auto item : **output) {
-                if(item != nullptr) delete item;
-            }
-            (*output)->clear();
+            QList<{{prefix}}Object*> output;
             QJsonArray arr = obj.toArray();
             for (const QJsonValue & jval : arr) {
                 // it's an object
-                {{prefix}}Object * val = ({{prefix}}Object*)::{{cppNamespace}}::create(complexType);
+                {{prefix}}Object * val = reinterpret_cast<{{prefix}}Object*>(create(complexType));
                 QJsonObject t = jval.toObject();
                 val->fromJsonObject(t);
-                (*output)->append(val);
+                output.push_back(val);
             }
+            QList<{{prefix}}Object*> *val = reinterpret_cast<QList<{{prefix}}Object*>*>(value);
+            qDeleteAll(*val);
+            *val = output;
         }
         else if(QStringLiteral("qint32").compare(complexType) == 0) {
-            auto output = reinterpret_cast<QList<qint32> **> (value);
-            (*output)->clear();
+            auto output = reinterpret_cast<QList<qint32> *> (value);
+            output->clear();
             QJsonArray arr = obj.toArray();
             for (const QJsonValue & jval : arr){
                 qint32 val;
-                ::{{cppNamespace}}::setValue(&val, jval, QStringLiteral("qint32"), QStringLiteral(""));
-                (*output)->push_back(val);
+                ::{{cppNamespace}}::setValue(&val, jval, QStringLiteral("qint32"), QString());
+                output->push_back(val);
             }
         }
         else if(QStringLiteral("qint64").compare(complexType) == 0) {
-            auto output = reinterpret_cast<QList<qint64> **> (value);
-            (*output)->clear();
+            auto output = reinterpret_cast<QList<qint64> *> (value);
+            output->clear();
             QJsonArray arr = obj.toArray();
             for (const QJsonValue & jval : arr){
                 qint64 val;
-                ::{{cppNamespace}}::setValue(&val, jval, QStringLiteral("qint64"), QStringLiteral(""));
-                (*output)->push_back(val);
+                ::{{cppNamespace}}::setValue(&val, jval, QStringLiteral("qint64"), QString());
+                output->push_back(val);
             }
         }
         else if(QStringLiteral("bool").compare(complexType) == 0) {
-            auto output = reinterpret_cast<QList<bool> **> (value);
-            (*output)->clear();
+            auto output = reinterpret_cast<QList<bool> *> (value);
+            output->clear();
             QJsonArray arr = obj.toArray();
             for (const QJsonValue & jval : arr){
                 bool val;
-                ::{{cppNamespace}}::setValue(&val, jval, QStringLiteral("bool"), QStringLiteral(""));
-                (*output)->push_back(val);
+                ::{{cppNamespace}}::setValue(&val, jval, QStringLiteral("bool"), QString());
+                output->push_back(val);
             }
         }
         else if(QStringLiteral("float").compare(complexType) == 0) {
-            auto output = reinterpret_cast<QList<float> **> (value);
-            (*output)->clear();
+            auto output = reinterpret_cast<QList<float> *> (value);
+            output->clear();
             QJsonArray arr = obj.toArray();
             for (const QJsonValue & jval : arr){
                 float val;
-                ::{{cppNamespace}}::setValue(&val, jval, QStringLiteral("float"), QStringLiteral(""));
-                (*output)->push_back(val);
+                ::{{cppNamespace}}::setValue(&val, jval, QStringLiteral("float"), QString());
+                output->push_back(val);
             }
         }
         else if(QStringLiteral("double").compare(complexType) == 0) {
-            auto output = reinterpret_cast<QList<double> **> (value);
-            (*output)->clear();
+            auto output = reinterpret_cast<QList<double> *> (value);
+            output->clear();
             QJsonArray arr = obj.toArray();
             for (const QJsonValue & jval : arr){
                 double val;
-                ::{{cppNamespace}}::setValue(&val, jval, QStringLiteral("double"), QStringLiteral(""));
-                (*output)->push_back(val);
+                ::{{cppNamespace}}::setValue(&val, jval, QStringLiteral("double"), QString());
+                output->push_back(val);
             }
         }
         else if(QStringLiteral("QString").compare(complexType) == 0) {
-            auto output = reinterpret_cast<QList<QString*> **> (value);
-            for (auto item : **output) {
-                if(item != nullptr) delete item;
-            }
-            (*output)->clear();
+            auto output = reinterpret_cast<QList<QString> *> (value);
+            output->clear();
             QJsonArray arr = obj.toArray();
             for (const QJsonValue & jval : arr){
-                QString * val = new QString();
-                ::{{cppNamespace}}::setValue(&val, jval, QStringLiteral("QString"), QStringLiteral(""));
-                (*output)->push_back(val);
+                QString val;
+                ::{{cppNamespace}}::setValue(&val, jval, QStringLiteral("QString"), QString());
+                output->push_back(val);
             }
         }
         else if(QStringLiteral("QDate").compare(complexType) == 0) {
-            auto output = reinterpret_cast<QList<QDate*> **> (value);
-            for (auto item : **output) {
-                if(item != nullptr) delete item;
-            }
-            (*output)->clear();
+            auto output = reinterpret_cast<QList<QDate> *> (value);
+            output->clear();
             QJsonArray arr = obj.toArray();
             for (const QJsonValue & jval : arr){
-                QDate * val = new QDate();
-                ::{{cppNamespace}}::setValue(&val, jval, QStringLiteral("QDate"), QStringLiteral(""));
-                (*output)->push_back(val);
+                QDate val;
+                ::{{cppNamespace}}::setValue(&val, jval, QStringLiteral("QDate"), QString());
+                output->push_back(val);
             }
         }
         else if(QStringLiteral("QDateTime").compare(complexType) == 0) {
-            auto output = reinterpret_cast<QList<QDateTime*> **> (value);
-            for (auto item : **output) {
-                if(item != nullptr) delete item;
-            }
-            (*output)->clear();
+            auto output = reinterpret_cast<QList<QDateTime> *> (value);
+            output->clear();
             QJsonArray arr = obj.toArray();
             for (const QJsonValue & jval : arr){
-                QDateTime * val = new QDateTime();
-                ::{{cppNamespace}}::setValue(&val, jval, QStringLiteral("QDateTime"), QStringLiteral(""));
-                (*output)->push_back(val);
+                QDateTime val;
+                ::{{cppNamespace}}::setValue(&val, jval, QStringLiteral("QDateTime"), QString());
+                output->push_back(val);
             }
         }
     }
@@ -371,72 +301,69 @@ setValue(void* value, QJsonValue obj, QString type, QString complexType) {
 }
 
 void
-toJsonValue(QString name, void* value, QJsonObject* output, QString type) {
+toJsonValue(QString name, void* value, QJsonObject& output, QString type) {
     if(value == nullptr) {
         return;
     }
     if(type.startsWith("{{prefix}}")) {
         {{prefix}}Object *{{prefix}}object = reinterpret_cast<{{prefix}}Object *>(value);
         if({{prefix}}object != nullptr) {
-            QJsonObject* o = (*{{prefix}}object).asJsonObject();
-            if(name != nullptr) {
-                output->insert(name, *o);
-                if(o != nullptr) delete o;
+            QJsonObject o = {{prefix}}object->asJsonObject();
+            if(!name.isNull()) {
+                output.insert(name, o);
             }
             else {
-                output->empty();
-                for(QString key : o->keys()) {
-                    output->insert(key, o->value(key));
+                output.empty();
+                for(QString key : o.keys()) {
+                    output.insert(key, o.value(key));
                 }
             }
         }
     }
     else if(QStringLiteral("QString").compare(type) == 0) {
         QString* str = static_cast<QString*>(value);
-        output->insert(name, QJsonValue(*str));
+        output.insert(name, QJsonValue(*str));
     }
     else if(QStringLiteral("qint32").compare(type) == 0) {
         qint32* str = static_cast<qint32*>(value);
-        output->insert(name, QJsonValue(*str));
+        output.insert(name, QJsonValue(*str));
     }
     else if(QStringLiteral("qint64").compare(type) == 0) {
         qint64* str = static_cast<qint64*>(value);
-        output->insert(name, QJsonValue(*str));
+        output.insert(name, QJsonValue(*str));
     }
     else if(QStringLiteral("bool").compare(type) == 0) {
         bool* str = static_cast<bool*>(value);
-        output->insert(name, QJsonValue(*str));
+        output.insert(name, QJsonValue(*str));
     }
     else if(QStringLiteral("float").compare(type) == 0) {
         float* str = static_cast<float*>(value);
-        output->insert(name, QJsonValue((double)*str));
+        output.insert(name, QJsonValue((double)*str));
     }
     else if(QStringLiteral("double").compare(type) == 0) {
         double* str = static_cast<double*>(value);
-        output->insert(name, QJsonValue(*str));
+        output.insert(name, QJsonValue(*str));
     }
     else if(QStringLiteral("QDate").compare(type) == 0) {
         QDate* date = static_cast<QDate*>(value);
-        output->insert(name, QJsonValue(date->toString(Qt::ISODate)));
+        output.insert(name, QJsonValue(date->toString(Qt::ISODate)));
     }
     else if(QStringLiteral("QDateTime").compare(type) == 0) {
         QDateTime* datetime = static_cast<QDateTime*>(value);
-        output->insert(name, QJsonValue(datetime->toString(Qt::ISODate)));
+        output.insert(name, QJsonValue(datetime->toString(Qt::ISODate)));
     }
     else if(QStringLiteral("QByteArray").compare(type) == 0) {
         QByteArray* byteArray = static_cast<QByteArray*>(value);
-        output->insert(name, QJsonValue(QString(byteArray->toBase64())));
+        output.insert(name, QJsonValue(QString(byteArray->toBase64())));
     }
 }
 
 void
-toJsonArray(QList<void*>* value, QJsonObject* output, QString innerName, QString innerType) {
-    if((value == nullptr) || (output == nullptr)) {
-        return;
-    }
+toJsonArray(QList<void*> value, QJsonObject& output, QString innerName, QString innerType) {
+
     QJsonArray outputarray;
     if(innerType.startsWith("{{prefix}}")){
-        for(void* obj : *value) {
+        for(void* obj : value) {
             {{prefix}}Object *{{prefix}}object = reinterpret_cast<{{prefix}}Object *>(obj);
             if({{prefix}}object != nullptr) {
                 outputarray.append(*({{prefix}}object->asJsonObject()));
@@ -444,42 +371,42 @@ toJsonArray(QList<void*>* value, QJsonObject* output, QString innerName, QString
         }
     }
     else if(QStringLiteral("QString").compare(innerType) == 0) {
-        for(QString* obj : *(reinterpret_cast<QList<QString*>*>(value))){
-            outputarray.append(QJsonValue(*obj));
+        for(QString obj : *(reinterpret_cast<QList<QString>*>(&value))){
+            outputarray.append(QJsonValue(obj));
         }
     }
     else if(QStringLiteral("QDate").compare(innerType) == 0) {
-        for(QDate* obj : *(reinterpret_cast<QList<QDate*>*>(value))){
-            outputarray.append(QJsonValue(obj->toString(Qt::ISODate)));
+        for(QDate obj : *(reinterpret_cast<QList<QDate>*>(&value))){
+            outputarray.append(QJsonValue(obj.toString(Qt::ISODate)));
         }
     }
     else if(QStringLiteral("QDateTime").compare(innerType) == 0) {
-        for(QDateTime* obj : *(reinterpret_cast<QList<QDateTime*>*>(value))){
-            outputarray.append(QJsonValue(obj->toString(Qt::ISODate)));        }
+        for(QDateTime obj : *(reinterpret_cast<QList<QDateTime>*>(&value))){
+            outputarray.append(QJsonValue(obj.toString(Qt::ISODate)));        }
     }
     else if(QStringLiteral("QByteArray").compare(innerType) == 0) {
-        for(QByteArray* obj : *(reinterpret_cast<QList<QByteArray*>*>(value))){
-            outputarray.append(QJsonValue(QString(obj->toBase64())));
+        for(QByteArray obj : *(reinterpret_cast<QList<QByteArray>*>(&value))){
+            outputarray.append(QJsonValue(QString(obj.toBase64())));
         }
     }
     else if(QStringLiteral("qint32").compare(innerType) == 0) {
-        for(qint32 obj : *(reinterpret_cast<QList<qint32>*>(value)))
+        for(qint32 obj : *(reinterpret_cast<QList<qint32>*>(&value)))
             outputarray.append(QJsonValue(obj));
     }
     else if(QStringLiteral("qint64").compare(innerType) == 0) {
-        for(qint64 obj : *(reinterpret_cast<QList<qint64>*>(value)))
+        for(qint64 obj : *(reinterpret_cast<QList<qint64>*>(&value)))
             outputarray.append(QJsonValue(obj));
     }
     else if(QStringLiteral("bool").compare(innerType) == 0) {
-        for(bool obj : *(reinterpret_cast<QList<bool>*>(value)))
+        for(bool obj : *(reinterpret_cast<QList<bool>*>(&value)))
             outputarray.append(QJsonValue(obj));
     }
     else if(QStringLiteral("float").compare(innerType) == 0) {
-        for(float obj : *(reinterpret_cast<QList<float>*>(value)))
+        for(float obj : *(reinterpret_cast<QList<float>*>(&value)))
             outputarray.append(QJsonValue(obj));
     }
     else if(QStringLiteral("double").compare(innerType) == 0) {
-        for(double obj : *(reinterpret_cast<QList<double>*>(value)))
+        for(double obj : *(reinterpret_cast<QList<double>*>(&value)))
             outputarray.append(QJsonValue(obj));
     }
     output->insert(innerName, outputarray);
@@ -557,12 +484,7 @@ toJsonMap(QMap<QString, void*>* value, QJsonObject* output, QString innerName, Q
         }
     }
     output->insert(innerName, mapobj);
-}
 
-QString
-stringValue(QString* value) {
-    QString* str = static_cast<QString*>(value);
-    return QString(*str);
 }
 
 QString

--- a/modules/swagger-codegen/src/main/resources/qt5cpp/helpers-header.mustache
+++ b/modules/swagger-codegen/src/main/resources/qt5cpp/helpers-header.mustache
@@ -11,11 +11,10 @@ namespace {{this}} {
 {{/cppNamespaceDeclarations}}
 
     void setValue(void* value, QJsonValue obj, QString type, QString complexType);
-    void toJsonArray(QList<void*>* value, QJsonObject* output, QString innerName, QString innerType);
-    void toJsonValue(QString name, void* value, QJsonObject* output, QString type);
+    void toJsonArray(QList<void*> value, QJsonObject& output, QString innerName, QString innerType);
+    void toJsonValue(QString name, void* value, QJsonObject& output, QString type);
     void toJsonMap(QMap<QString, void*>* value, QJsonObject* output, QString innerName, QString innerType);
     bool isCompatibleJsonValue(QString type);
-    QString stringValue(QString* value);
     QString stringValue(qint32 value);
     QString stringValue(qint64 value);
     QString stringValue(bool value);

--- a/modules/swagger-codegen/src/main/resources/qt5cpp/helpers-header.mustache
+++ b/modules/swagger-codegen/src/main/resources/qt5cpp/helpers-header.mustache
@@ -13,7 +13,7 @@ namespace {{this}} {
     void setValue(void* value, QJsonValue obj, QString type, QString complexType);
     void toJsonArray(QList<void*> value, QJsonObject& output, QString innerName, QString innerType);
     void toJsonValue(QString name, void* value, QJsonObject& output, QString type);
-    void toJsonMap(QMap<QString, void*>* value, QJsonObject* output, QString innerName, QString innerType);
+    void toJsonMap(QMap<QString, void*> value, QJsonObject& output, QString innerName, QString innerType);
     bool isCompatibleJsonValue(QString type);
     QString stringValue(qint32 value);
     QString stringValue(qint64 value);

--- a/modules/swagger-codegen/src/main/resources/qt5cpp/model-body.mustache
+++ b/modules/swagger-codegen/src/main/resources/qt5cpp/model-body.mustache
@@ -13,9 +13,9 @@
 namespace {{this}} {
 {{/cppNamespaceDeclarations}}
 
-{{classname}}::{{classname}}(QString* json) {
+{{classname}}::{{classname}}(QString json) {
     init();
-    this->fromJson(*json);
+    this->fromJson(json);
 }
 
 {{classname}}::{{classname}}() {
@@ -52,7 +52,7 @@ void
 }
 
 {{classname}}*
-{{classname}}::fromJson(QString &json) {
+{{classname}}::fromJson(QString json) {
     QByteArray array (json.toStdString().c_str());
     QJsonDocument doc = QJsonDocument::fromJson(array);
     QJsonObject jsonObject = doc.object();
@@ -61,7 +61,7 @@ void
 }
 
 void
-{{classname}}::fromJsonObject(QJsonObject &pJson) {
+{{classname}}::fromJsonObject(QJsonObject pJson) {
     {{#vars}}
     {{^isContainer}}::{{cppNamespace}}::setValue(&{{name}}, pJson["{{baseName}}"], "{{baseType}}", "{{complexType}}");{{/isContainer}}
     {{#isContainer}}{{^items.isContainer}}::{{cppNamespace}}::setValue(&{{name}}, pJson["{{baseName}}"], "{{baseType}}", "{{items.baseType}}");{{/items.isContainer}}{{#items.isContainer}}{{#isListContainer}}
@@ -94,16 +94,15 @@ void
 QString
 {{classname}}::asJson ()
 {
-    QJsonObject* obj = this->asJsonObject();
-
-    QJsonDocument doc(*obj);
+    QJsonObject obj = this->asJsonObject();
+    QJsonDocument doc(obj);
     QByteArray bytes = doc.toJson();
     return QString(bytes);
 }
 
-QJsonObject*
+QJsonObject
 {{classname}}::asJsonObject() {
-    QJsonObject* obj = new QJsonObject();
+    QJsonObject obj;
     {{#vars}}
     {{^isContainer}}
     {{#complexType}}
@@ -129,7 +128,7 @@ QJsonObject*
     {{^isDate}}
     {{^isByteArray}}
     if(m_{{name}}_isSet){
-        obj->insert("{{baseName}}", QJsonValue({{name}}));
+        obj.insert("{{baseName}}", QJsonValue({{name}}));
     }
     {{/isByteArray}}
     {{/isDate}}
@@ -142,7 +141,7 @@ QJsonObject*
     {{/isDate}}
     {{#isByteArray}}    
     if({{name}} != nullptr) { 
-        obj->insert("{{name}}", QJsonValue(*{{name}}));
+        obj.insert("{{name}}", QJsonValue(*{{name}}));
     }
     {{/isByteArray}}
     {{#isDateTime}}   
@@ -187,7 +186,7 @@ QJsonObject*
             {{/items.isMapContainer}}
             mapobj.insert(itemkey, jobj);
         }
-        obj->insert("{{baseName}}", mapobj);{{/items.isContainer}}
+        obj.insert("{{baseName}}", mapobj);{{/items.isContainer}}
     }
     {{/isMapContainer}}
     {{/isContainer}}

--- a/modules/swagger-codegen/src/main/resources/qt5cpp/model-header.mustache
+++ b/modules/swagger-codegen/src/main/resources/qt5cpp/model-header.mustache
@@ -25,15 +25,15 @@ namespace {{this}} {
 class {{classname}}: public {{prefix}}Object {
 public:
     {{classname}}();
-    {{classname}}(QString* json);
-    virtual ~{{classname}}();
+    {{classname}}(QString json);
+    ~{{classname}}();
     void init();
     void cleanup();
 
     QString asJson ();
-    QJsonObject* asJsonObject();
-    void fromJsonObject(QJsonObject &json);
-    {{classname}}* fromJson(QString &jsonString);
+    QJsonObject asJsonObject();
+    void fromJsonObject(QJsonObject json);
+    {{classname}}* fromJson(QString jsonString);
 
     {{#vars}}
     {{{datatype}}} {{getter}}();

--- a/modules/swagger-codegen/src/main/resources/qt5cpp/object.mustache
+++ b/modules/swagger-codegen/src/main/resources/qt5cpp/object.mustache
@@ -10,15 +10,15 @@ namespace {{this}} {
 
 class {{prefix}}Object {
   public:
-    virtual QJsonObject* asJsonObject() {
-      return new QJsonObject();
+    virtual QJsonObject asJsonObject() {
+      return QJsonObject();
     }
     virtual ~{{prefix}}Object() {}
-    virtual {{prefix}}Object* fromJson(QString &jsonString) {
+    virtual {{prefix}}Object* fromJson(QString jsonString) {
         Q_UNUSED(jsonString);
         return new {{prefix}}Object();
     }
-    virtual void fromJsonObject(QJsonObject &json) {
+    virtual void fromJsonObject(QJsonObject json) {
         Q_UNUSED(json);
     }
     virtual QString asJson() {

--- a/samples/client/petstore/qt5cpp/PetStore/PetApiTests.cpp
+++ b/samples/client/petstore/qt5cpp/PetStore/PetApiTests.cpp
@@ -36,44 +36,45 @@ void PetApiTests::runTests() {
 }
 
 void PetApiTests::findPetsByStatusTest() {
-    SWGPetApi* api = getApi();
-
-    static QEventLoop loop;
+    QEventLoop loop;
     QTimer timer;
-    timer.setInterval(14000);
     timer.setSingleShot(true);
+
+    SWGPetApi* api = getApi();
 
     auto validator = [](QList<SWGPet*>* pets) {
         foreach(SWGPet* pet, *pets) {
             QVERIFY(pet->getStatus()->startsWith("available") || pet->getStatus()->startsWith("sold"));
         }
         loop.quit();
+        qDeleteAll(pets);
+        delete api;
     };
 
     connect(api, &SWGPetApi::findPetsByStatusSignal, this, validator);
     connect(&timer, &QTimer::timeout, &loop, &QEventLoop::quit);
 
-    QList<QString*>* status = new QList<QString*>();
-    status->append(new QString("available"));
-    status->append(new QString("sold"));
+    QList<QString> status;
+    status.append(QStringLiteral("available"));
+    status.append(QStringLiteral("sold"));
     api->findPetsByStatus(status);
-    timer.start();
+    timer.start(14000);
     loop.exec();
     QVERIFY2(timer.isActive(), "didn't finish within timeout");
-    delete api;
 }
 
 void PetApiTests::createAndGetPetTest() {
-    SWGPetApi* api = getApi();
-
-    static QEventLoop loop;
+    QEventLoop loop;
     QTimer timer;
-    timer.setInterval(14000);
     timer.setSingleShot(true);
 
-    auto validator = []() {
+    // create pet
+    SWGPetApi* api = getApi();
+
+    auto validator = [&]() {
         // pet created
         loop.quit();
+        delete api;
     };
 
     connect(api, &SWGPetApi::addPetSignal, this, validator);
@@ -83,169 +84,171 @@ void PetApiTests::createAndGetPetTest() {
     qint64 id = pet->getId();
 
     api->addPet(*pet);
-    timer.start();
+    timer.start(14000);
     loop.exec();
     QVERIFY2(timer.isActive(), "didn't finish within timeout");
 
-    timer.setInterval(1000);
-    timer.setSingleShot(true);
+    // get it
+    api = getApi();
 
-    auto getPetValidator = [](SWGPet* pet) {
+    auto getPetValidator = [&](SWGPet* pet) {
         QVERIFY(pet->getId() > 0);
         QVERIFY(pet->getStatus()->compare("freaky") == 0);
         loop.quit();
+        delete api;
     };
 
     connect(api, &SWGPetApi::getPetByIdSignal, this, getPetValidator);
     connect(&timer, &QTimer::timeout, &loop, &QEventLoop::quit);
 
     api->getPetById(id);
-    timer.start();
+    timer.start(1000);
     loop.exec();
     QVERIFY2(timer.isActive(), "didn't finish within timeout");
-    delete api;
 }
 
 void PetApiTests::updatePetTest() {
-    static SWGPetApi* api = getApi();
-
     SWGPet* pet = createRandomPet();
-    static SWGPet* petToCheck;
+    SWGPet* petToCheck = nullptr;
     qint64 id = pet->getId();
-    static QEventLoop loop;
+    QEventLoop loop;
     QTimer timer;
-    timer.setInterval(100000);
     timer.setSingleShot(true);
 
-    auto validator = []() {
+    // create pet
+    SWGPetApi* api = getApi();
+
+    auto validator = [&]() {
         loop.quit();
+        delete api;
     };
 
     connect(api, &SWGPetApi::addPetSignal, this, validator);
     connect(&timer, &QTimer::timeout, &loop, &QEventLoop::quit);
 
-    // create pet
     api->addPet(*pet);
-    timer.start();
+    timer.start(100000);
     loop.exec();
     QVERIFY2(timer.isActive(), "didn't finish within timeout");
 
     // fetch it
-    timer.setInterval(1000);
-    timer.setSingleShot(true);
+    api = getApi();
 
-    auto fetchPet = [](SWGPet* pet) {
+    auto fetchPet = [&](SWGPet* pet) {
         petToCheck = pet;
         loop.quit();
+        delete api;
     };
     connect(api, &SWGPetApi::getPetByIdSignal, this, fetchPet);
     connect(&timer, &QTimer::timeout, &loop, &QEventLoop::quit);
 
-    // create pet
     api->getPetById(id);
-    timer.start();
+    timer.start(1000);
     loop.exec();
     QVERIFY2(timer.isActive(), "didn't finish within timeout");
 
     // update it
-    timer.setInterval(1000);
-    timer.setSingleShot(true);
-    auto updatePetTest = []() {
+    api = getApi();
+
+    auto updatePetTest = [&]() {
         loop.quit();
+        delete api;
     };
 
     connect(api, &SWGPetApi::updatePetSignal, this, updatePetTest);
     connect(&timer, &QTimer::timeout, &loop, &QEventLoop::quit);
 
-    // update pet
-    petToCheck->setStatus(new QString("scary"));
+    petToCheck->setStatus(QStringLiteral("scary"));
     api->updatePet(*petToCheck);
-    timer.start();
+    timer.start(1000);
     loop.exec();
     QVERIFY2(timer.isActive(), "didn't finish within timeout");
 
     // check it
-    timer.setInterval(1000);
-    timer.setSingleShot(true);
+    api = getApi();
 
-    auto fetchPet2 = [](SWGPet* pet) {
+    auto fetchPet2 = [&](SWGPet* pet) {
         QVERIFY(pet->getId() == petToCheck->getId());
         QVERIFY(pet->getStatus()->compare(petToCheck->getStatus()) == 0);
         loop.quit();
+        delete api;
     };
+
     connect(api, &SWGPetApi::getPetByIdSignal, this, fetchPet2);
     connect(&timer, &QTimer::timeout, &loop, &QEventLoop::quit);
+
     api->getPetById(id);
-    timer.start();
+    timer.start(1000);
     loop.exec();
     QVERIFY2(timer.isActive(), "didn't finish within timeout");
 }
 
 void PetApiTests::updatePetWithFormTest() {
-    static SWGPetApi* api = getApi();
-
     SWGPet* pet = createRandomPet();
-    static SWGPet* petToCheck;
+    SWGPet* petToCheck = nullptr;
     qint64 id = pet->getId();
-    static QEventLoop loop;
+    QEventLoop loop;
     QTimer timer;
-
-    // create pet
-    timer.setInterval(1000);
     timer.setSingleShot(true);
 
-    auto validator = []() {
+    // create pet
+    SWGPetApi* api = getApi();
+
+    auto validator = [&]() {
         loop.quit();
+        delete api;
     };
 
     connect(api, &SWGPetApi::addPetSignal, this, validator);
     connect(&timer, &QTimer::timeout, &loop, &QEventLoop::quit);
     api->addPet(*pet);
-    timer.start();
+    timer.start(1000);
     loop.exec();
     QVERIFY2(timer.isActive(), "didn't finish within timeout");
 
     // fetch it
-    timer.setInterval(1000);
-    timer.setSingleShot(true);
+    api = getApi();
 
-    auto fetchPet = [](SWGPet* pet) {
+    auto fetchPet = [&](SWGPet* pet) {
         petToCheck = pet;
         loop.quit();
+        delete api;
     };
     connect(api, &SWGPetApi::getPetByIdSignal, this, fetchPet);
     connect(&timer, &QTimer::timeout, &loop, &QEventLoop::quit);
 
     api->getPetById(id);
-    timer.start();
+    timer.start(1000);
     loop.exec();
     QVERIFY2(timer.isActive(), "didn't finish within timeout");
 
     // update it
-    timer.setInterval(1000);
-    timer.setSingleShot(true);
+    api = getApi();
 
-    connect(api, &SWGPetApi::updatePetWithFormSignal, this, [](){loop.quit();});
+    connect(api, &SWGPetApi::updatePetWithFormSignal, this, [&](){
+        loop.quit();
+        delete api;
+    });
     connect(&timer, &QTimer::timeout, &loop, &QEventLoop::quit);
 
     api->updatePetWithForm(id, new QString("gorilla"), NULL);
-    timer.start();
+    timer.start(1000);
     loop.exec();
     QVERIFY2(timer.isActive(), "didn't finish within timeout");
 
     // fetch it
-    timer.setInterval(1000);
-    timer.setSingleShot(true);
+    api = getApi();
 
-    auto fetchUpdatedPet = [](SWGPet* pet) {
+    auto fetchUpdatedPet = [&](SWGPet* pet) {
         QVERIFY(pet->getName()->compare(QString("gorilla")) == 0);
         loop.quit();
+        delete api;
     };
     connect(api, &SWGPetApi::getPetByIdSignal, this, fetchUpdatedPet);
     connect(&timer, &QTimer::timeout, &loop, &QEventLoop::quit);
 
     api->getPetById(id);
-    timer.start();
+    timer.start(1000);
     loop.exec();
     QVERIFY2(timer.isActive(), "didn't finish within timeout");
 }


### PR DESCRIPTION
The generated Qt5 code produces some serious memory leaks. What I noticed is, that one has to use the API for example like this in a real environment:

```c++
// "this" is assumed a valid QObject
void my_func() {
SWGDefaultApi* api = new SWGDefaultApi();
// actually "getSomethingSignalE" should be used always (!) instead - just for the example this is shorter to write
QObject::connect(api, &SWGDefaultApi::getSomethingSignal, this, [api](QList<SWGMyObject*>* list) {
  // do something with the list:
  // the following sample loop produces a definite (and serious) mem-leak
  for (auto swg_my_obj : *list) {
    qDebug() << swg_my_obj->asJson();
  }

  // manual cleanup is needed to free memory
  qDeleteAll(*list);
  delete list;
  delete api;
});

// finally call the api
api->getSomething();
}
```

While this looks very "unfamiliar" in the Qt world, it is also cumbersome and error prone in usage.

This PR is meant to fix those leaks and also should make maintenance of the templates more simple. This breaks compatibility though, because it uses Qt mechanisms (COW & smart-pointers instead of e.g. pointers to QList etc.). OTOH it plugs the most serious mem-leaks.

Unfortunately I had to make changes "blind" without a functional test or anything. So, if someone could actually check it, that would be great.