### PR TITLE
[kotlin] Fix NPE for POST/PUT/PATCH with empty request models.

### DIFF
--- a/modules/swagger-codegen/src/main/resources/kotlin-client/infrastructure/ApiClient.kt.mustache
+++ b/modules/swagger-codegen/src/main/resources/kotlin-client/infrastructure/ApiClient.kt.mustache
@@ -85,9 +85,9 @@ open class ApiClient(val baseUrl: String) {
             RequestMethod.DELETE -> Request.Builder().url(url).delete()
             RequestMethod.GET -> Request.Builder().url(url)
             RequestMethod.HEAD -> Request.Builder().url(url).head()
-            RequestMethod.PATCH -> Request.Builder().url(url).patch(safeRequestBody(body, contentType))
-            RequestMethod.PUT -> Request.Builder().url(url).put(safeRequestBody(body, contentType))
-            RequestMethod.POST -> Request.Builder().url(url).post(safeRequestBody(body, contentType))
+            RequestMethod.PATCH -> Request.Builder().url(url).patch(requestBody(body, contentType))
+            RequestMethod.PUT -> Request.Builder().url(url).put(requestBody(body, contentType))
+            RequestMethod.POST -> Request.Builder().url(url).post(requestBody(body, contentType))
             RequestMethod.OPTIONS -> Request.Builder().url(url).method("OPTIONS", null)
         }
 
@@ -125,9 +125,4 @@ open class ApiClient(val baseUrl: String) {
             )
         }
     }
-
-    inline protected fun safeRequestBody(body : Any?, contentType: String): RequestBody =
-        body?.let {
-            requestBody(body, contentType)
-        } ?: RequestBody.create(null, "")
 }

--- a/modules/swagger-codegen/src/main/resources/kotlin-client/infrastructure/ApiClient.kt.mustache
+++ b/modules/swagger-codegen/src/main/resources/kotlin-client/infrastructure/ApiClient.kt.mustache
@@ -85,9 +85,9 @@ open class ApiClient(val baseUrl: String) {
             RequestMethod.DELETE -> Request.Builder().url(url).delete()
             RequestMethod.GET -> Request.Builder().url(url)
             RequestMethod.HEAD -> Request.Builder().url(url).head()
-            RequestMethod.PATCH -> Request.Builder().url(url).patch(requestBody(body!!, contentType))
-            RequestMethod.PUT -> Request.Builder().url(url).put(requestBody(body!!, contentType))
-            RequestMethod.POST -> Request.Builder().url(url).post(requestBody(body!!, contentType))
+            RequestMethod.PATCH -> Request.Builder().url(url).patch(safeRequestBody(body, contentType))
+            RequestMethod.PUT -> Request.Builder().url(url).put(safeRequestBody(body, contentType))
+            RequestMethod.POST -> Request.Builder().url(url).post(safeRequestBody(body, contentType))
             RequestMethod.OPTIONS -> Request.Builder().url(url).method("OPTIONS", null)
         }
 
@@ -125,4 +125,9 @@ open class ApiClient(val baseUrl: String) {
             )
         }
     }
+
+    inline protected fun safeRequestBody(body : Any?, contentType: String): RequestBody =
+        body?.let {
+            requestBody(body, contentType)
+        } ?: RequestBody.create(null, "")
 }

--- a/samples/client/petstore/kotlin/src/main/kotlin/io/swagger/client/infrastructure/ApiClient.kt
+++ b/samples/client/petstore/kotlin/src/main/kotlin/io/swagger/client/infrastructure/ApiClient.kt
@@ -85,9 +85,9 @@ open class ApiClient(val baseUrl: String) {
             RequestMethod.DELETE -> Request.Builder().url(url).delete()
             RequestMethod.GET -> Request.Builder().url(url)
             RequestMethod.HEAD -> Request.Builder().url(url).head()
-            RequestMethod.PATCH -> Request.Builder().url(url).patch(safeRequestBody(body, contentType))
-            RequestMethod.PUT -> Request.Builder().url(url).put(safeRequestBody(body, contentType))
-            RequestMethod.POST -> Request.Builder().url(url).post(safeRequestBody(body, contentType))
+            RequestMethod.PATCH -> Request.Builder().url(url).patch(requestBody(body, contentType))
+            RequestMethod.PUT -> Request.Builder().url(url).put(requestBody(body, contentType))
+            RequestMethod.POST -> Request.Builder().url(url).post(requestBody(body, contentType))
             RequestMethod.OPTIONS -> Request.Builder().url(url).method("OPTIONS", null)
         }
 
@@ -125,9 +125,4 @@ open class ApiClient(val baseUrl: String) {
             )
         }
     }
-
-    inline protected fun safeRequestBody(body : Any?, contentType: String): RequestBody =
-        body?.let {
-            requestBody(body, contentType)
-        } ?: RequestBody.create(null, "")
 }

--- a/samples/client/petstore/kotlin/src/main/kotlin/io/swagger/client/infrastructure/ApiClient.kt
+++ b/samples/client/petstore/kotlin/src/main/kotlin/io/swagger/client/infrastructure/ApiClient.kt
@@ -85,9 +85,9 @@ open class ApiClient(val baseUrl: String) {
             RequestMethod.DELETE -> Request.Builder().url(url).delete()
             RequestMethod.GET -> Request.Builder().url(url)
             RequestMethod.HEAD -> Request.Builder().url(url).head()
-            RequestMethod.PATCH -> Request.Builder().url(url).patch(requestBody(body!!, contentType))
-            RequestMethod.PUT -> Request.Builder().url(url).put(requestBody(body!!, contentType))
-            RequestMethod.POST -> Request.Builder().url(url).post(requestBody(body!!, contentType))
+            RequestMethod.PATCH -> Request.Builder().url(url).patch(safeRequestBody(body, contentType))
+            RequestMethod.PUT -> Request.Builder().url(url).put(safeRequestBody(body, contentType))
+            RequestMethod.POST -> Request.Builder().url(url).post(safeRequestBody(body, contentType))
             RequestMethod.OPTIONS -> Request.Builder().url(url).method("OPTIONS", null)
         }
 
@@ -125,4 +125,9 @@ open class ApiClient(val baseUrl: String) {
             )
         }
     }
+
+    inline protected fun safeRequestBody(body : Any?, contentType: String): RequestBody =
+        body?.let {
+            requestBody(body, contentType)
+        } ?: RequestBody.create(null, "")
 }


### PR DESCRIPTION
…agger-codegen generates clients from Api models without bodies for these methods.

### PR checklist

- [X] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [X] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [X] Filed the PR against the correct branch: `3.0.0` branch for changes related to OpenAPI spec 3.0. Default: `master`.
- [X Copied the [technical committee](https://github.com/swagger-api/swagger-codegen/#swagger-codegen-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

This change prevents an NPE in the case that a POST/PUT/PATCH request did not specify a model.  The Java client allows empty models, so I believe this is a valid change.

See also: https://github.com/square/okhttp/issues/751

This is a resubmission of https://github.com/swagger-api/swagger-codegen/pull/7626 due to an issue w/ email address associated with commit.

Testing:

I've consumed my forked repo branch via jitpack on an internal project and have used the feature successfully.
Unit tests pass.

CC @jimschubert
