### PR TITLE
[Typescript jQuery] Added optional extra JQueryAjaxSettings at the class and function level

### DIFF
--- a/modules/swagger-codegen/src/main/resources/typescript-jquery/api.mustache
+++ b/modules/swagger-codegen/src/main/resources/typescript-jquery/api.mustache
@@ -22,14 +22,18 @@ import { Configuration } from '../configuration';
 export class {{classname}} {
     protected basePath = '{{{basePath}}}';
     public defaultHeaders: Array<string> = [];
+    public defaultExtraJQueryAjaxSettings?: JQueryAjaxSettings = null;
     public configuration: Configuration = new Configuration();
 
-    constructor(basePath?: string, configuration?: Configuration) {
+    constructor(basePath?: string, configuration?: Configuration, defaultExtraJQueryAjaxSettings?: JQueryAjaxSettings) {
         if (basePath) {
             this.basePath = basePath;
         }
         if (configuration) {
             this.configuration = configuration;
+        }
+        if (defaultExtraJQueryAjaxSettings) {
+            this.defaultExtraJQueryAjaxSettings = defaultExtraJQueryAjaxSettings;
         }
     }
 
@@ -52,7 +56,7 @@ export class {{classname}} {
      * @param {{paramName}} {{description}}
      {{/allParams}}
      */
-    public {{nickname}}({{#allParams}}{{paramName}}{{^required}}?{{/required}}: {{{dataType}}}{{#hasMore}}, {{/hasMore}}{{/allParams}}): JQueryPromise<{ response: JQueryXHR; {{#returnType}}body: {{{returnType}}}; {{/returnType}}{{^returnType}}body?: any; {{/returnType}} }> {
+    public {{nickname}}({{#allParams}}{{paramName}}{{^required}}?{{/required}}: {{{dataType}}}, {{/allParams}}extraJQueryAjaxSettings?: JQueryAjaxSettings): JQueryPromise<{ response: JQueryXHR; {{#returnType}}body: {{{returnType}}}; {{/returnType}}{{^returnType}}body?: any; {{/returnType}} }> {
         let localVarPath = this.basePath + '{{{path}}}'{{#pathParams}}.replace('{' + '{{baseName}}' + '}', encodeURIComponent(String({{paramName}}))){{/pathParams}};
 
         let queryParameters: any = {};
@@ -216,6 +220,14 @@ export class {{classname}} {
             requestOptions.contentType = false;
         }
 {{/hasFormParams}}
+
+        if (extraJQueryAjaxSettings) {
+            requestOptions = (<any>Object).assign(requestOptions, extraJQueryAjaxSettings);
+        }
+
+        if (this.defaultExtraJQueryAjaxSettings) {
+            requestOptions = (<any>Object).assign(requestOptions, this.defaultExtraJQueryAjaxSettings);
+        }
 
         let dfd = $.Deferred();
         $.ajax(requestOptions).then(

--- a/samples/client/petstore/typescript-jquery/default/api/PetApi.ts
+++ b/samples/client/petstore/typescript-jquery/default/api/PetApi.ts
@@ -22,14 +22,18 @@ import { Configuration } from '../configuration';
 export class PetApi {
     protected basePath = 'http://petstore.swagger.io/v2';
     public defaultHeaders: Array<string> = [];
+    public defaultExtraJQueryAjaxSettings?: JQueryAjaxSettings = null;
     public configuration: Configuration = new Configuration();
 
-    constructor(basePath?: string, configuration?: Configuration) {
+    constructor(basePath?: string, configuration?: Configuration, defaultExtraJQueryAjaxSettings?: JQueryAjaxSettings) {
         if (basePath) {
             this.basePath = basePath;
         }
         if (configuration) {
             this.configuration = configuration;
+        }
+        if (defaultExtraJQueryAjaxSettings) {
+            this.defaultExtraJQueryAjaxSettings = defaultExtraJQueryAjaxSettings;
         }
     }
 
@@ -47,7 +51,7 @@ export class PetApi {
      * @summary Add a new pet to the store
      * @param body Pet object that needs to be added to the store
      */
-    public addPet(body: models.Pet): JQueryPromise<{ response: JQueryXHR; body?: any;  }> {
+    public addPet(body: models.Pet, extraJQueryAjaxSettings?: JQueryAjaxSettings): JQueryPromise<{ response: JQueryXHR; body?: any;  }> {
         let localVarPath = this.basePath + '/pet';
 
         let queryParameters: any = {};
@@ -95,6 +99,14 @@ export class PetApi {
             requestOptions.contentType = headerParams['Content-Type'];
         }
 
+        if (extraJQueryAjaxSettings) {
+            requestOptions = (<any>Object).assign(requestOptions, extraJQueryAjaxSettings);
+        }
+
+        if (this.defaultExtraJQueryAjaxSettings) {
+            requestOptions = (<any>Object).assign(requestOptions, this.defaultExtraJQueryAjaxSettings);
+        }
+
         let dfd = $.Deferred();
         $.ajax(requestOptions).then(
             (data: any, textStatus: string, jqXHR: JQueryXHR) =>
@@ -111,7 +123,7 @@ export class PetApi {
      * @param petId Pet id to delete
      * @param apiKey 
      */
-    public deletePet(petId: number, apiKey?: string): JQueryPromise<{ response: JQueryXHR; body?: any;  }> {
+    public deletePet(petId: number, apiKey?: string, extraJQueryAjaxSettings?: JQueryAjaxSettings): JQueryPromise<{ response: JQueryXHR; body?: any;  }> {
         let localVarPath = this.basePath + '/pet/{petId}'.replace('{' + 'petId' + '}', encodeURIComponent(String(petId)));
 
         let queryParameters: any = {};
@@ -156,6 +168,14 @@ export class PetApi {
             requestOptions.contentType = headerParams['Content-Type'];
         }
 
+        if (extraJQueryAjaxSettings) {
+            requestOptions = (<any>Object).assign(requestOptions, extraJQueryAjaxSettings);
+        }
+
+        if (this.defaultExtraJQueryAjaxSettings) {
+            requestOptions = (<any>Object).assign(requestOptions, this.defaultExtraJQueryAjaxSettings);
+        }
+
         let dfd = $.Deferred();
         $.ajax(requestOptions).then(
             (data: any, textStatus: string, jqXHR: JQueryXHR) =>
@@ -171,7 +191,7 @@ export class PetApi {
      * @summary Finds Pets by status
      * @param status Status values that need to be considered for filter
      */
-    public findPetsByStatus(status: Array<string>): JQueryPromise<{ response: JQueryXHR; body: Array<models.Pet>;  }> {
+    public findPetsByStatus(status: Array<string>, extraJQueryAjaxSettings?: JQueryAjaxSettings): JQueryPromise<{ response: JQueryXHR; body: Array<models.Pet>;  }> {
         let localVarPath = this.basePath + '/pet/findByStatus';
 
         let queryParameters: any = {};
@@ -217,6 +237,14 @@ export class PetApi {
             requestOptions.contentType = headerParams['Content-Type'];
         }
 
+        if (extraJQueryAjaxSettings) {
+            requestOptions = (<any>Object).assign(requestOptions, extraJQueryAjaxSettings);
+        }
+
+        if (this.defaultExtraJQueryAjaxSettings) {
+            requestOptions = (<any>Object).assign(requestOptions, this.defaultExtraJQueryAjaxSettings);
+        }
+
         let dfd = $.Deferred();
         $.ajax(requestOptions).then(
             (data: Array<models.Pet>, textStatus: string, jqXHR: JQueryXHR) =>
@@ -232,7 +260,7 @@ export class PetApi {
      * @summary Finds Pets by tags
      * @param tags Tags to filter by
      */
-    public findPetsByTags(tags: Array<string>): JQueryPromise<{ response: JQueryXHR; body: Array<models.Pet>;  }> {
+    public findPetsByTags(tags: Array<string>, extraJQueryAjaxSettings?: JQueryAjaxSettings): JQueryPromise<{ response: JQueryXHR; body: Array<models.Pet>;  }> {
         let localVarPath = this.basePath + '/pet/findByTags';
 
         let queryParameters: any = {};
@@ -278,6 +306,14 @@ export class PetApi {
             requestOptions.contentType = headerParams['Content-Type'];
         }
 
+        if (extraJQueryAjaxSettings) {
+            requestOptions = (<any>Object).assign(requestOptions, extraJQueryAjaxSettings);
+        }
+
+        if (this.defaultExtraJQueryAjaxSettings) {
+            requestOptions = (<any>Object).assign(requestOptions, this.defaultExtraJQueryAjaxSettings);
+        }
+
         let dfd = $.Deferred();
         $.ajax(requestOptions).then(
             (data: Array<models.Pet>, textStatus: string, jqXHR: JQueryXHR) =>
@@ -293,7 +329,7 @@ export class PetApi {
      * @summary Find pet by ID
      * @param petId ID of pet to return
      */
-    public getPetById(petId: number): JQueryPromise<{ response: JQueryXHR; body: models.Pet;  }> {
+    public getPetById(petId: number, extraJQueryAjaxSettings?: JQueryAjaxSettings): JQueryPromise<{ response: JQueryXHR; body: models.Pet;  }> {
         let localVarPath = this.basePath + '/pet/{petId}'.replace('{' + 'petId' + '}', encodeURIComponent(String(petId)));
 
         let queryParameters: any = {};
@@ -332,6 +368,14 @@ export class PetApi {
             requestOptions.contentType = headerParams['Content-Type'];
         }
 
+        if (extraJQueryAjaxSettings) {
+            requestOptions = (<any>Object).assign(requestOptions, extraJQueryAjaxSettings);
+        }
+
+        if (this.defaultExtraJQueryAjaxSettings) {
+            requestOptions = (<any>Object).assign(requestOptions, this.defaultExtraJQueryAjaxSettings);
+        }
+
         let dfd = $.Deferred();
         $.ajax(requestOptions).then(
             (data: models.Pet, textStatus: string, jqXHR: JQueryXHR) =>
@@ -347,7 +391,7 @@ export class PetApi {
      * @summary Update an existing pet
      * @param body Pet object that needs to be added to the store
      */
-    public updatePet(body: models.Pet): JQueryPromise<{ response: JQueryXHR; body?: any;  }> {
+    public updatePet(body: models.Pet, extraJQueryAjaxSettings?: JQueryAjaxSettings): JQueryPromise<{ response: JQueryXHR; body?: any;  }> {
         let localVarPath = this.basePath + '/pet';
 
         let queryParameters: any = {};
@@ -395,6 +439,14 @@ export class PetApi {
             requestOptions.contentType = headerParams['Content-Type'];
         }
 
+        if (extraJQueryAjaxSettings) {
+            requestOptions = (<any>Object).assign(requestOptions, extraJQueryAjaxSettings);
+        }
+
+        if (this.defaultExtraJQueryAjaxSettings) {
+            requestOptions = (<any>Object).assign(requestOptions, this.defaultExtraJQueryAjaxSettings);
+        }
+
         let dfd = $.Deferred();
         $.ajax(requestOptions).then(
             (data: any, textStatus: string, jqXHR: JQueryXHR) =>
@@ -412,7 +464,7 @@ export class PetApi {
      * @param name Updated name of the pet
      * @param status Updated status of the pet
      */
-    public updatePetWithForm(petId: number, name?: string, status?: string): JQueryPromise<{ response: JQueryXHR; body?: any;  }> {
+    public updatePetWithForm(petId: number, name?: string, status?: string, extraJQueryAjaxSettings?: JQueryAjaxSettings): JQueryPromise<{ response: JQueryXHR; body?: any;  }> {
         let localVarPath = this.basePath + '/pet/{petId}'.replace('{' + 'petId' + '}', encodeURIComponent(String(petId)));
 
         let queryParameters: any = {};
@@ -473,6 +525,14 @@ export class PetApi {
             requestOptions.contentType = false;
         }
 
+        if (extraJQueryAjaxSettings) {
+            requestOptions = (<any>Object).assign(requestOptions, extraJQueryAjaxSettings);
+        }
+
+        if (this.defaultExtraJQueryAjaxSettings) {
+            requestOptions = (<any>Object).assign(requestOptions, this.defaultExtraJQueryAjaxSettings);
+        }
+
         let dfd = $.Deferred();
         $.ajax(requestOptions).then(
             (data: any, textStatus: string, jqXHR: JQueryXHR) =>
@@ -490,7 +550,7 @@ export class PetApi {
      * @param additionalMetadata Additional data to pass to server
      * @param file file to upload
      */
-    public uploadFile(petId: number, additionalMetadata?: string, file?: any): JQueryPromise<{ response: JQueryXHR; body: models.ApiResponse;  }> {
+    public uploadFile(petId: number, additionalMetadata?: string, file?: any, extraJQueryAjaxSettings?: JQueryAjaxSettings): JQueryPromise<{ response: JQueryXHR; body: models.ApiResponse;  }> {
         let localVarPath = this.basePath + '/pet/{petId}/uploadImage'.replace('{' + 'petId' + '}', encodeURIComponent(String(petId)));
 
         let queryParameters: any = {};
@@ -547,6 +607,14 @@ export class PetApi {
         requestOptions.data = formParams;
         if (reqHasFile) {
             requestOptions.contentType = false;
+        }
+
+        if (extraJQueryAjaxSettings) {
+            requestOptions = (<any>Object).assign(requestOptions, extraJQueryAjaxSettings);
+        }
+
+        if (this.defaultExtraJQueryAjaxSettings) {
+            requestOptions = (<any>Object).assign(requestOptions, this.defaultExtraJQueryAjaxSettings);
         }
 
         let dfd = $.Deferred();

--- a/samples/client/petstore/typescript-jquery/default/api/StoreApi.ts
+++ b/samples/client/petstore/typescript-jquery/default/api/StoreApi.ts
@@ -22,14 +22,18 @@ import { Configuration } from '../configuration';
 export class StoreApi {
     protected basePath = 'http://petstore.swagger.io/v2';
     public defaultHeaders: Array<string> = [];
+    public defaultExtraJQueryAjaxSettings?: JQueryAjaxSettings = null;
     public configuration: Configuration = new Configuration();
 
-    constructor(basePath?: string, configuration?: Configuration) {
+    constructor(basePath?: string, configuration?: Configuration, defaultExtraJQueryAjaxSettings?: JQueryAjaxSettings) {
         if (basePath) {
             this.basePath = basePath;
         }
         if (configuration) {
             this.configuration = configuration;
+        }
+        if (defaultExtraJQueryAjaxSettings) {
+            this.defaultExtraJQueryAjaxSettings = defaultExtraJQueryAjaxSettings;
         }
     }
 
@@ -47,7 +51,7 @@ export class StoreApi {
      * @summary Delete purchase order by ID
      * @param orderId ID of the order that needs to be deleted
      */
-    public deleteOrder(orderId: string): JQueryPromise<{ response: JQueryXHR; body?: any;  }> {
+    public deleteOrder(orderId: string, extraJQueryAjaxSettings?: JQueryAjaxSettings): JQueryPromise<{ response: JQueryXHR; body?: any;  }> {
         let localVarPath = this.basePath + '/store/order/{orderId}'.replace('{' + 'orderId' + '}', encodeURIComponent(String(orderId)));
 
         let queryParameters: any = {};
@@ -81,6 +85,14 @@ export class StoreApi {
             requestOptions.contentType = headerParams['Content-Type'];
         }
 
+        if (extraJQueryAjaxSettings) {
+            requestOptions = (<any>Object).assign(requestOptions, extraJQueryAjaxSettings);
+        }
+
+        if (this.defaultExtraJQueryAjaxSettings) {
+            requestOptions = (<any>Object).assign(requestOptions, this.defaultExtraJQueryAjaxSettings);
+        }
+
         let dfd = $.Deferred();
         $.ajax(requestOptions).then(
             (data: any, textStatus: string, jqXHR: JQueryXHR) =>
@@ -95,7 +107,7 @@ export class StoreApi {
      * Returns a map of status codes to quantities
      * @summary Returns pet inventories by status
      */
-    public getInventory(): JQueryPromise<{ response: JQueryXHR; body: { [key: string]: number; };  }> {
+    public getInventory(extraJQueryAjaxSettings?: JQueryAjaxSettings): JQueryPromise<{ response: JQueryXHR; body: { [key: string]: number; };  }> {
         let localVarPath = this.basePath + '/store/inventory';
 
         let queryParameters: any = {};
@@ -128,6 +140,14 @@ export class StoreApi {
             requestOptions.contentType = headerParams['Content-Type'];
         }
 
+        if (extraJQueryAjaxSettings) {
+            requestOptions = (<any>Object).assign(requestOptions, extraJQueryAjaxSettings);
+        }
+
+        if (this.defaultExtraJQueryAjaxSettings) {
+            requestOptions = (<any>Object).assign(requestOptions, this.defaultExtraJQueryAjaxSettings);
+        }
+
         let dfd = $.Deferred();
         $.ajax(requestOptions).then(
             (data: { [key: string]: number; }, textStatus: string, jqXHR: JQueryXHR) =>
@@ -143,7 +163,7 @@ export class StoreApi {
      * @summary Find purchase order by ID
      * @param orderId ID of pet that needs to be fetched
      */
-    public getOrderById(orderId: number): JQueryPromise<{ response: JQueryXHR; body: models.Order;  }> {
+    public getOrderById(orderId: number, extraJQueryAjaxSettings?: JQueryAjaxSettings): JQueryPromise<{ response: JQueryXHR; body: models.Order;  }> {
         let localVarPath = this.basePath + '/store/order/{orderId}'.replace('{' + 'orderId' + '}', encodeURIComponent(String(orderId)));
 
         let queryParameters: any = {};
@@ -177,6 +197,14 @@ export class StoreApi {
             requestOptions.contentType = headerParams['Content-Type'];
         }
 
+        if (extraJQueryAjaxSettings) {
+            requestOptions = (<any>Object).assign(requestOptions, extraJQueryAjaxSettings);
+        }
+
+        if (this.defaultExtraJQueryAjaxSettings) {
+            requestOptions = (<any>Object).assign(requestOptions, this.defaultExtraJQueryAjaxSettings);
+        }
+
         let dfd = $.Deferred();
         $.ajax(requestOptions).then(
             (data: models.Order, textStatus: string, jqXHR: JQueryXHR) =>
@@ -192,7 +220,7 @@ export class StoreApi {
      * @summary Place an order for a pet
      * @param body order placed for purchasing the pet
      */
-    public placeOrder(body: models.Order): JQueryPromise<{ response: JQueryXHR; body: models.Order;  }> {
+    public placeOrder(body: models.Order, extraJQueryAjaxSettings?: JQueryAjaxSettings): JQueryPromise<{ response: JQueryXHR; body: models.Order;  }> {
         let localVarPath = this.basePath + '/store/order';
 
         let queryParameters: any = {};
@@ -227,6 +255,14 @@ export class StoreApi {
         requestOptions.data = JSON.stringify(body);
         if (headerParams['Content-Type']) {
             requestOptions.contentType = headerParams['Content-Type'];
+        }
+
+        if (extraJQueryAjaxSettings) {
+            requestOptions = (<any>Object).assign(requestOptions, extraJQueryAjaxSettings);
+        }
+
+        if (this.defaultExtraJQueryAjaxSettings) {
+            requestOptions = (<any>Object).assign(requestOptions, this.defaultExtraJQueryAjaxSettings);
         }
 
         let dfd = $.Deferred();

--- a/samples/client/petstore/typescript-jquery/default/api/UserApi.ts
+++ b/samples/client/petstore/typescript-jquery/default/api/UserApi.ts
@@ -22,14 +22,18 @@ import { Configuration } from '../configuration';
 export class UserApi {
     protected basePath = 'http://petstore.swagger.io/v2';
     public defaultHeaders: Array<string> = [];
+    public defaultExtraJQueryAjaxSettings?: JQueryAjaxSettings = null;
     public configuration: Configuration = new Configuration();
 
-    constructor(basePath?: string, configuration?: Configuration) {
+    constructor(basePath?: string, configuration?: Configuration, defaultExtraJQueryAjaxSettings?: JQueryAjaxSettings) {
         if (basePath) {
             this.basePath = basePath;
         }
         if (configuration) {
             this.configuration = configuration;
+        }
+        if (defaultExtraJQueryAjaxSettings) {
+            this.defaultExtraJQueryAjaxSettings = defaultExtraJQueryAjaxSettings;
         }
     }
 
@@ -47,7 +51,7 @@ export class UserApi {
      * @summary Create user
      * @param body Created user object
      */
-    public createUser(body: models.User): JQueryPromise<{ response: JQueryXHR; body?: any;  }> {
+    public createUser(body: models.User, extraJQueryAjaxSettings?: JQueryAjaxSettings): JQueryPromise<{ response: JQueryXHR; body?: any;  }> {
         let localVarPath = this.basePath + '/user';
 
         let queryParameters: any = {};
@@ -84,6 +88,14 @@ export class UserApi {
             requestOptions.contentType = headerParams['Content-Type'];
         }
 
+        if (extraJQueryAjaxSettings) {
+            requestOptions = (<any>Object).assign(requestOptions, extraJQueryAjaxSettings);
+        }
+
+        if (this.defaultExtraJQueryAjaxSettings) {
+            requestOptions = (<any>Object).assign(requestOptions, this.defaultExtraJQueryAjaxSettings);
+        }
+
         let dfd = $.Deferred();
         $.ajax(requestOptions).then(
             (data: any, textStatus: string, jqXHR: JQueryXHR) =>
@@ -99,7 +111,7 @@ export class UserApi {
      * @summary Creates list of users with given input array
      * @param body List of user object
      */
-    public createUsersWithArrayInput(body: Array<models.User>): JQueryPromise<{ response: JQueryXHR; body?: any;  }> {
+    public createUsersWithArrayInput(body: Array<models.User>, extraJQueryAjaxSettings?: JQueryAjaxSettings): JQueryPromise<{ response: JQueryXHR; body?: any;  }> {
         let localVarPath = this.basePath + '/user/createWithArray';
 
         let queryParameters: any = {};
@@ -136,6 +148,14 @@ export class UserApi {
             requestOptions.contentType = headerParams['Content-Type'];
         }
 
+        if (extraJQueryAjaxSettings) {
+            requestOptions = (<any>Object).assign(requestOptions, extraJQueryAjaxSettings);
+        }
+
+        if (this.defaultExtraJQueryAjaxSettings) {
+            requestOptions = (<any>Object).assign(requestOptions, this.defaultExtraJQueryAjaxSettings);
+        }
+
         let dfd = $.Deferred();
         $.ajax(requestOptions).then(
             (data: any, textStatus: string, jqXHR: JQueryXHR) =>
@@ -151,7 +171,7 @@ export class UserApi {
      * @summary Creates list of users with given input array
      * @param body List of user object
      */
-    public createUsersWithListInput(body: Array<models.User>): JQueryPromise<{ response: JQueryXHR; body?: any;  }> {
+    public createUsersWithListInput(body: Array<models.User>, extraJQueryAjaxSettings?: JQueryAjaxSettings): JQueryPromise<{ response: JQueryXHR; body?: any;  }> {
         let localVarPath = this.basePath + '/user/createWithList';
 
         let queryParameters: any = {};
@@ -188,6 +208,14 @@ export class UserApi {
             requestOptions.contentType = headerParams['Content-Type'];
         }
 
+        if (extraJQueryAjaxSettings) {
+            requestOptions = (<any>Object).assign(requestOptions, extraJQueryAjaxSettings);
+        }
+
+        if (this.defaultExtraJQueryAjaxSettings) {
+            requestOptions = (<any>Object).assign(requestOptions, this.defaultExtraJQueryAjaxSettings);
+        }
+
         let dfd = $.Deferred();
         $.ajax(requestOptions).then(
             (data: any, textStatus: string, jqXHR: JQueryXHR) =>
@@ -203,7 +231,7 @@ export class UserApi {
      * @summary Delete user
      * @param username The name that needs to be deleted
      */
-    public deleteUser(username: string): JQueryPromise<{ response: JQueryXHR; body?: any;  }> {
+    public deleteUser(username: string, extraJQueryAjaxSettings?: JQueryAjaxSettings): JQueryPromise<{ response: JQueryXHR; body?: any;  }> {
         let localVarPath = this.basePath + '/user/{username}'.replace('{' + 'username' + '}', encodeURIComponent(String(username)));
 
         let queryParameters: any = {};
@@ -237,6 +265,14 @@ export class UserApi {
             requestOptions.contentType = headerParams['Content-Type'];
         }
 
+        if (extraJQueryAjaxSettings) {
+            requestOptions = (<any>Object).assign(requestOptions, extraJQueryAjaxSettings);
+        }
+
+        if (this.defaultExtraJQueryAjaxSettings) {
+            requestOptions = (<any>Object).assign(requestOptions, this.defaultExtraJQueryAjaxSettings);
+        }
+
         let dfd = $.Deferred();
         $.ajax(requestOptions).then(
             (data: any, textStatus: string, jqXHR: JQueryXHR) =>
@@ -252,7 +288,7 @@ export class UserApi {
      * @summary Get user by user name
      * @param username The name that needs to be fetched. Use user1 for testing. 
      */
-    public getUserByName(username: string): JQueryPromise<{ response: JQueryXHR; body: models.User;  }> {
+    public getUserByName(username: string, extraJQueryAjaxSettings?: JQueryAjaxSettings): JQueryPromise<{ response: JQueryXHR; body: models.User;  }> {
         let localVarPath = this.basePath + '/user/{username}'.replace('{' + 'username' + '}', encodeURIComponent(String(username)));
 
         let queryParameters: any = {};
@@ -286,6 +322,14 @@ export class UserApi {
             requestOptions.contentType = headerParams['Content-Type'];
         }
 
+        if (extraJQueryAjaxSettings) {
+            requestOptions = (<any>Object).assign(requestOptions, extraJQueryAjaxSettings);
+        }
+
+        if (this.defaultExtraJQueryAjaxSettings) {
+            requestOptions = (<any>Object).assign(requestOptions, this.defaultExtraJQueryAjaxSettings);
+        }
+
         let dfd = $.Deferred();
         $.ajax(requestOptions).then(
             (data: models.User, textStatus: string, jqXHR: JQueryXHR) =>
@@ -302,7 +346,7 @@ export class UserApi {
      * @param username The user name for login
      * @param password The password for login in clear text
      */
-    public loginUser(username: string, password: string): JQueryPromise<{ response: JQueryXHR; body: string;  }> {
+    public loginUser(username: string, password: string, extraJQueryAjaxSettings?: JQueryAjaxSettings): JQueryPromise<{ response: JQueryXHR; body: string;  }> {
         let localVarPath = this.basePath + '/user/login';
 
         let queryParameters: any = {};
@@ -347,6 +391,14 @@ export class UserApi {
             requestOptions.contentType = headerParams['Content-Type'];
         }
 
+        if (extraJQueryAjaxSettings) {
+            requestOptions = (<any>Object).assign(requestOptions, extraJQueryAjaxSettings);
+        }
+
+        if (this.defaultExtraJQueryAjaxSettings) {
+            requestOptions = (<any>Object).assign(requestOptions, this.defaultExtraJQueryAjaxSettings);
+        }
+
         let dfd = $.Deferred();
         $.ajax(requestOptions).then(
             (data: string, textStatus: string, jqXHR: JQueryXHR) =>
@@ -361,7 +413,7 @@ export class UserApi {
      * 
      * @summary Logs out current logged in user session
      */
-    public logoutUser(): JQueryPromise<{ response: JQueryXHR; body?: any;  }> {
+    public logoutUser(extraJQueryAjaxSettings?: JQueryAjaxSettings): JQueryPromise<{ response: JQueryXHR; body?: any;  }> {
         let localVarPath = this.basePath + '/user/logout';
 
         let queryParameters: any = {};
@@ -390,6 +442,14 @@ export class UserApi {
             requestOptions.contentType = headerParams['Content-Type'];
         }
 
+        if (extraJQueryAjaxSettings) {
+            requestOptions = (<any>Object).assign(requestOptions, extraJQueryAjaxSettings);
+        }
+
+        if (this.defaultExtraJQueryAjaxSettings) {
+            requestOptions = (<any>Object).assign(requestOptions, this.defaultExtraJQueryAjaxSettings);
+        }
+
         let dfd = $.Deferred();
         $.ajax(requestOptions).then(
             (data: any, textStatus: string, jqXHR: JQueryXHR) =>
@@ -406,7 +466,7 @@ export class UserApi {
      * @param username name that need to be deleted
      * @param body Updated user object
      */
-    public updateUser(username: string, body: models.User): JQueryPromise<{ response: JQueryXHR; body?: any;  }> {
+    public updateUser(username: string, body: models.User, extraJQueryAjaxSettings?: JQueryAjaxSettings): JQueryPromise<{ response: JQueryXHR; body?: any;  }> {
         let localVarPath = this.basePath + '/user/{username}'.replace('{' + 'username' + '}', encodeURIComponent(String(username)));
 
         let queryParameters: any = {};
@@ -446,6 +506,14 @@ export class UserApi {
         requestOptions.data = JSON.stringify(body);
         if (headerParams['Content-Type']) {
             requestOptions.contentType = headerParams['Content-Type'];
+        }
+
+        if (extraJQueryAjaxSettings) {
+            requestOptions = (<any>Object).assign(requestOptions, extraJQueryAjaxSettings);
+        }
+
+        if (this.defaultExtraJQueryAjaxSettings) {
+            requestOptions = (<any>Object).assign(requestOptions, this.defaultExtraJQueryAjaxSettings);
         }
 
         let dfd = $.Deferred();

--- a/samples/client/petstore/typescript-jquery/npm/api/PetApi.ts
+++ b/samples/client/petstore/typescript-jquery/npm/api/PetApi.ts
@@ -22,14 +22,18 @@ import { Configuration } from '../configuration';
 export class PetApi {
     protected basePath = 'http://petstore.swagger.io/v2';
     public defaultHeaders: Array<string> = [];
+    public defaultExtraJQueryAjaxSettings?: JQueryAjaxSettings = null;
     public configuration: Configuration = new Configuration();
 
-    constructor(basePath?: string, configuration?: Configuration) {
+    constructor(basePath?: string, configuration?: Configuration, defaultExtraJQueryAjaxSettings?: JQueryAjaxSettings) {
         if (basePath) {
             this.basePath = basePath;
         }
         if (configuration) {
             this.configuration = configuration;
+        }
+        if (defaultExtraJQueryAjaxSettings) {
+            this.defaultExtraJQueryAjaxSettings = defaultExtraJQueryAjaxSettings;
         }
     }
 
@@ -47,7 +51,7 @@ export class PetApi {
      * @summary Add a new pet to the store
      * @param body Pet object that needs to be added to the store
      */
-    public addPet(body: models.Pet): JQueryPromise<{ response: JQueryXHR; body?: any;  }> {
+    public addPet(body: models.Pet, extraJQueryAjaxSettings?: JQueryAjaxSettings): JQueryPromise<{ response: JQueryXHR; body?: any;  }> {
         let localVarPath = this.basePath + '/pet';
 
         let queryParameters: any = {};
@@ -95,6 +99,14 @@ export class PetApi {
             requestOptions.contentType = headerParams['Content-Type'];
         }
 
+        if (extraJQueryAjaxSettings) {
+            requestOptions = (<any>Object).assign(requestOptions, extraJQueryAjaxSettings);
+        }
+
+        if (this.defaultExtraJQueryAjaxSettings) {
+            requestOptions = (<any>Object).assign(requestOptions, this.defaultExtraJQueryAjaxSettings);
+        }
+
         let dfd = $.Deferred();
         $.ajax(requestOptions).then(
             (data: any, textStatus: string, jqXHR: JQueryXHR) =>
@@ -111,7 +123,7 @@ export class PetApi {
      * @param petId Pet id to delete
      * @param apiKey 
      */
-    public deletePet(petId: number, apiKey?: string): JQueryPromise<{ response: JQueryXHR; body?: any;  }> {
+    public deletePet(petId: number, apiKey?: string, extraJQueryAjaxSettings?: JQueryAjaxSettings): JQueryPromise<{ response: JQueryXHR; body?: any;  }> {
         let localVarPath = this.basePath + '/pet/{petId}'.replace('{' + 'petId' + '}', encodeURIComponent(String(petId)));
 
         let queryParameters: any = {};
@@ -156,6 +168,14 @@ export class PetApi {
             requestOptions.contentType = headerParams['Content-Type'];
         }
 
+        if (extraJQueryAjaxSettings) {
+            requestOptions = (<any>Object).assign(requestOptions, extraJQueryAjaxSettings);
+        }
+
+        if (this.defaultExtraJQueryAjaxSettings) {
+            requestOptions = (<any>Object).assign(requestOptions, this.defaultExtraJQueryAjaxSettings);
+        }
+
         let dfd = $.Deferred();
         $.ajax(requestOptions).then(
             (data: any, textStatus: string, jqXHR: JQueryXHR) =>
@@ -171,7 +191,7 @@ export class PetApi {
      * @summary Finds Pets by status
      * @param status Status values that need to be considered for filter
      */
-    public findPetsByStatus(status: Array<string>): JQueryPromise<{ response: JQueryXHR; body: Array<models.Pet>;  }> {
+    public findPetsByStatus(status: Array<string>, extraJQueryAjaxSettings?: JQueryAjaxSettings): JQueryPromise<{ response: JQueryXHR; body: Array<models.Pet>;  }> {
         let localVarPath = this.basePath + '/pet/findByStatus';
 
         let queryParameters: any = {};
@@ -217,6 +237,14 @@ export class PetApi {
             requestOptions.contentType = headerParams['Content-Type'];
         }
 
+        if (extraJQueryAjaxSettings) {
+            requestOptions = (<any>Object).assign(requestOptions, extraJQueryAjaxSettings);
+        }
+
+        if (this.defaultExtraJQueryAjaxSettings) {
+            requestOptions = (<any>Object).assign(requestOptions, this.defaultExtraJQueryAjaxSettings);
+        }
+
         let dfd = $.Deferred();
         $.ajax(requestOptions).then(
             (data: Array<models.Pet>, textStatus: string, jqXHR: JQueryXHR) =>
@@ -232,7 +260,7 @@ export class PetApi {
      * @summary Finds Pets by tags
      * @param tags Tags to filter by
      */
-    public findPetsByTags(tags: Array<string>): JQueryPromise<{ response: JQueryXHR; body: Array<models.Pet>;  }> {
+    public findPetsByTags(tags: Array<string>, extraJQueryAjaxSettings?: JQueryAjaxSettings): JQueryPromise<{ response: JQueryXHR; body: Array<models.Pet>;  }> {
         let localVarPath = this.basePath + '/pet/findByTags';
 
         let queryParameters: any = {};
@@ -278,6 +306,14 @@ export class PetApi {
             requestOptions.contentType = headerParams['Content-Type'];
         }
 
+        if (extraJQueryAjaxSettings) {
+            requestOptions = (<any>Object).assign(requestOptions, extraJQueryAjaxSettings);
+        }
+
+        if (this.defaultExtraJQueryAjaxSettings) {
+            requestOptions = (<any>Object).assign(requestOptions, this.defaultExtraJQueryAjaxSettings);
+        }
+
         let dfd = $.Deferred();
         $.ajax(requestOptions).then(
             (data: Array<models.Pet>, textStatus: string, jqXHR: JQueryXHR) =>
@@ -293,7 +329,7 @@ export class PetApi {
      * @summary Find pet by ID
      * @param petId ID of pet to return
      */
-    public getPetById(petId: number): JQueryPromise<{ response: JQueryXHR; body: models.Pet;  }> {
+    public getPetById(petId: number, extraJQueryAjaxSettings?: JQueryAjaxSettings): JQueryPromise<{ response: JQueryXHR; body: models.Pet;  }> {
         let localVarPath = this.basePath + '/pet/{petId}'.replace('{' + 'petId' + '}', encodeURIComponent(String(petId)));
 
         let queryParameters: any = {};
@@ -332,6 +368,14 @@ export class PetApi {
             requestOptions.contentType = headerParams['Content-Type'];
         }
 
+        if (extraJQueryAjaxSettings) {
+            requestOptions = (<any>Object).assign(requestOptions, extraJQueryAjaxSettings);
+        }
+
+        if (this.defaultExtraJQueryAjaxSettings) {
+            requestOptions = (<any>Object).assign(requestOptions, this.defaultExtraJQueryAjaxSettings);
+        }
+
         let dfd = $.Deferred();
         $.ajax(requestOptions).then(
             (data: models.Pet, textStatus: string, jqXHR: JQueryXHR) =>
@@ -347,7 +391,7 @@ export class PetApi {
      * @summary Update an existing pet
      * @param body Pet object that needs to be added to the store
      */
-    public updatePet(body: models.Pet): JQueryPromise<{ response: JQueryXHR; body?: any;  }> {
+    public updatePet(body: models.Pet, extraJQueryAjaxSettings?: JQueryAjaxSettings): JQueryPromise<{ response: JQueryXHR; body?: any;  }> {
         let localVarPath = this.basePath + '/pet';
 
         let queryParameters: any = {};
@@ -395,6 +439,14 @@ export class PetApi {
             requestOptions.contentType = headerParams['Content-Type'];
         }
 
+        if (extraJQueryAjaxSettings) {
+            requestOptions = (<any>Object).assign(requestOptions, extraJQueryAjaxSettings);
+        }
+
+        if (this.defaultExtraJQueryAjaxSettings) {
+            requestOptions = (<any>Object).assign(requestOptions, this.defaultExtraJQueryAjaxSettings);
+        }
+
         let dfd = $.Deferred();
         $.ajax(requestOptions).then(
             (data: any, textStatus: string, jqXHR: JQueryXHR) =>
@@ -412,7 +464,7 @@ export class PetApi {
      * @param name Updated name of the pet
      * @param status Updated status of the pet
      */
-    public updatePetWithForm(petId: number, name?: string, status?: string): JQueryPromise<{ response: JQueryXHR; body?: any;  }> {
+    public updatePetWithForm(petId: number, name?: string, status?: string, extraJQueryAjaxSettings?: JQueryAjaxSettings): JQueryPromise<{ response: JQueryXHR; body?: any;  }> {
         let localVarPath = this.basePath + '/pet/{petId}'.replace('{' + 'petId' + '}', encodeURIComponent(String(petId)));
 
         let queryParameters: any = {};
@@ -473,6 +525,14 @@ export class PetApi {
             requestOptions.contentType = false;
         }
 
+        if (extraJQueryAjaxSettings) {
+            requestOptions = (<any>Object).assign(requestOptions, extraJQueryAjaxSettings);
+        }
+
+        if (this.defaultExtraJQueryAjaxSettings) {
+            requestOptions = (<any>Object).assign(requestOptions, this.defaultExtraJQueryAjaxSettings);
+        }
+
         let dfd = $.Deferred();
         $.ajax(requestOptions).then(
             (data: any, textStatus: string, jqXHR: JQueryXHR) =>
@@ -490,7 +550,7 @@ export class PetApi {
      * @param additionalMetadata Additional data to pass to server
      * @param file file to upload
      */
-    public uploadFile(petId: number, additionalMetadata?: string, file?: any): JQueryPromise<{ response: JQueryXHR; body: models.ApiResponse;  }> {
+    public uploadFile(petId: number, additionalMetadata?: string, file?: any, extraJQueryAjaxSettings?: JQueryAjaxSettings): JQueryPromise<{ response: JQueryXHR; body: models.ApiResponse;  }> {
         let localVarPath = this.basePath + '/pet/{petId}/uploadImage'.replace('{' + 'petId' + '}', encodeURIComponent(String(petId)));
 
         let queryParameters: any = {};
@@ -547,6 +607,14 @@ export class PetApi {
         requestOptions.data = formParams;
         if (reqHasFile) {
             requestOptions.contentType = false;
+        }
+
+        if (extraJQueryAjaxSettings) {
+            requestOptions = (<any>Object).assign(requestOptions, extraJQueryAjaxSettings);
+        }
+
+        if (this.defaultExtraJQueryAjaxSettings) {
+            requestOptions = (<any>Object).assign(requestOptions, this.defaultExtraJQueryAjaxSettings);
         }
 
         let dfd = $.Deferred();

--- a/samples/client/petstore/typescript-jquery/npm/api/StoreApi.ts
+++ b/samples/client/petstore/typescript-jquery/npm/api/StoreApi.ts
@@ -22,14 +22,18 @@ import { Configuration } from '../configuration';
 export class StoreApi {
     protected basePath = 'http://petstore.swagger.io/v2';
     public defaultHeaders: Array<string> = [];
+    public defaultExtraJQueryAjaxSettings?: JQueryAjaxSettings = null;
     public configuration: Configuration = new Configuration();
 
-    constructor(basePath?: string, configuration?: Configuration) {
+    constructor(basePath?: string, configuration?: Configuration, defaultExtraJQueryAjaxSettings?: JQueryAjaxSettings) {
         if (basePath) {
             this.basePath = basePath;
         }
         if (configuration) {
             this.configuration = configuration;
+        }
+        if (defaultExtraJQueryAjaxSettings) {
+            this.defaultExtraJQueryAjaxSettings = defaultExtraJQueryAjaxSettings;
         }
     }
 
@@ -47,7 +51,7 @@ export class StoreApi {
      * @summary Delete purchase order by ID
      * @param orderId ID of the order that needs to be deleted
      */
-    public deleteOrder(orderId: string): JQueryPromise<{ response: JQueryXHR; body?: any;  }> {
+    public deleteOrder(orderId: string, extraJQueryAjaxSettings?: JQueryAjaxSettings): JQueryPromise<{ response: JQueryXHR; body?: any;  }> {
         let localVarPath = this.basePath + '/store/order/{orderId}'.replace('{' + 'orderId' + '}', encodeURIComponent(String(orderId)));
 
         let queryParameters: any = {};
@@ -81,6 +85,14 @@ export class StoreApi {
             requestOptions.contentType = headerParams['Content-Type'];
         }
 
+        if (extraJQueryAjaxSettings) {
+            requestOptions = (<any>Object).assign(requestOptions, extraJQueryAjaxSettings);
+        }
+
+        if (this.defaultExtraJQueryAjaxSettings) {
+            requestOptions = (<any>Object).assign(requestOptions, this.defaultExtraJQueryAjaxSettings);
+        }
+
         let dfd = $.Deferred();
         $.ajax(requestOptions).then(
             (data: any, textStatus: string, jqXHR: JQueryXHR) =>
@@ -95,7 +107,7 @@ export class StoreApi {
      * Returns a map of status codes to quantities
      * @summary Returns pet inventories by status
      */
-    public getInventory(): JQueryPromise<{ response: JQueryXHR; body: { [key: string]: number; };  }> {
+    public getInventory(extraJQueryAjaxSettings?: JQueryAjaxSettings): JQueryPromise<{ response: JQueryXHR; body: { [key: string]: number; };  }> {
         let localVarPath = this.basePath + '/store/inventory';
 
         let queryParameters: any = {};
@@ -128,6 +140,14 @@ export class StoreApi {
             requestOptions.contentType = headerParams['Content-Type'];
         }
 
+        if (extraJQueryAjaxSettings) {
+            requestOptions = (<any>Object).assign(requestOptions, extraJQueryAjaxSettings);
+        }
+
+        if (this.defaultExtraJQueryAjaxSettings) {
+            requestOptions = (<any>Object).assign(requestOptions, this.defaultExtraJQueryAjaxSettings);
+        }
+
         let dfd = $.Deferred();
         $.ajax(requestOptions).then(
             (data: { [key: string]: number; }, textStatus: string, jqXHR: JQueryXHR) =>
@@ -143,7 +163,7 @@ export class StoreApi {
      * @summary Find purchase order by ID
      * @param orderId ID of pet that needs to be fetched
      */
-    public getOrderById(orderId: number): JQueryPromise<{ response: JQueryXHR; body: models.Order;  }> {
+    public getOrderById(orderId: number, extraJQueryAjaxSettings?: JQueryAjaxSettings): JQueryPromise<{ response: JQueryXHR; body: models.Order;  }> {
         let localVarPath = this.basePath + '/store/order/{orderId}'.replace('{' + 'orderId' + '}', encodeURIComponent(String(orderId)));
 
         let queryParameters: any = {};
@@ -177,6 +197,14 @@ export class StoreApi {
             requestOptions.contentType = headerParams['Content-Type'];
         }
 
+        if (extraJQueryAjaxSettings) {
+            requestOptions = (<any>Object).assign(requestOptions, extraJQueryAjaxSettings);
+        }
+
+        if (this.defaultExtraJQueryAjaxSettings) {
+            requestOptions = (<any>Object).assign(requestOptions, this.defaultExtraJQueryAjaxSettings);
+        }
+
         let dfd = $.Deferred();
         $.ajax(requestOptions).then(
             (data: models.Order, textStatus: string, jqXHR: JQueryXHR) =>
@@ -192,7 +220,7 @@ export class StoreApi {
      * @summary Place an order for a pet
      * @param body order placed for purchasing the pet
      */
-    public placeOrder(body: models.Order): JQueryPromise<{ response: JQueryXHR; body: models.Order;  }> {
+    public placeOrder(body: models.Order, extraJQueryAjaxSettings?: JQueryAjaxSettings): JQueryPromise<{ response: JQueryXHR; body: models.Order;  }> {
         let localVarPath = this.basePath + '/store/order';
 
         let queryParameters: any = {};
@@ -227,6 +255,14 @@ export class StoreApi {
         requestOptions.data = JSON.stringify(body);
         if (headerParams['Content-Type']) {
             requestOptions.contentType = headerParams['Content-Type'];
+        }
+
+        if (extraJQueryAjaxSettings) {
+            requestOptions = (<any>Object).assign(requestOptions, extraJQueryAjaxSettings);
+        }
+
+        if (this.defaultExtraJQueryAjaxSettings) {
+            requestOptions = (<any>Object).assign(requestOptions, this.defaultExtraJQueryAjaxSettings);
         }
 
         let dfd = $.Deferred();

--- a/samples/client/petstore/typescript-jquery/npm/api/UserApi.ts
+++ b/samples/client/petstore/typescript-jquery/npm/api/UserApi.ts
@@ -22,14 +22,18 @@ import { Configuration } from '../configuration';
 export class UserApi {
     protected basePath = 'http://petstore.swagger.io/v2';
     public defaultHeaders: Array<string> = [];
+    public defaultExtraJQueryAjaxSettings?: JQueryAjaxSettings = null;
     public configuration: Configuration = new Configuration();
 
-    constructor(basePath?: string, configuration?: Configuration) {
+    constructor(basePath?: string, configuration?: Configuration, defaultExtraJQueryAjaxSettings?: JQueryAjaxSettings) {
         if (basePath) {
             this.basePath = basePath;
         }
         if (configuration) {
             this.configuration = configuration;
+        }
+        if (defaultExtraJQueryAjaxSettings) {
+            this.defaultExtraJQueryAjaxSettings = defaultExtraJQueryAjaxSettings;
         }
     }
 
@@ -47,7 +51,7 @@ export class UserApi {
      * @summary Create user
      * @param body Created user object
      */
-    public createUser(body: models.User): JQueryPromise<{ response: JQueryXHR; body?: any;  }> {
+    public createUser(body: models.User, extraJQueryAjaxSettings?: JQueryAjaxSettings): JQueryPromise<{ response: JQueryXHR; body?: any;  }> {
         let localVarPath = this.basePath + '/user';
 
         let queryParameters: any = {};
@@ -84,6 +88,14 @@ export class UserApi {
             requestOptions.contentType = headerParams['Content-Type'];
         }
 
+        if (extraJQueryAjaxSettings) {
+            requestOptions = (<any>Object).assign(requestOptions, extraJQueryAjaxSettings);
+        }
+
+        if (this.defaultExtraJQueryAjaxSettings) {
+            requestOptions = (<any>Object).assign(requestOptions, this.defaultExtraJQueryAjaxSettings);
+        }
+
         let dfd = $.Deferred();
         $.ajax(requestOptions).then(
             (data: any, textStatus: string, jqXHR: JQueryXHR) =>
@@ -99,7 +111,7 @@ export class UserApi {
      * @summary Creates list of users with given input array
      * @param body List of user object
      */
-    public createUsersWithArrayInput(body: Array<models.User>): JQueryPromise<{ response: JQueryXHR; body?: any;  }> {
+    public createUsersWithArrayInput(body: Array<models.User>, extraJQueryAjaxSettings?: JQueryAjaxSettings): JQueryPromise<{ response: JQueryXHR; body?: any;  }> {
         let localVarPath = this.basePath + '/user/createWithArray';
 
         let queryParameters: any = {};
@@ -136,6 +148,14 @@ export class UserApi {
             requestOptions.contentType = headerParams['Content-Type'];
         }
 
+        if (extraJQueryAjaxSettings) {
+            requestOptions = (<any>Object).assign(requestOptions, extraJQueryAjaxSettings);
+        }
+
+        if (this.defaultExtraJQueryAjaxSettings) {
+            requestOptions = (<any>Object).assign(requestOptions, this.defaultExtraJQueryAjaxSettings);
+        }
+
         let dfd = $.Deferred();
         $.ajax(requestOptions).then(
             (data: any, textStatus: string, jqXHR: JQueryXHR) =>
@@ -151,7 +171,7 @@ export class UserApi {
      * @summary Creates list of users with given input array
      * @param body List of user object
      */
-    public createUsersWithListInput(body: Array<models.User>): JQueryPromise<{ response: JQueryXHR; body?: any;  }> {
+    public createUsersWithListInput(body: Array<models.User>, extraJQueryAjaxSettings?: JQueryAjaxSettings): JQueryPromise<{ response: JQueryXHR; body?: any;  }> {
         let localVarPath = this.basePath + '/user/createWithList';
 
         let queryParameters: any = {};
@@ -188,6 +208,14 @@ export class UserApi {
             requestOptions.contentType = headerParams['Content-Type'];
         }
 
+        if (extraJQueryAjaxSettings) {
+            requestOptions = (<any>Object).assign(requestOptions, extraJQueryAjaxSettings);
+        }
+
+        if (this.defaultExtraJQueryAjaxSettings) {
+            requestOptions = (<any>Object).assign(requestOptions, this.defaultExtraJQueryAjaxSettings);
+        }
+
         let dfd = $.Deferred();
         $.ajax(requestOptions).then(
             (data: any, textStatus: string, jqXHR: JQueryXHR) =>
@@ -203,7 +231,7 @@ export class UserApi {
      * @summary Delete user
      * @param username The name that needs to be deleted
      */
-    public deleteUser(username: string): JQueryPromise<{ response: JQueryXHR; body?: any;  }> {
+    public deleteUser(username: string, extraJQueryAjaxSettings?: JQueryAjaxSettings): JQueryPromise<{ response: JQueryXHR; body?: any;  }> {
         let localVarPath = this.basePath + '/user/{username}'.replace('{' + 'username' + '}', encodeURIComponent(String(username)));
 
         let queryParameters: any = {};
@@ -237,6 +265,14 @@ export class UserApi {
             requestOptions.contentType = headerParams['Content-Type'];
         }
 
+        if (extraJQueryAjaxSettings) {
+            requestOptions = (<any>Object).assign(requestOptions, extraJQueryAjaxSettings);
+        }
+
+        if (this.defaultExtraJQueryAjaxSettings) {
+            requestOptions = (<any>Object).assign(requestOptions, this.defaultExtraJQueryAjaxSettings);
+        }
+
         let dfd = $.Deferred();
         $.ajax(requestOptions).then(
             (data: any, textStatus: string, jqXHR: JQueryXHR) =>
@@ -252,7 +288,7 @@ export class UserApi {
      * @summary Get user by user name
      * @param username The name that needs to be fetched. Use user1 for testing. 
      */
-    public getUserByName(username: string): JQueryPromise<{ response: JQueryXHR; body: models.User;  }> {
+    public getUserByName(username: string, extraJQueryAjaxSettings?: JQueryAjaxSettings): JQueryPromise<{ response: JQueryXHR; body: models.User;  }> {
         let localVarPath = this.basePath + '/user/{username}'.replace('{' + 'username' + '}', encodeURIComponent(String(username)));
 
         let queryParameters: any = {};
@@ -286,6 +322,14 @@ export class UserApi {
             requestOptions.contentType = headerParams['Content-Type'];
         }
 
+        if (extraJQueryAjaxSettings) {
+            requestOptions = (<any>Object).assign(requestOptions, extraJQueryAjaxSettings);
+        }
+
+        if (this.defaultExtraJQueryAjaxSettings) {
+            requestOptions = (<any>Object).assign(requestOptions, this.defaultExtraJQueryAjaxSettings);
+        }
+
         let dfd = $.Deferred();
         $.ajax(requestOptions).then(
             (data: models.User, textStatus: string, jqXHR: JQueryXHR) =>
@@ -302,7 +346,7 @@ export class UserApi {
      * @param username The user name for login
      * @param password The password for login in clear text
      */
-    public loginUser(username: string, password: string): JQueryPromise<{ response: JQueryXHR; body: string;  }> {
+    public loginUser(username: string, password: string, extraJQueryAjaxSettings?: JQueryAjaxSettings): JQueryPromise<{ response: JQueryXHR; body: string;  }> {
         let localVarPath = this.basePath + '/user/login';
 
         let queryParameters: any = {};
@@ -347,6 +391,14 @@ export class UserApi {
             requestOptions.contentType = headerParams['Content-Type'];
         }
 
+        if (extraJQueryAjaxSettings) {
+            requestOptions = (<any>Object).assign(requestOptions, extraJQueryAjaxSettings);
+        }
+
+        if (this.defaultExtraJQueryAjaxSettings) {
+            requestOptions = (<any>Object).assign(requestOptions, this.defaultExtraJQueryAjaxSettings);
+        }
+
         let dfd = $.Deferred();
         $.ajax(requestOptions).then(
             (data: string, textStatus: string, jqXHR: JQueryXHR) =>
@@ -361,7 +413,7 @@ export class UserApi {
      * 
      * @summary Logs out current logged in user session
      */
-    public logoutUser(): JQueryPromise<{ response: JQueryXHR; body?: any;  }> {
+    public logoutUser(extraJQueryAjaxSettings?: JQueryAjaxSettings): JQueryPromise<{ response: JQueryXHR; body?: any;  }> {
         let localVarPath = this.basePath + '/user/logout';
 
         let queryParameters: any = {};
@@ -390,6 +442,14 @@ export class UserApi {
             requestOptions.contentType = headerParams['Content-Type'];
         }
 
+        if (extraJQueryAjaxSettings) {
+            requestOptions = (<any>Object).assign(requestOptions, extraJQueryAjaxSettings);
+        }
+
+        if (this.defaultExtraJQueryAjaxSettings) {
+            requestOptions = (<any>Object).assign(requestOptions, this.defaultExtraJQueryAjaxSettings);
+        }
+
         let dfd = $.Deferred();
         $.ajax(requestOptions).then(
             (data: any, textStatus: string, jqXHR: JQueryXHR) =>
@@ -406,7 +466,7 @@ export class UserApi {
      * @param username name that need to be deleted
      * @param body Updated user object
      */
-    public updateUser(username: string, body: models.User): JQueryPromise<{ response: JQueryXHR; body?: any;  }> {
+    public updateUser(username: string, body: models.User, extraJQueryAjaxSettings?: JQueryAjaxSettings): JQueryPromise<{ response: JQueryXHR; body?: any;  }> {
         let localVarPath = this.basePath + '/user/{username}'.replace('{' + 'username' + '}', encodeURIComponent(String(username)));
 
         let queryParameters: any = {};
@@ -446,6 +506,14 @@ export class UserApi {
         requestOptions.data = JSON.stringify(body);
         if (headerParams['Content-Type']) {
             requestOptions.contentType = headerParams['Content-Type'];
+        }
+
+        if (extraJQueryAjaxSettings) {
+            requestOptions = (<any>Object).assign(requestOptions, extraJQueryAjaxSettings);
+        }
+
+        if (this.defaultExtraJQueryAjaxSettings) {
+            requestOptions = (<any>Object).assign(requestOptions, this.defaultExtraJQueryAjaxSettings);
         }
 
         let dfd = $.Deferred();


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [x] Filed the PR against the correct branch: `3.0.0` branch for changes related to OpenAPI spec 3.0. Default: `master`.
- [x] Copied the [technical committee](https://github.com/swagger-api/swagger-codegen/#swagger-codegen-technical-committee) to review the pull request if your PR is targeting a particular programming language.

@TiFu (2017/07) @taxpon (2017/07) @sebastianhaas (2017/07) @kenisteward (2017/07) @Vrolijkx (2017/09)

### Description of the PR

The jQuery generator was missing the possibility to specify options for the request. I added this feature like the other generators + the possibility to specify it at the class level which I think is a must (for example, if you want to use `withCredentials` everywhere.

