### PR TITLE
Fix for #7007: remove null operations

### DIFF
--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/utils/ModelUtils.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/utils/ModelUtils.java
@@ -1,6 +1,5 @@
 package io.swagger.codegen.utils;
 
-import io.swagger.codegen.CodegenConfig;
 import io.swagger.codegen.CodegenModel;
 import io.swagger.codegen.CodegenProperty;
 import io.swagger.v3.oas.models.Operation;
@@ -12,6 +11,9 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import static io.swagger.codegen.CodegenConstants.IS_ENUM_EXT_NAME;
 import static io.swagger.codegen.languages.helpers.ExtensionHelper.getBooleanValue;
@@ -46,15 +48,18 @@ public class ModelUtils {
     }
 
     public static Operation[] createOperationArray (PathItem pathItem) {
-        return new Operation[]{
-                pathItem.getGet(),
-                pathItem.getPost(),
-                pathItem.getDelete(),
-                pathItem.getHead(),
-                pathItem.getPut(),
-                pathItem.getPatch(),
-                pathItem.getOptions()
-        };
+        return Stream.of(
+                    pathItem.getGet(),
+                    pathItem.getPost(),
+                    pathItem.getDelete(),
+                    pathItem.getHead(),
+                    pathItem.getPut(),
+                    pathItem.getPatch(),
+                    pathItem.getOptions()
+               )
+               .filter(Objects::nonNull)
+               .collect(Collectors.toSet())
+               .toArray(new Operation[]{});
     }
 
     public static void processCodegenModels(Map<String, CodegenModel> allModels) {


### PR DESCRIPTION
### Description of the PR

Filtering out missing operations from the returned array (see issue #7007 )

### PR checklist

- [x] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [ ] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [X] Filed the PR against the correct branch: `3.0.0` branch for changes related to OpenAPI spec 3.0. Default: `master`.
- [ ] Copied the [technical committee](https://github.com/swagger-api/swagger-codegen/#swagger-codegen-technical-committee) to review the pull request if your PR is targeting a particular programming language.

