### PR TITLE
#7123 use correct jackson date library when using Java 8

### DIFF
--- a/modules/swagger-codegen/src/main/resources/JavaJaxRS/cxf/pom.mustache
+++ b/modules/swagger-codegen/src/main/resources/JavaJaxRS/cxf/pom.mustache
@@ -154,12 +154,20 @@
         <version>${jackson-jaxrs-version}</version>
         <scope>compile</scope>
     </dependency>
+{{#java8}}
     <dependency>
-       <groupId>com.fasterxml.jackson.datatype</groupId>
-       <artifactId>jackson-datatype-joda</artifactId>
-       <version>${jackson-jaxrs-version}</version>
-       <scope>compile</scope>
+        <groupId>com.fasterxml.jackson.datatype</groupId>
+        <artifactId>jackson-datatype-jsr310</artifactId>
+        <version>${jackson-jaxrs-version}</version>
     </dependency>
+{{/java8}}
+{{^java8}}
+    <dependency>
+        <groupId>com.fasterxml.jackson.datatype</groupId>
+        <artifactId>jackson-datatype-joda</artifactId>
+        <version>${jackson-jaxrs-version}</version>
+    </dependency>
+{{/java8}}
 {{#useBeanValidationFeature}}    
     <dependency>
         <groupId>org.hibernate</groupId>

--- a/modules/swagger-codegen/src/main/resources/JavaJaxRS/cxf/server/pom.mustache
+++ b/modules/swagger-codegen/src/main/resources/JavaJaxRS/cxf/server/pom.mustache
@@ -169,12 +169,20 @@
         <version>${jackson-jaxrs-version}</version>
         <scope>compile</scope>
     </dependency>
+{{#java8}}
     <dependency>
-       <groupId>com.fasterxml.jackson.datatype</groupId>
-       <artifactId>jackson-datatype-joda</artifactId>
-       <version>${jackson-jaxrs-version}</version>
-       <scope>compile</scope>
+        <groupId>com.fasterxml.jackson.datatype</groupId>
+        <artifactId>jackson-datatype-jsr310</artifactId>
+        <version>${jackson-jaxrs-version}</version>
     </dependency>
+{{/java8}}
+{{^java8}}
+    <dependency>
+        <groupId>com.fasterxml.jackson.datatype</groupId>
+        <artifactId>jackson-datatype-joda</artifactId>
+        <version>${jackson-jaxrs-version}</version>
+    </dependency>
+{{/java8}}
 {{#generateSpringApplication}}    
     <!-- Spring -->
     <dependency>

--- a/modules/swagger-codegen/src/main/resources/JavaJaxRS/pom.mustache
+++ b/modules/swagger-codegen/src/main/resources/JavaJaxRS/pom.mustache
@@ -133,11 +133,20 @@
       <artifactId>jersey-media-multipart</artifactId>
       <version>${jersey2-version}</version>
     </dependency>
+  {{#java8}}
     <dependency>
-      <groupId>com.fasterxml.jackson.datatype</groupId>
-      <artifactId>jackson-datatype-joda</artifactId>
-      <version>${jackson-version}</version>
+        <groupId>com.fasterxml.jackson.datatype</groupId>
+        <artifactId>jackson-datatype-jsr310</artifactId>
+        <version>${jackson-version}</version>
     </dependency>
+  {{/java8}}
+  {{^java8}}
+    <dependency>
+        <groupId>com.fasterxml.jackson.datatype</groupId>
+        <artifactId>jackson-datatype-joda</artifactId>
+        <version>${jackson-version}</version>
+    </dependency>
+  {{/java8}}
     <dependency>
       <groupId>com.fasterxml.jackson.jaxrs</groupId>
       <artifactId>jackson-jaxrs-json-provider</artifactId>


### PR DESCRIPTION
### PR checklist

- [X] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [X] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [X] Filed the PR against the correct branch: `3.0.0` branch for changes related to OpenAPI spec 3.0. Default: `master`.
- [X] Copied the [technical committee](https://github.com/swagger-api/swagger-codegen/#swagger-codegen-technical-committee) to review the pull request if your PR is targeting a particular programming language.
@bbdouglas (2017/07) @JFCote (2017/08) @sreeshas (2017/08) @jfiala (2017/08) @lukoyanov (2017/09) @cbornet (2017/09)

### Description of the PR

fix for #7123, differentiation is already in use for Jersey