### PR TITLE
[PHP] Tweak doc comment

### DIFF
--- a/modules/swagger-codegen/src/main/resources/php/model_test.mustache
+++ b/modules/swagger-codegen/src/main/resources/php/model_test.mustache
@@ -24,9 +24,8 @@ namespace {{invokerPackage}};
 /**
  * {{classname}}Test Class Doc Comment
  *
- * @category    Class */
-// * @description {{#description}}{{description}}{{/description}}{{^description}}{{classname}}{{/description}}
-/**
+ * @category    Class
+ * @description {{#description}}{{description}}{{/description}}{{^description}}{{classname}}{{/description}}
  * @package     {{invokerPackage}}
  * @author      Swagger Codegen team
  * @link        https://github.com/swagger-api/swagger-codegen


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [ ] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [x] Filed the PR against the correct branch: `3.0.0` branch for changes related to OpenAPI spec 3.0. Default: `master`.
- [x] Copied the [technical committee](https://github.com/swagger-api/swagger-codegen/#swagger-codegen-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

This PR tweaks test doc comment.

---

> PR checklist
> Ran the shell script under `./bin/` to update Petstore sample

I could't regenerate sample test codes because ["test"](https://github.com/swagger-api/swagger-codegen/tree/master/samples/client/petstore/php/SwaggerClient-php/test) contains real test code.
(refs: [[PHP] "test" should not contain real codes. · Issue #7200 · swagger-api/swagger-codegen](https://github.com/swagger-api/swagger-codegen/issues/7200))
