### PR TITLE
[scala] make stripPackage name configurable via property

### DIFF
--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/CodegenConstants.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/CodegenConstants.java
@@ -218,4 +218,7 @@ public class CodegenConstants {
 
     public static final String REMOVE_OPERATION_ID_PREFIX = "removeOperationIdPrefix";
     public static final String REMOVE_OPERATION_ID_PREFIX_DESC = "Remove prefix of operationId, e.g. config_getId => getId";
+
+    public static final String STRIP_PACKAGE_NAME = "stripPackageName";
+    public static final String STRIP_PACKAGE_NAME_DESC = "Whether to strip leading dot-separated packages from generated model classes";
 }

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/AbstractScalaCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/AbstractScalaCodegen.java
@@ -27,6 +27,7 @@ public abstract class AbstractScalaCodegen extends DefaultCodegen {
     protected String modelPropertyNaming = "camelCase";
     protected String invokerPackage = "io.swagger.client";
     protected String sourceFolder = "src/main/scala";
+    protected boolean stripPackageName = true;
 
     public AbstractScalaCodegen() {
         super();
@@ -56,6 +57,10 @@ public abstract class AbstractScalaCodegen extends DefaultCodegen {
 
         if (additionalProperties.containsKey(CodegenConstants.SOURCE_FOLDER)) {
             this.setSourceFolder((String) additionalProperties.get(CodegenConstants.SOURCE_FOLDER));
+        }
+        if (additionalProperties.containsKey(CodegenConstants.STRIP_PACKAGE_NAME) &&
+                "false".equalsIgnoreCase(additionalProperties.get(CodegenConstants.STRIP_PACKAGE_NAME).toString())) {
+            this.stripPackageName = false;
         }
     }
 
@@ -197,7 +202,7 @@ public abstract class AbstractScalaCodegen extends DefaultCodegen {
     }
 
     protected String stripPackageName(String input) {
-        if (StringUtils.isEmpty(input) || input.lastIndexOf(".") < 0)
+        if (!stripPackageName || StringUtils.isEmpty(input) || input.lastIndexOf(".") < 0)
             return input;
 
         int lastIndexOfDot = input.lastIndexOf(".");

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/AbstractScalaCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/AbstractScalaCodegen.java
@@ -61,6 +61,9 @@ public abstract class AbstractScalaCodegen extends DefaultCodegen {
         if (additionalProperties.containsKey(CodegenConstants.STRIP_PACKAGE_NAME) &&
                 "false".equalsIgnoreCase(additionalProperties.get(CodegenConstants.STRIP_PACKAGE_NAME).toString())) {
             this.stripPackageName = false;
+            additionalProperties.put(CodegenConstants.STRIP_PACKAGE_NAME, false);
+            LOGGER.warn("stripPackageName=false. Compilation errors may occur if API type names clash with types " +
+                    "in the default imports");
         }
     }
 

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/ScalaClientCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/ScalaClientCodegen.java
@@ -50,6 +50,7 @@ public class ScalaClientCodegen extends AbstractScalaCodegen implements CodegenC
         additionalProperties.put("authScheme", authScheme);
         additionalProperties.put("authPreemptive", authPreemptive);
         additionalProperties.put("clientName", clientName);
+        additionalProperties.put(CodegenConstants.STRIP_PACKAGE_NAME, stripPackageName);
 
         supportingFiles.add(new SupportingFile("pom.mustache", "", "pom.xml"));
         supportingFiles.add(new SupportingFile("apiInvoker.mustache",


### PR DESCRIPTION
See https://github.com/swagger-api/swagger-codegen/issues/7225

Needed because some APIs (e.g. Kubernetes) include version information in packages. Stripping causes many generated API and model classes to be named the same, causing a last-one-wins situation which is unacceptable.

@clasnake  @jimschubert
