### PR TITLE
[ISSUE-7276][akka-scala] exception template FileNotFoundException

### DIFF
--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/AbstractGenerator.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/AbstractGenerator.java
@@ -108,7 +108,7 @@ public abstract class AbstractGenerator {
         }
             
         // Fall back to the template file embedded/packaged in the JAR file...
-        return config.embeddedTemplateDir() + File.separator + templateFile;
+        return config.embeddedTemplateDir() + "/" + templateFile;
     }
 
     public String readResourceContents(String resourceFilePath) {


### PR DESCRIPTION
### PR checklist
1. replace the template path from `File.separator` to `/` to resolve template not found exception.
2. change `object` API to `class`, more easy use for java developer

### Description of the PR

https://github.com/swagger-api/swagger-codegen/issues/7276