### PR TITLE
[Java][Spring] fix optional query params missing in generated swagger

### DIFF
--- a/modules/swagger-codegen/src/main/resources/JavaSpring/libraries/spring-boot/swagger2SpringBoot.mustache
+++ b/modules/swagger-codegen/src/main/resources/JavaSpring/libraries/spring-boot/swagger2SpringBoot.mustache
@@ -10,7 +10,7 @@ import springfox.documentation.swagger2.annotations.EnableSwagger2;
 
 @SpringBootApplication
 @EnableSwagger2
-@ComponentScan(basePackages = { "{{basePackage}}", "{{apiPackage}}" })
+@ComponentScan(basePackages = { "{{basePackage}}", "{{apiPackage}}" , "{{configPackage}}"})
 public class Swagger2SpringBoot implements CommandLineRunner {
 
     @Override

--- a/modules/swagger-codegen/src/main/resources/JavaSpring/swaggerDocumentationConfig.mustache
+++ b/modules/swagger-codegen/src/main/resources/JavaSpring/swaggerDocumentationConfig.mustache
@@ -47,9 +47,9 @@ public class SwaggerDocumentationConfig {
                 .directModelSubstitute(org.threeten.bp.LocalDate.class, java.sql.Date.class)
                 .directModelSubstitute(org.threeten.bp.OffsetDateTime.class, java.util.Date.class)
                 {{/threetenbp}}
-				{{#useOptional}}
-				.genericModelSubstitutes(Optional.class)
-				{{/useOptional}}
+                {{#useOptional}}
+                .genericModelSubstitutes(Optional.class)
+                {{/useOptional}}
                 .apiInfo(apiInfo());
     }
 

--- a/modules/swagger-codegen/src/main/resources/JavaSpring/swaggerDocumentationConfig.mustache
+++ b/modules/swagger-codegen/src/main/resources/JavaSpring/swaggerDocumentationConfig.mustache
@@ -9,6 +9,9 @@ import springfox.documentation.service.ApiInfo;
 import springfox.documentation.service.Contact;
 import springfox.documentation.spi.DocumentationType;
 import springfox.documentation.spring.web.plugins.Docket;
+{{#useOptional}}
+import java.util.Optional;
+{{/useOptional}}
 
 {{>generatedAnnotation}}
 @Configuration
@@ -44,6 +47,9 @@ public class SwaggerDocumentationConfig {
                 .directModelSubstitute(org.threeten.bp.LocalDate.class, java.sql.Date.class)
                 .directModelSubstitute(org.threeten.bp.OffsetDateTime.class, java.util.Date.class)
                 {{/threetenbp}}
+				{{#useOptional}}
+				.genericModelSubstitutes(Optional.class)
+				{{/useOptional}}
                 .apiInfo(apiInfo());
     }
 

--- a/samples/server/petstore/springboot-beanvalidation/src/main/java/io/swagger/Swagger2SpringBoot.java
+++ b/samples/server/petstore/springboot-beanvalidation/src/main/java/io/swagger/Swagger2SpringBoot.java
@@ -10,7 +10,7 @@ import springfox.documentation.swagger2.annotations.EnableSwagger2;
 
 @SpringBootApplication
 @EnableSwagger2
-@ComponentScan(basePackages = { "io.swagger", "io.swagger.api" })
+@ComponentScan(basePackages = { "io.swagger", "io.swagger.api" , "io.swagger.configuration"})
 public class Swagger2SpringBoot implements CommandLineRunner {
 
     @Override

--- a/samples/server/petstore/springboot-delegate-j8/src/main/java/io/swagger/Swagger2SpringBoot.java
+++ b/samples/server/petstore/springboot-delegate-j8/src/main/java/io/swagger/Swagger2SpringBoot.java
@@ -10,7 +10,7 @@ import springfox.documentation.swagger2.annotations.EnableSwagger2;
 
 @SpringBootApplication
 @EnableSwagger2
-@ComponentScan(basePackages = { "io.swagger", "io.swagger.api" })
+@ComponentScan(basePackages = { "io.swagger", "io.swagger.api" , "io.swagger.configuration"})
 public class Swagger2SpringBoot implements CommandLineRunner {
 
     @Override

--- a/samples/server/petstore/springboot-delegate/src/main/java/io/swagger/Swagger2SpringBoot.java
+++ b/samples/server/petstore/springboot-delegate/src/main/java/io/swagger/Swagger2SpringBoot.java
@@ -10,7 +10,7 @@ import springfox.documentation.swagger2.annotations.EnableSwagger2;
 
 @SpringBootApplication
 @EnableSwagger2
-@ComponentScan(basePackages = { "io.swagger", "io.swagger.api" })
+@ComponentScan(basePackages = { "io.swagger", "io.swagger.api" , "io.swagger.configuration"})
 public class Swagger2SpringBoot implements CommandLineRunner {
 
     @Override

--- a/samples/server/petstore/springboot-implicitHeaders/src/main/java/io/swagger/Swagger2SpringBoot.java
+++ b/samples/server/petstore/springboot-implicitHeaders/src/main/java/io/swagger/Swagger2SpringBoot.java
@@ -10,7 +10,7 @@ import springfox.documentation.swagger2.annotations.EnableSwagger2;
 
 @SpringBootApplication
 @EnableSwagger2
-@ComponentScan(basePackages = { "io.swagger", "io.swagger.api" })
+@ComponentScan(basePackages = { "io.swagger", "io.swagger.api" , "io.swagger.configuration"})
 public class Swagger2SpringBoot implements CommandLineRunner {
 
     @Override

--- a/samples/server/petstore/springboot-useoptional/src/main/java/io/swagger/Swagger2SpringBoot.java
+++ b/samples/server/petstore/springboot-useoptional/src/main/java/io/swagger/Swagger2SpringBoot.java
@@ -10,7 +10,7 @@ import springfox.documentation.swagger2.annotations.EnableSwagger2;
 
 @SpringBootApplication
 @EnableSwagger2
-@ComponentScan(basePackages = { "io.swagger", "io.swagger.api" })
+@ComponentScan(basePackages = { "io.swagger", "io.swagger.api" , "io.swagger.configuration"})
 public class Swagger2SpringBoot implements CommandLineRunner {
 
     @Override

--- a/samples/server/petstore/springboot-useoptional/src/main/java/io/swagger/configuration/SwaggerDocumentationConfig.java
+++ b/samples/server/petstore/springboot-useoptional/src/main/java/io/swagger/configuration/SwaggerDocumentationConfig.java
@@ -9,6 +9,7 @@ import springfox.documentation.service.ApiInfo;
 import springfox.documentation.service.Contact;
 import springfox.documentation.spi.DocumentationType;
 import springfox.documentation.spring.web.plugins.Docket;
+import java.util.Optional;
 
 
 @Configuration
@@ -34,6 +35,7 @@ public class SwaggerDocumentationConfig {
                     .build()
                 .directModelSubstitute(org.threeten.bp.LocalDate.class, java.sql.Date.class)
                 .directModelSubstitute(org.threeten.bp.OffsetDateTime.class, java.util.Date.class)
+				.genericModelSubstitutes(Optional.class)
                 .apiInfo(apiInfo());
     }
 

--- a/samples/server/petstore/springboot-useoptional/src/main/java/io/swagger/configuration/SwaggerDocumentationConfig.java
+++ b/samples/server/petstore/springboot-useoptional/src/main/java/io/swagger/configuration/SwaggerDocumentationConfig.java
@@ -35,7 +35,7 @@ public class SwaggerDocumentationConfig {
                     .build()
                 .directModelSubstitute(org.threeten.bp.LocalDate.class, java.sql.Date.class)
                 .directModelSubstitute(org.threeten.bp.OffsetDateTime.class, java.util.Date.class)
-				.genericModelSubstitutes(Optional.class)
+                .genericModelSubstitutes(Optional.class)
                 .apiInfo(apiInfo());
     }
 

--- a/samples/server/petstore/springboot/src/main/java/io/swagger/Swagger2SpringBoot.java
+++ b/samples/server/petstore/springboot/src/main/java/io/swagger/Swagger2SpringBoot.java
@@ -10,7 +10,7 @@ import springfox.documentation.swagger2.annotations.EnableSwagger2;
 
 @SpringBootApplication
 @EnableSwagger2
-@ComponentScan(basePackages = { "io.swagger", "io.swagger.api" })
+@ComponentScan(basePackages = { "io.swagger", "io.swagger.api" , "io.swagger.configuration"})
 public class Swagger2SpringBoot implements CommandLineRunner {
 
     @Override


### PR DESCRIPTION
### PR checklist

- [X] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegenX/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [X] Filed the PR against the correct branch: `3.0.0` branch for changes related to OpenAPI spec 3.0. Default: `master`.
- [X] Copied the [technical committee](https://github.com/swagger-api/swagger-codegen/#swagger-codegen-technical-committee) to review the pull request if your PR is targeting a particular programming langauge.
@bbdouglas @JFCote @sreeshas @jfiala @lukoyanov @cbornet @jeff9finger

### Description of the PR
When a spring boot server stub is generated from a swagger spec which includes optional parameters and `useOptional` is true then the swagger generated from the resulting code omitted the optional parameters.  Fixed by adding `genericModelSubstitutes` to Docket generator, so `Optional<T>` is treated as the parametrised type `T` for documentation generation.

Additionally, if basePackage and apiPackage but not configPackage are specified when generating then the default io.swagger.configuration package is not scanned and so the Docket config is ignored.  Fixed by adding `configPackage` to the `ComponentScans` in Swagger2SprintBoot

Fixes #7601