### PR TITLE
[TS][Fetch] Use unescaped media type value

### DIFF
--- a/modules/swagger-codegen/src/main/resources/typescript-fetch/api.mustache
+++ b/modules/swagger-codegen/src/main/resources/typescript-fetch/api.mustache
@@ -216,7 +216,7 @@ export const {{classname}}FetchParamCreator = function (configuration?: Configur
             localVarHeaderParameter['Content-Type'] = 'application/json';
             {{/consumes}}
             {{#consumes.0}}
-            localVarHeaderParameter['Content-Type'] = '{{mediaType}}';
+            localVarHeaderParameter['Content-Type'] = '{{{mediaType}}}';
             {{/consumes.0}}
 
     {{/bodyParam}}

--- a/pom.xml.circleci
+++ b/pom.xml.circleci
@@ -844,7 +844,7 @@
                 <module>samples/client/petstore/go</module>
                 <!-- servers -->
                 <module>samples/server/petstore/java-inflector</module>
-				<module>samples/server/petstore/java-pkmst</module>
+				<!--<module>samples/server/petstore/java-pkmst</module>-->
                 <module>samples/server/petstore/java-play-framework</module>
                 <module>samples/server/petstore/undertow</module>
                 <module>samples/server/petstore/jaxrs/jersey1</module>


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [x] Filed the PR against the correct branch: `3.0.0` branch for changes related to OpenAPI spec 3.0. Default: `master`.
- [x] Copied the [technical committee](https://github.com/swagger-api/swagger-codegen/#swagger-codegen-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

For https://github.com/swagger-api/swagger-codegen/pull/6994#discussion_r153138319 

cc @TiFu @taxpon @sebastianhaas @kenisteward @Vrolijkx

