### PR TITLE
[Javascript] Set ES5 as default

### DIFF
--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/JavascriptClientCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/JavascriptClientCodegen.java
@@ -195,8 +195,8 @@ public class JavascriptClientCodegen extends DefaultCodegen implements CodegenCo
         cliOptions.add(new CliOption(CodegenConstants.HIDE_GENERATION_TIMESTAMP, "hides the timestamp when files were generated")
                 .defaultValue(Boolean.TRUE.toString()));
         cliOptions.add(new CliOption(USE_ES6,
-                "use JavaScript ES6 (ECMAScript 6)")
-                .defaultValue(Boolean.TRUE.toString()));
+                "use JavaScript ES6 (ECMAScript 6) (beta). Default is ES5.")
+                .defaultValue(Boolean.FALSE.toString()));
     }
 
     @Override

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/JavascriptClientCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/JavascriptClientCodegen.java
@@ -95,7 +95,7 @@ public class JavascriptClientCodegen extends DefaultCodegen implements CodegenCo
     protected String modelDocPath = "docs/";
     protected String apiTestPath = "api/";
     protected String modelTestPath = "model/";
-    protected boolean useES6 = true; // default is ES6
+    protected boolean useES6 = false; // default is ES5
 
     public JavascriptClientCodegen() {
         super();
@@ -219,7 +219,7 @@ public class JavascriptClientCodegen extends DefaultCodegen implements CodegenCo
         if (additionalProperties.containsKey(USE_ES6)) {
             setUseES6(convertPropertyToBooleanAndWriteBack(USE_ES6));
         } else {
-            setUseES6(true); // default to ES6
+            setUseES6(false); // default to ES5
         }
         super.processOpts();
 

--- a/samples/client/petstore/javascript-es6/docs/FakeApi.md
+++ b/samples/client/petstore/javascript-es6/docs/FakeApi.md
@@ -264,13 +264,13 @@ http_basic_test.password = 'YOUR PASSWORD';
 
 let apiInstance = new SwaggerPetstore.FakeApi();
 
-let _number = 3.4; // Number | None
+let _number = 8.14; // Number | None
 
 let _double = 1.2; // Number | None
 
 let patternWithoutDelimiter = "patternWithoutDelimiter_example"; // String | None
 
-let _byte = _byte_example; // Blob | None
+let _byte = B; // Blob | None
 
 let opts = { 
   'integer': 56, // Number | None

--- a/samples/client/petstore/javascript-promise-es6/docs/FakeApi.md
+++ b/samples/client/petstore/javascript-promise-es6/docs/FakeApi.md
@@ -254,13 +254,13 @@ http_basic_test.password = 'YOUR PASSWORD';
 
 let apiInstance = new SwaggerPetstore.FakeApi();
 
-let _number = 3.4; // Number | None
+let _number = 8.14; // Number | None
 
 let _double = 1.2; // Number | None
 
 let patternWithoutDelimiter = "patternWithoutDelimiter_example"; // String | None
 
-let _byte = _byte_example; // Blob | None
+let _byte = B; // Blob | None
 
 let opts = { 
   'integer': 56, // Number | None

--- a/samples/client/petstore/javascript-promise/docs/FakeApi.md
+++ b/samples/client/petstore/javascript-promise/docs/FakeApi.md
@@ -254,13 +254,13 @@ http_basic_test.password = 'YOUR PASSWORD';
 
 var apiInstance = new SwaggerPetstore.FakeApi();
 
-var _number = 3.4; // Number | None
+var _number = 8.14; // Number | None
 
 var _double = 1.2; // Number | None
 
 var patternWithoutDelimiter = "patternWithoutDelimiter_example"; // String | None
 
-var _byte = _byte_example; // Blob | None
+var _byte = B; // Blob | None
 
 var opts = { 
   'integer': 56, // Number | None

--- a/samples/client/petstore/javascript/docs/FakeApi.md
+++ b/samples/client/petstore/javascript/docs/FakeApi.md
@@ -269,13 +269,13 @@ http_basic_test.password = 'YOUR PASSWORD';
 
 var apiInstance = new SwaggerPetstore.FakeApi();
 
-var _number = 3.4; // Number | None
+var _number = 8.14; // Number | None
 
 var _double = 1.2; // Number | None
 
 var patternWithoutDelimiter = "patternWithoutDelimiter_example"; // String | None
 
-var _byte = _byte_example; // Blob | None
+var _byte = B; // Blob | None
 
 var opts = { 
   'integer': 56, // Number | None


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [x] Filed the PR against the correct branch: `3.0.0` branch for changes related to OpenAPI spec 3.0. Default: `master`.
- [x] Copied the [technical committee](https://github.com/swagger-api/swagger-codegen/#swagger-codegen-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

Given that JS (ES6) API client is still in beta, we'll set ES5 as the default. 
