### PR TITLE
fix: declare property headerSelector

### DIFF
--- a/modules/swagger-codegen/src/main/resources/php/api.mustache
+++ b/modules/swagger-codegen/src/main/resources/php/api.mustache
@@ -50,6 +50,11 @@ use {{invokerPackage}}\ObjectSerializer;
     protected $config;
 
     /**
+     * @var HeaderSelector
+     */
+    protected $headerSelector;
+
+    /**
      * @param ClientInterface $client
      * @param Configuration   $config
      * @param HeaderSelector  $selector

--- a/samples/client/petstore-security-test/php/SwaggerClient-php/lib/Api/FakeApi.php
+++ b/samples/client/petstore-security-test/php/SwaggerClient-php/lib/Api/FakeApi.php
@@ -60,6 +60,11 @@ class FakeApi
     protected $config;
 
     /**
+     * @var HeaderSelector
+     */
+    protected $headerSelector;
+
+    /**
      * @param ClientInterface $client
      * @param Configuration   $config
      * @param HeaderSelector  $selector

--- a/samples/client/petstore/php/SwaggerClient-php/docs/Api/FakeApi.md
+++ b/samples/client/petstore/php/SwaggerClient-php/docs/Api/FakeApi.md
@@ -379,11 +379,11 @@ try {
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
- **enum_form_string_array** | **string[]**| Form parameter enum test (string array) | [optional]
+ **enum_form_string_array** | [**string[]**](../Model/string.md)| Form parameter enum test (string array) | [optional]
  **enum_form_string** | **string**| Form parameter enum test (string) | [optional] [default to -efg]
- **enum_header_string_array** | **string[]**| Header parameter enum test (string array) | [optional]
+ **enum_header_string_array** | [**string[]**](../Model/string.md)| Header parameter enum test (string array) | [optional]
  **enum_header_string** | **string**| Header parameter enum test (string) | [optional] [default to -efg]
- **enum_query_string_array** | **string[]**| Query parameter enum test (string array) | [optional]
+ **enum_query_string_array** | [**string[]**](../Model/string.md)| Query parameter enum test (string array) | [optional]
  **enum_query_string** | **string**| Query parameter enum test (string) | [optional] [default to -efg]
  **enum_query_integer** | **int**| Query parameter enum test (double) | [optional]
  **enum_query_double** | **double**| Query parameter enum test (double) | [optional]

--- a/samples/client/petstore/php/SwaggerClient-php/docs/Api/PetApi.md
+++ b/samples/client/petstore/php/SwaggerClient-php/docs/Api/PetApi.md
@@ -156,7 +156,7 @@ try {
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
- **status** | **string[]**| Status values that need to be considered for filter |
+ **status** | [**string[]**](../Model/string.md)| Status values that need to be considered for filter |
 
 ### Return type
 
@@ -209,7 +209,7 @@ try {
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
- **tags** | **string[]**| Tags to filter by |
+ **tags** | [**string[]**](../Model/string.md)| Tags to filter by |
 
 ### Return type
 

--- a/samples/client/petstore/php/SwaggerClient-php/lib/Api/AnotherFakeApi.php
+++ b/samples/client/petstore/php/SwaggerClient-php/lib/Api/AnotherFakeApi.php
@@ -60,6 +60,11 @@ class AnotherFakeApi
     protected $config;
 
     /**
+     * @var HeaderSelector
+     */
+    protected $headerSelector;
+
+    /**
      * @param ClientInterface $client
      * @param Configuration   $config
      * @param HeaderSelector  $selector

--- a/samples/client/petstore/php/SwaggerClient-php/lib/Api/FakeApi.php
+++ b/samples/client/petstore/php/SwaggerClient-php/lib/Api/FakeApi.php
@@ -60,6 +60,11 @@ class FakeApi
     protected $config;
 
     /**
+     * @var HeaderSelector
+     */
+    protected $headerSelector;
+
+    /**
      * @param ClientInterface $client
      * @param Configuration   $config
      * @param HeaderSelector  $selector

--- a/samples/client/petstore/php/SwaggerClient-php/lib/Api/FakeClassnameTags123Api.php
+++ b/samples/client/petstore/php/SwaggerClient-php/lib/Api/FakeClassnameTags123Api.php
@@ -60,6 +60,11 @@ class FakeClassnameTags123Api
     protected $config;
 
     /**
+     * @var HeaderSelector
+     */
+    protected $headerSelector;
+
+    /**
      * @param ClientInterface $client
      * @param Configuration   $config
      * @param HeaderSelector  $selector

--- a/samples/client/petstore/php/SwaggerClient-php/lib/Api/PetApi.php
+++ b/samples/client/petstore/php/SwaggerClient-php/lib/Api/PetApi.php
@@ -60,6 +60,11 @@ class PetApi
     protected $config;
 
     /**
+     * @var HeaderSelector
+     */
+    protected $headerSelector;
+
+    /**
      * @param ClientInterface $client
      * @param Configuration   $config
      * @param HeaderSelector  $selector

--- a/samples/client/petstore/php/SwaggerClient-php/lib/Api/StoreApi.php
+++ b/samples/client/petstore/php/SwaggerClient-php/lib/Api/StoreApi.php
@@ -60,6 +60,11 @@ class StoreApi
     protected $config;
 
     /**
+     * @var HeaderSelector
+     */
+    protected $headerSelector;
+
+    /**
      * @param ClientInterface $client
      * @param Configuration   $config
      * @param HeaderSelector  $selector

--- a/samples/client/petstore/php/SwaggerClient-php/lib/Api/UserApi.php
+++ b/samples/client/petstore/php/SwaggerClient-php/lib/Api/UserApi.php
@@ -60,6 +60,11 @@ class UserApi
     protected $config;
 
     /**
+     * @var HeaderSelector
+     */
+    protected $headerSelector;
+
+    /**
      * @param ClientInterface $client
      * @param Configuration   $config
      * @param HeaderSelector  $selector


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [x] Filed the PR against the correct branch: `3.0.0` branch for changes related to OpenAPI spec 3.0. Default: `master`.
- [x] Copied the [technical committee](https://github.com/swagger-api/swagger-codegen/#swagger-codegen-technical-committee) to review the pull request if your PR is targeting a particular programming language.@jebentier (2017/07) @dkarlovi (2017/07) @mandrean (2017/08) @jfastnacht (2017/09) @ackintosh (2017/09)

### Description of the PR

The property `headerSelector` was created dynamically, it's a more clean approach to declare it as a member of the class.


