### PR TITLE
[Dart] Allow setting an accessToken for OAuth

### DIFF
--- a/modules/swagger-codegen/src/main/resources/dart/api_client.mustache
+++ b/modules/swagger-codegen/src/main/resources/dart/api_client.mustache
@@ -14,16 +14,15 @@ class ApiClient {
 
   Map<String, String> _defaultHeaderMap = {};
   Map<String, Authentication> _authentications = {};
-  String accessToken;
 
   final _RegList = new RegExp(r'^List<(.*)>$');
   final _RegMap = new RegExp(r'^Map<String,(.*)>$');
 
-  ApiClient({this.basePath: "{{{basePath}}}", this.accessToken}) {
+  ApiClient({this.basePath: "{{{basePath}}}"}) {
     // Setup authentications (key: authentication name, value: authentication).{{#authMethods}}{{#isBasic}}
     _authentications['{{name}}'] = new HttpBasicAuth();{{/isBasic}}{{#isApiKey}}
     _authentications['{{name}}'] = new ApiKeyAuth({{#isKeyInHeader}}"header"{{/isKeyInHeader}}{{^isKeyInHeader}}"query"{{/isKeyInHeader}}, "{{keyParamName}}");{{/isApiKey}}{{#isOAuth}}
-    _authentications['{{name}}'] = new OAuth(accessToken: this.accessToken);{{/isOAuth}}{{/authMethods}}
+    _authentications['{{name}}'] = new OAuth();{{/isOAuth}}{{/authMethods}}
   }
 
   void addDefaultHeader(String key, String value) {
@@ -156,7 +155,6 @@ class ApiClient {
   }
 
   void setAccessToken(String accessToken) {
-    this.accessToken = accessToken;
     _authentications.forEach((key, auth) {
       if (auth is OAuth) {
         auth.setAccessToken(accessToken);

--- a/modules/swagger-codegen/src/main/resources/dart/api_client.mustache
+++ b/modules/swagger-codegen/src/main/resources/dart/api_client.mustache
@@ -14,15 +14,16 @@ class ApiClient {
 
   Map<String, String> _defaultHeaderMap = {};
   Map<String, Authentication> _authentications = {};
+  String accessToken;
 
   final _RegList = new RegExp(r'^List<(.*)>$');
   final _RegMap = new RegExp(r'^Map<String,(.*)>$');
 
-  ApiClient({this.basePath: "{{{basePath}}}"}) {
+  ApiClient({this.basePath: "{{{basePath}}}", this.accessToken}) {
     // Setup authentications (key: authentication name, value: authentication).{{#authMethods}}{{#isBasic}}
     _authentications['{{name}}'] = new HttpBasicAuth();{{/isBasic}}{{#isApiKey}}
     _authentications['{{name}}'] = new ApiKeyAuth({{#isKeyInHeader}}"header"{{/isKeyInHeader}}{{^isKeyInHeader}}"query"{{/isKeyInHeader}}, "{{keyParamName}}");{{/isApiKey}}{{#isOAuth}}
-    _authentications['{{name}}'] = new OAuth();{{/isOAuth}}{{/authMethods}}
+    _authentications['{{name}}'] = new OAuth(accessToken: this.accessToken);{{/isOAuth}}{{/authMethods}}
   }
 
   void addDefaultHeader(String key, String value) {
@@ -151,6 +152,15 @@ class ApiClient {
       Authentication auth = _authentications[authName];
       if (auth == null) throw new ArgumentError("Authentication undefined: " + authName);
       auth.applyToParams(queryParams, headerParams);
+    });
+  }
+
+  void setAccessToken(String accessToken) {
+    this.accessToken = accessToken;
+    _authentications.forEach((key, auth) {
+      if (auth is OAuth) {
+        auth.setAccessToken(accessToken);
+      }
     });
   }
 }

--- a/modules/swagger-codegen/src/main/resources/dart/auth/oauth.mustache
+++ b/modules/swagger-codegen/src/main/resources/dart/auth/oauth.mustache
@@ -1,9 +1,19 @@
 part of {{pubName}}.api;
 
 class OAuth implements Authentication {
+  String accessToken;
+
+  OAuth({this.accessToken}) {
+  }
 
   @override
   void applyToParams(List<QueryParam> queryParams, Map<String, String> headerParams) {
-    // TODO: support oauth
+    if (accessToken != null) {
+      headerParams["Authorization"] = "Bearer " + accessToken;
+    }
+  }
+
+  void setAccessToken(String accessToken) {
+    this.accessToken = accessToken;
   }
 }


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [x] Filed the PR against the correct branch: `3.0.0` branch for changes related to OpenAPI spec 3.0. Default: `master`.
- [x] Copied the [technical committee](https://github.com/swagger-api/swagger-codegen/#swagger-codegen-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

The dart client generator was lacking oauth support completely. I took the Java implementation as a blueprint. This allows to set an `accessToken` from outside.

Hello again @ircecho  😄 