### PR TITLE
#6375 - Fix I/O Exception. Closed stream.

### DIFF
--- a/modules/swagger-codegen/src/main/resources/Java/libraries/resttemplate/ApiClient.mustache
+++ b/modules/swagger-codegen/src/main/resources/Java/libraries/resttemplate/ApiClient.mustache
@@ -646,7 +646,6 @@ public class ApiClient {
             log.info("HTTP Status Code: " + response.getRawStatusCode());
             log.info("Status Text: " + response.getStatusText());
             log.info("HTTP Headers: " + headersToString(response.getHeaders()));
-            log.info("Response Body: " + bodyToString(response.getBody()));
         }
 
         private String headersToString(HttpHeaders headers) {


### PR DESCRIPTION
Fix attempted read from closed stream, as response.getBody() was reading an InputStream that needs to be read later.

CC @jeff9finger 

