### PR TITLE
[scalatra]Rebuild Scalatra sample

### DIFF
--- a/samples/client/petstore/scala/src/main/scala/io/swagger/client/api/PetApi.scala
+++ b/samples/client/petstore/scala/src/main/scala/io/swagger/client/api/PetApi.scala
@@ -350,7 +350,6 @@ class PetApiAsyncHelper(client: TransportClient, config: SwaggerConfig) extends 
     val headerParams = new mutable.HashMap[String, String]
 
     if (status == null) throw new Exception("Missing required parameter 'status' when calling PetApi->findPetsByStatus")
-
     queryParams += "status" -> status.toString
 
     val resFuture = client.submit("GET", path, queryParams.toMap, headerParams.toMap, "")
@@ -368,7 +367,6 @@ class PetApiAsyncHelper(client: TransportClient, config: SwaggerConfig) extends 
     val headerParams = new mutable.HashMap[String, String]
 
     if (tags == null) throw new Exception("Missing required parameter 'tags' when calling PetApi->findPetsByTags")
-
     queryParams += "tags" -> tags.toString
 
     val resFuture = client.submit("GET", path, queryParams.toMap, headerParams.toMap, "")

--- a/samples/server/petstore/scalatra/src/main/resources/logback.xml
+++ b/samples/server/petstore/scalatra/src/main/resources/logback.xml
@@ -7,7 +7,23 @@
     </encoder>
   </appender>
 
-  <root level="warn">
+  <appender name="FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
+    <file>logFile.log</file>
+    <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
+      <!-- daily rollover -->
+      <fileNamePattern>logFile.%d{yyyy-MM-dd}.log</fileNamePattern>
+
+      <!-- keep 30 days' worth of history -->
+      <maxHistory>30</maxHistory>
+    </rollingPolicy>
+
+    <encoder>
+      <pattern>%-4relative [%thread] %-5level %logger{35} - %msg%n</pattern>
+    </encoder>
+  </appender>
+
+  <root level="info">
+    <appender-ref ref="FILE" />
     <appender-ref ref="STDOUT" />
   </root>
 </configuration>

--- a/samples/server/petstore/scalatra/src/main/scala/io/swagger/server/model/ApiResponse.scala
+++ b/samples/server/petstore/scalatra/src/main/scala/io/swagger/server/model/ApiResponse.scala
@@ -14,6 +14,6 @@ package io.swagger.server.model
 
 case class ApiResponse(
   code: Option[Int],
-    _type: Option[String],
+    `type`: Option[String],
     message: Option[String]
   )


### PR DESCRIPTION
When creating the following PR, sample was generated without reflecting the last change.

https://github.com/swagger-api/swagger-codegen/pull/7393

With this commit, it will be synchronized

### PR checklist

- [x] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [x] Filed the PR against the correct branch: `3.0.0` branch for changes related to OpenAPI spec 3.0. Default: `master`.
- [x] Copied the [technical committee](https://github.com/swagger-api/swagger-codegen/#swagger-codegen-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR


please review

@clasnake  @jimschubert   @shijinkui 
--


