### PR TITLE
[Rust] Format example with rustfmt

### DIFF
--- a/samples/client/petstore/rust/examples/client.rs
+++ b/samples/client/petstore/rust/examples/client.rs
@@ -1,35 +1,39 @@
-extern crate petstore_client;
-extern crate hyper;
-extern crate tokio_core;
 extern crate futures;
+extern crate hyper;
+extern crate petstore_client;
+extern crate tokio_core;
 
 use hyper::Client;
 use hyper::client::HttpConnector;
 use tokio_core::reactor::Core;
-use futures::{Future};
+use futures::Future;
 
 fn main() {
     let mut core = Core::new().expect("failed to init core");
     let handle = core.handle();
 
-    let new_pet = petstore_client::models::Pet::new("barker".to_owned(), vec![]).with_id(1337);
-
     let apicli = petstore_client::apis::client::APIClient::new(
         petstore_client::apis::configuration::Configuration::new(
-            Client::configure().connector(HttpConnector::new(4, &handle)).build(&handle)));
+            Client::configure()
+                .connector(HttpConnector::new(4, &handle))
+                .build(&handle),
+        ),
+    );
 
-    let work = apicli.pet_api().add_pet(new_pet)
-    // petstore_client::apis::add_pet(api, &client, &new_pet)
-    .and_then(|_| {
-        apicli.pet_api().update_pet_with_form(1337, "barko", "escaped")
-    })
-    .and_then(|_| {
-        apicli.pet_api().get_pet_by_id(1337)
-    })
-    .and_then(|pet| {
-        println!("pet: {:?}", pet);
-        futures::future::ok(())
-    });
+    let new_pet = petstore_client::models::Pet::new("barker".to_owned(), vec![]).with_id(1337);
+    let work = apicli
+        .pet_api()
+        .add_pet(new_pet)
+        .and_then(|_| {
+            apicli
+                .pet_api()
+                .update_pet_with_form(1337, "barko", "escaped")
+        })
+        .and_then(|_| apicli.pet_api().get_pet_by_id(1337))
+        .and_then(|pet| {
+            println!("pet: {:?}", pet);
+            futures::future::ok(())
+        });
 
     core.run(work).expect("failed to run core");
 }


### PR DESCRIPTION
This was handled via 'cargo fmt' on the current nightly rust. I also
moved a few lines around and deleted an old comment.

### PR checklist

- [x] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [x] Filed the PR against the correct branch: `master`
- [x] Copied the [technical committee](https://github.com/swagger-api/swagger-codegen/#swagger-codegen-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

Since #7335 merged, this updates the example to match that style in the sample example.

I'll go through and update the style in more places once I don't have other PRs which would merge-conflict in flight.

cc @frol @farcaller @bjgill