### PR TITLE
Use latest version in dependencies snippet

### DIFF
--- a/modules/swagger-codegen-maven-plugin/README.md
+++ b/modules/swagger-codegen-maven-plugin/README.md
@@ -11,7 +11,7 @@ Add to your `build->plugins` section (default phase is `generate-sources` phase)
 <plugin>
     <groupId>io.swagger</groupId>
     <artifactId>swagger-codegen-maven-plugin</artifactId>
-    <version>2.2.3</version>
+    <version>2.3.1</version>
     <executions>
         <execution>
             <goals>


### PR DESCRIPTION
Please use the latest version in the snippet as the older ones may contain nasty bugs (like this one https://github.com/swagger-api/swagger-codegen/issues/6122). Thanks.

### PR checklist

- [X] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [X] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [X] Filed the PR against the correct branch: `3.0.0` branch for changes related to OpenAPI spec 3.0. Default: `master`.
