### PR TITLE
fix typo

### DIFF
--- a/modules/swagger-codegen/src/test/resources/2_0/petstore-with-fake-endpoints-models-for-testing.yaml
+++ b/modules/swagger-codegen/src/test/resources/2_0/petstore-with-fake-endpoints-models-for-testing.yaml
@@ -565,7 +565,7 @@ paths:
       tags:
         - "fake_classname_tags 123#$%^"
       summary: To test class name in snake case
-      descriptions: To test class name in snake case
+      description: To test class name in snake case
       operationId: testClassname
       consumes:
         - application/json


### PR DESCRIPTION
### Description of the PR

fixed typo in `petstore-with-fake-endpoints-models-for-testing.yaml`
`descriptions:` -> `description:`

