### PR TITLE
add vendorExtensions field in CodegenSecurity class (ref: #7236)

### DIFF
--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/CodegenSecurity.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/CodegenSecurity.java
@@ -7,6 +7,7 @@ public class CodegenSecurity {
     public String name;
     public String type;
     public Boolean hasMore, isBasic, isOAuth, isApiKey;
+    public Map<String, Object> vendorExtensions;
     // ApiKey specific
     public String keyParamName;
     public Boolean isKeyInQuery, isKeyInHeader;
@@ -38,6 +39,8 @@ public class CodegenSecurity {
         if (isOAuth != null ? !isOAuth.equals(that.isOAuth) : that.isOAuth != null)
             return false;
         if (isApiKey != null ? !isApiKey.equals(that.isApiKey) : that.isApiKey != null)
+            return false;
+        if (vendorExtensions != null ? !vendorExtensions.equals(that.vendorExtensions) : that.vendorExtensions != null)
             return false;
         if (keyParamName != null ? !keyParamName.equals(that.keyParamName) : that.keyParamName != null)
             return false;
@@ -71,6 +74,7 @@ public class CodegenSecurity {
         result = 31 * result + (isBasic != null ? isBasic.hashCode() : 0);
         result = 31 * result + (isOAuth != null ? isOAuth.hashCode() : 0);
         result = 31 * result + (isApiKey != null ? isApiKey.hashCode() : 0);
+        result = 31 * result + (vendorExtensions != null ? vendorExtensions.hashCode() : 0);
         result = 31 * result + (keyParamName != null ? keyParamName.hashCode() : 0);
         result = 31 * result + (isKeyInQuery != null ? isKeyInQuery.hashCode() : 0);
         result = 31 * result + (isKeyInHeader != null ? isKeyInHeader.hashCode() : 0);

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/DefaultCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/DefaultCodegen.java
@@ -2756,6 +2756,7 @@ public class DefaultCodegen {
             sec.name = entry.getKey();
             sec.type = schemeDefinition.getType();
             sec.isCode = sec.isPassword = sec.isApplication = sec.isImplicit = false;
+            sec.vendorExtensions = schemeDefinition.getVendorExtensions();
 
             if (schemeDefinition instanceof ApiKeyAuthDefinition) {
                 final ApiKeyAuthDefinition apiKeyDefinition = (ApiKeyAuthDefinition) schemeDefinition;


### PR DESCRIPTION
### PR checklist

- [ ] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [ ] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [ ] Filed the PR against the correct branch: `3.0.0` branch for changes related to OpenAPI spec 3.0. Default: `master`.
- [ ] Copied the [technical committee](https://github.com/swagger-api/swagger-codegen/#swagger-codegen-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

(details of the change, additional tests that have been done, reference to the issue for tracking, etc)

ref: https://github.com/swagger-api/swagger-codegen/issues/7236
add vendorExtensions field in CodegenSecurity class