### PR TITLE
[Ruby] Correct minor typo in Ruby gemspec files

### DIFF
--- a/modules/swagger-codegen/src/main/resources/ruby/gemspec.mustache
+++ b/modules/swagger-codegen/src/main/resources/ruby/gemspec.mustache
@@ -20,7 +20,7 @@ Gem::Specification.new do |s|
   s.license     = "{{{gemLicense}}}"
   {{/gemLicense}}
   {{^gemLicense}}
-  # TODO uncommnet and update below with a proper license 
+  # TODO uncomment and update below with a proper license
   #s.license     = "Apache 2.0"
   {{/gemLicense}}
   s.required_ruby_version = "{{{gemRequiredRubyVersion}}}{{^gemRequiredRubyVersion}}>= 1.9{{/gemRequiredRubyVersion}}"

--- a/samples/client/petstore-security-test/ruby/petstore.gemspec
+++ b/samples/client/petstore-security-test/ruby/petstore.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |s|
   s.homepage    = "https://github.com/swagger-api/swagger-codegen"
   s.summary     = "Swagger Petstore */ ' \" =_end -- \\r\\n \\n \\r Ruby Gem"
   s.description = "This spec is mainly for testing Petstore server and contains fake endpoints, models. Please do not use this for any other purpose. Special characters: \" \\  */ ' \" =_end --       "
-  # TODO uncommnet and update below with a proper license 
+  # TODO uncomment and update below with a proper license
   #s.license     = "Apache 2.0"
   s.required_ruby_version = ">= 1.9"
 

--- a/samples/client/petstore/ruby/petstore.gemspec
+++ b/samples/client/petstore/ruby/petstore.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |s|
   s.homepage    = "https://github.com/swagger-api/swagger-codegen"
   s.summary     = "Swagger Petstore Ruby Gem"
   s.description = "This spec is mainly for testing Petstore server and contains fake endpoints, models. Please do not use this for any other purpose. Special characters: \" \\"
-  # TODO uncommnet and update below with a proper license 
+  # TODO uncomment and update below with a proper license
   #s.license     = "Apache 2.0"
   s.required_ruby_version = ">= 1.9"
 


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [x] Filed the PR against the correct branch: `3.0.0` branch for changes related to OpenAPI spec 3.0. Default: `master`.
- [n/a] Copied the [technical committee](https://github.com/swagger-api/swagger-codegen/#swagger-codegen-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

Fixes typo in Ruby gemspec. Replaces `uncommnet` to `uncomment` and removes a trailing space.
