### PR TITLE
[Java:vertx] Initialize router in init method and re-use router member to create S…

### DIFF
--- a/modules/swagger-codegen/src/main/resources/JavaVertXServer/MainApiVerticle.mustache
+++ b/modules/swagger-codegen/src/main/resources/JavaVertXServer/MainApiVerticle.mustache
@@ -25,14 +25,14 @@ public class MainApiVerticle extends AbstractVerticle {
 
     @Override
     public void init(Vertx vertx, Context context) {
-      super.init(vertx, context);
-      router = Router.router(vertx);
+        super.init(vertx, context);
+        router = Router.router(vertx);
     }
 
     @Override
     public void start(Future<Void> startFuture) throws Exception {
         Json.mapper.registerModule(new JavaTimeModule());
-    	FileSystem vertxFileSystem = vertx.fileSystem();
+        FileSystem vertxFileSystem = vertx.fileSystem();
         vertxFileSystem.readFile("swagger.json", readFile -> {
             if (readFile.succeeded()) {
                 Swagger swagger = new SwaggerParser().parse(readFile.result().toString(Charset.forName("utf-8")));

--- a/modules/swagger-codegen/src/main/resources/JavaVertXServer/MainApiVerticle.mustache
+++ b/modules/swagger-codegen/src/main/resources/JavaVertXServer/MainApiVerticle.mustache
@@ -9,18 +9,26 @@ import com.github.phiz71.vertx.swagger.router.SwaggerRouter;
 import io.swagger.models.Swagger;
 import io.swagger.parser.SwaggerParser;
 import io.vertx.core.AbstractVerticle;
+import io.vertx.core.Context;
 import io.vertx.core.Future;
 import io.vertx.core.file.FileSystem;
 import io.vertx.core.json.Json;
 import io.vertx.core.logging.Logger;
 import io.vertx.core.logging.LoggerFactory;
+import io.vertx.core.Vertx;
 import io.vertx.ext.web.Router;
 
 public class MainApiVerticle extends AbstractVerticle {
     final static Logger LOGGER = LoggerFactory.getLogger(MainApiVerticle.class); 
     
-    final Router router = Router.router(vertx);
-    
+    protected Router router;
+
+    @Override
+    public void init(Vertx vertx, Context context) {
+      super.init(vertx, context);
+      router = Router.router(vertx);
+    }
+
     @Override
     public void start(Future<Void> startFuture) throws Exception {
         Json.mapper.registerModule(new JavaTimeModule());
@@ -28,7 +36,7 @@ public class MainApiVerticle extends AbstractVerticle {
         vertxFileSystem.readFile("swagger.json", readFile -> {
             if (readFile.succeeded()) {
                 Swagger swagger = new SwaggerParser().parse(readFile.result().toString(Charset.forName("utf-8")));
-                Router swaggerRouter = SwaggerRouter.swaggerRouter(Router.router(vertx), swagger, vertx.eventBus(), new OperationIdServiceIdResolver());
+                Router swaggerRouter = SwaggerRouter.swaggerRouter(router, swagger, vertx.eventBus(), new OperationIdServiceIdResolver());
             
                 deployVerticles(startFuture);
                 
@@ -49,7 +57,7 @@ public class MainApiVerticle extends AbstractVerticle {
                 LOGGER.info("{{classname}}Verticle : Deployed");
             } else {
                 startFuture.fail(res.cause());
-                LOGGER.error("{{classname}}Verticle : Deployement failed");
+                LOGGER.error("{{classname}}Verticle : Deployment failed");
             }
         });
         {{/apis}}{{/apiInfo}}

--- a/samples/server/petstore/java-vertx/async/src/main/java/io/swagger/server/api/MainApiVerticle.java
+++ b/samples/server/petstore/java-vertx/async/src/main/java/io/swagger/server/api/MainApiVerticle.java
@@ -25,14 +25,14 @@ public class MainApiVerticle extends AbstractVerticle {
 
     @Override
     public void init(Vertx vertx, Context context) {
-      super.init(vertx, context);
-      router = Router.router(vertx);
+        super.init(vertx, context);
+        router = Router.router(vertx);
     }
 
     @Override
     public void start(Future<Void> startFuture) throws Exception {
         Json.mapper.registerModule(new JavaTimeModule());
-    	FileSystem vertxFileSystem = vertx.fileSystem();
+        FileSystem vertxFileSystem = vertx.fileSystem();
         vertxFileSystem.readFile("swagger.json", readFile -> {
             if (readFile.succeeded()) {
                 Swagger swagger = new SwaggerParser().parse(readFile.result().toString(Charset.forName("utf-8")));

--- a/samples/server/petstore/java-vertx/async/src/main/java/io/swagger/server/api/MainApiVerticle.java
+++ b/samples/server/petstore/java-vertx/async/src/main/java/io/swagger/server/api/MainApiVerticle.java
@@ -9,18 +9,26 @@ import com.github.phiz71.vertx.swagger.router.SwaggerRouter;
 import io.swagger.models.Swagger;
 import io.swagger.parser.SwaggerParser;
 import io.vertx.core.AbstractVerticle;
+import io.vertx.core.Context;
 import io.vertx.core.Future;
 import io.vertx.core.file.FileSystem;
 import io.vertx.core.json.Json;
 import io.vertx.core.logging.Logger;
 import io.vertx.core.logging.LoggerFactory;
+import io.vertx.core.Vertx;
 import io.vertx.ext.web.Router;
 
 public class MainApiVerticle extends AbstractVerticle {
     final static Logger LOGGER = LoggerFactory.getLogger(MainApiVerticle.class); 
     
-    final Router router = Router.router(vertx);
-    
+    protected Router router;
+
+    @Override
+    public void init(Vertx vertx, Context context) {
+      super.init(vertx, context);
+      router = Router.router(vertx);
+    }
+
     @Override
     public void start(Future<Void> startFuture) throws Exception {
         Json.mapper.registerModule(new JavaTimeModule());
@@ -28,7 +36,7 @@ public class MainApiVerticle extends AbstractVerticle {
         vertxFileSystem.readFile("swagger.json", readFile -> {
             if (readFile.succeeded()) {
                 Swagger swagger = new SwaggerParser().parse(readFile.result().toString(Charset.forName("utf-8")));
-                Router swaggerRouter = SwaggerRouter.swaggerRouter(Router.router(vertx), swagger, vertx.eventBus(), new OperationIdServiceIdResolver());
+                Router swaggerRouter = SwaggerRouter.swaggerRouter(router, swagger, vertx.eventBus(), new OperationIdServiceIdResolver());
             
                 deployVerticles(startFuture);
                 
@@ -49,7 +57,7 @@ public class MainApiVerticle extends AbstractVerticle {
                 LOGGER.info("PetApiVerticle : Deployed");
             } else {
                 startFuture.fail(res.cause());
-                LOGGER.error("PetApiVerticle : Deployement failed");
+                LOGGER.error("PetApiVerticle : Deployment failed");
             }
         });
         
@@ -58,7 +66,7 @@ public class MainApiVerticle extends AbstractVerticle {
                 LOGGER.info("StoreApiVerticle : Deployed");
             } else {
                 startFuture.fail(res.cause());
-                LOGGER.error("StoreApiVerticle : Deployement failed");
+                LOGGER.error("StoreApiVerticle : Deployment failed");
             }
         });
         
@@ -67,7 +75,7 @@ public class MainApiVerticle extends AbstractVerticle {
                 LOGGER.info("UserApiVerticle : Deployed");
             } else {
                 startFuture.fail(res.cause());
-                LOGGER.error("UserApiVerticle : Deployement failed");
+                LOGGER.error("UserApiVerticle : Deployment failed");
             }
         });
         

--- a/samples/server/petstore/java-vertx/async/src/main/resources/swagger.json
+++ b/samples/server/petstore/java-vertx/async/src/main/resources/swagger.json
@@ -112,8 +112,8 @@
           "type" : "array",
           "items" : {
             "type" : "string",
-            "enum" : [ "available", "pending", "sold" ],
-            "default" : "available"
+            "default" : "available",
+            "enum" : [ "available", "pending", "sold" ]
           },
           "collectionFormat" : "csv"
         } ],
@@ -134,7 +134,6 @@
         "security" : [ {
           "petstore_auth" : [ "write:pets", "read:pets" ]
         } ],
-        "x-contentType" : "application/json",
         "x-accepts" : "application/json"
       }
     },
@@ -174,7 +173,6 @@
           "petstore_auth" : [ "write:pets", "read:pets" ]
         } ],
         "deprecated" : true,
-        "x-contentType" : "application/json",
         "x-accepts" : "application/json"
       }
     },
@@ -210,7 +208,6 @@
         "security" : [ {
           "api_key" : [ ]
         } ],
-        "x-contentType" : "application/json",
         "x-accepts" : "application/json"
       },
       "post" : {
@@ -278,7 +275,6 @@
         "security" : [ {
           "petstore_auth" : [ "write:pets", "read:pets" ]
         } ],
-        "x-contentType" : "application/json",
         "x-accepts" : "application/json"
       }
     },
@@ -348,7 +344,6 @@
         "security" : [ {
           "api_key" : [ ]
         } ],
-        "x-contentType" : "application/json",
         "x-accepts" : "application/json"
       }
     },
@@ -414,7 +409,6 @@
             "description" : "Order not found"
           }
         },
-        "x-contentType" : "application/json",
         "x-accepts" : "application/json"
       },
       "delete" : {
@@ -438,7 +432,6 @@
             "description" : "Order not found"
           }
         },
-        "x-contentType" : "application/json",
         "x-accepts" : "application/json"
       }
     },
@@ -566,7 +559,6 @@
             "description" : "Invalid username/password supplied"
           }
         },
-        "x-contentType" : "application/json",
         "x-accepts" : "application/json"
       }
     },
@@ -583,7 +575,6 @@
             "description" : "successful operation"
           }
         },
-        "x-contentType" : "application/json",
         "x-accepts" : "application/json"
       }
     },
@@ -615,7 +606,6 @@
             "description" : "User not found"
           }
         },
-        "x-contentType" : "application/json",
         "x-accepts" : "application/json"
       },
       "put" : {
@@ -671,7 +661,6 @@
             "description" : "User not found"
           }
         },
-        "x-contentType" : "application/json",
         "x-accepts" : "application/json"
       }
     }

--- a/samples/server/petstore/java-vertx/rx/src/main/java/io/swagger/server/api/MainApiVerticle.java
+++ b/samples/server/petstore/java-vertx/rx/src/main/java/io/swagger/server/api/MainApiVerticle.java
@@ -25,14 +25,14 @@ public class MainApiVerticle extends AbstractVerticle {
 
     @Override
     public void init(Vertx vertx, Context context) {
-      super.init(vertx, context);
-      router = Router.router(vertx);
+        super.init(vertx, context);
+        router = Router.router(vertx);
     }
 
     @Override
     public void start(Future<Void> startFuture) throws Exception {
         Json.mapper.registerModule(new JavaTimeModule());
-    	FileSystem vertxFileSystem = vertx.fileSystem();
+        FileSystem vertxFileSystem = vertx.fileSystem();
         vertxFileSystem.readFile("swagger.json", readFile -> {
             if (readFile.succeeded()) {
                 Swagger swagger = new SwaggerParser().parse(readFile.result().toString(Charset.forName("utf-8")));

--- a/samples/server/petstore/java-vertx/rx/src/main/java/io/swagger/server/api/MainApiVerticle.java
+++ b/samples/server/petstore/java-vertx/rx/src/main/java/io/swagger/server/api/MainApiVerticle.java
@@ -9,18 +9,26 @@ import com.github.phiz71.vertx.swagger.router.SwaggerRouter;
 import io.swagger.models.Swagger;
 import io.swagger.parser.SwaggerParser;
 import io.vertx.core.AbstractVerticle;
+import io.vertx.core.Context;
 import io.vertx.core.Future;
 import io.vertx.core.file.FileSystem;
 import io.vertx.core.json.Json;
 import io.vertx.core.logging.Logger;
 import io.vertx.core.logging.LoggerFactory;
+import io.vertx.core.Vertx;
 import io.vertx.ext.web.Router;
 
 public class MainApiVerticle extends AbstractVerticle {
     final static Logger LOGGER = LoggerFactory.getLogger(MainApiVerticle.class); 
     
-    final Router router = Router.router(vertx);
-    
+    protected Router router;
+
+    @Override
+    public void init(Vertx vertx, Context context) {
+      super.init(vertx, context);
+      router = Router.router(vertx);
+    }
+
     @Override
     public void start(Future<Void> startFuture) throws Exception {
         Json.mapper.registerModule(new JavaTimeModule());
@@ -28,7 +36,7 @@ public class MainApiVerticle extends AbstractVerticle {
         vertxFileSystem.readFile("swagger.json", readFile -> {
             if (readFile.succeeded()) {
                 Swagger swagger = new SwaggerParser().parse(readFile.result().toString(Charset.forName("utf-8")));
-                Router swaggerRouter = SwaggerRouter.swaggerRouter(Router.router(vertx), swagger, vertx.eventBus(), new OperationIdServiceIdResolver());
+                Router swaggerRouter = SwaggerRouter.swaggerRouter(router, swagger, vertx.eventBus(), new OperationIdServiceIdResolver());
             
                 deployVerticles(startFuture);
                 
@@ -49,7 +57,7 @@ public class MainApiVerticle extends AbstractVerticle {
                 LOGGER.info("PetApiVerticle : Deployed");
             } else {
                 startFuture.fail(res.cause());
-                LOGGER.error("PetApiVerticle : Deployement failed");
+                LOGGER.error("PetApiVerticle : Deployment failed");
             }
         });
         
@@ -58,7 +66,7 @@ public class MainApiVerticle extends AbstractVerticle {
                 LOGGER.info("StoreApiVerticle : Deployed");
             } else {
                 startFuture.fail(res.cause());
-                LOGGER.error("StoreApiVerticle : Deployement failed");
+                LOGGER.error("StoreApiVerticle : Deployment failed");
             }
         });
         
@@ -67,7 +75,7 @@ public class MainApiVerticle extends AbstractVerticle {
                 LOGGER.info("UserApiVerticle : Deployed");
             } else {
                 startFuture.fail(res.cause());
-                LOGGER.error("UserApiVerticle : Deployement failed");
+                LOGGER.error("UserApiVerticle : Deployment failed");
             }
         });
         

--- a/samples/server/petstore/java-vertx/rx/src/main/resources/swagger.json
+++ b/samples/server/petstore/java-vertx/rx/src/main/resources/swagger.json
@@ -112,8 +112,8 @@
           "type" : "array",
           "items" : {
             "type" : "string",
-            "enum" : [ "available", "pending", "sold" ],
-            "default" : "available"
+            "default" : "available",
+            "enum" : [ "available", "pending", "sold" ]
           },
           "collectionFormat" : "csv"
         } ],
@@ -134,7 +134,6 @@
         "security" : [ {
           "petstore_auth" : [ "write:pets", "read:pets" ]
         } ],
-        "x-contentType" : "application/json",
         "x-accepts" : "application/json"
       }
     },
@@ -174,7 +173,6 @@
           "petstore_auth" : [ "write:pets", "read:pets" ]
         } ],
         "deprecated" : true,
-        "x-contentType" : "application/json",
         "x-accepts" : "application/json"
       }
     },
@@ -210,7 +208,6 @@
         "security" : [ {
           "api_key" : [ ]
         } ],
-        "x-contentType" : "application/json",
         "x-accepts" : "application/json"
       },
       "post" : {
@@ -278,7 +275,6 @@
         "security" : [ {
           "petstore_auth" : [ "write:pets", "read:pets" ]
         } ],
-        "x-contentType" : "application/json",
         "x-accepts" : "application/json"
       }
     },
@@ -348,7 +344,6 @@
         "security" : [ {
           "api_key" : [ ]
         } ],
-        "x-contentType" : "application/json",
         "x-accepts" : "application/json"
       }
     },
@@ -414,7 +409,6 @@
             "description" : "Order not found"
           }
         },
-        "x-contentType" : "application/json",
         "x-accepts" : "application/json"
       },
       "delete" : {
@@ -438,7 +432,6 @@
             "description" : "Order not found"
           }
         },
-        "x-contentType" : "application/json",
         "x-accepts" : "application/json"
       }
     },
@@ -566,7 +559,6 @@
             "description" : "Invalid username/password supplied"
           }
         },
-        "x-contentType" : "application/json",
         "x-accepts" : "application/json"
       }
     },
@@ -583,7 +575,6 @@
             "description" : "successful operation"
           }
         },
-        "x-contentType" : "application/json",
         "x-accepts" : "application/json"
       }
     },
@@ -615,7 +606,6 @@
             "description" : "User not found"
           }
         },
-        "x-contentType" : "application/json",
         "x-accepts" : "application/json"
       },
       "put" : {
@@ -671,7 +661,6 @@
             "description" : "User not found"
           }
         },
-        "x-contentType" : "application/json",
         "x-accepts" : "application/json"
       }
     }


### PR DESCRIPTION
…waggerRouter

### PR checklist

- [x] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [x] Filed the PR against the correct branch: `3.0.0` branch for changes related to OpenAPI spec 3.0. Default: `master`.
- [x] Copied the [technical committee](https://github.com/swagger-api/swagger-codegen/#swagger-codegen-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

Modify MainApiVerticle.mustache template to properly initialize main router and re-use the router to create SwaggerRouter - fix for #7230 
