### PR TITLE
Fix code to let Erlang server codegen work

### DIFF
--- a/modules/swagger-codegen/src/main/resources/erlang-server/api.mustache
+++ b/modules/swagger-codegen/src/main/resources/erlang-server/api.mustache
@@ -18,7 +18,7 @@
 request_params('{{operationId}}') ->
     [{{#allParams}}{{^isBodyParam}}
         '{{baseName}}'{{/isBodyParam}}{{#isBodyParam}}
-        '{{dataType}}'{{/isBodyParam}}{{#hasMore}},{{/hasMore}}{{/allParams}}
+        '{{dataType}}'{{/isBodyParam}}{{^@last}},{{/@last}}{{/allParams}}
     ];
 {{/operation}}{{/operations}}{{/apis}}{{/apiInfo}}
 request_params(_) ->
@@ -53,7 +53,7 @@ request_params(_) ->
 {{#operations}}{{#operation}}{{#allParams}}
 request_param_info('{{operationId}}', {{^isBodyParam}}'{{baseName}}'{{/isBodyParam}}{{#isBodyParam}}'{{dataType}}'{{/isBodyParam}}) ->
     #{
-        source => {{#isQueryParam}}qs_val{{/isQueryParam}} {{#isPathParam}}binding{{/isPathParam}} {{#isHeaderParam}}header{{/isHeaderParam}}{{#isBodyParam}}body{{/isBodyParam}},
+        source => {{#vendorExtensions.x-is-query-param}}qs_val{{/vendorExtensions.x-is-query-param}} {{#isPathParam}}binding{{/isPathParam}} {{#isHeaderParam}}header{{/isHeaderParam}}{{#isBodyParam}}body{{/isBodyParam}},
         rules => [{{#isString}}
             {type, 'binary'},{{/isString}}{{#isInteger}}
             {type, 'integer'},{{/isInteger}}{{#isLong}}
@@ -65,7 +65,7 @@ request_param_info('{{operationId}}', {{^isBodyParam}}'{{baseName}}'{{/isBodyPar
             {type, 'boolean'},{{/isBoolean}}{{#isDate}}
             {type, 'date'},{{/isDate}}{{#isDateTime}}
             {type, 'datetime'},{{/isDateTime}}{{#isEnum}}
-            {enum, [{{#allowableValues}}{{#values}}'{{.}}'{{^-last}}, {{/-last}}{{/values}}{{/allowableValues}}] },{{/isEnum}}{{#maximum}}
+            {enum, [{{#allowableValues}}{{#values}}'{{.}}'{{^@last}}, {{/@last}}{{/values}}{{/allowableValues}}] },{{/isEnum}}{{#maximum}}
             {max, {{maximum}} }, {{/maximum}}{{#exclusiveMaximum}}
             {exclusive_max, {{exclusiveMaximum}} },{{/exclusiveMaximum}}{{#minimum}}
             {min, {{minimum}} },{{/minimum}}{{#exclusiveMinimum}}

--- a/modules/swagger-codegen/src/main/resources/erlang-server/app.src.mustache
+++ b/modules/swagger-codegen/src/main/resources/erlang-server/app.src.mustache
@@ -1,5 +1,5 @@
 {application, {{packageName}}, [
-    {description, {{#appDescription}}"{{appDescription}}"{{/appDescription}}{{^appDescription}}"Swagger rest server library"{{/appDescription}}},
+    {description, {{#appDescription}}"{{appDescription}}"{{/appDescription}}{{^appDescription}}"Swagger rest server library"{{/appDescription}} },
     {vsn, "{{apiVersion}}"},
     {registered, []},
     {applications, [

--- a/modules/swagger-codegen/src/main/resources/erlang-server/handler.mustache
+++ b/modules/swagger-codegen/src/main/resources/erlang-server/handler.mustache
@@ -90,7 +90,7 @@ is_authorized(
     ),
     case Result of
         {true, Context, Req} ->  {true, Req, State#state{context = Context}};
-        {false, AuthHeader, Req} ->  {{false, AuthHeader}, Req, State}
+        {false, AuthHeader, Req} ->  { {false, AuthHeader}, Req, State}
     end;
   {{/isApiKey}}
 {{/authMethods}}
@@ -101,7 +101,7 @@ is_authorized(Req, State) ->
 {{/authMethods}}
 {{#authMethods}}
 is_authorized(Req, State) ->
-    {{false, <<"">>}, Req, State}.
+    { {false, <<"">>}, Req, State}.
 {{/authMethods}}
 
 -spec content_types_accepted(Req :: cowboy_req:req(), State :: state()) ->

--- a/modules/swagger-codegen/src/main/resources/erlang-server/router.mustache
+++ b/modules/swagger-codegen/src/main/resources/erlang-server/router.mustache
@@ -59,7 +59,7 @@ get_operations() ->
             path => "{{{basePathWithoutHost}}}{{{path}}}",
             method => <<"{{httpMethod}}">>,
             handler => '{{classname}}'
-        }{{#hasMore}},{{/hasMore}}{{/operation}}{{#hasMore}},{{/hasMore}}{{/operations}}{{/apis}}{{/apiInfo}}
+        }{{^@last}},{{/@last}}{{/operation}}{{^@last}},{{/@last}}{{/operations}}{{/apis}}{{/apiInfo}}
     }.
 
 prepare_validator() ->


### PR DESCRIPTION
Trying to gen erlang-server v3 I found it just not working due to numerous problems.

1. Some legitimate {{ and }} Erlang braces wrongly interpreted as mustaches in templates (it would be wise to select custom delimiter for Erlang templates from the beginning)

2. It seems that templates were initially made for jmustache extensions, but for some reason default template machine used is handlebars, so instead of -last one should use @last etc.

3. Somehow isQueryParam was not working, but I got it to work using vendorExtensions.x-is-query-param instead. Not sure if this is right solution though.

4. Intentionally or not, but hasMore was not properly populated, so I quick-fixed it using {{^@last}} in templates instead.

Finally I did manage to generate and compile some code from the v3 spec, but have not yet chance to review and test it thoroughly.

Please let me know if my fixes are not following design ideas or guidelines, or consider to apply otherwise. Thanks.