### PR TITLE
Specifing the base type of elements in array

### DIFF
--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/DefaultCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/DefaultCodegen.java
@@ -1835,6 +1835,17 @@ public class DefaultCodegen {
             property.complexType = innerProperty.baseType;
         } else {
             property.isPrimitiveType = true;
+			property.isBoolean = innerProperty.isBoolean;
+            property.isLong = innerProperty.isLong;
+            property.isInteger = innerProperty.isInteger;
+            property.isDouble = innerProperty.isDouble;
+            property.isFloat = innerProperty.isFloat;
+            property.isByteArray = innerProperty.isByteArray;
+            property.isBinary = innerProperty.isBinary;
+            property.isFile = innerProperty.isFile;
+            property.isDate = innerProperty.isDate;
+            property.isDateTime = innerProperty.isDateTime;      
+            property.isString = innerProperty.isString;
         }
         property.items = innerProperty;
         // inner item is Enum

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/AbstractEiffelCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/AbstractEiffelCodegen.java
@@ -584,6 +584,17 @@ public abstract class AbstractEiffelCodegen extends DefaultCodegen implements Co
             property.complexType = innerProperty.baseType;
         } else {
             property.isPrimitiveType = true;
+			property.isBoolean = innerProperty.isBoolean;
+            property.isLong = innerProperty.isLong;
+            property.isInteger = innerProperty.isInteger;
+            property.isDouble = innerProperty.isDouble;
+            property.isFloat = innerProperty.isFloat;
+            property.isByteArray = innerProperty.isByteArray;
+            property.isBinary = innerProperty.isBinary;
+            property.isFile = innerProperty.isFile;
+            property.isDate = innerProperty.isDate;
+            property.isDateTime = innerProperty.isDateTime;      
+            property.isString = innerProperty.isString;
         }
         property.items = innerProperty;
         // inner item is Enum


### PR DESCRIPTION
Added copying array type descriptors (isBoolean, isNumber, etc) to specify the type of items in array

### PR checklist

- [x ] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [x ] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [x ] Filed the PR against the correct branch: `3.0.0` branch for changes related to OpenAPI spec 3.0. Default: `master`.
- [ x] Copied the [technical committee](https://github.com/swagger-api/swagger-codegen/#swagger-codegen-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

(details of the change, additional tests that have been done, reference to the issue for tracking, etc)

