### PR TITLE
[Doc] add huawei cloud to companies list #7308

### DIFF
--- a/README.md
+++ b/README.md
@@ -789,6 +789,7 @@ Here are some companies/projects using Swagger Codegen in production. To add you
 - [Hewlett Packard Enterprise](https://hpe.com)
 - [High Technologies Center](http://htc-cs.com)
 - [Hootsuite](https://hootsuite.com/)
+- [Huawei Cloud](https://www.huaweicloud.com) - [Cloud Stream Serivce](http://www.huaweicloud.com/en-us/product/cs.html)
 - [IBM](https://www.ibm.com)
 - [IMS Health](http://www.imshealth.com/en/solution-areas/technology-and-applications)
 - [Individual Standard IVS](http://www.individual-standard.com)


### PR DESCRIPTION
We use swagger-codegen `akka-scala` to generate sdk, [here](https://github.com/huaweicloudsdk/huaweicloud-cs-sdk)

Add huawei cloud and CS service to the company lists.