### PR TITLE
[Rust] Add user agent handling for rust template (3.0.0)

### DIFF
--- a/modules/swagger-codegen/src/main/resources/rust/api.mustache
+++ b/modules/swagger-codegen/src/main/resources/rust/api.mustache
@@ -1,11 +1,14 @@
 {{>partial_header}}
 use std::rc::Rc;
 use std::borrow::Borrow;
+use std::borrow::Cow;
 
 use hyper;
 use serde_json;
 use futures;
 use futures::{Future, Stream};
+
+use hyper::header::UserAgent;
 
 use super::{Error, configuration};
 
@@ -56,6 +59,10 @@ impl<C: hyper::client::Connect>{{classname}} for {{classname}}Client<C> {
         //     return Box::new(futures::future::err(e));
         // }
         let mut req = hyper::Request::new(method, uri.unwrap());
+
+        if let Some(ref user_agent) = configuration.user_agent {
+            req.headers_mut().set(UserAgent::new(Cow::Owned(user_agent.clone())));
+        }
 
         {{#hasHeaderParams}}
         {

--- a/modules/swagger-codegen/src/main/resources/rust/configuration.mustache
+++ b/modules/swagger-codegen/src/main/resources/rust/configuration.mustache
@@ -3,6 +3,7 @@ use hyper;
 
 pub struct Configuration<C: hyper::client::Connect> {
   pub base_path: String,
+  pub user_agent: Option<String>,
   pub client: hyper::client::Client<C>,
 }
 
@@ -10,6 +11,7 @@ impl<C: hyper::client::Connect> Configuration<C> {
   pub fn new(client: hyper::client::Client<C>) -> Configuration<C> {
     Configuration {
       base_path: "{{{basePath}}}".to_owned(),
+      user_agent: {{#httpUserAgent}}Some("{{{.}}}".to_owned()){{/httpUserAgent}}{{^httpUserAgent}}None{{/httpUserAgent}},
       client: client,
     }
   }


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [ ] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.

**I'm unable to run this script on 3.0.0. I'm assuming that this is because this part hasn't been updated yet.**

- [x] Filed the PR against the correct branch: `3.0.0` branch for changes related to OpenAPI spec 3.0. Default: `master`.
- [x] Copied the [technical committee](https://github.com/swagger-api/swagger-codegen/#swagger-codegen-technical-committee) to review the pull request if your PR is targeting a particular programming language.

@frol @farcaller @bjgill 

### Description of the PR

Solves issue #7289 by adding a field in the `Configuration` structure, with an initial value if the `--http-user-agent` option has been passed to `swagger-codegen`. Otherwise, the field is set by default to `None` but can be modified by the client API user at a later stage. In any case, if there is no user agent set, no header is added to the request.