### PR TITLE
Fix array model type to also work with primitive types

### DIFF
--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/DefaultCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/DefaultCodegen.java
@@ -1108,7 +1108,7 @@ public class DefaultCodegen implements CodegenConfig {
 
         if (schema instanceof ArraySchema) {
             codegenModel.getVendorExtensions().put(IS_ARRAY_MODEL_EXT_NAME, Boolean.TRUE);
-            codegenModel.arrayModelType = fromProperty(name, schema).complexType;
+            codegenModel.arrayModelType = fromProperty(name, schema).items.baseType;
             addParentContainer(codegenModel, name, schema);
             //} else if (schema instanceof RefModel) {
             // TODO


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [ ] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.

**I'm unable to run this script on 3.0.0. I'm assuming that this is because this part hasn't been updated yet.**

- [x] Filed the PR against the correct branch: `3.0.0` branch for changes related to OpenAPI spec 3.0. Default: `master`.
- [x] Copied the [technical committee](https://github.com/swagger-api/swagger-codegen/#swagger-codegen-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

Solves issue #7291. The `arrayModelType` will now use the type of the `items` object all the time instead of using it only with complex types.

