### PR TITLE
[kotlin] Allow clients to specify OkHttpClient instance for configura…

### DIFF
--- a/modules/swagger-codegen/src/main/resources/kotlin-client/api.mustache
+++ b/modules/swagger-codegen/src/main/resources/kotlin-client/api.mustache
@@ -5,12 +5,13 @@ package {{apiPackage}}
 {{/imports}}
 
 import {{packageName}}.infrastructure.*
+import okhttp3.OkHttpClient
 {{#threetenbp}}
 import org.threeten.bp.LocalDateTime
 {{/threetenbp}}
 
 {{#operations}}
-class {{classname}}(basePath: kotlin.String = "{{{basePath}}}") : ApiClient(basePath) {
+class {{classname}}(basePath: kotlin.String = "{{{basePath}}}", httpClient: OkHttpClient = OkHttpClient()) : ApiClient(basePath, httpClient) {
 
     {{#operation}}
     /**

--- a/modules/swagger-codegen/src/main/resources/kotlin-client/infrastructure/ApiClient.kt.mustache
+++ b/modules/swagger-codegen/src/main/resources/kotlin-client/infrastructure/ApiClient.kt.mustache
@@ -3,16 +3,13 @@ package {{packageName}}.infrastructure
 import okhttp3.*
 import java.io.File
 
-open class ApiClient(val baseUrl: String) {
+open class ApiClient(val baseUrl: String, val httpClient: OkHttpClient) {
     companion object {
         protected val ContentType = "Content-Type"
         protected val Accept = "Accept"
         protected val JsonMediaType = "application/json"
         protected val FormDataMediaType = "multipart/form-data"
         protected val XmlMediaType = "application/xml"
-
-        @JvmStatic
-        val client : OkHttpClient = OkHttpClient()
 
         @JvmStatic
         var defaultHeaders: Map<String, String> by ApplicationDelegates.setOnce(mapOf(ContentType to JsonMediaType, Accept to JsonMediaType))
@@ -94,7 +91,7 @@ open class ApiClient(val baseUrl: String) {
         headers.forEach { header -> request = request.addHeader(header.key, header.value) }
 
         val realRequest = request.build()
-        val response = client.newCall(realRequest).execute()
+        val response = httpClient.newCall(realRequest).execute()
 
         // TODO: handle specific mapping types. e.g. Map<int, Class<?>>
         when {

--- a/samples/client/petstore/kotlin/src/main/kotlin/io/swagger/client/apis/PetApi.kt
+++ b/samples/client/petstore/kotlin/src/main/kotlin/io/swagger/client/apis/PetApi.kt
@@ -15,8 +15,9 @@ import io.swagger.client.models.ApiResponse
 import io.swagger.client.models.Pet
 
 import io.swagger.client.infrastructure.*
+import okhttp3.OkHttpClient
 
-class PetApi(basePath: kotlin.String = "http://petstore.swagger.io/v2") : ApiClient(basePath) {
+class PetApi(basePath: kotlin.String = "http://petstore.swagger.io/v2", httpClient: OkHttpClient = OkHttpClient()) : ApiClient(basePath, httpClient) {
 
     /**
     * Add a new pet to the store

--- a/samples/client/petstore/kotlin/src/main/kotlin/io/swagger/client/apis/StoreApi.kt
+++ b/samples/client/petstore/kotlin/src/main/kotlin/io/swagger/client/apis/StoreApi.kt
@@ -14,8 +14,9 @@ package io.swagger.client.apis
 import io.swagger.client.models.Order
 
 import io.swagger.client.infrastructure.*
+import okhttp3.OkHttpClient
 
-class StoreApi(basePath: kotlin.String = "http://petstore.swagger.io/v2") : ApiClient(basePath) {
+class StoreApi(basePath: kotlin.String = "http://petstore.swagger.io/v2", httpClient: OkHttpClient = OkHttpClient()) : ApiClient(basePath, httpClient) {
 
     /**
     * Delete purchase order by ID

--- a/samples/client/petstore/kotlin/src/main/kotlin/io/swagger/client/apis/UserApi.kt
+++ b/samples/client/petstore/kotlin/src/main/kotlin/io/swagger/client/apis/UserApi.kt
@@ -14,8 +14,9 @@ package io.swagger.client.apis
 import io.swagger.client.models.User
 
 import io.swagger.client.infrastructure.*
+import okhttp3.OkHttpClient
 
-class UserApi(basePath: kotlin.String = "http://petstore.swagger.io/v2") : ApiClient(basePath) {
+class UserApi(basePath: kotlin.String = "http://petstore.swagger.io/v2", httpClient: OkHttpClient = OkHttpClient()) : ApiClient(basePath, httpClient) {
 
     /**
     * Create user

--- a/samples/client/petstore/kotlin/src/main/kotlin/io/swagger/client/infrastructure/ApiClient.kt
+++ b/samples/client/petstore/kotlin/src/main/kotlin/io/swagger/client/infrastructure/ApiClient.kt
@@ -3,16 +3,13 @@ package io.swagger.client.infrastructure
 import okhttp3.*
 import java.io.File
 
-open class ApiClient(val baseUrl: String) {
+open class ApiClient(val baseUrl: String, val httpClient: OkHttpClient) {
     companion object {
         protected val ContentType = "Content-Type"
         protected val Accept = "Accept"
         protected val JsonMediaType = "application/json"
         protected val FormDataMediaType = "multipart/form-data"
         protected val XmlMediaType = "application/xml"
-
-        @JvmStatic
-        val client : OkHttpClient = OkHttpClient()
 
         @JvmStatic
         var defaultHeaders: Map<String, String> by ApplicationDelegates.setOnce(mapOf(ContentType to JsonMediaType, Accept to JsonMediaType))
@@ -94,7 +91,7 @@ open class ApiClient(val baseUrl: String) {
         headers.forEach { header -> request = request.addHeader(header.key, header.value) }
 
         val realRequest = request.build()
-        val response = client.newCall(realRequest).execute()
+        val response = httpClient.newCall(realRequest).execute()
 
         // TODO: handle specific mapping types. e.g. Map<int, Class<?>>
         when {


### PR DESCRIPTION
…tion use cases.

### PR checklist

- [X] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [X] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [X] Filed the PR against the correct branch: `3.0.0` branch for changes related to OpenAPI spec 3.0. Default: `master`.
- [X] Copied the [technical committee](https://github.com/swagger-api/swagger-codegen/#swagger-codegen-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

This change causes the internal static OkHttpClient in ApiClient to be passed in the constructor rather than using a private static instance.  This is desired so that HTTP debug logging can be configured.  The constructor change propagates to DefaultApi class.  A default value is constructed which can alternatively be supplied by the client.

This was the simplest way that occurred to me to allow this access but there may be other approaches that are better.  

I had a git configuration issue with my work computer, this is a fixed PR.  The original: https://github.com/swagger-api/swagger-codegen/pull/7623.  The only difference is my email address associated with the commit.

Testing: 
* I've consumed my forked repo branch via jitpack on an internal project and have used the feature successfully.
* Unit tests pass.

CC @jimschubert
