### PR TITLE
[C++][Qt5] use QJsonObject instead of QJsonArray for maps

### DIFF
--- a/modules/swagger-codegen/src/main/resources/qt5cpp/model-body.mustache
+++ b/modules/swagger-codegen/src/main/resources/qt5cpp/model-body.mustache
@@ -120,13 +120,11 @@ QJsonObject*
     obj->insert("{{baseName}}", {{name}}JsonArray);
     {{/isListContainer}}
     {{#isMapContainer}}
-    QJsonArray {{name}}JsonArray;
+    QJsonObject {{name}}_jobj;
     for(auto keyval : {{name}}->keys()){
-	    QJsonObject {{name}}_jobj;
-	    toJsonValue(keyval, ((*{{name}})[keyval]), &{{name}}_jobj, "{{complexType}}");
-	    {{name}}JsonArray.append({{name}}_jobj);
-	}   
-    obj->insert("{{baseName}}", {{name}}JsonArray);
+        toJsonValue(keyval, ((*{{name}})[keyval]), &{{name}}_jobj, "{{complexType}}");
+    }   
+    obj->insert("{{baseName}}", {{name}}_jobj);
     {{/isMapContainer}}
     {{/complexType}}
     {{^complexType}}
@@ -139,13 +137,11 @@ QJsonObject*
     obj->insert("{{baseName}}", {{name}}JsonArray);
     {{/isListContainer}}
     {{#isMapContainer}}
-    QJsonArray {{name}}JsonArray;
+    QJsonObject {{name}}_jobj;
     for(auto keyval : {{name}}->keys()){
-	    QJsonObject {{name}}_jobj;
-	    toJsonValue(keyval, ((*{{name}})[keyval]), &{{name}}_jobj, "{{items.baseType}}");
-	    {{name}}JsonArray.append(portsobj);
-	}     
-    obj->insert("{{baseName}}", {{name}}JsonArray);
+        toJsonValue(keyval, ((*{{name}})[keyval]), &{{name}}_jobj, "{{items.baseType}}");
+    }     
+    obj->insert("{{baseName}}", {{name}}_jobj);
     {{/isMapContainer}}
     {{/complexType}}
     {{/vars}}


### PR DESCRIPTION
### PR checklist

- [X] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [X] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [X] Filed the PR against the correct branch: `3.0.0` branch for changes related to OpenAPI spec 3.0. Default: `master`.
- [X] Copied the [technical committee](https://github.com/swagger-api/swagger-codegen/#swagger-codegen-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

(details of the change, additional tests that have been done, reference to the issue for tracking, etc)

Generated code for Docker API version 1.32. Client code communicates with dockerd with the parameters successfully interpreted by dockerd.

cc @stkrwork @ravinikam @fvarose 
  