### PR TITLE
Add object definition returned in nested array/map to the imports

### DIFF
--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/CodegenProperty.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/CodegenProperty.java
@@ -62,6 +62,7 @@ public class CodegenProperty implements Cloneable {
     public String xmlName;
     public String xmlNamespace;
     public boolean isXmlWrapped = false;
+    public String containedType;
 
 
     @Override

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/CodegenResponse.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/CodegenResponse.java
@@ -22,6 +22,7 @@ public class CodegenResponse {
     public Object schema;
     public String jsonSchema;
     public Map<String, Object> vendorExtensions;
+    public String containedType;
 
     public boolean isWildcard() {
         return "0".equals(code) || "default".equals(code);

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/DefaultCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/DefaultCodegen.java
@@ -1833,8 +1833,14 @@ public class DefaultCodegen {
         property.dataFormat = innerProperty.dataFormat;
         if (!languageSpecificPrimitives.contains(innerProperty.baseType)) {
             property.complexType = innerProperty.baseType;
+            if (!innerProperty.isContainer) {
+        			property.containedType = innerProperty.baseType;
+            }
         } else {
             property.isPrimitiveType = true;
+        }
+        if (innerProperty.containedType != null && !languageSpecificPrimitives.contains(innerProperty.containedType)) {
+        		property.containedType = innerProperty.containedType;
         }
         property.items = innerProperty;
         // inner item is Enum
@@ -1863,8 +1869,14 @@ public class DefaultCodegen {
         }
         if (!languageSpecificPrimitives.contains(innerProperty.baseType)) {
             property.complexType = innerProperty.baseType;
+            if (!innerProperty.isContainer) {
+            		property.containedType = innerProperty.baseType;
+            }
         } else {
             property.isPrimitiveType = true;
+        }
+        if (innerProperty.containedType != null && !languageSpecificPrimitives.contains(innerProperty.containedType)) {
+    			property.containedType = innerProperty.containedType;
         }
         property.items = innerProperty;
         property.dataFormat = innerProperty.dataFormat;
@@ -2131,6 +2143,10 @@ public class DefaultCodegen {
                         !languageSpecificPrimitives.contains(r.baseType)) {
                     imports.add(r.baseType);
                 }
+                if (r.containerType != null && !defaultIncludes.contains(r.containerType) &&
+                        !languageSpecificPrimitives.contains(r.containerType)) {
+                		imports.add(r.containedType);
+                }
                 r.isDefault = response == methodResponse;
                 op.responses.add(r);
                 if (Boolean.TRUE.equals(r.isBinary) && Boolean.TRUE.equals(r.isDefault)){
@@ -2333,7 +2349,7 @@ public class DefaultCodegen {
             Property responseProperty = response.getSchema();
             responseProperty.setRequired(true);
             CodegenProperty cm = fromProperty("response", responseProperty);
-
+            r.containedType = cm.containedType;
             if (responseProperty instanceof ArrayProperty) {
                 ArrayProperty ap = (ArrayProperty) responseProperty;
                 CodegenProperty innerProperty = fromProperty("response", ap.getItems());


### PR DESCRIPTION
### Description of the PR
Code generation on operation that return object in "nested" array/map does not add the required definition to the import list.
This patch address the issue saving the contained object type during the recursion.
This should solve issue #7444 

