### PR TITLE
Re-organize the reserved words for Swift4

### DIFF
--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/Swift4Codegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/Swift4Codegen.java
@@ -139,19 +139,52 @@ public class Swift4Codegen extends DefaultCodegen implements CodegenConfig {
                     // name used by swift client
                     "ErrorResponse", "Response",
 
-                    // swift keywords
-                    "Int", "Int32", "Int64", "Int64", "Float", "Double", "Bool", "Void", "String",
-                    "Character", "AnyObject", "Any", "Error", "URL", "class", "Class", "break",
-                    "as", "associativity", "deinit", "case", "dynamicType", "convenience", "enum",
-                    "continue", "false", "dynamic", "extension", "default", "is", "didSet",
-                    "func", "do", "nil", "final", "import", "else", "self", "get", "init",
-                    "fallthrough", "Self", "infix", "internal", "for", "super", "inout", "let",
-                    "if", "true", "lazy", "operator", "in", "COLUMN", "left", "private", "return",
-                    "FILE", "mutating", "protocol", "switch", "FUNCTION", "none", "public",
-                    "where", "LINE", "nonmutating", "static", "while", "optional", "struct",
-                    "override", "subscript", "postfix", "typealias", "precedence", "var",
-                    "prefix", "Protocol", "required", "right", "set", "throw", "Type", "unowned", "weak",
-                    "Data", "Codable", "Encodable", "Decodable")
+                    // Added for Objective-C compatibility
+                    "id", "description", "NSArray", "NSURL", "CGFloat", "NSSet", "NSString", "NSInteger", "NSUInteger",
+                    "NSError", "NSDictionary", 
+
+                    //
+                    // Swift keywords. This list is taken from here:
+                    // https://developer.apple.com/library/content/documentation/Swift/Conceptual/Swift_Programming_Language/LexicalStructure.html#//apple_ref/doc/uid/TP40014097-CH30-ID410
+                    //
+                    // Keywords used in declarations
+                    "associatedtype", "class", "deinit", "enum", "extension", "fileprivate", "func", "import", "init",
+                    "inout", "internal", "let", "open", "operator", "private", "protocol", "public", "static", "struct",
+                    "subscript", "typealias", "var",
+                    // Keywords uses in statements
+                    "break", "case", "continue", "default", "defer", "do", "else", "fallthrough", "for", "guard", "if",
+                    "in", "repeat", "return", "switch", "where", "while",
+                    // Keywords used in expressions and types
+                    "as", "Any", "catch", "false", "is", "nil", "rethrows", "super", "self", "Self", "throw", "throws", "true", "try",
+                    // Keywords used in patterns
+                    "_",
+                    // Keywords that begin with a number sign
+                    "#available", "#colorLiteral", "#column", "#else", "#elseif", "#endif", "#file", "#fileLiteral", "#function", "#if",
+                    "#imageLiteral", "#line", "#selector", "#sourceLocation",
+                    // Keywords reserved in particular contexts
+                    "associativity", "convenience", "dynamic", "didSet", "final", "get", "infix", "indirect", "lazy", "left",
+                    "mutating", "none", "nonmutating", "optional", "override", "postfix", "precedence", "prefix", "Protocol",
+                    "required", "right", "set", "Type", "unowned", "weak", "willSet",
+
+                    //
+                    // Swift Standard Library types
+                    // https://developer.apple.com/documentation/swift
+                    //
+                    // Numbers and Basic Values
+                    "Bool", "Int", "Double", "Float", "Range", "ClosedRange", "Error", "Optional",
+                    // Special-Use Numeric Types
+                    "UInt", "UInt8", "UInt16", "UInt32", "UInt64", "Int8", "Int16", "Int32", "Int64", "Float80", "Float32", "Float64",
+                    // Strings and Text
+                    "String", "Character", "Unicode", "StaticString",
+                    // Collections
+                    "Array", "Dictionary", "Set", "OptionSet", "CountableRange", "CountableClosedRange",
+
+                    // The following are commonly-used Foundation types
+                    "URL", "Data", "Codable", "Encodable", "Decodable",
+
+                    // The following are other words we want to reserve
+                    "Void", "AnyObject", "Class", "dynamicType", "COLUMN", "FILE", "FUNCTION", "LINE"
+                    )
         );
 
         typeMapping = new HashMap<>();


### PR DESCRIPTION
### PR checklist

- [x ] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [x ] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [x ] Filed the PR against the correct branch: `3.0.0` branch for changes related to OpenAPI spec 3.0. Default: `master`.
- [x ] Copied the [technical committee](https://github.com/swagger-api/swagger-codegen/#swagger-codegen-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

There was a previous issue (https://github.com/swagger-api/swagger-codegen/issues/6919) and subsequent PR (https://github.com/swagger-api/swagger-codegen/pull/6952) to add "throw" to the list of reserved words for Swift 4.

I decided it would be helpful to group the Swift4 reserved words into groups that we can check against future revisions of swift. For each group, I provided a reference link so that we can check in the future if new reserved words have been added. I verified that all of the current reserved words are included somewhere in the new groupings. The groups are:

* Reserved words specifically called out in the Swift 4 Language Reference (link provided in the source)
* Reserved words from the Swift Standard Library (link provided in the reference)
* Objective-C compatibility types
* Commonly-used Foundation types
* Others

