### PR TITLE
[qt5cpp] Add nullptr guard to prevent crash when empty model is being serialized

### DIFF
--- a/modules/swagger-codegen/src/main/resources/qt5cpp/helpers-header.mustache
+++ b/modules/swagger-codegen/src/main/resources/qt5cpp/helpers-header.mustache
@@ -3,6 +3,8 @@
 #define {{prefix}}_HELPERS_H
 
 #include <QJsonValue>
+#include <QList>
+#include <QMap>
 
 {{#cppNamespaceDeclarations}}
 namespace {{this}} {

--- a/modules/swagger-codegen/src/main/resources/qt5cpp/model-body.mustache
+++ b/modules/swagger-codegen/src/main/resources/qt5cpp/model-body.mustache
@@ -105,7 +105,7 @@ QJsonObject*
     QJsonObject* obj = new QJsonObject();
     {{#vars}}
     {{^isContainer}}{{#complexType}}{{^isString}}{{^isDate}}{{^isDateTime}}{{^isByteArray}} 
-    if({{name}}->isSet()){
+    if(({{name}} != nullptr) && ({{name}}->isSet())){
         toJsonValue(QString("{{baseName}}"), {{name}}, obj, QString("{{complexType}}"));
     }{{/isByteArray}}{{/isDateTime}}{{/isDate}}{{/isString}}{{#isString}}
     if({{name}} != nullptr && *{{name}} != QString("")){

--- a/samples/client/petstore/qt5cpp/client/SWGHelpers.h
+++ b/samples/client/petstore/qt5cpp/client/SWGHelpers.h
@@ -14,6 +14,8 @@
 #define SWG_HELPERS_H
 
 #include <QJsonValue>
+#include <QList>
+#include <QMap>
 
 namespace Swagger {
 

--- a/samples/client/petstore/qt5cpp/client/SWGPet.cpp
+++ b/samples/client/petstore/qt5cpp/client/SWGPet.cpp
@@ -122,7 +122,7 @@ SWGPet::asJsonObject() {
         obj->insert("id", QJsonValue(id));
     }
      
-    if(category->isSet()){
+    if((category != nullptr) && (category->isSet())){
         toJsonValue(QString("category"), category, obj, QString("SWGCategory"));
     }
     


### PR DESCRIPTION
### PR checklist

- [X] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [X] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [X] Filed the PR against the correct branch: `3.0.0` branch for changes related to OpenAPI spec 3.0. Default: `master`.
- [X] Copied the [technical committee](https://github.com/swagger-api/swagger-codegen/#swagger-codegen-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

(details of the change, additional tests that have been done, reference to the issue for tracking, etc)

- Small Changes to check object against nullptr to prevent crash whe empty json body is provided
- Add QMap and QList to Helper includes.

cc @stkrwork @ravinikam @fvarose 