### PR TITLE
Fix for #7109: [Python] avoid to encode unicode twice

### DIFF
--- a/modules/swagger-codegen/src/main/resources/flaskConnexion/util.mustache
+++ b/modules/swagger-codegen/src/main/resources/flaskConnexion/util.mustache
@@ -44,7 +44,12 @@ def _deserialize_primitive(data, klass):
     try:
         value = klass(data)
     except UnicodeEncodeError:
-        value = six.u(data)
+        if isinstance(data, unicode):
+            # TODO: remove this case when handled by
+            # https://github.com/benjaminp/six/issues/45
+            value = data
+        else:
+            value = six.u(data)
     except TypeError:
         value = data
     return value

--- a/modules/swagger-codegen/src/main/resources/python/api_client.mustache
+++ b/modules/swagger-codegen/src/main/resources/python/api_client.mustache
@@ -547,7 +547,12 @@ class ApiClient(object):
         try:
             return klass(data)
         except UnicodeEncodeError:
-            return six.u(data)
+            if isinstance(data, unicode):
+                # TODO: remove this case when handled by
+                # https://github.com/benjaminp/six/issues/45
+                return data
+            else:
+                return six.u(data)
         except TypeError:
             return data
 


### PR DESCRIPTION
- this can be a temporary solution until the function `six.u` is
  fixed.

(unicode strings should not be try to be encoded again)

### PR checklist

- [ ] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [ ] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [ ] Filed the PR against the correct branch: `3.0.0` branch for changes related to OpenAPI spec 3.0. Default: `master`.
- [ ] Copied the [technical committee](https://github.com/swagger-api/swagger-codegen/#swagger-codegen-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

(details of the change, additional tests that have been done, reference to the issue for tracking, etc)

