### PR TITLE
[Ada] fix PUT request and authentication checks for the server skeleton

### DIFF
--- a/modules/swagger-codegen/src/main/resources/Ada/server-skeleton-body.mustache
+++ b/modules/swagger-codegen/src/main/resources/Ada/server-skeleton-body.mustache
@@ -33,6 +33,10 @@ package body {{package}}.Skeletons is
          {{/returnType}}
       begin
          {{#authMethods}}
+         if not Context.Is_Authenticated then
+            Context.Set_Error (401, "Not authenticated");
+            return;
+         end if;
          {{#scopes}}
          if not Context.Has_Permission (ACL_{{ident}}.Permission) then
             Context.Set_Error (403, "Permission denied");
@@ -48,7 +52,7 @@ package body {{package}}.Skeletons is
          {{/pathParams}}
          {{#hasFormParams}}
          {{#formParams}}
-         Swagger.Servers.Get_Parameter (Req, "{{baseName}}", {{paramName}});
+         Swagger.Servers.Get_Parameter (Context, "{{baseName}}", {{paramName}});
          {{/formParams}}
          {{/hasFormParams}}
          {{#hasParams}}
@@ -122,6 +126,18 @@ package body {{package}}.Skeletons is
          Result : {{returnType}};
          {{/returnType}}
       begin
+         {{#authMethods}}
+         if not Context.Is_Authenticated then
+            Context.Set_Error (401, "Not authenticated");
+            return;
+         end if;
+         {{#scopes}}
+         if not Context.Has_Permission (ACL_{{ident}}.Permission) then
+            Context.Set_Error (403, "Permission denied");
+            return;
+         end if;
+         {{/scopes}}
+         {{/authMethods}}
          {{#queryParams}}
          Swagger.Servers.Get_Query_Parameter (Req, "{{baseName}}", {{paramName}});
          {{/queryParams}}
@@ -130,7 +146,7 @@ package body {{package}}.Skeletons is
          {{/pathParams}}
          {{#hasFormParams}}
          {{#formParams}}
-         Swagger.Servers.Get_Parameter (Req, "{{baseName}}", {{paramName}});
+         Swagger.Servers.Get_Parameter (Context, "{{baseName}}", {{paramName}});
          {{/formParams}}
          {{/hasFormParams}}
          {{#hasParams}}


### PR DESCRIPTION
Fix the extraction of form parameters to use the Context to get the parameters

### PR checklist

- [x] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [ ] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [ ] Filed the PR against the correct branch: `3.0.0` branch for changes related to OpenAPI spec 3.0. Default: `master`.
- [ ] Copied the [technical committee](https://github.com/swagger-api/swagger-codegen/#swagger-codegen-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

This pull request fixes #7513 . This fixes the Ada skeleton template:

- The Shared_Instance now handles the authsMethods to authenticate the request
- The extraction of form parameters now uses the Context object

