### PR TITLE
Fixed unicode error and supported allow_nonstandard_methods in tornado based python client

### DIFF
--- a/modules/swagger-codegen/src/main/resources/python/api_client.mustache
+++ b/modules/swagger-codegen/src/main/resources/python/api_client.mustache
@@ -547,7 +547,7 @@ class ApiClient(object):
         try:
             return klass(data)
         except UnicodeEncodeError:
-            return six.u(data)
+            return u"".join(data).encode("utf-8")
         except TypeError:
             return data
 

--- a/modules/swagger-codegen/src/main/resources/python/api_client.mustache
+++ b/modules/swagger-codegen/src/main/resources/python/api_client.mustache
@@ -547,7 +547,7 @@ class ApiClient(object):
         try:
             return klass(data)
         except UnicodeEncodeError:
-            return u"".join(data).encode("utf-8")
+            return six.text_type(data)
         except TypeError:
             return data
 

--- a/modules/swagger-codegen/src/main/resources/python/tornado/rest.mustache
+++ b/modules/swagger-codegen/src/main/resources/python/tornado/rest.mustache
@@ -83,7 +83,7 @@ class RESTClientObject(object):
                 "body parameter cannot be used with post_params parameter."
             )
 
-        request = httpclient.HTTPRequest(url)
+        request = httpclient.HTTPRequest(url, allow_nonstandard_methods=True)
         request.ca_certs = self.ca_certs
         request.client_key = self.client_key
         request.client_cert = self.client_cert

--- a/samples/client/petstore-security-test/python/petstore_api/api_client.py
+++ b/samples/client/petstore-security-test/python/petstore_api/api_client.py
@@ -541,7 +541,7 @@ class ApiClient(object):
         try:
             return klass(data)
         except UnicodeEncodeError:
-            return six.u(data)
+            return u"".join(data).encode("utf-8")
         except TypeError:
             return data
 

--- a/samples/client/petstore-security-test/python/petstore_api/api_client.py
+++ b/samples/client/petstore-security-test/python/petstore_api/api_client.py
@@ -541,7 +541,7 @@ class ApiClient(object):
         try:
             return klass(data)
         except UnicodeEncodeError:
-            return u"".join(data).encode("utf-8")
+            return six.text_type(data)
         except TypeError:
             return data
 

--- a/samples/client/petstore/python-asyncio/petstore_api/api_client.py
+++ b/samples/client/petstore/python-asyncio/petstore_api/api_client.py
@@ -541,7 +541,7 @@ class ApiClient(object):
         try:
             return klass(data)
         except UnicodeEncodeError:
-            return six.u(data)
+            return u"".join(data).encode("utf-8")
         except TypeError:
             return data
 

--- a/samples/client/petstore/python-asyncio/petstore_api/api_client.py
+++ b/samples/client/petstore/python-asyncio/petstore_api/api_client.py
@@ -541,7 +541,7 @@ class ApiClient(object):
         try:
             return klass(data)
         except UnicodeEncodeError:
-            return u"".join(data).encode("utf-8")
+            return six.text_type(data)
         except TypeError:
             return data
 

--- a/samples/client/petstore/python-tornado/petstore_api/api_client.py
+++ b/samples/client/petstore/python-tornado/petstore_api/api_client.py
@@ -543,7 +543,7 @@ class ApiClient(object):
         try:
             return klass(data)
         except UnicodeEncodeError:
-            return u"".join(data).encode("utf-8")
+            return six.text_type(data)
         except TypeError:
             return data
 

--- a/samples/client/petstore/python-tornado/petstore_api/api_client.py
+++ b/samples/client/petstore/python-tornado/petstore_api/api_client.py
@@ -543,7 +543,7 @@ class ApiClient(object):
         try:
             return klass(data)
         except UnicodeEncodeError:
-            return six.u(data)
+            return u"".join(data).encode("utf-8")
         except TypeError:
             return data
 

--- a/samples/client/petstore/python/petstore_api/api_client.py
+++ b/samples/client/petstore/python/petstore_api/api_client.py
@@ -541,7 +541,7 @@ class ApiClient(object):
         try:
             return klass(data)
         except UnicodeEncodeError:
-            return six.u(data)
+            return u"".join(data).encode("utf-8")
         except TypeError:
             return data
 

--- a/samples/client/petstore/python/petstore_api/api_client.py
+++ b/samples/client/petstore/python/petstore_api/api_client.py
@@ -541,7 +541,7 @@ class ApiClient(object):
         try:
             return klass(data)
         except UnicodeEncodeError:
-            return u"".join(data).encode("utf-8")
+            return six.text_type(data)
         except TypeError:
             return data
 


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [x] Filed the PR against the correct branch: `3.0.0` branch for changes related to OpenAPI spec 3.0. Default: `master`.
- [ ] Copied the [technical committee](https://github.com/swagger-api/swagger-codegen/#swagger-codegen-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

This PR will fix https://github.com/swagger-api/swagger-codegen/issues/7559 and https://github.com/swagger-api/swagger-codegen/issues/7109

1) Setting  _allow_nonstandard_methods_ flag by default to TRUE to make sure that tornado client can be used for DELETE and other methods with body.

2) six.u does not support Unicode as an input and end up throwing exception in python2 for unicode inputs. Now, using six.text_type to for reliable conversion.

