### PR TITLE
Fix that prevents generating interfaces when interfaceOnly is false.

### DIFF
--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/JavaJAXRSSpecServerCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/JavaJAXRSSpecServerCodegen.java
@@ -85,6 +85,9 @@ public class JavaJAXRSSpecServerCodegen extends AbstractJavaJAXRSServerCodegen
         }
         if (additionalProperties.containsKey(INTERFACE_ONLY)) {
             interfaceOnly = Boolean.valueOf(additionalProperties.get(INTERFACE_ONLY).toString());
+            if (!interfaceOnly) {
+                additionalProperties.remove(INTERFACE_ONLY);
+            }
         }
         if (interfaceOnly) {
             // Change default artifactId if genereating interfaces only, before command line options are applied in base class.

--- a/modules/swagger-codegen/src/test/java/io/swagger/codegen/languages/JavaJAXRSSpecServerCodegenTest.java
+++ b/modules/swagger-codegen/src/test/java/io/swagger/codegen/languages/JavaJAXRSSpecServerCodegenTest.java
@@ -74,4 +74,18 @@ public class JavaJAXRSSpecServerCodegenTest {
         }
         Assert.fail("Missing " + JavaJAXRSSpecServerCodegen.INTERFACE_ONLY);
     }
+
+    @Test
+    public void verify_that_interfaceOnly_is_removed_from_additional_properties_if_false() {
+        generator.additionalProperties().put(JavaJAXRSSpecServerCodegen.INTERFACE_ONLY, Boolean.FALSE.toString());
+        generator.processOpts();
+        Assert.assertFalse(generator.additionalProperties().containsKey(JavaJAXRSSpecServerCodegen.INTERFACE_ONLY));
+    }
+
+    @Test
+    public void verify_that_interfaceOnly_is_preserved_in_additional_properties_if_true() {
+        generator.additionalProperties().put(JavaJAXRSSpecServerCodegen.INTERFACE_ONLY, Boolean.TRUE.toString());
+        generator.processOpts();
+        Assert.assertTrue(generator.additionalProperties().containsKey(JavaJAXRSSpecServerCodegen.INTERFACE_ONLY));
+    }
 }


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [x] Filed the PR against the correct branch: `3.0.0` branch for changes related to OpenAPI spec 3.0. Default: `master`.
- [ ] Copied the [technical committee](https://github.com/swagger-api/swagger-codegen/#swagger-codegen-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

Fixing jaxrs-spec to handle interfaceOnly=false as intended. Added to unit tests exposing the behaviour.

To fix #7438