### PR TITLE
[Java][Spring] Adds missing import for Map - Fixes #7432

### DIFF
--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/DefaultCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/DefaultCodegen.java
@@ -2131,8 +2131,13 @@ public class DefaultCodegen {
                         !languageSpecificPrimitives.contains(r.baseType)) {
                     imports.add(r.baseType);
                 }
-                if (!r.simpleType) {
-                    imports.add(typeMapping.get(r.containerType));
+                if (r.baseType != null &&
+                        !r.simpleType &&
+                        !defaultIncludes.contains(r.containerType)) {
+                    String containerTypeMapping = typeMapping.get(r.containerType);
+                    if (containerTypeMapping != null) {
+                        imports.add(containerTypeMapping);
+                    }
                 }
                 r.isDefault = response == methodResponse;
                 op.responses.add(r);


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [x] Filed the PR against the correct branch: `3.0.0` branch for changes related to OpenAPI spec 3.0. Default: `master`.
- [x] Copied the [technical committee](https://github.com/swagger-api/swagger-codegen/#swagger-codegen-technical-committee) to review the pull request if your PR is targeting a particular programming language.

@bbdouglas @JFCote @sreeshas @jfiala @lukoyanov @cbornet @jeff9finger

### Description of the PR

Java Spring code generator has missing `java.util.Map` import when api return type is `Map`.

Tested with:
```yaml
paths:
  /customer:
    get:
      tags:
        - Customers
      summary: Retrieve all customers
      produces:
        - application/json
      responses:
        '200':
          description: OK
          schema:
            type: object
            additionalProperties:
              type: array
              items:
                type: string
```

Fixes #7432
