### PR TITLE
Changes to support modelAsSchema in response

### DIFF
--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/DefaultCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/DefaultCodegen.java
@@ -2142,9 +2142,11 @@ public class DefaultCodegen {
 
             if (methodResponse != null) {
                 if (methodResponse.getSchema() != null) {
-                    CodegenProperty cm = fromProperty("response", methodResponse.getSchema());
+                    Property responseProp = methodResponse.getSchema();
+                    responseProp.setRequired(true);
+                    CodegenProperty cm = fromProperty("response", responseProp);
 
-                    Property responseProperty = methodResponse.getSchema();
+                    Property responseProperty = responseProp;
 
                     if (responseProperty instanceof ArrayProperty) {
                         ArrayProperty ap = (ArrayProperty) responseProperty;
@@ -2320,7 +2322,7 @@ public class DefaultCodegen {
             r.code = responseCode;
         }
         r.message = escapeText(response.getDescription());
-        r.schema = response.getSchema();
+        r.schema = response.getResponseSchema();
         r.examples = toExamples(response.getExamples());
         r.jsonSchema = Json.pretty(response);
         r.vendorExtensions = response.getVendorExtensions();

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/DefaultCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/DefaultCodegen.java
@@ -2322,7 +2322,7 @@ public class DefaultCodegen {
             r.code = responseCode;
         }
         r.message = escapeText(response.getDescription());
-        r.schema = response.getResponseSchema();
+        r.schema = response.getSchema();
         r.examples = toExamples(response.getExamples());
         r.jsonSchema = Json.pretty(response);
         r.vendorExtensions = response.getVendorExtensions();

--- a/pom.xml
+++ b/pom.xml
@@ -930,10 +930,10 @@
         </repository>
     </repositories>
     <properties>
-        <swagger-parser-version>1.0.33</swagger-parser-version>
+        <swagger-parser-version>1.0.34-SNAPSHOT</swagger-parser-version>
         <scala-version>2.11.1</scala-version>
         <felix-version>3.3.0</felix-version>
-        <swagger-core-version>1.5.17</swagger-core-version>
+        <swagger-core-version>1.5.18-SNAPSHOT</swagger-core-version>
         <commons-io-version>2.4</commons-io-version>
         <commons-cli-version>1.2</commons-cli-version>
         <junit-version>4.8.1</junit-version>


### PR DESCRIPTION
This PR supports the changes made in:
The Response attribute schema, has been change from property to model, this is a big change and affects the projects below, including codegen. I write here the PR's of every project and the changes made, also the issues related.

Core: https://github.com/swagger-api/swagger-core/pull/2583
Parser: https://github.com/swagger-api/swagger-parser/pull/610
Issues: swagger-api/swagger-parser#567 - swagger-api/swagger-parser#488
Inflector: https://github.com/swagger-api/swagger-inflector/pull/231


