### PR TITLE
[Ada] Fix GNAT project and server skeleton to avoid sending a response when an error is returned

### DIFF
--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/AdaCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/AdaCodegen.java
@@ -66,6 +66,7 @@ public class AdaCodegen extends AbstractAdaCodegen implements CodegenConfig {
         additionalProperties.put("packageConfig", configBaseName);
         additionalProperties.put("packageDir", "client");
         additionalProperties.put("mainName", "client");
+        additionalProperties.put("isServer", false);
         additionalProperties.put(CodegenConstants.PROJECT_NAME, projectName);
 
         String names[] = this.modelPackage.split("\\.");

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/AdaServerCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/AdaServerCodegen.java
@@ -69,6 +69,7 @@ public class AdaServerCodegen extends AbstractAdaCodegen implements CodegenConfi
         additionalProperties.put("packageConfig", configBaseName);
         additionalProperties.put("packageDir", "server");
         additionalProperties.put("mainName", "server");
+        additionalProperties.put("isServer", "true");
         additionalProperties.put(CodegenConstants.PROJECT_NAME, projectName);
 
         String names[] = this.modelPackage.split("\\.");

--- a/modules/swagger-codegen/src/main/resources/Ada/gnat-project.mustache
+++ b/modules/swagger-codegen/src/main/resources/Ada/gnat-project.mustache
@@ -8,9 +8,10 @@
 with "config";
 with "util";
 with "util_http";
-with "asf";
 with "security";
-with "swagger";
+with "swagger";{{#isServer}}
+with "servlet";
+with "swagger_server";{{/isServer}}
 project {{{projectName}}} is
 
     Mains := ("{{{packageName}}}-{{{mainName}}}.adb");

--- a/modules/swagger-codegen/src/main/resources/Ada/server-properties.mustache
+++ b/modules/swagger-codegen/src/main/resources/Ada/server-properties.mustache
@@ -1,6 +1,21 @@
 swagger.dir=web
 swagger.web.enable=false
 swagger.ui.enable=true
+swagger.port=8080
+swagger.apps=app
+swagger.users=users
+swagger.key=NTk4YzEyODNhMjM4IDJjMjNkOGFiNThkYSBkZWExOTQ1MTQ2YjkgZmIxNGM4NWY4OGQzCg
+
+app.list=1
+app.1.client_id=test-app
+app.1.client_secret=test-app-secret
+app.1.scope=none
+
+users.list=1,2
+users.1.username=admin
+users.1.password=admin
+users.2.username=test
+users.2.password=test
 
 # Configuration for log4j
 log4j.rootCategory=DEBUG,console,result
@@ -15,7 +30,7 @@ log4j.logger.log=WARN
 log4j.logger.Util.Properties=DEBUG
 log4j.logger.Util.Log=WARN
 log4j.logger.Util=DEBUG
-log4j.logger.ASF=DEBUG
+log4j.logger.Servlet=DEBUG
 log4j.logger.Util.Serialize.Mappers=WARN
 log4j.logger.Util.Serialize.IO=INFO
 

--- a/modules/swagger-codegen/src/main/resources/Ada/server-skeleton-body.mustache
+++ b/modules/swagger-codegen/src/main/resources/Ada/server-skeleton-body.mustache
@@ -77,11 +77,13 @@ package body {{package}}.Skeletons is
          {{/returnType}}
          {{/hasParams}}
          {{#returnType}}
-         Stream.Start_Document;{{#vendorExtensions.x-codegen-response.isString}}
-         Swagger.Streams.Serialize (Stream, "", Result);{{/vendorExtensions.x-codegen-response.isString}}{{^vendorExtensions.x-codegen-response.isString}}{{#returnTypeIsPrimitive}}
-         Swagger.Streams.Serialize (Stream, "", Result);{{/returnTypeIsPrimitive}}{{^returnTypeIsPrimitive}}
-         {{package}}.Models.Serialize (Stream, "", Result);{{/returnTypeIsPrimitive}}{{/vendorExtensions.x-codegen-response.isString}}
-         Stream.End_Document;{{/returnType}}
+         if Context.Get_Status = 200 then
+            Stream.Start_Document;{{#vendorExtensions.x-codegen-response.isString}}
+            Swagger.Streams.Serialize (Stream, "", Result);{{/vendorExtensions.x-codegen-response.isString}}{{^vendorExtensions.x-codegen-response.isString}}{{#returnTypeIsPrimitive}}
+            Swagger.Streams.Serialize (Stream, "", Result);{{/returnTypeIsPrimitive}}{{^returnTypeIsPrimitive}}
+            {{package}}.Models.Serialize (Stream, "", Result);{{/returnTypeIsPrimitive}}{{/vendorExtensions.x-codegen-response.isString}}
+            Stream.End_Document;
+         end if;{{/returnType}}
       end {{operationId}};
 {{/operation}}
 {{/operations}}
@@ -171,11 +173,13 @@ package body {{package}}.Skeletons is
          {{/returnType}}
          {{/hasParams}}
          {{#returnType}}
-         Stream.Start_Document;{{#vendorExtensions.x-codegen-response.isString}}
-         Swagger.Streams.Serialize (Stream, "", Result);{{/vendorExtensions.x-codegen-response.isString}}{{^vendorExtensions.x-codegen-response.isString}}{{#returnTypeIsPrimitive}}
-         Swagger.Streams.Serialize (Stream, "", Result);{{/returnTypeIsPrimitive}}{{^returnTypeIsPrimitive}}
-         {{package}}.Models.Serialize (Stream, "", Result);{{/returnTypeIsPrimitive}}{{/vendorExtensions.x-codegen-response.isString}}
-         Stream.End_Document;{{/returnType}}
+         if Context.Get_Status = 200 then
+            Stream.Start_Document;{{#vendorExtensions.x-codegen-response.isString}}
+            Swagger.Streams.Serialize (Stream, "", Result);{{/vendorExtensions.x-codegen-response.isString}}{{^vendorExtensions.x-codegen-response.isString}}{{#returnTypeIsPrimitive}}
+            Swagger.Streams.Serialize (Stream, "", Result);{{/returnTypeIsPrimitive}}{{^returnTypeIsPrimitive}}
+            {{package}}.Models.Serialize (Stream, "", Result);{{/returnTypeIsPrimitive}}{{/vendorExtensions.x-codegen-response.isString}}
+            Stream.End_Document;
+         end if;{{/returnType}}
       end {{operationId}};
 
       package API_{{operationId}} is

--- a/samples/client/petstore/ada/petstore.gpr
+++ b/samples/client/petstore/ada/petstore.gpr
@@ -8,7 +8,6 @@
 with "config";
 with "util";
 with "util_http";
-with "asf";
 with "security";
 with "swagger";
 project Petstore is


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [ ] Filed the PR against the correct branch: `3.0.0` branch for changes related to OpenAPI spec 3.0. Default: `master`.
- [ ] Copied the [technical committee](https://github.com/swagger-api/swagger-codegen/#swagger-codegen-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

The GNAT project that allows to build the samples must now be based on the 'servlet' project and not 'asf' because 'servlet' project is a light version of 'asf'. The 'servlet' project is also not necessary when we build the Ada client, hence we can omit its inclusion in that case.

Updated the server configuration properties for the server to describe the OAuth2 allowed applications and users.

The server skeleton must not emit a JSON/XML response if the server operation returned a response other than 200. Otherwise, we also send some possibly spurious content together with a 204 response for example.


