### PR TITLE
[Rust] Changes hard coded body to dynamic parameter name - Fixes #6569

### DIFF
--- a/modules/swagger-codegen/src/main/resources/rust/api.mustache
+++ b/modules/swagger-codegen/src/main/resources/rust/api.mustache
@@ -75,7 +75,7 @@ impl<C: hyper::client::Connect>{{classname}} for {{classname}}Client<C> {
 
         {{#hasBodyParam}}
         {{#bodyParams}}
-        let serialized = serde_json::to_string(&body).unwrap();
+        let serialized = serde_json::to_string(&{{paramName}}).unwrap();
         req.headers_mut().set(hyper::header::ContentType::json());
         req.headers_mut().set(hyper::header::ContentLength(serialized.len() as u64));
         req.set_body(serialized);


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [x] Filed the PR against the correct branch: `3.0.0` branch for changes related to OpenAPI spec 3.0. Default: `master`.
- [x] Copied the [technical committee](https://github.com/swagger-api/swagger-codegen/#swagger-codegen-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

Changed to `{{paramName}}` instead of `body`. Otherwise generated code cannot be compiled since method parameter is named with `{{paramName}}` and there is no variable named `body`.

Test has been done with suggested yaml:
```yaml
paths:
  '/ExampleResource':
    post:
      summary: Example
      parameters:
        - in: body
          name: body_param_name
          schema:
            $ref: '#/definitions/Example'
      responses:
        '200':
          description: Successful operation.
definitions:
  Example:
    description: "example"
    type: string
```