### PR TITLE
Upgraded swagger-parser and swagger-core versions

### DIFF
--- a/modules/swagger-codegen/src/main/resources/Java/libraries/feign/pom.mustache
+++ b/modules/swagger-codegen/src/main/resources/Java/libraries/feign/pom.mustache
@@ -294,7 +294,7 @@
         <java.version>{{#java8}}1.8{{/java8}}{{^java8}}1.7{{/java8}}</java.version>
         <maven.compiler.source>${java.version}</maven.compiler.source>
         <maven.compiler.target>${java.version}</maven.compiler.target>
-        <swagger-core-version>1.5.15</swagger-core-version>
+        <swagger-core-version>1.5.18</swagger-core-version>
         <feign-version>9.4.0</feign-version>
         <feign-form-version>2.1.0</feign-form-version>
         <jackson-version>2.8.9</jackson-version>

--- a/modules/swagger-codegen/src/main/resources/Java/libraries/jersey2/pom.mustache
+++ b/modules/swagger-codegen/src/main/resources/Java/libraries/jersey2/pom.mustache
@@ -314,7 +314,7 @@
     </dependencies>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <swagger-core-version>1.5.15</swagger-core-version>
+        <swagger-core-version>1.5.18</swagger-core-version>
         {{^supportJava6}}
             <jersey-version>2.25.1</jersey-version>
         {{/supportJava6}}

--- a/modules/swagger-codegen/src/main/resources/Java/libraries/okhttp-gson/pom.mustache
+++ b/modules/swagger-codegen/src/main/resources/Java/libraries/okhttp-gson/pom.mustache
@@ -271,7 +271,7 @@
         <maven.compiler.source>${java.version}</maven.compiler.source>
         <maven.compiler.target>${java.version}</maven.compiler.target>
         <gson-fire-version>1.8.0</gson-fire-version>
-        <swagger-core-version>1.5.15</swagger-core-version>
+        <swagger-core-version>1.5.18</swagger-core-version>
         <okhttp-version>2.7.5</okhttp-version>
         <gson-version>2.8.1</gson-version>
         {{#joda}}

--- a/modules/swagger-codegen/src/main/resources/Java/libraries/resteasy/pom.mustache
+++ b/modules/swagger-codegen/src/main/resources/Java/libraries/resteasy/pom.mustache
@@ -247,7 +247,7 @@
     </dependencies>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <swagger-core-version>1.5.15</swagger-core-version>
+        <swagger-core-version>1.5.18</swagger-core-version>
         <resteasy-version>3.1.3.Final</resteasy-version>
         <jackson-version>2.6.4</jackson-version>
         {{^java8}}

--- a/modules/swagger-codegen/src/main/resources/Java/libraries/retrofit/pom.mustache
+++ b/modules/swagger-codegen/src/main/resources/Java/libraries/retrofit/pom.mustache
@@ -243,7 +243,7 @@
     </dependencies>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <swagger-core-version>1.5.15</swagger-core-version>
+        <swagger-core-version>1.5.18</swagger-core-version>
         <retrofit-version>1.9.0</retrofit-version>
         <okhttp-version>2.7.5</okhttp-version>
         <jodatime-version>2.9.9</jodatime-version>

--- a/modules/swagger-codegen/src/main/resources/Java/libraries/retrofit2/pom.mustache
+++ b/modules/swagger-codegen/src/main/resources/Java/libraries/retrofit2/pom.mustache
@@ -331,7 +331,7 @@
         <maven.compiler.source>${java.version}</maven.compiler.source>
         <maven.compiler.target>${java.version}</maven.compiler.target>
         <gson-fire-version>1.8.0</gson-fire-version>
-        <swagger-core-version>1.5.15</swagger-core-version>
+        <swagger-core-version>1.5.18</swagger-core-version>
         {{#usePlayWS}}
             {{#play24}}
                 <jackson-version>2.6.6</jackson-version>

--- a/modules/swagger-codegen/src/main/resources/Java/libraries/vertx/pom.mustache
+++ b/modules/swagger-codegen/src/main/resources/Java/libraries/vertx/pom.mustache
@@ -272,7 +272,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <vertx-version>3.4.2</vertx-version>
-        <swagger-core-version>1.5.16</swagger-core-version>
+        <swagger-core-version>1.5.18</swagger-core-version>
         <jackson-version>{{^threetenbp}}2.8.9{{/threetenbp}}{{#threetenbp}}2.6.4{{/threetenbp}}</jackson-version>
         <junit-version>4.12</junit-version>
     </properties>

--- a/modules/swagger-codegen/src/main/resources/JavaJaxRS/cxf/pom.mustache
+++ b/modules/swagger-codegen/src/main/resources/JavaJaxRS/cxf/pom.mustache
@@ -181,7 +181,7 @@
     <java.version>{{#java8}}1.8{{/java8}}{{^java8}}1.7{{/java8}}</java.version>
     <maven.compiler.source>${java.version}</maven.compiler.source>
     <maven.compiler.target>${java.version}</maven.compiler.target>
-    <swagger-core-version>1.5.17</swagger-core-version>
+    <swagger-core-version>1.5.18</swagger-core-version>
     <jetty-version>9.2.9.v20150224</jetty-version>
     <junit-version>4.12</junit-version>
     <logback-version>1.1.7</logback-version>

--- a/modules/swagger-codegen/src/main/resources/JavaJaxRS/cxf/server/pom.mustache
+++ b/modules/swagger-codegen/src/main/resources/JavaJaxRS/cxf/server/pom.mustache
@@ -232,7 +232,7 @@
     <java.version>{{#java8}}1.8{{/java8}}{{^java8}}1.7{{/java8}}</java.version>
     <maven.compiler.source>${java.version}</maven.compiler.source>
     <maven.compiler.target>${java.version}</maven.compiler.target>
-    <swagger-core-version>1.5.17</swagger-core-version>
+    <swagger-core-version>1.5.18</swagger-core-version>
     <jetty-version>9.2.9.v20150224</jetty-version>
     <junit-version>4.12</junit-version>
     <logback-version>1.1.7</logback-version>

--- a/modules/swagger-codegen/src/main/resources/JavaJaxRS/libraries/jersey1/pom.mustache
+++ b/modules/swagger-codegen/src/main/resources/JavaJaxRS/libraries/jersey1/pom.mustache
@@ -191,7 +191,7 @@
     <java.version>{{#java8}}1.8{{/java8}}{{^java8}}1.7{{/java8}}</java.version>
     <maven.compiler.source>${java.version}</maven.compiler.source>
     <maven.compiler.target>${java.version}</maven.compiler.target>
-    <swagger-core-version>1.5.15</swagger-core-version>
+    <swagger-core-version>1.5.18</swagger-core-version>
     <jetty-version>9.2.9.v20150224</jetty-version>
     <jersey-version>1.19.1</jersey-version>
     <jackson-version>2.8.9</jackson-version>

--- a/modules/swagger-codegen/src/main/resources/JavaJaxRS/pom.mustache
+++ b/modules/swagger-codegen/src/main/resources/JavaJaxRS/pom.mustache
@@ -188,7 +188,7 @@
     <java.version>{{#java8}}1.8{{/java8}}{{^java8}}1.7{{/java8}}</java.version>
     <maven.compiler.source>${java.version}</maven.compiler.source>
     <maven.compiler.target>${java.version}</maven.compiler.target>
-    <swagger-core-version>1.5.15</swagger-core-version>
+    <swagger-core-version>1.5.18</swagger-core-version>
     <jetty-version>9.2.9.v20150224</jetty-version>
     <jersey2-version>2.22.2</jersey2-version>
     <jackson-version>2.8.9</jackson-version>

--- a/modules/swagger-codegen/src/main/resources/JavaJaxRS/resteasy/eap/pom.mustache
+++ b/modules/swagger-codegen/src/main/resources/JavaJaxRS/resteasy/eap/pom.mustache
@@ -178,7 +178,7 @@
         </repository>
     </repositories>
     <properties>
-        <swagger-core-version>1.5.15</swagger-core-version>
+        <swagger-core-version>1.5.18</swagger-core-version>
         <jetty-version>9.2.9.v20150224</jetty-version>
         <resteasy-version>3.0.11.Final</resteasy-version>
         <slf4j-version>1.6.3</slf4j-version>

--- a/modules/swagger-codegen/src/main/resources/JavaJaxRS/resteasy/pom.mustache
+++ b/modules/swagger-codegen/src/main/resources/JavaJaxRS/resteasy/pom.mustache
@@ -182,7 +182,7 @@
         </repository>
     </repositories>
     <properties>
-        <swagger-core-version>1.5.15</swagger-core-version>
+        <swagger-core-version>1.5.18</swagger-core-version>
         <jetty-version>9.2.9.v20150224</jetty-version>
         <resteasy-version>3.0.11.Final</resteasy-version>
         <slf4j-version>1.6.3</slf4j-version>

--- a/modules/swagger-codegen/src/main/resources/JavaSpring/libraries/spring-cloud/pom.mustache
+++ b/modules/swagger-codegen/src/main/resources/JavaSpring/libraries/spring-cloud/pom.mustache
@@ -9,7 +9,7 @@
         <java.version>{{#java8}}1.8{{/java8}}{{^java8}}1.7{{/java8}}</java.version>
         <maven.compiler.source>${java.version}</maven.compiler.source>
         <maven.compiler.target>${java.version}</maven.compiler.target>
-        <swagger-core-version>1.5.15</swagger-core-version>
+        <swagger-core-version>1.5.18</swagger-core-version>
     </properties>
     <parent>
         <groupId>org.springframework.boot</groupId>

--- a/modules/swagger-codegen/src/main/resources/MSF4J/pom.mustache
+++ b/modules/swagger-codegen/src/main/resources/MSF4J/pom.mustache
@@ -75,7 +75,7 @@
     <java.version>{{#java8}}1.8{{/java8}}{{^java8}}1.7{{/java8}}</java.version>
     <maven.compiler.source>${java.version}</maven.compiler.source>
     <maven.compiler.target>${java.version}</maven.compiler.target>
-    <swagger-core-version>1.5.15</swagger-core-version>
+    <swagger-core-version>1.5.18</swagger-core-version>
     <jetty-version>9.2.9.v20150224</jetty-version>
     <jersey2-version>2.22.2</jersey2-version>
     <junit-version>4.12</junit-version>

--- a/modules/swagger-codegen/src/main/resources/android/pom.mustache
+++ b/modules/swagger-codegen/src/main/resources/android/pom.mustache
@@ -165,7 +165,7 @@
     </repositories>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <swagger-core-version>1.5.15</swagger-core-version>
+        <swagger-core-version>1.5.18</swagger-core-version>
         <gson-version>2.3.1</gson-version>
         <junit-version>4.8.1</junit-version>
         <maven-plugin-version>1.0.0</maven-plugin-version>

--- a/modules/swagger-codegen/src/main/resources/scala/pom.mustache
+++ b/modules/swagger-codegen/src/main/resources/scala/pom.mustache
@@ -240,7 +240,7 @@
         <joda-version>1.9.2</joda-version>
         <joda-time-version>2.9.9</joda-time-version>
         <jersey-version>1.19.4</jersey-version>
-        <swagger-core-version>1.5.16</swagger-core-version>
+        <swagger-core-version>1.5.18</swagger-core-version>
         <jersey-async-version>1.0.5</jersey-async-version>
         <maven-plugin.version>1.0.0</maven-plugin.version>
         <jackson-version>2.9.2</jackson-version>

--- a/modules/swagger-codegen/src/test/resources/2_0/templates/Java/libraries/jersey2/pom.mustache
+++ b/modules/swagger-codegen/src/test/resources/2_0/templates/Java/libraries/jersey2/pom.mustache
@@ -296,7 +296,7 @@
     </dependencies>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <swagger-core-version>1.5.15</swagger-core-version>
+        <swagger-core-version>1.5.18</swagger-core-version>
         <jersey-version>2.22.2</jersey-version>
         <jackson-version>2.8.9</jackson-version>
         {{^java8}}

--- a/pom.xml
+++ b/pom.xml
@@ -930,10 +930,10 @@
         </repository>
     </repositories>
     <properties>
-        <swagger-parser-version>1.0.33</swagger-parser-version>
+        <swagger-parser-version>1.0.34</swagger-parser-version>
         <scala-version>2.11.1</scala-version>
         <felix-version>3.3.0</felix-version>
-        <swagger-core-version>1.5.17</swagger-core-version>
+        <swagger-core-version>1.5.18</swagger-core-version>
         <commons-io-version>2.4</commons-io-version>
         <commons-cli-version>1.2</commons-cli-version>
         <junit-version>4.8.1</junit-version>

--- a/pom.xml.bash
+++ b/pom.xml.bash
@@ -909,10 +909,10 @@
         </repository>
     </repositories>
     <properties>
-        <swagger-parser-version>1.0.32</swagger-parser-version>
+        <swagger-parser-version>1.0.34</swagger-parser-version>
         <scala-version>2.11.1</scala-version>
         <felix-version>3.3.0</felix-version>
-        <swagger-core-version>1.5.16</swagger-core-version>
+        <swagger-core-version>1.5.18</swagger-core-version>
         <commons-io-version>2.4</commons-io-version>
         <commons-cli-version>1.2</commons-cli-version>
         <junit-version>4.8.1</junit-version>

--- a/pom.xml.circleci
+++ b/pom.xml.circleci
@@ -945,10 +945,10 @@
         </repository>
     </repositories>
     <properties>
-        <swagger-parser-version>1.0.31</swagger-parser-version>
+        <swagger-parser-version>1.0.34</swagger-parser-version>
         <scala-version>2.11.1</scala-version>
         <felix-version>3.3.0</felix-version>
-        <swagger-core-version>1.5.15</swagger-core-version>
+        <swagger-core-version>1.5.18</swagger-core-version>
         <commons-io-version>2.4</commons-io-version>
         <commons-cli-version>1.2</commons-cli-version>
         <junit-version>4.8.1</junit-version>

--- a/pom.xml.circleci.java7
+++ b/pom.xml.circleci.java7
@@ -939,10 +939,10 @@
         </repository>
     </repositories>
     <properties>
-        <swagger-parser-version>1.0.31</swagger-parser-version>
+        <swagger-parser-version>1.0.34</swagger-parser-version>
         <scala-version>2.11.1</scala-version>
         <felix-version>3.3.0</felix-version>
-        <swagger-core-version>1.5.15</swagger-core-version>
+        <swagger-core-version>1.5.18</swagger-core-version>
         <commons-io-version>2.4</commons-io-version>
         <commons-cli-version>1.2</commons-cli-version>
         <junit-version>4.8.1</junit-version>

--- a/pom.xml.shippable
+++ b/pom.xml.shippable
@@ -911,10 +911,10 @@
         </repository>
     </repositories>
     <properties>
-        <swagger-parser-version>1.0.32</swagger-parser-version>
+        <swagger-parser-version>1.0.34</swagger-parser-version>
         <scala-version>2.11.1</scala-version>
         <felix-version>3.3.0</felix-version>
-        <swagger-core-version>1.5.16</swagger-core-version>
+        <swagger-core-version>1.5.18</swagger-core-version>
         <commons-io-version>2.4</commons-io-version>
         <commons-cli-version>1.2</commons-cli-version>
         <junit-version>4.8.1</junit-version>

--- a/samples/client/petstore-security-test/java/okhttp-gson/pom.xml
+++ b/samples/client/petstore-security-test/java/okhttp-gson/pom.xml
@@ -206,7 +206,7 @@
     <java.version>1.7</java.version>
     <maven.compiler.source>${java.version}</maven.compiler.source>
     <maven.compiler.target>${java.version}</maven.compiler.target>
-    <swagger-core-version>1.5.15</swagger-core-version>
+    <swagger-core-version>1.5.18</swagger-core-version>
     <okhttp-version>2.7.5</okhttp-version>
     <gson-version>2.8.1</gson-version>
     <threetenbp-version>1.3.5</threetenbp-version>

--- a/samples/client/petstore-security-test/scala/pom.xml
+++ b/samples/client/petstore-security-test/scala/pom.xml
@@ -240,7 +240,7 @@
         <joda-version>1.9.2</joda-version>
         <joda-time-version>2.9.9</joda-time-version>
         <jersey-version>1.19.4</jersey-version>
-        <swagger-core-version>1.5.16</swagger-core-version>
+        <swagger-core-version>1.5.18</swagger-core-version>
         <jersey-async-version>1.0.5</jersey-async-version>
         <maven-plugin.version>1.0.0</maven-plugin.version>
         <jackson-version>2.9.2</jackson-version>

--- a/samples/client/petstore/android/httpclient/pom.xml
+++ b/samples/client/petstore/android/httpclient/pom.xml
@@ -145,7 +145,7 @@
     </repository>
   </repositories>
   <properties>
-    <swagger-core-version>1.5.15</swagger-core-version>
+    <swagger-core-version>1.5.18</swagger-core-version>
     <gson-version>2.3.1</gson-version>
     <junit-version>4.8.1</junit-version>
     <maven-plugin-version>1.0.0</maven-plugin-version>

--- a/samples/client/petstore/java/feign/pom.xml
+++ b/samples/client/petstore/java/feign/pom.xml
@@ -268,7 +268,7 @@
         <java.version>1.7</java.version>
         <maven.compiler.source>${java.version}</maven.compiler.source>
         <maven.compiler.target>${java.version}</maven.compiler.target>
-        <swagger-core-version>1.5.15</swagger-core-version>
+        <swagger-core-version>1.5.18</swagger-core-version>
         <feign-version>9.4.0</feign-version>
         <feign-form-version>2.1.0</feign-form-version>
         <jackson-version>2.8.9</jackson-version>

--- a/samples/client/petstore/java/jersey2-java6/pom.xml
+++ b/samples/client/petstore/java/jersey2-java6/pom.xml
@@ -249,7 +249,7 @@
     </dependency>
   </dependencies>
   <properties>
-    <swagger-core-version>1.5.15</swagger-core-version>
+    <swagger-core-version>1.5.18</swagger-core-version>
     <jersey-version>2.6</jersey-version>
     <commons_io_version>2.5</commons_io_version>
     <commons_lang3_version>3.6</commons_lang3_version>

--- a/samples/client/petstore/java/jersey2-java8/pom.xml
+++ b/samples/client/petstore/java/jersey2-java8/pom.xml
@@ -234,7 +234,7 @@
     </dependency>
   </dependencies>
   <properties>
-    <swagger-core-version>1.5.15</swagger-core-version>
+    <swagger-core-version>1.5.18</swagger-core-version>
     <jersey-version>2.25.1</jersey-version>
     <jackson-version>2.7.5</jackson-version>
     <maven-plugin-version>1.0.0</maven-plugin-version>

--- a/samples/client/petstore/java/jersey2/pom.xml
+++ b/samples/client/petstore/java/jersey2/pom.xml
@@ -240,7 +240,7 @@
     </dependency>
   </dependencies>
   <properties>
-    <swagger-core-version>1.5.15</swagger-core-version>
+    <swagger-core-version>1.5.18</swagger-core-version>
     <jersey-version>2.25.1</jersey-version>
     <jackson-version>2.6.4</jackson-version>
     <maven-plugin-version>1.0.0</maven-plugin-version>

--- a/samples/client/petstore/java/okhttp-gson-parcelableModel/pom.xml
+++ b/samples/client/petstore/java/okhttp-gson-parcelableModel/pom.xml
@@ -238,7 +238,7 @@
         <maven.compiler.source>${java.version}</maven.compiler.source>
         <maven.compiler.target>${java.version}</maven.compiler.target>
         <gson-fire-version>1.8.0</gson-fire-version>
-        <swagger-core-version>1.5.15</swagger-core-version>
+        <swagger-core-version>1.5.18</swagger-core-version>
         <okhttp-version>2.7.5</okhttp-version>
         <gson-version>2.8.1</gson-version>
             <threetenbp-version>1.3.5</threetenbp-version>

--- a/samples/client/petstore/java/okhttp-gson/pom.xml
+++ b/samples/client/petstore/java/okhttp-gson/pom.xml
@@ -231,7 +231,7 @@
         <maven.compiler.source>${java.version}</maven.compiler.source>
         <maven.compiler.target>${java.version}</maven.compiler.target>
         <gson-fire-version>1.8.0</gson-fire-version>
-        <swagger-core-version>1.5.15</swagger-core-version>
+        <swagger-core-version>1.5.18</swagger-core-version>
         <okhttp-version>2.7.5</okhttp-version>
         <gson-version>2.8.1</gson-version>
             <threetenbp-version>1.3.5</threetenbp-version>

--- a/samples/client/petstore/java/resteasy/pom.xml
+++ b/samples/client/petstore/java/resteasy/pom.xml
@@ -191,7 +191,7 @@
     </dependencies>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <swagger-core-version>1.5.15</swagger-core-version>
+        <swagger-core-version>1.5.18</swagger-core-version>
         <resteasy-version>3.1.3.Final</resteasy-version>
         <jackson-version>2.6.4</jackson-version>
         <jodatime-version>2.9.9</jodatime-version>

--- a/samples/client/petstore/java/retrofit/pom.xml
+++ b/samples/client/petstore/java/retrofit/pom.xml
@@ -216,7 +216,7 @@
     </dependency>
   </dependencies>
   <properties>
-    <swagger-core-version>1.5.15</swagger-core-version>
+    <swagger-core-version>1.5.18</swagger-core-version>
     <retrofit-version>1.9.0</retrofit-version>
     <okhttp-version>2.7.5</okhttp-version>
     <jodatime-version>2.9.9</jodatime-version>

--- a/samples/client/petstore/java/retrofit2-play24/pom.xml
+++ b/samples/client/petstore/java/retrofit2-play24/pom.xml
@@ -272,7 +272,7 @@
         <maven.compiler.source>${java.version}</maven.compiler.source>
         <maven.compiler.target>${java.version}</maven.compiler.target>
         <gson-fire-version>1.8.0</gson-fire-version>
-        <swagger-core-version>1.5.15</swagger-core-version>
+        <swagger-core-version>1.5.18</swagger-core-version>
                 <jackson-version>2.6.6</jackson-version>
                 <play-version>2.4.11</play-version>
         <retrofit-version>2.3.0</retrofit-version>

--- a/samples/client/petstore/java/retrofit2-play25/pom.xml
+++ b/samples/client/petstore/java/retrofit2-play25/pom.xml
@@ -278,7 +278,7 @@
         <maven.compiler.source>${java.version}</maven.compiler.source>
         <maven.compiler.target>${java.version}</maven.compiler.target>
         <gson-fire-version>1.8.0</gson-fire-version>
-        <swagger-core-version>1.5.15</swagger-core-version>
+        <swagger-core-version>1.5.18</swagger-core-version>
                 <jackson-version>2.7.8</jackson-version>
                 <play-version>2.5.15</play-version>
         <retrofit-version>2.3.0</retrofit-version>

--- a/samples/client/petstore/java/retrofit2/pom.xml
+++ b/samples/client/petstore/java/retrofit2/pom.xml
@@ -247,7 +247,7 @@
         <maven.compiler.source>${java.version}</maven.compiler.source>
         <maven.compiler.target>${java.version}</maven.compiler.target>
         <gson-fire-version>1.8.0</gson-fire-version>
-        <swagger-core-version>1.5.15</swagger-core-version>
+        <swagger-core-version>1.5.18</swagger-core-version>
         <retrofit-version>2.3.0</retrofit-version>
             <threetenbp-version>1.3.5</threetenbp-version>
         <oltu-version>1.0.1</oltu-version>

--- a/samples/client/petstore/java/retrofit2rx/pom.xml
+++ b/samples/client/petstore/java/retrofit2rx/pom.xml
@@ -257,7 +257,7 @@
         <maven.compiler.source>${java.version}</maven.compiler.source>
         <maven.compiler.target>${java.version}</maven.compiler.target>
         <gson-fire-version>1.8.0</gson-fire-version>
-        <swagger-core-version>1.5.15</swagger-core-version>
+        <swagger-core-version>1.5.18</swagger-core-version>
         <retrofit-version>2.3.0</retrofit-version>
             <rxjava-version>1.3.0</rxjava-version>
             <threetenbp-version>1.3.5</threetenbp-version>

--- a/samples/client/petstore/java/retrofit2rx2/pom.xml
+++ b/samples/client/petstore/java/retrofit2rx2/pom.xml
@@ -257,7 +257,7 @@
         <maven.compiler.source>${java.version}</maven.compiler.source>
         <maven.compiler.target>${java.version}</maven.compiler.target>
         <gson-fire-version>1.8.0</gson-fire-version>
-        <swagger-core-version>1.5.15</swagger-core-version>
+        <swagger-core-version>1.5.18</swagger-core-version>
         <retrofit-version>2.3.0</retrofit-version>
             <rxjava-version>2.1.1</rxjava-version>
             <threetenbp-version>1.3.5</threetenbp-version>

--- a/samples/client/petstore/java/vertx/pom.xml
+++ b/samples/client/petstore/java/vertx/pom.xml
@@ -241,7 +241,7 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <vertx-version>3.4.2</vertx-version>
-    <swagger-core-version>1.5.16</swagger-core-version>
+    <swagger-core-version>1.5.18</swagger-core-version>
     <jackson-version>2.6.4</jackson-version>
     <junit-version>4.12</junit-version>
   </properties>

--- a/samples/client/petstore/jaxrs-cxf-client/pom.xml
+++ b/samples/client/petstore/jaxrs-cxf-client/pom.xml
@@ -185,7 +185,7 @@
     <java.version>1.7</java.version>
     <maven.compiler.source>${java.version}</maven.compiler.source>
     <maven.compiler.target>${java.version}</maven.compiler.target>
-    <swagger-core-version>1.5.17</swagger-core-version>
+    <swagger-core-version>1.5.18</swagger-core-version>
     <jetty-version>9.2.9.v20150224</jetty-version>
     <junit-version>4.12</junit-version>
     <logback-version>1.1.7</logback-version>

--- a/samples/client/petstore/jaxrs-cxf/pom.xml
+++ b/samples/client/petstore/jaxrs-cxf/pom.xml
@@ -162,7 +162,7 @@
     <java.version>1.7</java.version>
     <maven.compiler.source>${java.version}</maven.compiler.source>
     <maven.compiler.target>${java.version}</maven.compiler.target>
-    <swagger-core-version>1.5.17</swagger-core-version>
+    <swagger-core-version>1.5.18</swagger-core-version>
     <jetty-version>9.2.9.v20150224</jetty-version>
     <junit-version>4.12</junit-version>
     <logback-version>1.1.7</logback-version>

--- a/samples/client/petstore/scala/pom.xml
+++ b/samples/client/petstore/scala/pom.xml
@@ -240,7 +240,7 @@
         <joda-version>1.9.2</joda-version>
         <joda-time-version>2.9.9</joda-time-version>
         <jersey-version>1.19.4</jersey-version>
-        <swagger-core-version>1.5.16</swagger-core-version>
+        <swagger-core-version>1.5.18</swagger-core-version>
         <jersey-async-version>1.0.5</jersey-async-version>
         <maven-plugin.version>1.0.0</maven-plugin.version>
         <jackson-version>2.9.2</jackson-version>

--- a/samples/client/petstore/spring-cloud/pom.xml
+++ b/samples/client/petstore/spring-cloud/pom.xml
@@ -9,7 +9,7 @@
         <java.version>1.7</java.version>
         <maven.compiler.source>${java.version}</maven.compiler.source>
         <maven.compiler.target>${java.version}</maven.compiler.target>
-        <swagger-core-version>1.5.15</swagger-core-version>
+        <swagger-core-version>1.5.18</swagger-core-version>
     </properties>
     <parent>
         <groupId>org.springframework.boot</groupId>

--- a/samples/server/petstore/java-msf4j/dependency-reduced-pom.xml
+++ b/samples/server/petstore/java-msf4j/dependency-reduced-pom.xml
@@ -53,7 +53,7 @@
     </repository>
   </repositories>
   <properties>
-    <swagger-core-version>1.5.15</swagger-core-version>
+    <swagger-core-version>1.5.18</swagger-core-version>
     <jersey2-version>2.22.2</jersey2-version>
     <java.version>1.8</java.version>
     <junit-version>4.12</junit-version>

--- a/samples/server/petstore/java-msf4j/pom.xml
+++ b/samples/server/petstore/java-msf4j/pom.xml
@@ -75,7 +75,7 @@
     <java.version>1.8</java.version>
     <maven.compiler.source>${java.version}</maven.compiler.source>
     <maven.compiler.target>${java.version}</maven.compiler.target>
-    <swagger-core-version>1.5.15</swagger-core-version>
+    <swagger-core-version>1.5.18</swagger-core-version>
     <jetty-version>9.2.9.v20150224</jetty-version>
     <jersey2-version>2.22.2</jersey2-version>
     <junit-version>4.12</junit-version>

--- a/samples/server/petstore/jaxrs-cxf-annotated-base-path/pom.xml
+++ b/samples/server/petstore/jaxrs-cxf-annotated-base-path/pom.xml
@@ -185,7 +185,7 @@
     <java.version>1.7</java.version>
     <maven.compiler.source>${java.version}</maven.compiler.source>
     <maven.compiler.target>${java.version}</maven.compiler.target>
-    <swagger-core-version>1.5.17</swagger-core-version>
+    <swagger-core-version>1.5.18</swagger-core-version>
     <jetty-version>9.2.9.v20150224</jetty-version>
     <junit-version>4.12</junit-version>
     <logback-version>1.1.7</logback-version>

--- a/samples/server/petstore/jaxrs-cxf-non-spring-app/pom.xml
+++ b/samples/server/petstore/jaxrs-cxf-non-spring-app/pom.xml
@@ -185,7 +185,7 @@
     <java.version>1.7</java.version>
     <maven.compiler.source>${java.version}</maven.compiler.source>
     <maven.compiler.target>${java.version}</maven.compiler.target>
-    <swagger-core-version>1.5.17</swagger-core-version>
+    <swagger-core-version>1.5.18</swagger-core-version>
     <jetty-version>9.2.9.v20150224</jetty-version>
     <junit-version>4.12</junit-version>
     <logback-version>1.1.7</logback-version>

--- a/samples/server/petstore/jaxrs-cxf/pom.xml
+++ b/samples/server/petstore/jaxrs-cxf/pom.xml
@@ -185,7 +185,7 @@
     <java.version>1.7</java.version>
     <maven.compiler.source>${java.version}</maven.compiler.source>
     <maven.compiler.target>${java.version}</maven.compiler.target>
-    <swagger-core-version>1.5.17</swagger-core-version>
+    <swagger-core-version>1.5.18</swagger-core-version>
     <jetty-version>9.2.9.v20150224</jetty-version>
     <junit-version>4.12</junit-version>
     <logback-version>1.1.7</logback-version>

--- a/samples/server/petstore/jaxrs-resteasy/default/pom.xml
+++ b/samples/server/petstore/jaxrs-resteasy/default/pom.xml
@@ -180,7 +180,7 @@
         </repository>
     </repositories>
     <properties>
-        <swagger-core-version>1.5.15</swagger-core-version>
+        <swagger-core-version>1.5.18</swagger-core-version>
         <jetty-version>9.2.9.v20150224</jetty-version>
         <resteasy-version>3.0.11.Final</resteasy-version>
         <slf4j-version>1.6.3</slf4j-version>

--- a/samples/server/petstore/jaxrs-resteasy/eap-java8/pom.xml
+++ b/samples/server/petstore/jaxrs-resteasy/eap-java8/pom.xml
@@ -162,7 +162,7 @@
         </repository>
     </repositories>
     <properties>
-        <swagger-core-version>1.5.15</swagger-core-version>
+        <swagger-core-version>1.5.18</swagger-core-version>
         <jetty-version>9.2.9.v20150224</jetty-version>
         <resteasy-version>3.0.11.Final</resteasy-version>
         <slf4j-version>1.6.3</slf4j-version>

--- a/samples/server/petstore/jaxrs-resteasy/eap-joda/pom.xml
+++ b/samples/server/petstore/jaxrs-resteasy/eap-joda/pom.xml
@@ -167,7 +167,7 @@
         </repository>
     </repositories>
     <properties>
-        <swagger-core-version>1.5.15</swagger-core-version>
+        <swagger-core-version>1.5.18</swagger-core-version>
         <jetty-version>9.2.9.v20150224</jetty-version>
         <resteasy-version>3.0.11.Final</resteasy-version>
         <slf4j-version>1.6.3</slf4j-version>

--- a/samples/server/petstore/jaxrs-resteasy/eap/pom.xml
+++ b/samples/server/petstore/jaxrs-resteasy/eap/pom.xml
@@ -167,7 +167,7 @@
         </repository>
     </repositories>
     <properties>
-        <swagger-core-version>1.5.15</swagger-core-version>
+        <swagger-core-version>1.5.18</swagger-core-version>
         <jetty-version>9.2.9.v20150224</jetty-version>
         <resteasy-version>3.0.11.Final</resteasy-version>
         <slf4j-version>1.6.3</slf4j-version>

--- a/samples/server/petstore/jaxrs-resteasy/joda/pom.xml
+++ b/samples/server/petstore/jaxrs-resteasy/joda/pom.xml
@@ -180,7 +180,7 @@
         </repository>
     </repositories>
     <properties>
-        <swagger-core-version>1.5.15</swagger-core-version>
+        <swagger-core-version>1.5.18</swagger-core-version>
         <jetty-version>9.2.9.v20150224</jetty-version>
         <resteasy-version>3.0.11.Final</resteasy-version>
         <slf4j-version>1.6.3</slf4j-version>

--- a/samples/server/petstore/jaxrs/jersey1-useTags/pom.xml
+++ b/samples/server/petstore/jaxrs/jersey1-useTags/pom.xml
@@ -189,7 +189,7 @@
     <java.version>1.7</java.version>
     <maven.compiler.source>${java.version}</maven.compiler.source>
     <maven.compiler.target>${java.version}</maven.compiler.target>
-    <swagger-core-version>1.5.15</swagger-core-version>
+    <swagger-core-version>1.5.18</swagger-core-version>
     <jetty-version>9.2.9.v20150224</jetty-version>
     <jersey-version>1.19.1</jersey-version>
     <jackson-version>2.8.9</jackson-version>

--- a/samples/server/petstore/jaxrs/jersey1/pom.xml
+++ b/samples/server/petstore/jaxrs/jersey1/pom.xml
@@ -189,7 +189,7 @@
     <java.version>1.7</java.version>
     <maven.compiler.source>${java.version}</maven.compiler.source>
     <maven.compiler.target>${java.version}</maven.compiler.target>
-    <swagger-core-version>1.5.15</swagger-core-version>
+    <swagger-core-version>1.5.18</swagger-core-version>
     <jetty-version>9.2.9.v20150224</jetty-version>
     <jersey-version>1.19.1</jersey-version>
     <jackson-version>2.8.9</jackson-version>

--- a/samples/server/petstore/jaxrs/jersey2-useTags/pom.xml
+++ b/samples/server/petstore/jaxrs/jersey2-useTags/pom.xml
@@ -173,7 +173,7 @@
     <java.version>1.7</java.version>
     <maven.compiler.source>${java.version}</maven.compiler.source>
     <maven.compiler.target>${java.version}</maven.compiler.target>
-    <swagger-core-version>1.5.15</swagger-core-version>
+    <swagger-core-version>1.5.18</swagger-core-version>
     <jetty-version>9.2.9.v20150224</jetty-version>
     <jersey2-version>2.22.2</jersey2-version>
     <jackson-version>2.8.9</jackson-version>

--- a/samples/server/petstore/jaxrs/jersey2/pom.xml
+++ b/samples/server/petstore/jaxrs/jersey2/pom.xml
@@ -173,7 +173,7 @@
     <java.version>1.7</java.version>
     <maven.compiler.source>${java.version}</maven.compiler.source>
     <maven.compiler.target>${java.version}</maven.compiler.target>
-    <swagger-core-version>1.5.15</swagger-core-version>
+    <swagger-core-version>1.5.18</swagger-core-version>
     <jetty-version>9.2.9.v20150224</jetty-version>
     <jersey2-version>2.22.2</jersey2-version>
     <jackson-version>2.8.9</jackson-version>


### PR DESCRIPTION
`swagger-parser` released a new version on 1/23/2018. It has lots of fixes for `allOf` notation. Also updating `swagger-core versions` since it came as transitive dependency of `swagger-parser`.
The code diff is only version number change throughout the codebase. No other files/classes/tests changed here.

Ran all tests and they passed with flying colors.

Not sure if I need to..
* Create a new issue for this upgrade PR
* Include all the sample files that changes due after running `bin/java-petstore-all.sh`