### PR TITLE
[Java Play Framework] Fix a regression bug that was introduced in a recent commit in routes

### DIFF
--- a/modules/swagger-codegen/src/main/resources/JavaPlayFramework/routes.mustache
+++ b/modules/swagger-codegen/src/main/resources/JavaPlayFramework/routes.mustache
@@ -3,19 +3,19 @@
 # ~~~~
 
 {{#useSwaggerUI}}
-    GET     /api                        controllers.ApiDocController.api
+GET     /api                        controllers.ApiDocController.api
 {{/useSwaggerUI}}
 
 {{#apiInfo}}
-    {{#apis}}
+{{#apis}}
 
-        #Functions for {{{baseName}}} API
-        {{#operations}}
-            {{#operation}}
-                {{httpMethod}}     {{{contextPath}}}{{{path}}}                     controllers.{{classname}}Controller.{{operationId}}({{#pathParams}}{{paramName}}: {{#isUuid}}java.util.UUID{{/isUuid}}{{^isUuid}}{{{dataType}}}{{/isUuid}}{{#hasMore}}, {{/hasMore}}{{/pathParams}})
-            {{/operation}}
-        {{/operations}}
-    {{/apis}}
+#Functions for {{{baseName}}} API
+{{#operations}}
+{{#operation}}
+{{httpMethod}}     {{{contextPath}}}{{{path}}}                     controllers.{{classname}}Controller.{{operationId}}({{#pathParams}}{{paramName}}: {{#isUuid}}java.util.UUID{{/isUuid}}{{^isUuid}}{{{dataType}}}{{/isUuid}}{{#hasMore}}, {{/hasMore}}{{/pathParams}})
+{{/operation}}
+{{/operations}}
+{{/apis}}
 {{/apiInfo}}
 
 # Map static resources from the /public folder to the /assets URL path

--- a/samples/server/petstore/java-play-framework-controller-only/app/apimodels/Pet.java
+++ b/samples/server/petstore/java-play-framework-controller-only/app/apimodels/Pet.java
@@ -25,7 +25,7 @@ public class Pet   {
   private String name = null;
 
   @JsonProperty("photoUrls")
-  private List<String> photoUrls = new ArrayList<String>();
+  private List<String> photoUrls = new ArrayList<>();
 
   @JsonProperty("tags")
   private List<Tag> tags = null;
@@ -149,7 +149,7 @@ public class Pet   {
 
   public Pet addTagsItem(Tag tagsItem) {
     if (tags == null) {
-      tags = new ArrayList<Tag>();
+      tags = new ArrayList<>();
     }
     tags.add(tagsItem);
     return this;

--- a/samples/server/petstore/java-play-framework-controller-only/conf/routes
+++ b/samples/server/petstore/java-play-framework-controller-only/conf/routes
@@ -2,34 +2,34 @@
 # This file defines all application routes (Higher priority routes first)
 # ~~~~
 
-    GET     /api                        controllers.ApiDocController.api
+GET     /api                        controllers.ApiDocController.api
 
 
-        #Functions for Pet API
-                POST     /v2/pet                     controllers.PetApiController.addPet()
-                DELETE     /v2/pet/:petId                     controllers.PetApiController.deletePet(petId: Long)
-                GET     /v2/pet/findByStatus                     controllers.PetApiController.findPetsByStatus()
-                GET     /v2/pet/findByTags                     controllers.PetApiController.findPetsByTags()
-                GET     /v2/pet/:petId                     controllers.PetApiController.getPetById(petId: Long)
-                PUT     /v2/pet                     controllers.PetApiController.updatePet()
-                POST     /v2/pet/:petId                     controllers.PetApiController.updatePetWithForm(petId: Long)
-                POST     /v2/pet/:petId/uploadImage                     controllers.PetApiController.uploadFile(petId: Long)
+#Functions for Pet API
+POST     /v2/pet                     controllers.PetApiController.addPet()
+DELETE     /v2/pet/:petId                     controllers.PetApiController.deletePet(petId: Long)
+GET     /v2/pet/findByStatus                     controllers.PetApiController.findPetsByStatus()
+GET     /v2/pet/findByTags                     controllers.PetApiController.findPetsByTags()
+GET     /v2/pet/:petId                     controllers.PetApiController.getPetById(petId: Long)
+PUT     /v2/pet                     controllers.PetApiController.updatePet()
+POST     /v2/pet/:petId                     controllers.PetApiController.updatePetWithForm(petId: Long)
+POST     /v2/pet/:petId/uploadImage                     controllers.PetApiController.uploadFile(petId: Long)
 
-        #Functions for Store API
-                DELETE     /v2/store/order/:orderId                     controllers.StoreApiController.deleteOrder(orderId: String)
-                GET     /v2/store/inventory                     controllers.StoreApiController.getInventory()
-                GET     /v2/store/order/:orderId                     controllers.StoreApiController.getOrderById(orderId: Long)
-                POST     /v2/store/order                     controllers.StoreApiController.placeOrder()
+#Functions for Store API
+DELETE     /v2/store/order/:orderId                     controllers.StoreApiController.deleteOrder(orderId: String)
+GET     /v2/store/inventory                     controllers.StoreApiController.getInventory()
+GET     /v2/store/order/:orderId                     controllers.StoreApiController.getOrderById(orderId: Long)
+POST     /v2/store/order                     controllers.StoreApiController.placeOrder()
 
-        #Functions for User API
-                POST     /v2/user                     controllers.UserApiController.createUser()
-                POST     /v2/user/createWithArray                     controllers.UserApiController.createUsersWithArrayInput()
-                POST     /v2/user/createWithList                     controllers.UserApiController.createUsersWithListInput()
-                DELETE     /v2/user/:username                     controllers.UserApiController.deleteUser(username: String)
-                GET     /v2/user/:username                     controllers.UserApiController.getUserByName(username: String)
-                GET     /v2/user/login                     controllers.UserApiController.loginUser()
-                GET     /v2/user/logout                     controllers.UserApiController.logoutUser()
-                PUT     /v2/user/:username                     controllers.UserApiController.updateUser(username: String)
+#Functions for User API
+POST     /v2/user                     controllers.UserApiController.createUser()
+POST     /v2/user/createWithArray                     controllers.UserApiController.createUsersWithArrayInput()
+POST     /v2/user/createWithList                     controllers.UserApiController.createUsersWithListInput()
+DELETE     /v2/user/:username                     controllers.UserApiController.deleteUser(username: String)
+GET     /v2/user/:username                     controllers.UserApiController.getUserByName(username: String)
+GET     /v2/user/login                     controllers.UserApiController.loginUser()
+GET     /v2/user/logout                     controllers.UserApiController.logoutUser()
+PUT     /v2/user/:username                     controllers.UserApiController.updateUser(username: String)
 
 # Map static resources from the /public folder to the /assets URL path
 GET /assets/*file           controllers.Assets.at(file)

--- a/samples/server/petstore/java-play-framework-controller-only/public/swagger.json
+++ b/samples/server/petstore/java-play-framework-controller-only/public/swagger.json
@@ -112,8 +112,8 @@
           "type" : "array",
           "items" : {
             "type" : "string",
-            "enum" : [ "available", "pending", "sold" ],
-            "default" : "available"
+            "default" : "available",
+            "enum" : [ "available", "pending", "sold" ]
           },
           "collectionFormat" : "csv"
         } ],
@@ -134,7 +134,6 @@
         "security" : [ {
           "petstore_auth" : [ "write:pets", "read:pets" ]
         } ],
-        "x-contentType" : "application/json",
         "x-accepts" : "application/json"
       }
     },
@@ -174,7 +173,6 @@
           "petstore_auth" : [ "write:pets", "read:pets" ]
         } ],
         "deprecated" : true,
-        "x-contentType" : "application/json",
         "x-accepts" : "application/json"
       }
     },
@@ -210,7 +208,6 @@
         "security" : [ {
           "api_key" : [ ]
         } ],
-        "x-contentType" : "application/json",
         "x-accepts" : "application/json"
       },
       "post" : {
@@ -278,7 +275,6 @@
         "security" : [ {
           "petstore_auth" : [ "write:pets", "read:pets" ]
         } ],
-        "x-contentType" : "application/json",
         "x-accepts" : "application/json"
       }
     },
@@ -348,7 +344,6 @@
         "security" : [ {
           "api_key" : [ ]
         } ],
-        "x-contentType" : "application/json",
         "x-accepts" : "application/json"
       }
     },
@@ -414,7 +409,6 @@
             "description" : "Order not found"
           }
         },
-        "x-contentType" : "application/json",
         "x-accepts" : "application/json"
       },
       "delete" : {
@@ -438,7 +432,6 @@
             "description" : "Order not found"
           }
         },
-        "x-contentType" : "application/json",
         "x-accepts" : "application/json"
       }
     },
@@ -566,7 +559,6 @@
             "description" : "Invalid username/password supplied"
           }
         },
-        "x-contentType" : "application/json",
         "x-accepts" : "application/json"
       }
     },
@@ -583,7 +575,6 @@
             "description" : "successful operation"
           }
         },
-        "x-contentType" : "application/json",
         "x-accepts" : "application/json"
       }
     },
@@ -615,7 +606,6 @@
             "description" : "User not found"
           }
         },
-        "x-contentType" : "application/json",
         "x-accepts" : "application/json"
       },
       "put" : {
@@ -671,7 +661,6 @@
             "description" : "User not found"
           }
         },
-        "x-contentType" : "application/json",
         "x-accepts" : "application/json"
       }
     }

--- a/samples/server/petstore/java-play-framework-fake-endpoints/app/apimodels/AdditionalPropertiesClass.java
+++ b/samples/server/petstore/java-play-framework-fake-endpoints/app/apimodels/AdditionalPropertiesClass.java
@@ -27,7 +27,7 @@ public class AdditionalPropertiesClass   {
 
   public AdditionalPropertiesClass putMapPropertyItem(String key, String mapPropertyItem) {
     if (this.mapProperty == null) {
-      this.mapProperty = new HashMap<String, String>();
+      this.mapProperty = new HashMap<>();
     }
     this.mapProperty.put(key, mapPropertyItem);
     return this;
@@ -52,7 +52,7 @@ public class AdditionalPropertiesClass   {
 
   public AdditionalPropertiesClass putMapOfMapPropertyItem(String key, Map<String, String> mapOfMapPropertyItem) {
     if (this.mapOfMapProperty == null) {
-      this.mapOfMapProperty = new HashMap<String, Map<String, String>>();
+      this.mapOfMapProperty = new HashMap<>();
     }
     this.mapOfMapProperty.put(key, mapOfMapPropertyItem);
     return this;

--- a/samples/server/petstore/java-play-framework-fake-endpoints/app/apimodels/ArrayOfArrayOfNumberOnly.java
+++ b/samples/server/petstore/java-play-framework-fake-endpoints/app/apimodels/ArrayOfArrayOfNumberOnly.java
@@ -24,7 +24,7 @@ public class ArrayOfArrayOfNumberOnly   {
 
   public ArrayOfArrayOfNumberOnly addArrayArrayNumberItem(List<BigDecimal> arrayArrayNumberItem) {
     if (arrayArrayNumber == null) {
-      arrayArrayNumber = new ArrayList<List<BigDecimal>>();
+      arrayArrayNumber = new ArrayList<>();
     }
     arrayArrayNumber.add(arrayArrayNumberItem);
     return this;

--- a/samples/server/petstore/java-play-framework-fake-endpoints/app/apimodels/ArrayOfNumberOnly.java
+++ b/samples/server/petstore/java-play-framework-fake-endpoints/app/apimodels/ArrayOfNumberOnly.java
@@ -24,7 +24,7 @@ public class ArrayOfNumberOnly   {
 
   public ArrayOfNumberOnly addArrayNumberItem(BigDecimal arrayNumberItem) {
     if (arrayNumber == null) {
-      arrayNumber = new ArrayList<BigDecimal>();
+      arrayNumber = new ArrayList<>();
     }
     arrayNumber.add(arrayNumberItem);
     return this;

--- a/samples/server/petstore/java-play-framework-fake-endpoints/app/apimodels/ArrayTest.java
+++ b/samples/server/petstore/java-play-framework-fake-endpoints/app/apimodels/ArrayTest.java
@@ -30,7 +30,7 @@ public class ArrayTest   {
 
   public ArrayTest addArrayOfStringItem(String arrayOfStringItem) {
     if (arrayOfString == null) {
-      arrayOfString = new ArrayList<String>();
+      arrayOfString = new ArrayList<>();
     }
     arrayOfString.add(arrayOfStringItem);
     return this;
@@ -55,7 +55,7 @@ public class ArrayTest   {
 
   public ArrayTest addArrayArrayOfIntegerItem(List<Long> arrayArrayOfIntegerItem) {
     if (arrayArrayOfInteger == null) {
-      arrayArrayOfInteger = new ArrayList<List<Long>>();
+      arrayArrayOfInteger = new ArrayList<>();
     }
     arrayArrayOfInteger.add(arrayArrayOfIntegerItem);
     return this;
@@ -81,7 +81,7 @@ public class ArrayTest   {
 
   public ArrayTest addArrayArrayOfModelItem(List<ReadOnlyFirst> arrayArrayOfModelItem) {
     if (arrayArrayOfModel == null) {
-      arrayArrayOfModel = new ArrayList<List<ReadOnlyFirst>>();
+      arrayArrayOfModel = new ArrayList<>();
     }
     arrayArrayOfModel.add(arrayArrayOfModelItem);
     return this;

--- a/samples/server/petstore/java-play-framework-fake-endpoints/app/apimodels/EnumArrays.java
+++ b/samples/server/petstore/java-play-framework-fake-endpoints/app/apimodels/EnumArrays.java
@@ -105,7 +105,7 @@ public class EnumArrays   {
 
   public EnumArrays addArrayEnumItem(ArrayEnumEnum arrayEnumItem) {
     if (arrayEnum == null) {
-      arrayEnum = new ArrayList<ArrayEnumEnum>();
+      arrayEnum = new ArrayList<>();
     }
     arrayEnum.add(arrayEnumItem);
     return this;

--- a/samples/server/petstore/java-play-framework-fake-endpoints/app/apimodels/MapTest.java
+++ b/samples/server/petstore/java-play-framework-fake-endpoints/app/apimodels/MapTest.java
@@ -58,7 +58,7 @@ public class MapTest   {
 
   public MapTest putMapMapOfStringItem(String key, Map<String, String> mapMapOfStringItem) {
     if (this.mapMapOfString == null) {
-      this.mapMapOfString = new HashMap<String, Map<String, String>>();
+      this.mapMapOfString = new HashMap<>();
     }
     this.mapMapOfString.put(key, mapMapOfStringItem);
     return this;
@@ -84,7 +84,7 @@ public class MapTest   {
 
   public MapTest putMapOfEnumStringItem(String key, InnerEnum mapOfEnumStringItem) {
     if (this.mapOfEnumString == null) {
-      this.mapOfEnumString = new HashMap<String, InnerEnum>();
+      this.mapOfEnumString = new HashMap<>();
     }
     this.mapOfEnumString.put(key, mapOfEnumStringItem);
     return this;

--- a/samples/server/petstore/java-play-framework-fake-endpoints/app/apimodels/MixedPropertiesAndAdditionalPropertiesClass.java
+++ b/samples/server/petstore/java-play-framework-fake-endpoints/app/apimodels/MixedPropertiesAndAdditionalPropertiesClass.java
@@ -69,7 +69,7 @@ public class MixedPropertiesAndAdditionalPropertiesClass   {
 
   public MixedPropertiesAndAdditionalPropertiesClass putMapItem(String key, Animal mapItem) {
     if (this.map == null) {
-      this.map = new HashMap<String, Animal>();
+      this.map = new HashMap<>();
     }
     this.map.put(key, mapItem);
     return this;

--- a/samples/server/petstore/java-play-framework-fake-endpoints/app/apimodels/Pet.java
+++ b/samples/server/petstore/java-play-framework-fake-endpoints/app/apimodels/Pet.java
@@ -25,7 +25,7 @@ public class Pet   {
   private String name = null;
 
   @JsonProperty("photoUrls")
-  private List<String> photoUrls = new ArrayList<String>();
+  private List<String> photoUrls = new ArrayList<>();
 
   @JsonProperty("tags")
   private List<Tag> tags = null;
@@ -149,7 +149,7 @@ public class Pet   {
 
   public Pet addTagsItem(Tag tagsItem) {
     if (tags == null) {
-      tags = new ArrayList<Tag>();
+      tags = new ArrayList<>();
     }
     tags.add(tagsItem);
     return this;

--- a/samples/server/petstore/java-play-framework-fake-endpoints/public/swagger.json
+++ b/samples/server/petstore/java-play-framework-fake-endpoints/public/swagger.json
@@ -112,8 +112,8 @@
           "type" : "array",
           "items" : {
             "type" : "string",
-            "enum" : [ "available", "pending", "sold" ],
-            "default" : "available"
+            "default" : "available",
+            "enum" : [ "available", "pending", "sold" ]
           },
           "collectionFormat" : "csv"
         } ],
@@ -134,7 +134,6 @@
         "security" : [ {
           "petstore_auth" : [ "write:pets", "read:pets" ]
         } ],
-        "x-contentType" : "application/json",
         "x-accepts" : "application/json"
       }
     },
@@ -174,7 +173,6 @@
           "petstore_auth" : [ "write:pets", "read:pets" ]
         } ],
         "deprecated" : true,
-        "x-contentType" : "application/json",
         "x-accepts" : "application/json"
       }
     },
@@ -210,7 +208,6 @@
         "security" : [ {
           "api_key" : [ ]
         } ],
-        "x-contentType" : "application/json",
         "x-accepts" : "application/json"
       },
       "post" : {
@@ -278,7 +275,6 @@
         "security" : [ {
           "petstore_auth" : [ "write:pets", "read:pets" ]
         } ],
-        "x-contentType" : "application/json",
         "x-accepts" : "application/json"
       }
     },
@@ -348,7 +344,6 @@
         "security" : [ {
           "api_key" : [ ]
         } ],
-        "x-contentType" : "application/json",
         "x-accepts" : "application/json"
       }
     },
@@ -414,7 +409,6 @@
             "description" : "Order not found"
           }
         },
-        "x-contentType" : "application/json",
         "x-accepts" : "application/json"
       },
       "delete" : {
@@ -438,7 +432,6 @@
             "description" : "Order not found"
           }
         },
-        "x-contentType" : "application/json",
         "x-accepts" : "application/json"
       }
     },
@@ -566,7 +559,6 @@
             "description" : "Invalid username/password supplied"
           }
         },
-        "x-contentType" : "application/json",
         "x-accepts" : "application/json"
       }
     },
@@ -583,7 +575,6 @@
             "description" : "successful operation"
           }
         },
-        "x-contentType" : "application/json",
         "x-accepts" : "application/json"
       }
     },
@@ -615,7 +606,6 @@
             "description" : "User not found"
           }
         },
-        "x-contentType" : "application/json",
         "x-accepts" : "application/json"
       },
       "put" : {
@@ -671,7 +661,6 @@
             "description" : "User not found"
           }
         },
-        "x-contentType" : "application/json",
         "x-accepts" : "application/json"
       }
     },
@@ -722,8 +711,8 @@
           "type" : "array",
           "items" : {
             "type" : "string",
-            "enum" : [ ">", "$" ],
-            "default" : "$"
+            "default" : "$",
+            "enum" : [ ">", "$" ]
           }
         }, {
           "name" : "enum_form_string",
@@ -741,8 +730,8 @@
           "type" : "array",
           "items" : {
             "type" : "string",
-            "enum" : [ ">", "$" ],
-            "default" : "$"
+            "default" : "$",
+            "enum" : [ ">", "$" ]
           }
         }, {
           "name" : "enum_header_string",
@@ -760,8 +749,8 @@
           "type" : "array",
           "items" : {
             "type" : "string",
-            "enum" : [ ">", "$" ],
-            "default" : "$"
+            "default" : "$",
+            "enum" : [ ">", "$" ]
           }
         }, {
           "name" : "enum_query_string",

--- a/samples/server/petstore/java-play-framework-no-bean-validation/app/apimodels/Pet.java
+++ b/samples/server/petstore/java-play-framework-no-bean-validation/app/apimodels/Pet.java
@@ -24,7 +24,7 @@ public class Pet   {
   private String name = null;
 
   @JsonProperty("photoUrls")
-  private List<String> photoUrls = new ArrayList<String>();
+  private List<String> photoUrls = new ArrayList<>();
 
   @JsonProperty("tags")
   private List<Tag> tags = null;
@@ -145,7 +145,7 @@ public class Pet   {
 
   public Pet addTagsItem(Tag tagsItem) {
     if (tags == null) {
-      tags = new ArrayList<Tag>();
+      tags = new ArrayList<>();
     }
     tags.add(tagsItem);
     return this;

--- a/samples/server/petstore/java-play-framework-no-bean-validation/conf/routes
+++ b/samples/server/petstore/java-play-framework-no-bean-validation/conf/routes
@@ -2,34 +2,34 @@
 # This file defines all application routes (Higher priority routes first)
 # ~~~~
 
-    GET     /api                        controllers.ApiDocController.api
+GET     /api                        controllers.ApiDocController.api
 
 
-        #Functions for Pet API
-                POST     /v2/pet                     controllers.PetApiController.addPet()
-                DELETE     /v2/pet/:petId                     controllers.PetApiController.deletePet(petId: Long)
-                GET     /v2/pet/findByStatus                     controllers.PetApiController.findPetsByStatus()
-                GET     /v2/pet/findByTags                     controllers.PetApiController.findPetsByTags()
-                GET     /v2/pet/:petId                     controllers.PetApiController.getPetById(petId: Long)
-                PUT     /v2/pet                     controllers.PetApiController.updatePet()
-                POST     /v2/pet/:petId                     controllers.PetApiController.updatePetWithForm(petId: Long)
-                POST     /v2/pet/:petId/uploadImage                     controllers.PetApiController.uploadFile(petId: Long)
+#Functions for Pet API
+POST     /v2/pet                     controllers.PetApiController.addPet()
+DELETE     /v2/pet/:petId                     controllers.PetApiController.deletePet(petId: Long)
+GET     /v2/pet/findByStatus                     controllers.PetApiController.findPetsByStatus()
+GET     /v2/pet/findByTags                     controllers.PetApiController.findPetsByTags()
+GET     /v2/pet/:petId                     controllers.PetApiController.getPetById(petId: Long)
+PUT     /v2/pet                     controllers.PetApiController.updatePet()
+POST     /v2/pet/:petId                     controllers.PetApiController.updatePetWithForm(petId: Long)
+POST     /v2/pet/:petId/uploadImage                     controllers.PetApiController.uploadFile(petId: Long)
 
-        #Functions for Store API
-                DELETE     /v2/store/order/:orderId                     controllers.StoreApiController.deleteOrder(orderId: String)
-                GET     /v2/store/inventory                     controllers.StoreApiController.getInventory()
-                GET     /v2/store/order/:orderId                     controllers.StoreApiController.getOrderById(orderId: Long)
-                POST     /v2/store/order                     controllers.StoreApiController.placeOrder()
+#Functions for Store API
+DELETE     /v2/store/order/:orderId                     controllers.StoreApiController.deleteOrder(orderId: String)
+GET     /v2/store/inventory                     controllers.StoreApiController.getInventory()
+GET     /v2/store/order/:orderId                     controllers.StoreApiController.getOrderById(orderId: Long)
+POST     /v2/store/order                     controllers.StoreApiController.placeOrder()
 
-        #Functions for User API
-                POST     /v2/user                     controllers.UserApiController.createUser()
-                POST     /v2/user/createWithArray                     controllers.UserApiController.createUsersWithArrayInput()
-                POST     /v2/user/createWithList                     controllers.UserApiController.createUsersWithListInput()
-                DELETE     /v2/user/:username                     controllers.UserApiController.deleteUser(username: String)
-                GET     /v2/user/:username                     controllers.UserApiController.getUserByName(username: String)
-                GET     /v2/user/login                     controllers.UserApiController.loginUser()
-                GET     /v2/user/logout                     controllers.UserApiController.logoutUser()
-                PUT     /v2/user/:username                     controllers.UserApiController.updateUser(username: String)
+#Functions for User API
+POST     /v2/user                     controllers.UserApiController.createUser()
+POST     /v2/user/createWithArray                     controllers.UserApiController.createUsersWithArrayInput()
+POST     /v2/user/createWithList                     controllers.UserApiController.createUsersWithListInput()
+DELETE     /v2/user/:username                     controllers.UserApiController.deleteUser(username: String)
+GET     /v2/user/:username                     controllers.UserApiController.getUserByName(username: String)
+GET     /v2/user/login                     controllers.UserApiController.loginUser()
+GET     /v2/user/logout                     controllers.UserApiController.logoutUser()
+PUT     /v2/user/:username                     controllers.UserApiController.updateUser(username: String)
 
 # Map static resources from the /public folder to the /assets URL path
 GET /assets/*file           controllers.Assets.at(file)

--- a/samples/server/petstore/java-play-framework-no-bean-validation/public/swagger.json
+++ b/samples/server/petstore/java-play-framework-no-bean-validation/public/swagger.json
@@ -112,8 +112,8 @@
           "type" : "array",
           "items" : {
             "type" : "string",
-            "enum" : [ "available", "pending", "sold" ],
-            "default" : "available"
+            "default" : "available",
+            "enum" : [ "available", "pending", "sold" ]
           },
           "collectionFormat" : "csv"
         } ],
@@ -134,7 +134,6 @@
         "security" : [ {
           "petstore_auth" : [ "write:pets", "read:pets" ]
         } ],
-        "x-contentType" : "application/json",
         "x-accepts" : "application/json"
       }
     },
@@ -174,7 +173,6 @@
           "petstore_auth" : [ "write:pets", "read:pets" ]
         } ],
         "deprecated" : true,
-        "x-contentType" : "application/json",
         "x-accepts" : "application/json"
       }
     },
@@ -210,7 +208,6 @@
         "security" : [ {
           "api_key" : [ ]
         } ],
-        "x-contentType" : "application/json",
         "x-accepts" : "application/json"
       },
       "post" : {
@@ -278,7 +275,6 @@
         "security" : [ {
           "petstore_auth" : [ "write:pets", "read:pets" ]
         } ],
-        "x-contentType" : "application/json",
         "x-accepts" : "application/json"
       }
     },
@@ -348,7 +344,6 @@
         "security" : [ {
           "api_key" : [ ]
         } ],
-        "x-contentType" : "application/json",
         "x-accepts" : "application/json"
       }
     },
@@ -414,7 +409,6 @@
             "description" : "Order not found"
           }
         },
-        "x-contentType" : "application/json",
         "x-accepts" : "application/json"
       },
       "delete" : {
@@ -438,7 +432,6 @@
             "description" : "Order not found"
           }
         },
-        "x-contentType" : "application/json",
         "x-accepts" : "application/json"
       }
     },
@@ -566,7 +559,6 @@
             "description" : "Invalid username/password supplied"
           }
         },
-        "x-contentType" : "application/json",
         "x-accepts" : "application/json"
       }
     },
@@ -583,7 +575,6 @@
             "description" : "successful operation"
           }
         },
-        "x-contentType" : "application/json",
         "x-accepts" : "application/json"
       }
     },
@@ -615,7 +606,6 @@
             "description" : "User not found"
           }
         },
-        "x-contentType" : "application/json",
         "x-accepts" : "application/json"
       },
       "put" : {
@@ -671,7 +661,6 @@
             "description" : "User not found"
           }
         },
-        "x-contentType" : "application/json",
         "x-accepts" : "application/json"
       }
     }

--- a/samples/server/petstore/java-play-framework-no-exception-handling/app/apimodels/Pet.java
+++ b/samples/server/petstore/java-play-framework-no-exception-handling/app/apimodels/Pet.java
@@ -25,7 +25,7 @@ public class Pet   {
   private String name = null;
 
   @JsonProperty("photoUrls")
-  private List<String> photoUrls = new ArrayList<String>();
+  private List<String> photoUrls = new ArrayList<>();
 
   @JsonProperty("tags")
   private List<Tag> tags = null;
@@ -149,7 +149,7 @@ public class Pet   {
 
   public Pet addTagsItem(Tag tagsItem) {
     if (tags == null) {
-      tags = new ArrayList<Tag>();
+      tags = new ArrayList<>();
     }
     tags.add(tagsItem);
     return this;

--- a/samples/server/petstore/java-play-framework-no-exception-handling/conf/routes
+++ b/samples/server/petstore/java-play-framework-no-exception-handling/conf/routes
@@ -2,34 +2,34 @@
 # This file defines all application routes (Higher priority routes first)
 # ~~~~
 
-    GET     /api                        controllers.ApiDocController.api
+GET     /api                        controllers.ApiDocController.api
 
 
-        #Functions for Pet API
-                POST     /v2/pet                     controllers.PetApiController.addPet()
-                DELETE     /v2/pet/:petId                     controllers.PetApiController.deletePet(petId: Long)
-                GET     /v2/pet/findByStatus                     controllers.PetApiController.findPetsByStatus()
-                GET     /v2/pet/findByTags                     controllers.PetApiController.findPetsByTags()
-                GET     /v2/pet/:petId                     controllers.PetApiController.getPetById(petId: Long)
-                PUT     /v2/pet                     controllers.PetApiController.updatePet()
-                POST     /v2/pet/:petId                     controllers.PetApiController.updatePetWithForm(petId: Long)
-                POST     /v2/pet/:petId/uploadImage                     controllers.PetApiController.uploadFile(petId: Long)
+#Functions for Pet API
+POST     /v2/pet                     controllers.PetApiController.addPet()
+DELETE     /v2/pet/:petId                     controllers.PetApiController.deletePet(petId: Long)
+GET     /v2/pet/findByStatus                     controllers.PetApiController.findPetsByStatus()
+GET     /v2/pet/findByTags                     controllers.PetApiController.findPetsByTags()
+GET     /v2/pet/:petId                     controllers.PetApiController.getPetById(petId: Long)
+PUT     /v2/pet                     controllers.PetApiController.updatePet()
+POST     /v2/pet/:petId                     controllers.PetApiController.updatePetWithForm(petId: Long)
+POST     /v2/pet/:petId/uploadImage                     controllers.PetApiController.uploadFile(petId: Long)
 
-        #Functions for Store API
-                DELETE     /v2/store/order/:orderId                     controllers.StoreApiController.deleteOrder(orderId: String)
-                GET     /v2/store/inventory                     controllers.StoreApiController.getInventory()
-                GET     /v2/store/order/:orderId                     controllers.StoreApiController.getOrderById(orderId: Long)
-                POST     /v2/store/order                     controllers.StoreApiController.placeOrder()
+#Functions for Store API
+DELETE     /v2/store/order/:orderId                     controllers.StoreApiController.deleteOrder(orderId: String)
+GET     /v2/store/inventory                     controllers.StoreApiController.getInventory()
+GET     /v2/store/order/:orderId                     controllers.StoreApiController.getOrderById(orderId: Long)
+POST     /v2/store/order                     controllers.StoreApiController.placeOrder()
 
-        #Functions for User API
-                POST     /v2/user                     controllers.UserApiController.createUser()
-                POST     /v2/user/createWithArray                     controllers.UserApiController.createUsersWithArrayInput()
-                POST     /v2/user/createWithList                     controllers.UserApiController.createUsersWithListInput()
-                DELETE     /v2/user/:username                     controllers.UserApiController.deleteUser(username: String)
-                GET     /v2/user/:username                     controllers.UserApiController.getUserByName(username: String)
-                GET     /v2/user/login                     controllers.UserApiController.loginUser()
-                GET     /v2/user/logout                     controllers.UserApiController.logoutUser()
-                PUT     /v2/user/:username                     controllers.UserApiController.updateUser(username: String)
+#Functions for User API
+POST     /v2/user                     controllers.UserApiController.createUser()
+POST     /v2/user/createWithArray                     controllers.UserApiController.createUsersWithArrayInput()
+POST     /v2/user/createWithList                     controllers.UserApiController.createUsersWithListInput()
+DELETE     /v2/user/:username                     controllers.UserApiController.deleteUser(username: String)
+GET     /v2/user/:username                     controllers.UserApiController.getUserByName(username: String)
+GET     /v2/user/login                     controllers.UserApiController.loginUser()
+GET     /v2/user/logout                     controllers.UserApiController.logoutUser()
+PUT     /v2/user/:username                     controllers.UserApiController.updateUser(username: String)
 
 # Map static resources from the /public folder to the /assets URL path
 GET /assets/*file           controllers.Assets.at(file)

--- a/samples/server/petstore/java-play-framework-no-exception-handling/public/swagger.json
+++ b/samples/server/petstore/java-play-framework-no-exception-handling/public/swagger.json
@@ -112,8 +112,8 @@
           "type" : "array",
           "items" : {
             "type" : "string",
-            "enum" : [ "available", "pending", "sold" ],
-            "default" : "available"
+            "default" : "available",
+            "enum" : [ "available", "pending", "sold" ]
           },
           "collectionFormat" : "csv"
         } ],
@@ -134,7 +134,6 @@
         "security" : [ {
           "petstore_auth" : [ "write:pets", "read:pets" ]
         } ],
-        "x-contentType" : "application/json",
         "x-accepts" : "application/json"
       }
     },
@@ -174,7 +173,6 @@
           "petstore_auth" : [ "write:pets", "read:pets" ]
         } ],
         "deprecated" : true,
-        "x-contentType" : "application/json",
         "x-accepts" : "application/json"
       }
     },
@@ -210,7 +208,6 @@
         "security" : [ {
           "api_key" : [ ]
         } ],
-        "x-contentType" : "application/json",
         "x-accepts" : "application/json"
       },
       "post" : {
@@ -278,7 +275,6 @@
         "security" : [ {
           "petstore_auth" : [ "write:pets", "read:pets" ]
         } ],
-        "x-contentType" : "application/json",
         "x-accepts" : "application/json"
       }
     },
@@ -348,7 +344,6 @@
         "security" : [ {
           "api_key" : [ ]
         } ],
-        "x-contentType" : "application/json",
         "x-accepts" : "application/json"
       }
     },
@@ -414,7 +409,6 @@
             "description" : "Order not found"
           }
         },
-        "x-contentType" : "application/json",
         "x-accepts" : "application/json"
       },
       "delete" : {
@@ -438,7 +432,6 @@
             "description" : "Order not found"
           }
         },
-        "x-contentType" : "application/json",
         "x-accepts" : "application/json"
       }
     },
@@ -566,7 +559,6 @@
             "description" : "Invalid username/password supplied"
           }
         },
-        "x-contentType" : "application/json",
         "x-accepts" : "application/json"
       }
     },
@@ -583,7 +575,6 @@
             "description" : "successful operation"
           }
         },
-        "x-contentType" : "application/json",
         "x-accepts" : "application/json"
       }
     },
@@ -615,7 +606,6 @@
             "description" : "User not found"
           }
         },
-        "x-contentType" : "application/json",
         "x-accepts" : "application/json"
       },
       "put" : {
@@ -671,7 +661,6 @@
             "description" : "User not found"
           }
         },
-        "x-contentType" : "application/json",
         "x-accepts" : "application/json"
       }
     }

--- a/samples/server/petstore/java-play-framework-no-interface/app/apimodels/Pet.java
+++ b/samples/server/petstore/java-play-framework-no-interface/app/apimodels/Pet.java
@@ -25,7 +25,7 @@ public class Pet   {
   private String name = null;
 
   @JsonProperty("photoUrls")
-  private List<String> photoUrls = new ArrayList<String>();
+  private List<String> photoUrls = new ArrayList<>();
 
   @JsonProperty("tags")
   private List<Tag> tags = null;
@@ -149,7 +149,7 @@ public class Pet   {
 
   public Pet addTagsItem(Tag tagsItem) {
     if (tags == null) {
-      tags = new ArrayList<Tag>();
+      tags = new ArrayList<>();
     }
     tags.add(tagsItem);
     return this;

--- a/samples/server/petstore/java-play-framework-no-interface/conf/routes
+++ b/samples/server/petstore/java-play-framework-no-interface/conf/routes
@@ -2,34 +2,34 @@
 # This file defines all application routes (Higher priority routes first)
 # ~~~~
 
-    GET     /api                        controllers.ApiDocController.api
+GET     /api                        controllers.ApiDocController.api
 
 
-        #Functions for Pet API
-                POST     /v2/pet                     controllers.PetApiController.addPet()
-                DELETE     /v2/pet/:petId                     controllers.PetApiController.deletePet(petId: Long)
-                GET     /v2/pet/findByStatus                     controllers.PetApiController.findPetsByStatus()
-                GET     /v2/pet/findByTags                     controllers.PetApiController.findPetsByTags()
-                GET     /v2/pet/:petId                     controllers.PetApiController.getPetById(petId: Long)
-                PUT     /v2/pet                     controllers.PetApiController.updatePet()
-                POST     /v2/pet/:petId                     controllers.PetApiController.updatePetWithForm(petId: Long)
-                POST     /v2/pet/:petId/uploadImage                     controllers.PetApiController.uploadFile(petId: Long)
+#Functions for Pet API
+POST     /v2/pet                     controllers.PetApiController.addPet()
+DELETE     /v2/pet/:petId                     controllers.PetApiController.deletePet(petId: Long)
+GET     /v2/pet/findByStatus                     controllers.PetApiController.findPetsByStatus()
+GET     /v2/pet/findByTags                     controllers.PetApiController.findPetsByTags()
+GET     /v2/pet/:petId                     controllers.PetApiController.getPetById(petId: Long)
+PUT     /v2/pet                     controllers.PetApiController.updatePet()
+POST     /v2/pet/:petId                     controllers.PetApiController.updatePetWithForm(petId: Long)
+POST     /v2/pet/:petId/uploadImage                     controllers.PetApiController.uploadFile(petId: Long)
 
-        #Functions for Store API
-                DELETE     /v2/store/order/:orderId                     controllers.StoreApiController.deleteOrder(orderId: String)
-                GET     /v2/store/inventory                     controllers.StoreApiController.getInventory()
-                GET     /v2/store/order/:orderId                     controllers.StoreApiController.getOrderById(orderId: Long)
-                POST     /v2/store/order                     controllers.StoreApiController.placeOrder()
+#Functions for Store API
+DELETE     /v2/store/order/:orderId                     controllers.StoreApiController.deleteOrder(orderId: String)
+GET     /v2/store/inventory                     controllers.StoreApiController.getInventory()
+GET     /v2/store/order/:orderId                     controllers.StoreApiController.getOrderById(orderId: Long)
+POST     /v2/store/order                     controllers.StoreApiController.placeOrder()
 
-        #Functions for User API
-                POST     /v2/user                     controllers.UserApiController.createUser()
-                POST     /v2/user/createWithArray                     controllers.UserApiController.createUsersWithArrayInput()
-                POST     /v2/user/createWithList                     controllers.UserApiController.createUsersWithListInput()
-                DELETE     /v2/user/:username                     controllers.UserApiController.deleteUser(username: String)
-                GET     /v2/user/:username                     controllers.UserApiController.getUserByName(username: String)
-                GET     /v2/user/login                     controllers.UserApiController.loginUser()
-                GET     /v2/user/logout                     controllers.UserApiController.logoutUser()
-                PUT     /v2/user/:username                     controllers.UserApiController.updateUser(username: String)
+#Functions for User API
+POST     /v2/user                     controllers.UserApiController.createUser()
+POST     /v2/user/createWithArray                     controllers.UserApiController.createUsersWithArrayInput()
+POST     /v2/user/createWithList                     controllers.UserApiController.createUsersWithListInput()
+DELETE     /v2/user/:username                     controllers.UserApiController.deleteUser(username: String)
+GET     /v2/user/:username                     controllers.UserApiController.getUserByName(username: String)
+GET     /v2/user/login                     controllers.UserApiController.loginUser()
+GET     /v2/user/logout                     controllers.UserApiController.logoutUser()
+PUT     /v2/user/:username                     controllers.UserApiController.updateUser(username: String)
 
 # Map static resources from the /public folder to the /assets URL path
 GET /assets/*file           controllers.Assets.at(file)

--- a/samples/server/petstore/java-play-framework-no-interface/public/swagger.json
+++ b/samples/server/petstore/java-play-framework-no-interface/public/swagger.json
@@ -112,8 +112,8 @@
           "type" : "array",
           "items" : {
             "type" : "string",
-            "enum" : [ "available", "pending", "sold" ],
-            "default" : "available"
+            "default" : "available",
+            "enum" : [ "available", "pending", "sold" ]
           },
           "collectionFormat" : "csv"
         } ],
@@ -134,7 +134,6 @@
         "security" : [ {
           "petstore_auth" : [ "write:pets", "read:pets" ]
         } ],
-        "x-contentType" : "application/json",
         "x-accepts" : "application/json"
       }
     },
@@ -174,7 +173,6 @@
           "petstore_auth" : [ "write:pets", "read:pets" ]
         } ],
         "deprecated" : true,
-        "x-contentType" : "application/json",
         "x-accepts" : "application/json"
       }
     },
@@ -210,7 +208,6 @@
         "security" : [ {
           "api_key" : [ ]
         } ],
-        "x-contentType" : "application/json",
         "x-accepts" : "application/json"
       },
       "post" : {
@@ -278,7 +275,6 @@
         "security" : [ {
           "petstore_auth" : [ "write:pets", "read:pets" ]
         } ],
-        "x-contentType" : "application/json",
         "x-accepts" : "application/json"
       }
     },
@@ -348,7 +344,6 @@
         "security" : [ {
           "api_key" : [ ]
         } ],
-        "x-contentType" : "application/json",
         "x-accepts" : "application/json"
       }
     },
@@ -414,7 +409,6 @@
             "description" : "Order not found"
           }
         },
-        "x-contentType" : "application/json",
         "x-accepts" : "application/json"
       },
       "delete" : {
@@ -438,7 +432,6 @@
             "description" : "Order not found"
           }
         },
-        "x-contentType" : "application/json",
         "x-accepts" : "application/json"
       }
     },
@@ -566,7 +559,6 @@
             "description" : "Invalid username/password supplied"
           }
         },
-        "x-contentType" : "application/json",
         "x-accepts" : "application/json"
       }
     },
@@ -583,7 +575,6 @@
             "description" : "successful operation"
           }
         },
-        "x-contentType" : "application/json",
         "x-accepts" : "application/json"
       }
     },
@@ -615,7 +606,6 @@
             "description" : "User not found"
           }
         },
-        "x-contentType" : "application/json",
         "x-accepts" : "application/json"
       },
       "put" : {
@@ -671,7 +661,6 @@
             "description" : "User not found"
           }
         },
-        "x-contentType" : "application/json",
         "x-accepts" : "application/json"
       }
     }

--- a/samples/server/petstore/java-play-framework-no-swagger-ui/app/apimodels/Pet.java
+++ b/samples/server/petstore/java-play-framework-no-swagger-ui/app/apimodels/Pet.java
@@ -25,7 +25,7 @@ public class Pet   {
   private String name = null;
 
   @JsonProperty("photoUrls")
-  private List<String> photoUrls = new ArrayList<String>();
+  private List<String> photoUrls = new ArrayList<>();
 
   @JsonProperty("tags")
   private List<Tag> tags = null;
@@ -149,7 +149,7 @@ public class Pet   {
 
   public Pet addTagsItem(Tag tagsItem) {
     if (tags == null) {
-      tags = new ArrayList<Tag>();
+      tags = new ArrayList<>();
     }
     tags.add(tagsItem);
     return this;

--- a/samples/server/petstore/java-play-framework-no-swagger-ui/conf/routes
+++ b/samples/server/petstore/java-play-framework-no-swagger-ui/conf/routes
@@ -4,31 +4,31 @@
 
 
 
-        #Functions for Pet API
-                POST     /v2/pet                     controllers.PetApiController.addPet()
-                DELETE     /v2/pet/:petId                     controllers.PetApiController.deletePet(petId: Long)
-                GET     /v2/pet/findByStatus                     controllers.PetApiController.findPetsByStatus()
-                GET     /v2/pet/findByTags                     controllers.PetApiController.findPetsByTags()
-                GET     /v2/pet/:petId                     controllers.PetApiController.getPetById(petId: Long)
-                PUT     /v2/pet                     controllers.PetApiController.updatePet()
-                POST     /v2/pet/:petId                     controllers.PetApiController.updatePetWithForm(petId: Long)
-                POST     /v2/pet/:petId/uploadImage                     controllers.PetApiController.uploadFile(petId: Long)
+#Functions for Pet API
+POST     /v2/pet                     controllers.PetApiController.addPet()
+DELETE     /v2/pet/:petId                     controllers.PetApiController.deletePet(petId: Long)
+GET     /v2/pet/findByStatus                     controllers.PetApiController.findPetsByStatus()
+GET     /v2/pet/findByTags                     controllers.PetApiController.findPetsByTags()
+GET     /v2/pet/:petId                     controllers.PetApiController.getPetById(petId: Long)
+PUT     /v2/pet                     controllers.PetApiController.updatePet()
+POST     /v2/pet/:petId                     controllers.PetApiController.updatePetWithForm(petId: Long)
+POST     /v2/pet/:petId/uploadImage                     controllers.PetApiController.uploadFile(petId: Long)
 
-        #Functions for Store API
-                DELETE     /v2/store/order/:orderId                     controllers.StoreApiController.deleteOrder(orderId: String)
-                GET     /v2/store/inventory                     controllers.StoreApiController.getInventory()
-                GET     /v2/store/order/:orderId                     controllers.StoreApiController.getOrderById(orderId: Long)
-                POST     /v2/store/order                     controllers.StoreApiController.placeOrder()
+#Functions for Store API
+DELETE     /v2/store/order/:orderId                     controllers.StoreApiController.deleteOrder(orderId: String)
+GET     /v2/store/inventory                     controllers.StoreApiController.getInventory()
+GET     /v2/store/order/:orderId                     controllers.StoreApiController.getOrderById(orderId: Long)
+POST     /v2/store/order                     controllers.StoreApiController.placeOrder()
 
-        #Functions for User API
-                POST     /v2/user                     controllers.UserApiController.createUser()
-                POST     /v2/user/createWithArray                     controllers.UserApiController.createUsersWithArrayInput()
-                POST     /v2/user/createWithList                     controllers.UserApiController.createUsersWithListInput()
-                DELETE     /v2/user/:username                     controllers.UserApiController.deleteUser(username: String)
-                GET     /v2/user/:username                     controllers.UserApiController.getUserByName(username: String)
-                GET     /v2/user/login                     controllers.UserApiController.loginUser()
-                GET     /v2/user/logout                     controllers.UserApiController.logoutUser()
-                PUT     /v2/user/:username                     controllers.UserApiController.updateUser(username: String)
+#Functions for User API
+POST     /v2/user                     controllers.UserApiController.createUser()
+POST     /v2/user/createWithArray                     controllers.UserApiController.createUsersWithArrayInput()
+POST     /v2/user/createWithList                     controllers.UserApiController.createUsersWithListInput()
+DELETE     /v2/user/:username                     controllers.UserApiController.deleteUser(username: String)
+GET     /v2/user/:username                     controllers.UserApiController.getUserByName(username: String)
+GET     /v2/user/login                     controllers.UserApiController.loginUser()
+GET     /v2/user/logout                     controllers.UserApiController.logoutUser()
+PUT     /v2/user/:username                     controllers.UserApiController.updateUser(username: String)
 
 # Map static resources from the /public folder to the /assets URL path
 GET /assets/*file           controllers.Assets.at(file)

--- a/samples/server/petstore/java-play-framework-no-wrap-calls/app/apimodels/Pet.java
+++ b/samples/server/petstore/java-play-framework-no-wrap-calls/app/apimodels/Pet.java
@@ -25,7 +25,7 @@ public class Pet   {
   private String name = null;
 
   @JsonProperty("photoUrls")
-  private List<String> photoUrls = new ArrayList<String>();
+  private List<String> photoUrls = new ArrayList<>();
 
   @JsonProperty("tags")
   private List<Tag> tags = null;
@@ -149,7 +149,7 @@ public class Pet   {
 
   public Pet addTagsItem(Tag tagsItem) {
     if (tags == null) {
-      tags = new ArrayList<Tag>();
+      tags = new ArrayList<>();
     }
     tags.add(tagsItem);
     return this;

--- a/samples/server/petstore/java-play-framework-no-wrap-calls/conf/routes
+++ b/samples/server/petstore/java-play-framework-no-wrap-calls/conf/routes
@@ -2,34 +2,34 @@
 # This file defines all application routes (Higher priority routes first)
 # ~~~~
 
-    GET     /api                        controllers.ApiDocController.api
+GET     /api                        controllers.ApiDocController.api
 
 
-        #Functions for Pet API
-                POST     /v2/pet                     controllers.PetApiController.addPet()
-                DELETE     /v2/pet/:petId                     controllers.PetApiController.deletePet(petId: Long)
-                GET     /v2/pet/findByStatus                     controllers.PetApiController.findPetsByStatus()
-                GET     /v2/pet/findByTags                     controllers.PetApiController.findPetsByTags()
-                GET     /v2/pet/:petId                     controllers.PetApiController.getPetById(petId: Long)
-                PUT     /v2/pet                     controllers.PetApiController.updatePet()
-                POST     /v2/pet/:petId                     controllers.PetApiController.updatePetWithForm(petId: Long)
-                POST     /v2/pet/:petId/uploadImage                     controllers.PetApiController.uploadFile(petId: Long)
+#Functions for Pet API
+POST     /v2/pet                     controllers.PetApiController.addPet()
+DELETE     /v2/pet/:petId                     controllers.PetApiController.deletePet(petId: Long)
+GET     /v2/pet/findByStatus                     controllers.PetApiController.findPetsByStatus()
+GET     /v2/pet/findByTags                     controllers.PetApiController.findPetsByTags()
+GET     /v2/pet/:petId                     controllers.PetApiController.getPetById(petId: Long)
+PUT     /v2/pet                     controllers.PetApiController.updatePet()
+POST     /v2/pet/:petId                     controllers.PetApiController.updatePetWithForm(petId: Long)
+POST     /v2/pet/:petId/uploadImage                     controllers.PetApiController.uploadFile(petId: Long)
 
-        #Functions for Store API
-                DELETE     /v2/store/order/:orderId                     controllers.StoreApiController.deleteOrder(orderId: String)
-                GET     /v2/store/inventory                     controllers.StoreApiController.getInventory()
-                GET     /v2/store/order/:orderId                     controllers.StoreApiController.getOrderById(orderId: Long)
-                POST     /v2/store/order                     controllers.StoreApiController.placeOrder()
+#Functions for Store API
+DELETE     /v2/store/order/:orderId                     controllers.StoreApiController.deleteOrder(orderId: String)
+GET     /v2/store/inventory                     controllers.StoreApiController.getInventory()
+GET     /v2/store/order/:orderId                     controllers.StoreApiController.getOrderById(orderId: Long)
+POST     /v2/store/order                     controllers.StoreApiController.placeOrder()
 
-        #Functions for User API
-                POST     /v2/user                     controllers.UserApiController.createUser()
-                POST     /v2/user/createWithArray                     controllers.UserApiController.createUsersWithArrayInput()
-                POST     /v2/user/createWithList                     controllers.UserApiController.createUsersWithListInput()
-                DELETE     /v2/user/:username                     controllers.UserApiController.deleteUser(username: String)
-                GET     /v2/user/:username                     controllers.UserApiController.getUserByName(username: String)
-                GET     /v2/user/login                     controllers.UserApiController.loginUser()
-                GET     /v2/user/logout                     controllers.UserApiController.logoutUser()
-                PUT     /v2/user/:username                     controllers.UserApiController.updateUser(username: String)
+#Functions for User API
+POST     /v2/user                     controllers.UserApiController.createUser()
+POST     /v2/user/createWithArray                     controllers.UserApiController.createUsersWithArrayInput()
+POST     /v2/user/createWithList                     controllers.UserApiController.createUsersWithListInput()
+DELETE     /v2/user/:username                     controllers.UserApiController.deleteUser(username: String)
+GET     /v2/user/:username                     controllers.UserApiController.getUserByName(username: String)
+GET     /v2/user/login                     controllers.UserApiController.loginUser()
+GET     /v2/user/logout                     controllers.UserApiController.logoutUser()
+PUT     /v2/user/:username                     controllers.UserApiController.updateUser(username: String)
 
 # Map static resources from the /public folder to the /assets URL path
 GET /assets/*file           controllers.Assets.at(file)

--- a/samples/server/petstore/java-play-framework-no-wrap-calls/public/swagger.json
+++ b/samples/server/petstore/java-play-framework-no-wrap-calls/public/swagger.json
@@ -112,8 +112,8 @@
           "type" : "array",
           "items" : {
             "type" : "string",
-            "enum" : [ "available", "pending", "sold" ],
-            "default" : "available"
+            "default" : "available",
+            "enum" : [ "available", "pending", "sold" ]
           },
           "collectionFormat" : "csv"
         } ],
@@ -134,7 +134,6 @@
         "security" : [ {
           "petstore_auth" : [ "write:pets", "read:pets" ]
         } ],
-        "x-contentType" : "application/json",
         "x-accepts" : "application/json"
       }
     },
@@ -174,7 +173,6 @@
           "petstore_auth" : [ "write:pets", "read:pets" ]
         } ],
         "deprecated" : true,
-        "x-contentType" : "application/json",
         "x-accepts" : "application/json"
       }
     },
@@ -210,7 +208,6 @@
         "security" : [ {
           "api_key" : [ ]
         } ],
-        "x-contentType" : "application/json",
         "x-accepts" : "application/json"
       },
       "post" : {
@@ -278,7 +275,6 @@
         "security" : [ {
           "petstore_auth" : [ "write:pets", "read:pets" ]
         } ],
-        "x-contentType" : "application/json",
         "x-accepts" : "application/json"
       }
     },
@@ -348,7 +344,6 @@
         "security" : [ {
           "api_key" : [ ]
         } ],
-        "x-contentType" : "application/json",
         "x-accepts" : "application/json"
       }
     },
@@ -414,7 +409,6 @@
             "description" : "Order not found"
           }
         },
-        "x-contentType" : "application/json",
         "x-accepts" : "application/json"
       },
       "delete" : {
@@ -438,7 +432,6 @@
             "description" : "Order not found"
           }
         },
-        "x-contentType" : "application/json",
         "x-accepts" : "application/json"
       }
     },
@@ -566,7 +559,6 @@
             "description" : "Invalid username/password supplied"
           }
         },
-        "x-contentType" : "application/json",
         "x-accepts" : "application/json"
       }
     },
@@ -583,7 +575,6 @@
             "description" : "successful operation"
           }
         },
-        "x-contentType" : "application/json",
         "x-accepts" : "application/json"
       }
     },
@@ -615,7 +606,6 @@
             "description" : "User not found"
           }
         },
-        "x-contentType" : "application/json",
         "x-accepts" : "application/json"
       },
       "put" : {
@@ -671,7 +661,6 @@
             "description" : "User not found"
           }
         },
-        "x-contentType" : "application/json",
         "x-accepts" : "application/json"
       }
     }

--- a/samples/server/petstore/java-play-framework/app/apimodels/Pet.java
+++ b/samples/server/petstore/java-play-framework/app/apimodels/Pet.java
@@ -25,7 +25,7 @@ public class Pet   {
   private String name = null;
 
   @JsonProperty("photoUrls")
-  private List<String> photoUrls = new ArrayList<String>();
+  private List<String> photoUrls = new ArrayList<>();
 
   @JsonProperty("tags")
   private List<Tag> tags = null;
@@ -149,7 +149,7 @@ public class Pet   {
 
   public Pet addTagsItem(Tag tagsItem) {
     if (tags == null) {
-      tags = new ArrayList<Tag>();
+      tags = new ArrayList<>();
     }
     tags.add(tagsItem);
     return this;

--- a/samples/server/petstore/java-play-framework/conf/routes
+++ b/samples/server/petstore/java-play-framework/conf/routes
@@ -2,34 +2,34 @@
 # This file defines all application routes (Higher priority routes first)
 # ~~~~
 
-    GET     /api                        controllers.ApiDocController.api
+GET     /api                        controllers.ApiDocController.api
 
 
-        #Functions for Pet API
-                POST     /v2/pet                     controllers.PetApiController.addPet()
-                DELETE     /v2/pet/:petId                     controllers.PetApiController.deletePet(petId: Long)
-                GET     /v2/pet/findByStatus                     controllers.PetApiController.findPetsByStatus()
-                GET     /v2/pet/findByTags                     controllers.PetApiController.findPetsByTags()
-                GET     /v2/pet/:petId                     controllers.PetApiController.getPetById(petId: Long)
-                PUT     /v2/pet                     controllers.PetApiController.updatePet()
-                POST     /v2/pet/:petId                     controllers.PetApiController.updatePetWithForm(petId: Long)
-                POST     /v2/pet/:petId/uploadImage                     controllers.PetApiController.uploadFile(petId: Long)
+#Functions for Pet API
+POST     /v2/pet                     controllers.PetApiController.addPet()
+DELETE     /v2/pet/:petId                     controllers.PetApiController.deletePet(petId: Long)
+GET     /v2/pet/findByStatus                     controllers.PetApiController.findPetsByStatus()
+GET     /v2/pet/findByTags                     controllers.PetApiController.findPetsByTags()
+GET     /v2/pet/:petId                     controllers.PetApiController.getPetById(petId: Long)
+PUT     /v2/pet                     controllers.PetApiController.updatePet()
+POST     /v2/pet/:petId                     controllers.PetApiController.updatePetWithForm(petId: Long)
+POST     /v2/pet/:petId/uploadImage                     controllers.PetApiController.uploadFile(petId: Long)
 
-        #Functions for Store API
-                DELETE     /v2/store/order/:orderId                     controllers.StoreApiController.deleteOrder(orderId: String)
-                GET     /v2/store/inventory                     controllers.StoreApiController.getInventory()
-                GET     /v2/store/order/:orderId                     controllers.StoreApiController.getOrderById(orderId: Long)
-                POST     /v2/store/order                     controllers.StoreApiController.placeOrder()
+#Functions for Store API
+DELETE     /v2/store/order/:orderId                     controllers.StoreApiController.deleteOrder(orderId: String)
+GET     /v2/store/inventory                     controllers.StoreApiController.getInventory()
+GET     /v2/store/order/:orderId                     controllers.StoreApiController.getOrderById(orderId: Long)
+POST     /v2/store/order                     controllers.StoreApiController.placeOrder()
 
-        #Functions for User API
-                POST     /v2/user                     controllers.UserApiController.createUser()
-                POST     /v2/user/createWithArray                     controllers.UserApiController.createUsersWithArrayInput()
-                POST     /v2/user/createWithList                     controllers.UserApiController.createUsersWithListInput()
-                DELETE     /v2/user/:username                     controllers.UserApiController.deleteUser(username: String)
-                GET     /v2/user/:username                     controllers.UserApiController.getUserByName(username: String)
-                GET     /v2/user/login                     controllers.UserApiController.loginUser()
-                GET     /v2/user/logout                     controllers.UserApiController.logoutUser()
-                PUT     /v2/user/:username                     controllers.UserApiController.updateUser(username: String)
+#Functions for User API
+POST     /v2/user                     controllers.UserApiController.createUser()
+POST     /v2/user/createWithArray                     controllers.UserApiController.createUsersWithArrayInput()
+POST     /v2/user/createWithList                     controllers.UserApiController.createUsersWithListInput()
+DELETE     /v2/user/:username                     controllers.UserApiController.deleteUser(username: String)
+GET     /v2/user/:username                     controllers.UserApiController.getUserByName(username: String)
+GET     /v2/user/login                     controllers.UserApiController.loginUser()
+GET     /v2/user/logout                     controllers.UserApiController.logoutUser()
+PUT     /v2/user/:username                     controllers.UserApiController.updateUser(username: String)
 
 # Map static resources from the /public folder to the /assets URL path
 GET /assets/*file           controllers.Assets.at(file)

--- a/samples/server/petstore/java-play-framework/public/swagger.json
+++ b/samples/server/petstore/java-play-framework/public/swagger.json
@@ -112,8 +112,8 @@
           "type" : "array",
           "items" : {
             "type" : "string",
-            "enum" : [ "available", "pending", "sold" ],
-            "default" : "available"
+            "default" : "available",
+            "enum" : [ "available", "pending", "sold" ]
           },
           "collectionFormat" : "csv"
         } ],
@@ -134,7 +134,6 @@
         "security" : [ {
           "petstore_auth" : [ "write:pets", "read:pets" ]
         } ],
-        "x-contentType" : "application/json",
         "x-accepts" : "application/json"
       }
     },
@@ -174,7 +173,6 @@
           "petstore_auth" : [ "write:pets", "read:pets" ]
         } ],
         "deprecated" : true,
-        "x-contentType" : "application/json",
         "x-accepts" : "application/json"
       }
     },
@@ -210,7 +208,6 @@
         "security" : [ {
           "api_key" : [ ]
         } ],
-        "x-contentType" : "application/json",
         "x-accepts" : "application/json"
       },
       "post" : {
@@ -278,7 +275,6 @@
         "security" : [ {
           "petstore_auth" : [ "write:pets", "read:pets" ]
         } ],
-        "x-contentType" : "application/json",
         "x-accepts" : "application/json"
       }
     },
@@ -348,7 +344,6 @@
         "security" : [ {
           "api_key" : [ ]
         } ],
-        "x-contentType" : "application/json",
         "x-accepts" : "application/json"
       }
     },
@@ -414,7 +409,6 @@
             "description" : "Order not found"
           }
         },
-        "x-contentType" : "application/json",
         "x-accepts" : "application/json"
       },
       "delete" : {
@@ -438,7 +432,6 @@
             "description" : "Order not found"
           }
         },
-        "x-contentType" : "application/json",
         "x-accepts" : "application/json"
       }
     },
@@ -566,7 +559,6 @@
             "description" : "Invalid username/password supplied"
           }
         },
-        "x-contentType" : "application/json",
         "x-accepts" : "application/json"
       }
     },
@@ -583,7 +575,6 @@
             "description" : "successful operation"
           }
         },
-        "x-contentType" : "application/json",
         "x-accepts" : "application/json"
       }
     },
@@ -615,7 +606,6 @@
             "description" : "User not found"
           }
         },
-        "x-contentType" : "application/json",
         "x-accepts" : "application/json"
       },
       "put" : {
@@ -671,7 +661,6 @@
             "description" : "User not found"
           }
         },
-        "x-contentType" : "application/json",
         "x-accepts" : "application/json"
       }
     }


### PR DESCRIPTION
Indentations were added in the route files which prevent Play Framework compilation

### PR checklist

- [x] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [x] Filed the PR against the correct branch: `3.0.0` branch for changes related to OpenAPI spec 3.0. Default: `master`.
- [x] Copied the [technical committee](https://github.com/swagger-api/swagger-codegen/#swagger-codegen-technical-committee) to review the pull request if your PR is targeting a particular programming language.

@bbdouglas (2017/07) @JFCote (2017/08) @sreeshas (2017/08) @jfiala (2017/08) @lukoyanov (2017/09) @cbornet (2017/09)

### Description of the PR

Rollback the template file for routes which prevented the Play Framework from compiling.


