### PR TITLE
[Python][Flask] Handles UUID format - Fixes #7469

### DIFF
--- a/modules/swagger-codegen/src/main/resources/flaskConnexion/controller.mustache
+++ b/modules/swagger-codegen/src/main/resources/flaskConnexion/controller.mustache
@@ -19,12 +19,17 @@ def {{operationId}}({{#allParams}}{{paramName}}{{^required}}=None{{/required}}{{
             {{#isPrimitiveType}}
     :type {{paramName}}: {{>param_type}}
             {{/isPrimitiveType}}
+            {{#isUuid}}
+    :type {{paramName}}: {{>param_type}}
+            {{/isUuid}}
             {{^isPrimitiveType}}
                 {{#isFile}}
     :type {{paramName}}: werkzeug.datastructures.FileStorage
                 {{/isFile}}
                 {{^isFile}}
+                    {{^isUuid}}
     :type {{paramName}}: dict | bytes
+                    {{/isUuid}}
                 {{/isFile}}
             {{/isPrimitiveType}}
         {{/isContainer}}
@@ -62,8 +67,10 @@ def {{operationId}}({{#allParams}}{{paramName}}{{^required}}=None{{/required}}{{
             {{/isDateTime}}
             {{^isPrimitiveType}}
                 {{^isFile}}
+                    {{^isUuid}}
     if connexion.request.is_json:
         {{paramName}} = {{baseType}}.from_dict(connexion.request.get_json())  # noqa: E501
+                    {{/isUuid}}
                 {{/isFile}}
             {{/isPrimitiveType}}
         {{/isContainer}}


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [x] Filed the PR against the correct branch: `3.0.0` branch for changes related to OpenAPI spec 3.0. Default: `master`.
- [x] Copied the [technical committee](https://github.com/swagger-api/swagger-codegen/#swagger-codegen-technical-committee) to review the pull request if your PR is targeting a particular programming language.

@taxpon @frol @mbohlool @cbornet @kenjones-cisco

### Description of the PR

If format of the parameter is set as UUID, generated code is broken. As a solution, special check is added similar to primitive types.

Code tested with:
```yaml
  /pet/{petId}/testUuid:
    post:
      tags:
      - pets
      summary: My test with Uuid
      operationId: testUuid
      parameters:
      - name: petId
        in: path
        description: The id of pet to update
        required: true
        format: uuid
        type: string
  /pet/{petId}/testString:
    post:
      tags:
      - pets
      summary: My test with String
      operationId: testString
      parameters:
      - name: petId
        in: path
        description: The id of pet to update
        required: true
        type: string
```

Fixes #7469
