### PR TITLE
fix 7444  "resurfacing" of nested contained defined object and adding …

### DIFF
--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/CodegenProperty.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/CodegenProperty.java
@@ -62,6 +62,7 @@ public class CodegenProperty implements Cloneable {
     public String xmlName;
     public String xmlNamespace;
     public boolean isXmlWrapped = false;
+    public String containedType;
 
 
     @Override

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/CodegenResponse.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/CodegenResponse.java
@@ -22,6 +22,7 @@ public class CodegenResponse {
     public Object schema;
     public String jsonSchema;
     public Map<String, Object> vendorExtensions;
+    public String containedType;
 
     public boolean isWildcard() {
         return "0".equals(code) || "default".equals(code);

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/DefaultCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/DefaultCodegen.java
@@ -1833,8 +1833,14 @@ public class DefaultCodegen {
         property.dataFormat = innerProperty.dataFormat;
         if (!languageSpecificPrimitives.contains(innerProperty.baseType)) {
             property.complexType = innerProperty.baseType;
+            if (!innerProperty.isContainer) {
+                property.containedType = innerProperty.baseType;
+            }
         } else {
             property.isPrimitiveType = true;
+        }
+        if (innerProperty.containedType != null && !languageSpecificPrimitives.contains(innerProperty.containedType)) {
+            property.containedType = innerProperty.containedType;
         }
         property.items = innerProperty;
         // inner item is Enum
@@ -1863,8 +1869,14 @@ public class DefaultCodegen {
         }
         if (!languageSpecificPrimitives.contains(innerProperty.baseType)) {
             property.complexType = innerProperty.baseType;
+            if (!innerProperty.isContainer) {
+                property.containedType = innerProperty.baseType;
+            }
         } else {
             property.isPrimitiveType = true;
+        }
+        if (innerProperty.containedType != null && !languageSpecificPrimitives.contains(innerProperty.containedType)) {
+            property.containedType = innerProperty.containedType;
         }
         property.items = innerProperty;
         property.dataFormat = innerProperty.dataFormat;
@@ -2134,6 +2146,9 @@ public class DefaultCodegen {
                         !languageSpecificPrimitives.contains(r.baseType)) {
                     imports.add(r.baseType);
                 }
+                if (r.containedType != null && !defaultIncludes.contains(r.containedType) && !languageSpecificPrimitives.contains(r.containedType)) {
+                    imports.add(r.containedType);
+                }
                 r.isDefault = response == methodResponse;
                 op.responses.add(r);
                 if (Boolean.TRUE.equals(r.isBinary) && Boolean.TRUE.equals(r.isDefault)){
@@ -2336,7 +2351,7 @@ public class DefaultCodegen {
             Property responseProperty = response.getSchema();
             responseProperty.setRequired(true);
             CodegenProperty cm = fromProperty("response", responseProperty);
-
+            r.containedType = cm.containedType;
             if (responseProperty instanceof ArrayProperty) {
                 ArrayProperty ap = (ArrayProperty) responseProperty;
                 CodegenProperty innerProperty = fromProperty("response", ap.getItems());

--- a/modules/swagger-codegen/src/test/resources/2_0/return-nested.yaml
+++ b/modules/swagger-codegen/src/test/resources/2_0/return-nested.yaml
@@ -1,0 +1,68 @@
+basePath: /v1
+definitions:
+  Pet:
+    properties:
+      id:
+        format: int64
+        type: integer
+      name:
+        example: doggie
+        type: string
+    required:
+      - name
+    type: object
+    xml:
+      name: Pet
+host: test.io
+info:
+  contact:
+    email: apiteam@swagger.io
+  description: nested collection return type test
+  license:
+    name: Apache 2.0
+    url: 'http://www.apache.org/licenses/LICENSE-2.0.html'
+  termsOfService: 'http://swagger.io/terms/'
+  title: nested collection return type test
+  version: 1.0.0
+paths:
+  /arraytest:
+    get:
+      description: return a nested collection containing a defined type
+      operationId: arraytest
+      produces:
+        - application/json
+        - application/xml
+      responses:
+        '200':
+          description: successful operation
+          schema:
+            type: array
+            items:
+              type: array
+              items:
+                $ref: '#/definitions/Pet'
+      summary: return a  nested collection return type
+      tags:
+        - pet
+  /maptest:
+    get:
+      description: return a nested map containing a defined type
+      operationId: maptest
+      produces:
+        - application/json
+        - application/xml
+      responses:
+        '200':
+          description: successful operation
+          schema:
+            type: object
+            additionalProperties:
+              type: object
+              additionalProperties:
+                $ref: '#/definitions/Pet'
+      summary: return a  nested collection return type
+      tags:
+        - pet
+schemes:
+  - http
+swagger: '2.0'


### PR DESCRIPTION
Description of the PR

Code generation on operation that return object in "nested" array/map does not add the required definition to the import list.
This revised patch address the issue saving the contained object type during the recursion.

Specs demostrating this ussye is in modules/swagger-codegen/src/test/resources/2_0/return-nested.yaml

This should solve issue #7444
