### PR TITLE
[Java][library: vertx] Expose getter/setter for serverPort to facilitate testing. Fixes #7478

### DIFF
--- a/modules/swagger-codegen/src/main/resources/JavaVertXServer/MainApiVerticle.mustache
+++ b/modules/swagger-codegen/src/main/resources/JavaVertXServer/MainApiVerticle.mustache
@@ -19,9 +19,18 @@ import io.vertx.core.Vertx;
 import io.vertx.ext.web.Router;
 
 public class MainApiVerticle extends AbstractVerticle {
-    final static Logger LOGGER = LoggerFactory.getLogger(MainApiVerticle.class); 
-    
+    final static Logger LOGGER = LoggerFactory.getLogger(MainApiVerticle.class);
+
+    private int serverPort = {{serverPort}};
     protected Router router;
+
+    public int getServerPort() {
+        return serverPort;
+    }
+
+    public void setServerPort(int serverPort) {
+        this.serverPort = serverPort;
+    }
 
     @Override
     public void init(Vertx vertx, Context context) {
@@ -37,13 +46,18 @@ public class MainApiVerticle extends AbstractVerticle {
             if (readFile.succeeded()) {
                 Swagger swagger = new SwaggerParser().parse(readFile.result().toString(Charset.forName("utf-8")));
                 Router swaggerRouter = SwaggerRouter.swaggerRouter(router, swagger, vertx.eventBus(), new OperationIdServiceIdResolver());
-            
+
                 deployVerticles(startFuture);
-                
-                vertx.createHttpServer() 
+
+                vertx.createHttpServer()
                     .requestHandler(swaggerRouter::accept) 
-                    .listen({{serverPort}});
-                startFuture.complete();
+                    .listen(serverPort, h -> {
+                        if (h.succeeded()) {
+                            startFuture.complete();
+                        } else {
+                            startFuture.fail(h.cause());
+                        }
+                    });
             } else {
             	startFuture.fail(readFile.cause());
             }


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [x] Filed the PR against the correct branch: `3.0.0` branch for changes related to OpenAPI spec 3.0. Default: `master`.
- [x] Copied the [technical committee](https://github.com/swagger-api/swagger-codegen/#swagger-codegen-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

Fix for #7478 

Added getter/setter for serverPort to allow override of port for testing. Default behavior maintains port assignment from `host` value defined in spec.

@wing328 @bbdouglas (2017/07) @JFCote (2017/08) @sreeshas (2017/08) @jfiala (2017/08) @lukoyanov (2017/09) @cbornet (2017/09)