### PR TITLE
Kotlin: Correct data_class.mustache to use proper property for inner enum data type

### DIFF
--- a/modules/swagger-codegen/src/main/resources/kotlin-client/data_class.mustache
+++ b/modules/swagger-codegen/src/main/resources/kotlin-client/data_class.mustache
@@ -16,7 +16,7 @@ data class {{classname}} (
     * {{{description}}}
     * Values: {{#allowableValues}}{{#enumVars}}{{&name}}{{^-last}},{{/-last}}{{/enumVars}}{{/allowableValues}}
     */
-    enum class {{nameInCamelCase}}(val value: {{dataType}}){
+    enum class {{nameInCamelCase}}(val value: {{datatype}}){
     {{#allowableValues}}{{#enumVars}}
         {{&name}}({{{value}}}){{^-last}},{{/-last}}{{#-last}};{{/-last}}
     {{/enumVars}}{{/allowableValues}}

--- a/samples/client/petstore/kotlin/src/main/kotlin/io/swagger/client/models/Order.kt
+++ b/samples/client/petstore/kotlin/src/main/kotlin/io/swagger/client/models/Order.kt
@@ -35,7 +35,7 @@ data class Order (
     * Order Status
     * Values: placed,approved,delivered
     */
-    enum class Status(val value: kotlin.Any){
+    enum class Status(val value: kotlin.String){
     
         placed("placed"),
     

--- a/samples/client/petstore/kotlin/src/main/kotlin/io/swagger/client/models/Pet.kt
+++ b/samples/client/petstore/kotlin/src/main/kotlin/io/swagger/client/models/Pet.kt
@@ -37,7 +37,7 @@ data class Pet (
     * pet status in the store
     * Values: available,pending,sold
     */
-    enum class Status(val value: kotlin.Any){
+    enum class Status(val value: kotlin.String){
     
         available("available"),
     


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [x] Filed the PR against the correct branch: `3.0.0` branch for changes related to OpenAPI spec 3.0. Default: `master`.
- [x] Copied the [technical committee](https://github.com/swagger-api/swagger-codegen/#swagger-codegen-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

The name of the property is "datatype" lowercase, as can be seen in https://github.com/swagger-api/swagger-codegen/blob/master/modules/swagger-codegen/src/main/java/io/swagger/codegen/CodegenProperty.java#L10

While the name of the property is "dataType" camelCase in the https://github.com/swagger-api/swagger-codegen/blob/master/modules/swagger-codegen/src/main/java/io/swagger/codegen/CodegenParameter.java#L12 file.

Using "dataType" does not work, and the type of the inner enum is null.
The confusion comes from some casing issue between 

fixes #7596
cc @jimschubert 