### PR TITLE
[javascript] Fixing variable name typo (instane -> instance)

### DIFF
--- a/modules/swagger-codegen/src/main/resources/Javascript/model_test.mustache
+++ b/modules/swagger-codegen/src/main/resources/Javascript/model_test.mustache
@@ -44,7 +44,7 @@
   describe('{{classname}}', function() {
     it('should create an instance of {{classname}}', function() {
       // uncomment below and update the code to test {{classname}}
-      //var instane = new {{moduleName}}.{{classname}}();
+      //var instance = new {{moduleName}}.{{classname}}();
       //expect(instance).to.be.a({{moduleName}}.{{classname}});
     });
 
@@ -53,7 +53,7 @@
 {{#vars}}
     it('should have the property {{name}} (base name: "{{baseName}}")', function() {
       // uncomment below and update the code to test the property {{name}}
-      //var instane = new {{moduleName}}.{{classname}}();
+      //var instance = new {{moduleName}}.{{classname}}();
       //expect(instance).to.be();
     });
 


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [ ] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [x] Filed the PR against the correct branch: `3.0.0` branch for changes related to OpenAPI spec 3.0. Default: `master`.
- [x] Copied the [technical committee](https://github.com/swagger-api/swagger-codegen/#swagger-codegen-technical-committee) to review the pull request if your PR is targeting a particular programming language: @CodeNinjai @frol @cliffano

### Description of the PR

Fixes a variable name typo in two commented pieces of code.

