### PR TITLE
feat: add cookie auth for security scheme

### DIFF
--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/CodegenConstants.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/CodegenConstants.java
@@ -286,6 +286,7 @@ public class CodegenConstants {
     public static final String IS_API_KEY_EXT_NAME = PREFIX_IS + "api-key";
     public static final String IS_KEY_IN_QUERY_EXT_NAME = PREFIX_IS + "key-in-query";
     public static final String IS_KEY_IN_HEADER_EXT_NAME = PREFIX_IS + "key-in-header";
+    public static final String IS_KEY_IN_COOKIE_EXT_NAME = PREFIX_IS + "key-in-cookie";
     public static final String IS_CODE_EXT_NAME = PREFIX_IS + "code";
     public static final String IS_PASSWORD_EXT_NAME = PREFIX_IS + "password";
     public static final String IS_APPLICATION_EXT_NAME = PREFIX_IS + "application";

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/DefaultCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/DefaultCodegen.java
@@ -2380,8 +2380,11 @@ public class DefaultCodegen implements CodegenConfig {
                 codegenSecurity.getVendorExtensions().put(CodegenConstants.IS_API_KEY_EXT_NAME, Boolean.TRUE);
 
                 boolean isKeyInHeader = schemeDefinition.getIn() == SecurityScheme.In.HEADER;
+                boolean isKeyInCookie = schemeDefinition.getIn() == SecurityScheme.In.COOKIE;
+                boolean isKeyInQuery  = schemeDefinition.getIn() == SecurityScheme.In.QUERY;
                 codegenSecurity.getVendorExtensions().put(CodegenConstants.IS_KEY_IN_HEADER_EXT_NAME, isKeyInHeader);
-                codegenSecurity.getVendorExtensions().put(CodegenConstants.IS_KEY_IN_QUERY_EXT_NAME, !isKeyInHeader);
+                codegenSecurity.getVendorExtensions().put(CodegenConstants.IS_KEY_IN_COOKIE_EXT_NAME, isKeyInCookie);
+                codegenSecurity.getVendorExtensions().put(CodegenConstants.IS_KEY_IN_QUERY_EXT_NAME,  isKeyInQuery);
 
             } else if (SecurityScheme.Type.HTTP.equals(schemeDefinition.getType())) {
                 codegenSecurity.getVendorExtensions().put(CodegenConstants.IS_BASIC_EXT_NAME, Boolean.TRUE);


### PR DESCRIPTION
in OpenApi 3.0.0 the apiKey can also be passed as cookies

### PR checklist

- [x] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [ ] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [x] Filed the PR against the correct branch: `3.0.0` branch for changes related to OpenAPI spec 3.0. Default: `master`.
- [ ] Copied the [technical committee](https://github.com/swagger-api/swagger-codegen/#swagger-codegen-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

in OpenApi 3.0.0 the apiKey can also be passed as cookies.
add the support for this feature, to be used in template files:

output sample:

```JSON
"authMethods" : [ {
        "name" : "cookieAuth",
        "type" : "apiKey",
        "keyParamName" : "JSESSIONID",
        "vendorExtensions" : {
          "x-is-key-in-header" : false,
          "x-is-key-in-cookie" : true,
          "x-has-more" : false,
          "x-is-api-key" : true,
          "x-is-key-in-query" : false
        }
      } ],
```