### PR TITLE
Fix typo in Petstore yaml #7190

### DIFF
--- a/modules/swagger-codegen/src/test/resources/2_0/petstore.yaml
+++ b/modules/swagger-codegen/src/test/resources/2_0/petstore.yaml
@@ -602,7 +602,7 @@ definitions:
     xml:
       name: Order
   Category:
-    title: Pet catehgry
+    title: Pet category
     description: A category for a pet
     type: object
     properties:

--- a/samples/client/petstore/ada/src/client/samples-petstore-models.ads
+++ b/samples/client/petstore/ada/src/client/samples-petstore-models.ads
@@ -45,7 +45,7 @@ package Samples.Petstore.Models is
 
 
    --  ------------------------------
-   --  Pet catehgry
+   --  Pet category
    --  A category for a pet
    --  ------------------------------
    type Category_Type is

--- a/samples/html/index.html
+++ b/samples/html/index.html
@@ -1277,7 +1277,7 @@ font-style: italic;
   <h3>Table of Contents</h3>
   <ol>
     <li><a href="#ApiResponse"><code>ApiResponse</code> - An uploaded response</a></li>
-    <li><a href="#Category"><code>Category</code> - Pet catehgry</a></li>
+    <li><a href="#Category"><code>Category</code> - Pet category</a></li>
     <li><a href="#Order"><code>Order</code> - Pet Order</a></li>
     <li><a href="#Pet"><code>Pet</code> - a Pet</a></li>
     <li><a href="#Tag"><code>Tag</code> - Pet Tag</a></li>
@@ -1294,7 +1294,7 @@ font-style: italic;
     </div>  <!-- field-items -->
   </div>
   <div class="model">
-    <h3><a name="Category"><code>Category</code> - Pet catehgry</a> <a class="up" href="#__Models">Up</a></h3>
+    <h3><a name="Category"><code>Category</code> - Pet category</a> <a class="up" href="#__Models">Up</a></h3>
     <div class='model-description'>A category for a pet</div>
     <div class="field-items">
       <div class="param">id (optional)</div><div class="param-desc"><span class="param-type"><a href="#long">Long</a></span>  format: int64</div>

--- a/samples/html2/index.html
+++ b/samples/html2/index.html
@@ -723,7 +723,7 @@ margin-bottom: 20px;
       "type" : "string"
     }
   },
-  "title" : "Pet catehgry",
+  "title" : "Pet category",
   "description" : "A category for a pet",
   "xml" : {
     "name" : "Category"

--- a/samples/server/petstore/aspnetcore/src/IO.Swagger/wwwroot/swagger-original.json
+++ b/samples/server/petstore/aspnetcore/src/IO.Swagger/wwwroot/swagger-original.json
@@ -707,7 +707,7 @@
           "type" : "string"
         }
       },
-      "title" : "Pet catehgry",
+      "title" : "Pet category",
       "description" : "A category for a pet",
       "example" : {
         "id" : 6,

--- a/samples/server/petstore/erlang-server/priv/swagger.json
+++ b/samples/server/petstore/erlang-server/priv/swagger.json
@@ -699,7 +699,7 @@
           "type" : "string"
         }
       },
-      "title" : "Pet catehgry",
+      "title" : "Pet category",
       "description" : "A category for a pet",
       "xml" : {
         "name" : "Category"

--- a/samples/server/petstore/flaskConnexion-python2/swagger_server/swagger/swagger.yaml
+++ b/samples/server/petstore/flaskConnexion-python2/swagger_server/swagger/swagger.yaml
@@ -643,7 +643,7 @@ definitions:
         format: "int64"
       name:
         type: "string"
-    title: "Pet catehgry"
+    title: "Pet category"
     description: "A category for a pet"
     example:
       name: "name"

--- a/samples/server/petstore/flaskConnexion/swagger_server/swagger/swagger.yaml
+++ b/samples/server/petstore/flaskConnexion/swagger_server/swagger/swagger.yaml
@@ -643,7 +643,7 @@ definitions:
         format: "int64"
       name:
         type: "string"
-    title: "Pet catehgry"
+    title: "Pet category"
     description: "A category for a pet"
     example:
       name: "name"

--- a/samples/server/petstore/go-api-server/api/swagger.yaml
+++ b/samples/server/petstore/go-api-server/api/swagger.yaml
@@ -648,7 +648,7 @@ definitions:
         format: "int64"
       name:
         type: "string"
-    title: "Pet catehgry"
+    title: "Pet category"
     description: "A category for a pet"
     example:
       name: "name"

--- a/samples/server/petstore/java-play-framework-controller-only/public/swagger.json
+++ b/samples/server/petstore/java-play-framework-controller-only/public/swagger.json
@@ -747,7 +747,7 @@
           "type" : "string"
         }
       },
-      "title" : "Pet catehgry",
+      "title" : "Pet category",
       "description" : "A category for a pet",
       "example" : {
         "name" : "name",

--- a/samples/server/petstore/java-play-framework-no-bean-validation/public/swagger.json
+++ b/samples/server/petstore/java-play-framework-no-bean-validation/public/swagger.json
@@ -747,7 +747,7 @@
           "type" : "string"
         }
       },
-      "title" : "Pet catehgry",
+      "title" : "Pet category",
       "description" : "A category for a pet",
       "example" : {
         "name" : "name",

--- a/samples/server/petstore/java-play-framework-no-exception-handling/public/swagger.json
+++ b/samples/server/petstore/java-play-framework-no-exception-handling/public/swagger.json
@@ -747,7 +747,7 @@
           "type" : "string"
         }
       },
-      "title" : "Pet catehgry",
+      "title" : "Pet category",
       "description" : "A category for a pet",
       "example" : {
         "name" : "name",

--- a/samples/server/petstore/java-play-framework-no-interface/public/swagger.json
+++ b/samples/server/petstore/java-play-framework-no-interface/public/swagger.json
@@ -747,7 +747,7 @@
           "type" : "string"
         }
       },
-      "title" : "Pet catehgry",
+      "title" : "Pet category",
       "description" : "A category for a pet",
       "example" : {
         "name" : "name",

--- a/samples/server/petstore/java-play-framework-no-wrap-calls/public/swagger.json
+++ b/samples/server/petstore/java-play-framework-no-wrap-calls/public/swagger.json
@@ -747,7 +747,7 @@
           "type" : "string"
         }
       },
-      "title" : "Pet catehgry",
+      "title" : "Pet category",
       "description" : "A category for a pet",
       "example" : {
         "name" : "name",

--- a/samples/server/petstore/java-play-framework/public/swagger.json
+++ b/samples/server/petstore/java-play-framework/public/swagger.json
@@ -747,7 +747,7 @@
           "type" : "string"
         }
       },
-      "title" : "Pet catehgry",
+      "title" : "Pet category",
       "description" : "A category for a pet",
       "example" : {
         "name" : "name",

--- a/samples/server/petstore/java-vertx/async/src/main/resources/swagger.json
+++ b/samples/server/petstore/java-vertx/async/src/main/resources/swagger.json
@@ -739,7 +739,7 @@
           "type" : "string"
         }
       },
-      "title" : "Pet catehgry",
+      "title" : "Pet category",
       "description" : "A category for a pet",
       "xml" : {
         "name" : "Category"

--- a/samples/server/petstore/java-vertx/rx/src/main/resources/swagger.json
+++ b/samples/server/petstore/java-vertx/rx/src/main/resources/swagger.json
@@ -739,7 +739,7 @@
           "type" : "string"
         }
       },
-      "title" : "Pet catehgry",
+      "title" : "Pet category",
       "description" : "A category for a pet",
       "xml" : {
         "name" : "Category"

--- a/samples/server/petstore/jaxrs-cxf-cdi/swagger.json
+++ b/samples/server/petstore/jaxrs-cxf-cdi/swagger.json
@@ -699,7 +699,7 @@
           "type" : "string"
         }
       },
-      "title" : "Pet catehgry",
+      "title" : "Pet category",
       "description" : "A category for a pet",
       "xml" : {
         "name" : "Category"

--- a/samples/server/petstore/nodejs-google-cloud-functions/api/swagger.yaml
+++ b/samples/server/petstore/nodejs-google-cloud-functions/api/swagger.yaml
@@ -635,7 +635,7 @@ definitions:
         format: "int64"
       name:
         type: "string"
-    title: "Pet catehgry"
+    title: "Pet category"
     description: "A category for a pet"
     xml:
       name: "Category"

--- a/samples/server/petstore/nodejs/api/swagger.yaml
+++ b/samples/server/petstore/nodejs/api/swagger.yaml
@@ -635,7 +635,7 @@ definitions:
         format: "int64"
       name:
         type: "string"
-    title: "Pet catehgry"
+    title: "Pet category"
     description: "A category for a pet"
     xml:
       name: "Category"

--- a/samples/server/petstore/sinatra/swagger.yaml
+++ b/samples/server/petstore/sinatra/swagger.yaml
@@ -615,7 +615,7 @@ definitions:
         format: "int64"
       name:
         type: "string"
-    title: "Pet catehgry"
+    title: "Pet category"
     description: "A category for a pet"
     xml:
       name: "Category"

--- a/samples/server/petstore/undertow/src/main/resources/config/swagger.json
+++ b/samples/server/petstore/undertow/src/main/resources/config/swagger.json
@@ -747,7 +747,7 @@
           "type" : "string"
         }
       },
-      "title" : "Pet catehgry",
+      "title" : "Pet category",
       "description" : "A category for a pet",
       "example" : {
         "name" : "name",


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [x] Filed the PR against the correct branch: `3.0.0` branch for changes related to OpenAPI spec 3.0. Default: `master`.
- [ ] Copied the [technical committee](https://github.com/swagger-api/swagger-codegen/#swagger-codegen-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

Fix typo in Petstore.yaml file to address #7190. Also correct in all generated client/server samples.
