### PR TITLE
7616 correct body params filename

### DIFF
--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/ScalaGatlingCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/ScalaGatlingCodegen.java
@@ -252,7 +252,7 @@ public class ScalaGatlingCodegen extends AbstractScalaCodegen implements Codegen
                             operation.setVendorExtension("x-gatling-body-feeder", operation.getOperationId() + "BodyFeeder");
                             operation.setVendorExtension("x-gatling-body-feeder-params", StringUtils.join(sessionBodyVars, ","));
                             try {
-                                FileUtils.writeStringToFile(new File(outputFolder + File.separator + dataFolder + File.separator + operation.getOperationId() + "-" + "BodyParams.csv"), StringUtils.join(bodyFeederParams, ","));
+                                FileUtils.writeStringToFile(new File(outputFolder + File.separator + dataFolder + File.separator + operation.getOperationId() + "-" + "bodyParams.csv"), StringUtils.join(bodyFeederParams, ","));
                             } catch (IOException ioe) {
                                 LOGGER.error("Could not create feeder file for operationId" + operation.getOperationId(), ioe);
                             }

--- a/modules/swagger-codegen/src/main/resources/scala-gatling/build.gradle
+++ b/modules/swagger-codegen/src/main/resources/scala-gatling/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id 'com.github.lkishalmi.gatling' version '0.4.1'
+    id 'com.github.lkishalmi.gatling' version '0.7.1'
 }
 
 repositories {


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [x] Filed the PR against the correct branch: `3.0.0` branch for changes related to OpenAPI spec 3.0. Default: `master`.
- [x] Copied the [technical committee](https://github.com/swagger-api/swagger-codegen/#swagger-codegen-technical-committee) to review the pull request if your PR is targeting a particular programming language.

@clasnake @jimschubert @shijinkui 

### Description of the PR

The `-BodyParams.csv` file must be named `-bodyParams.csv` as that file is used in the gatling test defnition. Futhermore all other files are also using lowercase names (e.g. `-headerParams.csv`).

close #7616 

