### PR TITLE
Swift4: Split up model template into partials

### DIFF
--- a/modules/swagger-codegen/src/main/resources/swift4/model.mustache
+++ b/modules/swagger-codegen/src/main/resources/swift4/model.mustache
@@ -11,102 +11,14 @@ import Foundation
 
 /** {{description}} */{{/description}}
 {{#isArrayModel}}
-public typealias {{classname}} = {{parent}}
+{{> modelArray}}
 {{/isArrayModel}}
 {{^isArrayModel}}
 {{#isEnum}}
-public enum {{classname}}: {{dataType}}, Codable {
-{{#allowableValues}}{{#enumVars}}    case {{name}} = "{{{value}}}"
-{{/enumVars}}{{/allowableValues}}
-}
+{{> modelEnum}}
 {{/isEnum}}
 {{^isEnum}}
-
-open class {{classname}}: {{#parent}}{{{parent}}}{{/parent}}{{^parent}}Codable{{/parent}} {
-
-{{#vars}}
-{{#isEnum}}
-    public enum {{enumName}}: {{^isContainer}}{{datatype}}{{/isContainer}}{{#isContainer}}String{{/isContainer}}, Codable { {{#allowableValues}}{{#enumVars}}
-        case {{name}} = {{#isContainer}}"{{/isContainer}}{{#isString}}"{{/isString}}{{{value}}}{{#isString}}"{{/isString}}{{#isContainer}}"{{/isContainer}}{{/enumVars}}{{/allowableValues}}
-    }
-{{/isEnum}}
-{{/vars}}
-{{#vars}}
-{{#isEnum}}
-    {{#description}}/** {{description}} */
-    {{/description}}public var {{name}}: {{{datatypeWithEnum}}}{{^required}}?{{/required}}{{#defaultValue}} = {{{defaultValue}}}{{/defaultValue}}
-{{/isEnum}}
-{{^isEnum}}
-    {{#description}}/** {{description}} */
-    {{/description}}public var {{name}}: {{{datatype}}}{{^required}}?{{/required}}{{#defaultValue}} = {{{defaultValue}}}{{/defaultValue}}{{#objcCompatible}}{{#vendorExtensions.x-swift-optional-scalar}}
-    public var {{name}}Num: NSNumber? {
-        get {
-            return {{name}}.map({ return NSNumber(value: $0) })
-        }
-    }{{/vendorExtensions.x-swift-optional-scalar}}{{/objcCompatible}}
-{{/isEnum}}
-{{/vars}}
-
-{{#additionalPropertiesType}}
-    public var additionalProperties: [String:{{{additionalPropertiesType}}}] = [:]
-
-    public subscript(key: String) -> {{{additionalPropertiesType}}}? {
-        get {
-            if let value = additionalProperties[key] {
-                return value
-            }
-            return nil
-        }
-
-        set {
-            additionalProperties[key] = newValue
-        }
-    }
-{{/additionalPropertiesType}}
-
-    {{^parent}}{{#hasVars}}
-    public init({{#vars}}{{name}}: {{{datatypeWithEnum}}}{{^required}}?{{/required}}{{#hasMore}}, {{/hasMore}}{{/vars}}) {
-        {{#vars}}
-        self.{{name}} = {{name}}
-        {{/vars}}
-    }
-    {{/hasVars}}{{/parent}}
-
-    // Encodable protocol methods
-
-    public {{#parent}}override {{/parent}}func encode(to encoder: Encoder) throws {
-
-        var container = encoder.container(keyedBy: String.self)
-
-        {{#vars}}
-        try container.encode{{^required}}IfPresent{{/required}}({{{name}}}, forKey: "{{{baseName}}}")
-        {{/vars}}
-        {{#additionalPropertiesType}}
-        try container.encodeMap(additionalProperties)
-        {{/additionalPropertiesType}}
-    }
-
-    // Decodable protocol methods
-
-    public required init(from decoder: Decoder) throws {
-        let container = try decoder.container(keyedBy: String.self)
-
-        {{#vars}}
-        {{name}} = try container.decode{{^required}}IfPresent{{/required}}({{{datatypeWithEnum}}}.self, forKey: "{{{baseName}}}")
-        {{/vars}}
-        {{#additionalPropertiesType}}
-        var nonAdditionalPropertyKeys = Set<String>()
-        {{#vars}}
-        nonAdditionalPropertyKeys.insert("{{{baseName}}}")
-        {{/vars}}
-        additionalProperties = try container.decodeMap({{{additionalPropertiesType}}}.self, excludedKeys: nonAdditionalPropertyKeys)
-        {{/additionalPropertiesType}}
-        {{#parent}}
-        try super.init(from: decoder)
-        {{/parent}}
-    }
-}
-
+{{> modelObject}}
 {{/isEnum}}
 {{/isArrayModel}}
 {{/model}}

--- a/modules/swagger-codegen/src/main/resources/swift4/modelArray.mustache
+++ b/modules/swagger-codegen/src/main/resources/swift4/modelArray.mustache
@@ -1,0 +1,1 @@
+public typealias {{classname}} = {{parent}}

--- a/modules/swagger-codegen/src/main/resources/swift4/modelEnum.mustache
+++ b/modules/swagger-codegen/src/main/resources/swift4/modelEnum.mustache
@@ -1,0 +1,4 @@
+public enum {{classname}}: {{dataType}}, Codable {
+{{#allowableValues}}{{#enumVars}}    case {{name}} = "{{{value}}}"
+{{/enumVars}}{{/allowableValues}}
+}

--- a/modules/swagger-codegen/src/main/resources/swift4/modelInlineEnumDeclaration.mustache
+++ b/modules/swagger-codegen/src/main/resources/swift4/modelInlineEnumDeclaration.mustache
@@ -1,0 +1,3 @@
+    public enum {{enumName}}: {{^isContainer}}{{datatype}}{{/isContainer}}{{#isContainer}}String{{/isContainer}}, Codable { {{#allowableValues}}{{#enumVars}}
+        case {{name}} = {{#isContainer}}"{{/isContainer}}{{#isString}}"{{/isString}}{{{value}}}{{#isString}}"{{/isString}}{{#isContainer}}"{{/isContainer}}{{/enumVars}}{{/allowableValues}}
+    }

--- a/modules/swagger-codegen/src/main/resources/swift4/modelObject.mustache
+++ b/modules/swagger-codegen/src/main/resources/swift4/modelObject.mustache
@@ -1,0 +1,83 @@
+
+open class {{classname}}: {{#parent}}{{{parent}}}{{/parent}}{{^parent}}Codable{{/parent}} {
+
+{{#vars}}
+{{#isEnum}}
+{{> modelInlineEnumDeclaration}}
+{{/isEnum}}
+{{/vars}}
+{{#vars}}
+{{#isEnum}}
+    {{#description}}/** {{description}} */
+    {{/description}}public var {{name}}: {{{datatypeWithEnum}}}{{^required}}?{{/required}}{{#defaultValue}} = {{{defaultValue}}}{{/defaultValue}}
+{{/isEnum}}
+{{^isEnum}}
+    {{#description}}/** {{description}} */
+    {{/description}}public var {{name}}: {{{datatype}}}{{^required}}?{{/required}}{{#defaultValue}} = {{{defaultValue}}}{{/defaultValue}}{{#objcCompatible}}{{#vendorExtensions.x-swift-optional-scalar}}
+    public var {{name}}Num: NSNumber? {
+        get {
+            return {{name}}.map({ return NSNumber(value: $0) })
+        }
+    }{{/vendorExtensions.x-swift-optional-scalar}}{{/objcCompatible}}
+{{/isEnum}}
+{{/vars}}
+
+{{#additionalPropertiesType}}
+    public var additionalProperties: [String:{{{additionalPropertiesType}}}] = [:]
+
+    public subscript(key: String) -> {{{additionalPropertiesType}}}? {
+        get {
+            if let value = additionalProperties[key] {
+                return value
+            }
+            return nil
+        }
+
+        set {
+            additionalProperties[key] = newValue
+        }
+    }
+{{/additionalPropertiesType}}
+
+    {{^parent}}{{#hasVars}}
+    public init({{#vars}}{{name}}: {{{datatypeWithEnum}}}{{^required}}?{{/required}}{{#hasMore}}, {{/hasMore}}{{/vars}}) {
+        {{#vars}}
+        self.{{name}} = {{name}}
+        {{/vars}}
+    }
+    {{/hasVars}}{{/parent}}
+
+    // Encodable protocol methods
+
+    public {{#parent}}override {{/parent}}func encode(to encoder: Encoder) throws {
+
+        var container = encoder.container(keyedBy: String.self)
+
+        {{#vars}}
+        try container.encode{{^required}}IfPresent{{/required}}({{{name}}}, forKey: "{{{baseName}}}")
+        {{/vars}}
+        {{#additionalPropertiesType}}
+        try container.encodeMap(additionalProperties)
+        {{/additionalPropertiesType}}
+    }
+
+    // Decodable protocol methods
+
+    public required init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: String.self)
+
+        {{#vars}}
+        {{name}} = try container.decode{{^required}}IfPresent{{/required}}({{{datatypeWithEnum}}}.self, forKey: "{{{baseName}}}")
+        {{/vars}}
+        {{#additionalPropertiesType}}
+        var nonAdditionalPropertyKeys = Set<String>()
+        {{#vars}}
+        nonAdditionalPropertyKeys.insert("{{{baseName}}}")
+        {{/vars}}
+        additionalProperties = try container.decodeMap({{{additionalPropertiesType}}}.self, excludedKeys: nonAdditionalPropertyKeys)
+        {{/additionalPropertiesType}}
+        {{#parent}}
+        try super.init(from: decoder)
+        {{/parent}}
+    }
+}


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [x] Filed the PR against the correct branch: `3.0.0` branch for changes related to OpenAPI spec 3.0. Default: `master`.
- [x] Copied the [technical committee](https://github.com/swagger-api/swagger-codegen/#swagger-codegen-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

The Swift4 model.mustache was getting unwieldy and difficult to read. This change simply splits model.mustache up into partials. I took care so that the changes did not result in any change to the generated code.

The model.mustache template hierarchy is now:

* model.mustache
  * modelArray.mustache - for models which are arrays
  * modelEnum.mustache - for models which are enums
  * modelObject.mustache - for models which are normal type=object models
    * modelInlineEnumDeclaration.mustache - declares Swift enums for properties which are inline enum definitions
 
