### PR TITLE
 Add support for array schemas in rust template 

### DIFF
--- a/modules/swagger-codegen/src/main/resources/rust/README.mustache
+++ b/modules/swagger-codegen/src/main/resources/rust/README.mustache
@@ -92,5 +92,5 @@ Or via OAuth2 module to automatically refresh tokens and perform user authentica
 
 ## Author
 
-{{#apiInfo}}{{#apis}}{{^hasMore}}{{infoEmail}}
-{{/hasMore}}{{/apis}}{{/apiInfo}}
+{{#apiInfo}}{{#apis}}{{#@last}}{{infoEmail}}
+{{/@last}}{{/apis}}{{/apiInfo}}

--- a/modules/swagger-codegen/src/main/resources/rust/api.mustache
+++ b/modules/swagger-codegen/src/main/resources/rust/api.mustache
@@ -24,7 +24,7 @@ impl<C: hyper::client::Connect> {{{classname}}}Client<C> {
 pub trait {{classname}} {
 {{#operations}}
 {{#operation}}
-    fn {{{operationId}}}(&self, {{#allParams}}{{paramName}}: {{#isString}}&str{{/isString}}{{^isString}}{{^isPrimitiveType}}{{^isContainer}}::models::{{/isContainer}}{{/isPrimitiveType}}{{{dataType}}}{{/isString}}{{#hasMore}}, {{/hasMore}}{{/allParams}}) -> Box<Future<Item = {{^returnType}}(){{/returnType}}{{#returnType}}{{{returnType}}}{{/returnType}}, Error = Error>>;
+    fn {{{operationId}}}(&self, {{#allParams}}{{paramName}}: {{#vendorExtensions.x-is-string}}&str{{/vendorExtensions.x-is-string}}{{^vendorExtensions.x-is-string}}{{^vendorExtensions.x-is-primitive-type}}{{^vendorExtensions.x-is-container}}::models::{{/vendorExtensions.x-is-container}}{{/vendorExtensions.x-is-primitive-type}}{{{dataType}}}{{/vendorExtensions.x-is-string}}{{^@last}}, {{/@last}}{{/allParams}}) -> Box<Future<Item = {{^returnType}}(){{/returnType}}{{#returnType}}{{{returnType}}}{{/returnType}}, Error = Error>>;
 {{/operation}}
 {{/operations}}
 }
@@ -33,7 +33,7 @@ pub trait {{classname}} {
 impl<C: hyper::client::Connect>{{classname}} for {{classname}}Client<C> {
 {{#operations}}
 {{#operation}}
-    fn {{{operationId}}}(&self, {{#allParams}}{{paramName}}: {{#isString}}&str{{/isString}}{{^isString}}{{^isPrimitiveType}}{{^isContainer}}::models::{{/isContainer}}{{/isPrimitiveType}}{{{dataType}}}{{/isString}}{{#hasMore}}, {{/hasMore}}{{/allParams}}) -> Box<Future<Item = {{^returnType}}(){{/returnType}}{{#returnType}}{{{.}}}{{/returnType}}, Error = Error>> {
+    fn {{{operationId}}}(&self, {{#allParams}}{{paramName}}: {{#vendorExtensions.x-is-string}}&str{{/vendorExtensions.x-is-string}}{{^vendorExtensions.x-is-string}}{{^vendorExtensions.x-is-primitive-type}}{{^vendorExtensions.x-is-container}}::models::{{/vendorExtensions.x-is-container}}{{/vendorExtensions.x-is-primitive-type}}{{{dataType}}}{{/vendorExtensions.x-is-string}}{{^@last}}, {{/@last}}{{/allParams}}) -> Box<Future<Item = {{^returnType}}(){{/returnType}}{{#returnType}}{{{.}}}{{/returnType}}, Error = Error>> {
         let configuration: &configuration::Configuration<C> = self.configuration.borrow();
 
         let method = hyper::Method::{{httpMethod}};

--- a/modules/swagger-codegen/src/main/resources/rust/api_doc.mustache
+++ b/modules/swagger-codegen/src/main/resources/rust/api_doc.mustache
@@ -11,25 +11,25 @@ Method | HTTP request | Description
 {{#operations}}
 {{#operation}}
 # **{{{operationId}}}**
-> {{#returnType}}{{{returnType}}} {{/returnType}}{{{operationId}}}({{#authMethods}}ctx, {{/authMethods}}{{#allParams}}{{#required}}{{paramName}}{{#hasMore}}, {{/hasMore}}{{/required}}{{/allParams}}{{#hasOptionalParams}}optional{{/hasOptionalParams}})
+> {{#returnType}}{{{returnType}}} {{/returnType}}{{{operationId}}}({{#authMethods}}ctx, {{/authMethods}}{{#allParams}}{{#required}}{{paramName}}{{^@last}}, {{/@last}}{{/required}}{{/allParams}}{{#hasOptionalParams}}optional{{/hasOptionalParams}})
 {{{summary}}}{{#notes}}
 
 {{{notes}}}{{/notes}}
 
 ### Required Parameters
-{{^allParams}}This endpoint does not need any parameter.{{/allParams}}{{#allParams}}{{#-last}}
+{{^allParams}}This endpoint does not need any parameter.{{/allParams}}{{#allParams}}{{#@last}}
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------{{#authMethods}}
- **ctx** | **context.Context** | context containing the authentication | nil if no authentication{{/authMethods}}{{/-last}}{{/allParams}}{{#allParams}}{{#required}}
-  **{{paramName}}** | {{#isFile}}**{{dataType}}**{{/isFile}}{{#isPrimitiveType}}**{{dataType}}**{{/isPrimitiveType}}{{^isPrimitiveType}}{{^isFile}}[**{{dataType}}**]({{baseType}}.md){{/isFile}}{{/isPrimitiveType}}| {{description}} | {{#defaultValue}}[default to {{defaultValue}}]{{/defaultValue}}{{/required}}{{/allParams}}{{#hasOptionalParams}}
+ **ctx** | **context.Context** | context containing the authentication | nil if no authentication{{/authMethods}}{{/@last}}{{/allParams}}{{#allParams}}{{#required}}
+  **{{paramName}}** | {{#isFile}}**{{dataType}}**{{/isFile}}{{#vendorExtensions.x-is-primitive-type}}**{{dataType}}**{{/vendorExtensions.x-is-primitive-type}}{{^vendorExtensions.x-is-primitive-type}}{{^isFile}}[**{{dataType}}**]({{baseType}}.md){{/isFile}}{{/vendorExtensions.x-is-primitive-type}}| {{description}} | {{#defaultValue}}[default to {{defaultValue}}]{{/defaultValue}}{{/required}}{{/allParams}}{{#hasOptionalParams}}
  **optional** | **map[string]interface{}** | optional parameters | nil if no parameters
 
 ### Optional Parameters
 Optional parameters are passed through a map[string]interface{}.
-{{#allParams}}{{#-last}}
+{{#allParams}}{{#@last}}
 Name | Type | Description  | Notes
-------------- | ------------- | ------------- | -------------{{/-last}}{{/allParams}}{{#allParams}}
- **{{paramName}}** | {{#isFile}}**{{dataType}}**{{/isFile}}{{#isPrimitiveType}}**{{dataType}}**{{/isPrimitiveType}}{{^isPrimitiveType}}{{^isFile}}[**{{dataType}}**]({{baseType}}.md){{/isFile}}{{/isPrimitiveType}}| {{description}} | {{#defaultValue}}[default to {{defaultValue}}]{{/defaultValue}}{{/allParams}}{{/hasOptionalParams}}
+------------- | ------------- | ------------- | -------------{{/@last}}{{/allParams}}{{#allParams}}
+ **{{paramName}}** | {{#isFile}}**{{dataType}}**{{/isFile}}{{#vendorExtensions.x-is-primitive-type}}**{{dataType}}**{{/vendorExtensions.x-is-primitive-type}}{{^vendorExtensions.x-is-primitive-type}}{{^isFile}}[**{{dataType}}**]({{baseType}}.md){{/isFile}}{{/vendorExtensions.x-is-primitive-type}}| {{description}} | {{#defaultValue}}[default to {{defaultValue}}]{{/defaultValue}}{{/allParams}}{{/hasOptionalParams}}
 
 ### Return type
 
@@ -37,12 +37,12 @@ Name | Type | Description  | Notes
 
 ### Authorization
 
-{{^authMethods}}No authorization required{{/authMethods}}{{#authMethods}}[{{{name}}}](../README.md#{{{name}}}){{^-last}}, {{/-last}}{{/authMethods}}
+{{^authMethods}}No authorization required{{/authMethods}}{{#authMethods}}[{{{name}}}](../README.md#{{{name}}}){{^@last}}, {{/@last}}{{/authMethods}}
 
 ### HTTP request headers
 
- - **Content-Type**: {{#consumes}}{{{mediaType}}}{{#hasMore}}, {{/hasMore}}{{/consumes}}{{^consumes}}Not defined{{/consumes}}
- - **Accept**: {{#produces}}{{{mediaType}}}{{#hasMore}}, {{/hasMore}}{{/produces}}{{^produces}}Not defined{{/produces}}
+ - **Content-Type**: {{#consumes}}{{{mediaType}}}{{^@last}}, {{/@last}}{{/consumes}}{{^consumes}}Not defined{{/consumes}}
+ - **Accept**: {{#produces}}{{{mediaType}}}{{^@last}}, {{/@last}}{{/produces}}{{^produces}}Not defined{{/produces}}
 
 [[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
 

--- a/modules/swagger-codegen/src/main/resources/rust/api_mod.mustache
+++ b/modules/swagger-codegen/src/main/resources/rust/api_mod.mustache
@@ -26,9 +26,9 @@ use super::models::*;
 mod {{classFilename}};
 {{#operations}}
 {{#operation}}
-{{#-last}}
+{{#@last}}
 pub use self::{{classFilename}}::{ {{classname}}, {{classname}}Client };
-{{/-last}}
+{{/@last}}
 {{/operation}}
 {{/operations}}
 {{/apis}}

--- a/modules/swagger-codegen/src/main/resources/rust/client.mustache
+++ b/modules/swagger-codegen/src/main/resources/rust/client.mustache
@@ -9,9 +9,9 @@ pub struct APIClient<C: hyper::client::Connect> {
 {{#apis}}
 {{#operations}}
 {{#operation}}
-  {{#-last}}
+  {{#@last}}
   {{classFilename}}: Box<::apis::{{classname}}>,
-  {{/-last}}
+  {{/@last}}
 {{/operation}}
 {{/operations}}
 {{/apis}}
@@ -28,9 +28,9 @@ impl<C: hyper::client::Connect> APIClient<C> {
 {{#apis}}
 {{#operations}}
 {{#operation}}
-      {{#-last}}
+      {{#@last}}
       {{classFilename}}: Box::new(::apis::{{classname}}Client::new(rc.clone())),
-      {{/-last}}
+      {{/@last}}
 {{/operation}}
 {{/operations}}
 {{/apis}}
@@ -42,12 +42,12 @@ impl<C: hyper::client::Connect> APIClient<C> {
 {{#apis}}
 {{#operations}}
 {{#operation}}
-{{#-last}}
+{{#@last}}
   pub fn {{classFilename}}(&self) -> &::apis::{{classname}}{
     self.{{classFilename}}.as_ref()
   }
 
-{{/-last}}
+{{/@last}}
 {{/operation}}
 {{/operations}}
 {{/apis}}

--- a/modules/swagger-codegen/src/main/resources/rust/model.mustache
+++ b/modules/swagger-codegen/src/main/resources/rust/model.mustache
@@ -15,7 +15,7 @@ pub struct {{classname}} {
   /// {{{description}}}
   {{/description}}
   #[serde(rename = "{{baseName}}")]
-  {{name}}: {{^required}}Option<{{/required}}{{{datatype}}}{{^required}}>{{/required}}{{#hasMore}},{{/hasMore}}
+  {{name}}: {{^required}}Option<{{/required}}{{{datatype}}}{{^required}}>{{/required}}{{^@last}},{{/@last}}
 {{/vars}}
 }
 
@@ -23,10 +23,10 @@ impl {{classname}} {
   {{#description}}
   /// {{{description}}}
   {{/description}}
-  pub fn new({{#requiredVars}}{{name}}: {{{datatype}}}{{^-last}}, {{/-last}}{{/requiredVars}}) -> {{classname}} {
+  pub fn new({{#requiredVars}}{{name}}: {{{datatype}}}{{^@last}}, {{/@last}}{{/requiredVars}}) -> {{classname}} {
     {{classname}} {
       {{#vars}}
-      {{name}}: {{#required}}{{name}}{{/required}}{{^required}}{{#isListContainer}}None{{/isListContainer}}{{#isMapContainer}}None{{/isMapContainer}}{{^isContainer}}None{{/isContainer}}{{/required}}{{#hasMore}},{{/hasMore}}
+      {{name}}: {{#required}}{{name}}{{/required}}{{^required}}{{#vendorExtensions.x-is-list-container}}None{{/vendorExtensions.x-is-list-container}}{{#vendorExtensions.x-is-map-container}}None{{/vendorExtensions.x-is-map-container}}{{^vendorExtensions.x-is-container}}None{{/vendorExtensions.x-is-container}}{{/required}}{{^@last}},{{/@last}}
       {{/vars}}
     }
   }

--- a/modules/swagger-codegen/src/main/resources/rust/model.mustache
+++ b/modules/swagger-codegen/src/main/resources/rust/model.mustache
@@ -8,6 +8,11 @@
 #[allow(unused_imports)]
 use serde_json::Value;
 
+{{#vendorExtensions.x-is-array-model}}
+#[derive(Debug, Serialize, Deserialize)]
+pub struct {{classname}}(Vec<{{{arrayModelType}}}>);
+{{/vendorExtensions.x-is-array-model}}
+{{^vendorExtensions.x-is-array-model}}
 #[derive(Debug, Serialize, Deserialize)]
 pub struct {{classname}} {
 {{#vars}}
@@ -18,17 +23,23 @@ pub struct {{classname}} {
   {{name}}: {{^required}}Option<{{/required}}{{{datatype}}}{{^required}}>{{/required}}{{^@last}},{{/@last}}
 {{/vars}}
 }
+{{/vendorExtensions.x-is-array-model}}
 
 impl {{classname}} {
   {{#description}}
   /// {{{description}}}
   {{/description}}
   pub fn new({{#requiredVars}}{{name}}: {{{datatype}}}{{^@last}}, {{/@last}}{{/requiredVars}}) -> {{classname}} {
+    {{#vendorExtensions.x-is-array-model}}
+    {{classname}}(Vec::new())
+    {{/vendorExtensions.x-is-array-model}}
+    {{^vendorExtensions.x-is-array-model}}
     {{classname}} {
       {{#vars}}
       {{name}}: {{#required}}{{name}}{{/required}}{{^required}}{{#vendorExtensions.x-is-list-container}}None{{/vendorExtensions.x-is-list-container}}{{#vendorExtensions.x-is-map-container}}None{{/vendorExtensions.x-is-map-container}}{{^vendorExtensions.x-is-container}}None{{/vendorExtensions.x-is-container}}{{/required}}{{^@last}},{{/@last}}
       {{/vars}}
     }
+    {{/vendorExtensions.x-is-array-model}}
   }
 
   {{#vars}}

--- a/modules/swagger-codegen/src/main/resources/rust/model_doc.mustache
+++ b/modules/swagger-codegen/src/main/resources/rust/model_doc.mustache
@@ -3,7 +3,7 @@
 ## Properties
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-{{#vars}}**{{name}}** | {{#isPrimitiveType}}**{{{datatype}}}**{{/isPrimitiveType}}{{^isPrimitiveType}}[**{{^isContainer}}{{^isDateTime}}*{{/isDateTime}}{{/isContainer}}{{{datatype}}}**]({{complexType}}.md){{/isPrimitiveType}} | {{description}} | {{^required}}[optional] {{/required}}{{#readOnly}}[readonly] {{/readOnly}}{{#defaultValue}}[default to {{{.}}}]{{/defaultValue}}
+{{#vars}}**{{name}}** | {{#vendorExtensions.x-is-primitive-type}}**{{{datatype}}}**{{/vendorExtensions.x-is-primitive-type}}{{^vendorExtensions.x-is-primitive-type}}[**{{^vendorExtensions.x-is-container}}{{^isDateTime}}*{{/isDateTime}}{{/vendorExtensions.x-is-container}}{{{datatype}}}**]({{complexType}}.md){{/vendorExtensions.x-is-primitive-type}} | {{description}} | {{^required}}[optional] {{/required}}{{#readOnly}}[readonly] {{/readOnly}}{{#defaultValue}}[default to {{{.}}}]{{/defaultValue}}
 {{/vars}}
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)


### PR DESCRIPTION
**THIS PR DEPENDS ON #7288, DO NOT MERGE UNTIL #7288 IS MERGED.**
---
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [ ] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.

**I'm unable to run this script on 3.0.0. I'm assuming that this is because this part hasn't been updated yet.**

- [x] Filed the PR against the correct branch: `3.0.0` branch for changes related to OpenAPI spec 3.0. Default: `master`.
- [x] Copied the [technical committee](https://github.com/swagger-api/swagger-codegen/#swagger-codegen-technical-committee) to review the pull request if your PR is targeting a particular programming language.

@frol @farcaller @bjgill

### Description of the PR

Solves issue #7293. This adds a condition based on `vendorExtensions.x-is-array-model` for code of the struct as well as its initialization in the constructor.

