### PR TITLE
[Java] update CXF to latest release (3.2.1)

### DIFF
--- a/modules/swagger-codegen/src/main/resources/JavaJaxRS/cxf/pom.mustache
+++ b/modules/swagger-codegen/src/main/resources/JavaJaxRS/cxf/pom.mustache
@@ -181,7 +181,7 @@
     <java.version>{{#java8}}1.8{{/java8}}{{^java8}}1.7{{/java8}}</java.version>
     <maven.compiler.source>${java.version}</maven.compiler.source>
     <maven.compiler.target>${java.version}</maven.compiler.target>
-    <swagger-core-version>1.5.15</swagger-core-version>
+    <swagger-core-version>1.5.17</swagger-core-version>
     <jetty-version>9.2.9.v20150224</jetty-version>
     <junit-version>4.12</junit-version>
     <logback-version>1.1.7</logback-version>
@@ -189,8 +189,8 @@
 {{#useBeanValidation}}    
     <beanvalidation-version>1.1.0.Final</beanvalidation-version>
 {{/useBeanValidation}}    
-    <cxf-version>3.1.11</cxf-version>
-    <jackson-jaxrs-version>2.8.9</jackson-jaxrs-version>
+    <cxf-version>3.2.1</cxf-version>
+    <jackson-jaxrs-version>2.9.1</jackson-jaxrs-version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
   </properties>
 </project>

--- a/modules/swagger-codegen/src/main/resources/JavaJaxRS/cxf/server/pom.mustache
+++ b/modules/swagger-codegen/src/main/resources/JavaJaxRS/cxf/server/pom.mustache
@@ -215,7 +215,7 @@
         <dependency>
             <groupId>org.webjars</groupId>
             <artifactId>swagger-ui</artifactId>
-            <version>3.0.17</version>
+            <version>3.6.1</version>
         </dependency>
 {{/useSwaggerUI}}
   </dependencies>
@@ -232,7 +232,7 @@
     <java.version>{{#java8}}1.8{{/java8}}{{^java8}}1.7{{/java8}}</java.version>
     <maven.compiler.source>${java.version}</maven.compiler.source>
     <maven.compiler.target>${java.version}</maven.compiler.target>
-    <swagger-core-version>1.5.15</swagger-core-version>
+    <swagger-core-version>1.5.17</swagger-core-version>
     <jetty-version>9.2.9.v20150224</jetty-version>
     <junit-version>4.12</junit-version>
     <logback-version>1.1.7</logback-version>
@@ -241,13 +241,13 @@
     <beanvalidation-version>1.1.0.Final</beanvalidation-version>
 {{/useBeanValidation}}    
 {{#generateSpringApplication}}    
-    <spring-version>4.3.9.RELEASE</spring-version>
+    <spring-version>4.3.13.RELEASE</spring-version>
 {{/generateSpringApplication}}    
 {{#generateSpringBootApplication}}
-    <spring.boot-version>1.5.4.RELEASE</spring.boot-version>
+    <spring.boot-version>1.5.9.RELEASE</spring.boot-version>
 {{/generateSpringBootApplication}}    
-    <cxf-version>3.1.11</cxf-version>
-    <jackson-jaxrs-version>2.8.9</jackson-jaxrs-version>
+    <cxf-version>3.2.1</cxf-version>
+    <jackson-jaxrs-version>2.9.1</jackson-jaxrs-version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
   </properties>
 </project>

--- a/samples/client/petstore/jaxrs-cxf-client/pom.xml
+++ b/samples/client/petstore/jaxrs-cxf-client/pom.xml
@@ -185,14 +185,14 @@
     <java.version>1.7</java.version>
     <maven.compiler.source>${java.version}</maven.compiler.source>
     <maven.compiler.target>${java.version}</maven.compiler.target>
-    <swagger-core-version>1.5.15</swagger-core-version>
+    <swagger-core-version>1.5.17</swagger-core-version>
     <jetty-version>9.2.9.v20150224</jetty-version>
     <junit-version>4.12</junit-version>
     <logback-version>1.1.7</logback-version>
     <servlet-api-version>2.5</servlet-api-version>
     <beanvalidation-version>1.1.0.Final</beanvalidation-version>
-    <cxf-version>3.1.11</cxf-version>
-    <jackson-jaxrs-version>2.8.9</jackson-jaxrs-version>
+    <cxf-version>3.2.1</cxf-version>
+    <jackson-jaxrs-version>2.9.1</jackson-jaxrs-version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
   </properties>
 </project>

--- a/samples/client/petstore/jaxrs-cxf/pom.xml
+++ b/samples/client/petstore/jaxrs-cxf/pom.xml
@@ -162,13 +162,13 @@
     <java.version>1.7</java.version>
     <maven.compiler.source>${java.version}</maven.compiler.source>
     <maven.compiler.target>${java.version}</maven.compiler.target>
-    <swagger-core-version>1.5.15</swagger-core-version>
+    <swagger-core-version>1.5.17</swagger-core-version>
     <jetty-version>9.2.9.v20150224</jetty-version>
     <junit-version>4.12</junit-version>
     <logback-version>1.1.7</logback-version>
     <servlet-api-version>2.5</servlet-api-version>
-    <cxf-version>3.1.11</cxf-version>
-    <jackson-jaxrs-version>2.8.9</jackson-jaxrs-version>
+    <cxf-version>3.2.1</cxf-version>
+    <jackson-jaxrs-version>2.9.1</jackson-jaxrs-version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
   </properties>
 </project>

--- a/samples/server/petstore/jaxrs-cxf-annotated-base-path/pom.xml
+++ b/samples/server/petstore/jaxrs-cxf-annotated-base-path/pom.xml
@@ -185,14 +185,14 @@
     <java.version>1.7</java.version>
     <maven.compiler.source>${java.version}</maven.compiler.source>
     <maven.compiler.target>${java.version}</maven.compiler.target>
-    <swagger-core-version>1.5.15</swagger-core-version>
+    <swagger-core-version>1.5.17</swagger-core-version>
     <jetty-version>9.2.9.v20150224</jetty-version>
     <junit-version>4.12</junit-version>
     <logback-version>1.1.7</logback-version>
     <servlet-api-version>2.5</servlet-api-version>
     <beanvalidation-version>1.1.0.Final</beanvalidation-version>
-    <cxf-version>3.1.11</cxf-version>
-    <jackson-jaxrs-version>2.8.9</jackson-jaxrs-version>
+    <cxf-version>3.2.1</cxf-version>
+    <jackson-jaxrs-version>2.9.1</jackson-jaxrs-version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
   </properties>
 </project>

--- a/samples/server/petstore/jaxrs-cxf-non-spring-app/pom.xml
+++ b/samples/server/petstore/jaxrs-cxf-non-spring-app/pom.xml
@@ -185,14 +185,14 @@
     <java.version>1.7</java.version>
     <maven.compiler.source>${java.version}</maven.compiler.source>
     <maven.compiler.target>${java.version}</maven.compiler.target>
-    <swagger-core-version>1.5.15</swagger-core-version>
+    <swagger-core-version>1.5.17</swagger-core-version>
     <jetty-version>9.2.9.v20150224</jetty-version>
     <junit-version>4.12</junit-version>
     <logback-version>1.1.7</logback-version>
     <servlet-api-version>2.5</servlet-api-version>
     <beanvalidation-version>1.1.0.Final</beanvalidation-version>
-    <cxf-version>3.1.11</cxf-version>
-    <jackson-jaxrs-version>2.8.9</jackson-jaxrs-version>
+    <cxf-version>3.2.1</cxf-version>
+    <jackson-jaxrs-version>2.9.1</jackson-jaxrs-version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
   </properties>
 </project>

--- a/samples/server/petstore/jaxrs-cxf/pom.xml
+++ b/samples/server/petstore/jaxrs-cxf/pom.xml
@@ -185,14 +185,14 @@
     <java.version>1.7</java.version>
     <maven.compiler.source>${java.version}</maven.compiler.source>
     <maven.compiler.target>${java.version}</maven.compiler.target>
-    <swagger-core-version>1.5.15</swagger-core-version>
+    <swagger-core-version>1.5.17</swagger-core-version>
     <jetty-version>9.2.9.v20150224</jetty-version>
     <junit-version>4.12</junit-version>
     <logback-version>1.1.7</logback-version>
     <servlet-api-version>2.5</servlet-api-version>
     <beanvalidation-version>1.1.0.Final</beanvalidation-version>
-    <cxf-version>3.1.11</cxf-version>
-    <jackson-jaxrs-version>2.8.9</jackson-jaxrs-version>
+    <cxf-version>3.2.1</cxf-version>
+    <jackson-jaxrs-version>2.9.1</jackson-jaxrs-version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
   </properties>
 </project>


### PR DESCRIPTION
### PR checklist

- [X] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [X] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [X] Filed the PR against the correct branch: `3.0.0` branch for changes related to OpenAPI spec 3.0. Default: `master`.
- [X] Copied the [technical committee](https://github.com/swagger-api/swagger-codegen/#swagger-codegen-technical-committee) to review the pull request if your PR is targeting a particular programming language.
@bbdouglas (2017/07) @JFCote (2017/08) @sreeshas (2017/08) @jfiala (2017/08) @lukoyanov (2017/09) @cbornet (2017/09)

### Description of the PR

I've updated the CXF version to the latest release and adapted transitive dependencies accordingly. Already did a similar update in #5923 half a year ago...