### PR TITLE
7644 objc deprecated afnetworking datataskwithrequest

### DIFF
--- a/modules/swagger-codegen/src/main/resources/objc/ApiClient-body.mustache
+++ b/modules/swagger-codegen/src/main/resources/objc/ApiClient-body.mustache
@@ -90,7 +90,7 @@ static NSString * {{classPrefix}}__fileNameForResponse(NSURLResponse *response) 
 
 - (NSURLSessionDataTask*) taskWithCompletionBlock: (NSURLRequest *)request completionBlock: (void (^)(id, NSError *))completionBlock {
 
-    NSURLSessionDataTask *task = [self dataTaskWithRequest:request completionHandler:^(NSURLResponse * _Nonnull response, id  _Nullable responseObject, NSError * _Nullable error) {
+    NSURLSessionDataTask *task = [self dataTaskWithRequest:request uploadProgress:nil downloadProgress:nil completionHandler:^(NSURLResponse * _Nonnull response, id  _Nullable responseObject, NSError * _Nullable error) {
         {{classPrefix}}DebugLogResponse(response, responseObject,request,error);
         if(!error) {
             completionBlock(responseObject, nil);
@@ -112,7 +112,7 @@ static NSString * {{classPrefix}}__fileNameForResponse(NSURLResponse *response) 
 
     __block NSString * tempFolderPath = [self.configuration.tempFolderPath copy];
 
-    NSURLSessionDataTask* task = [self dataTaskWithRequest:request completionHandler:^(NSURLResponse *response, id responseObject, NSError *error) {
+    NSURLSessionDataTask* task = [self dataTaskWithRequest:request uploadProgress:nil downloadProgress:nil completionHandler:^(NSURLResponse *response, id responseObject, NSError *error) {
         {{classPrefix}}DebugLogResponse(response, responseObject,request,error);
 
         if(error) {

--- a/samples/client/petstore-security-test/objc/SwaggerClient/Core/SWGApiClient.h
+++ b/samples/client/petstore-security-test/objc/SwaggerClient/Core/SWGApiClient.h
@@ -66,7 +66,7 @@ extern NSString *const SWGResponseObjectErrorKey;
 /**
  * Updates header parameters and query parameters for authentication
  *
- * @param headers The header parameter will be udpated, passed by pointer to pointer.
+ * @param headers The header parameter will be updated, passed by pointer to pointer.
  * @param querys The query parameters will be updated, passed by pointer to pointer.
  * @param authSettings The authentication names NSArray.
  */

--- a/samples/client/petstore-security-test/objc/SwaggerClient/Core/SWGApiClient.m
+++ b/samples/client/petstore-security-test/objc/SwaggerClient/Core/SWGApiClient.m
@@ -90,7 +90,7 @@ static NSString * SWG__fileNameForResponse(NSURLResponse *response) {
 
 - (NSURLSessionDataTask*) taskWithCompletionBlock: (NSURLRequest *)request completionBlock: (void (^)(id, NSError *))completionBlock {
 
-    NSURLSessionDataTask *task = [self dataTaskWithRequest:request completionHandler:^(NSURLResponse * _Nonnull response, id  _Nullable responseObject, NSError * _Nullable error) {
+    NSURLSessionDataTask *task = [self dataTaskWithRequest:request uploadProgress:nil downloadProgress:nil completionHandler:^(NSURLResponse * _Nonnull response, id  _Nullable responseObject, NSError * _Nullable error) {
         SWGDebugLogResponse(response, responseObject,request,error);
         if(!error) {
             completionBlock(responseObject, nil);
@@ -112,7 +112,7 @@ static NSString * SWG__fileNameForResponse(NSURLResponse *response) {
 
     __block NSString * tempFolderPath = [self.configuration.tempFolderPath copy];
 
-    NSURLSessionDataTask* task = [self dataTaskWithRequest:request completionHandler:^(NSURLResponse *response, id responseObject, NSError *error) {
+    NSURLSessionDataTask* task = [self dataTaskWithRequest:request uploadProgress:nil downloadProgress:nil completionHandler:^(NSURLResponse *response, id responseObject, NSError *error) {
         SWGDebugLogResponse(response, responseObject,request,error);
 
         if(error) {

--- a/samples/client/petstore-security-test/objc/git_push.sh
+++ b/samples/client/petstore-security-test/objc/git_push.sh
@@ -36,7 +36,7 @@ git_remote=`git remote`
 if [ "$git_remote" = "" ]; then # git remote not defined
 
     if [ "$GIT_TOKEN" = "" ]; then
-        echo "[INFO] \$GIT_TOKEN (environment variable) is not set. Using the git crediential in your environment."
+        echo "[INFO] \$GIT_TOKEN (environment variable) is not set. Using the git credential in your environment."
         git remote add origin https://github.com/${git_user_id}/${git_repo_id}.git
     else
         git remote add origin https://${git_user_id}:${GIT_TOKEN}@github.com/${git_user_id}/${git_repo_id}.git

--- a/samples/client/petstore/objc/default/SwaggerClient/Core/SWGApiClient.m
+++ b/samples/client/petstore/objc/default/SwaggerClient/Core/SWGApiClient.m
@@ -90,7 +90,7 @@ static NSString * SWG__fileNameForResponse(NSURLResponse *response) {
 
 - (NSURLSessionDataTask*) taskWithCompletionBlock: (NSURLRequest *)request completionBlock: (void (^)(id, NSError *))completionBlock {
 
-    NSURLSessionDataTask *task = [self dataTaskWithRequest:request completionHandler:^(NSURLResponse * _Nonnull response, id  _Nullable responseObject, NSError * _Nullable error) {
+    NSURLSessionDataTask *task = [self dataTaskWithRequest:request uploadProgress:nil downloadProgress:nil completionHandler:^(NSURLResponse * _Nonnull response, id  _Nullable responseObject, NSError * _Nullable error) {
         SWGDebugLogResponse(response, responseObject,request,error);
         if(!error) {
             completionBlock(responseObject, nil);
@@ -112,7 +112,7 @@ static NSString * SWG__fileNameForResponse(NSURLResponse *response) {
 
     __block NSString * tempFolderPath = [self.configuration.tempFolderPath copy];
 
-    NSURLSessionDataTask* task = [self dataTaskWithRequest:request completionHandler:^(NSURLResponse *response, id responseObject, NSError *error) {
+    NSURLSessionDataTask* task = [self dataTaskWithRequest:request uploadProgress:nil downloadProgress:nil completionHandler:^(NSURLResponse *response, id responseObject, NSError *error) {
         SWGDebugLogResponse(response, responseObject,request,error);
 
         if(error) {

--- a/samples/client/petstore/objc/default/git_push.sh
+++ b/samples/client/petstore/objc/default/git_push.sh
@@ -36,7 +36,7 @@ git_remote=`git remote`
 if [ "$git_remote" = "" ]; then # git remote not defined
 
     if [ "$GIT_TOKEN" = "" ]; then
-        echo "[INFO] \$GIT_TOKEN (environment variable) is not set. Using the git crediential in your environment."
+        echo "[INFO] \$GIT_TOKEN (environment variable) is not set. Using the git credential in your environment."
         git remote add origin https://github.com/${git_user_id}/${git_repo_id}.git
     else
         git remote add origin https://${git_user_id}:${GIT_TOKEN}@github.com/${git_user_id}/${git_repo_id}.git


### PR DESCRIPTION
### PR checklist

- [X] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [X] Filed the PR against the correct branch: `3.0.0` branch for changes related to OpenAPI spec 3.0. Default: `master`.
- [X] Copied the [technical committee](https://github.com/swagger-api/swagger-codegen/#swagger-codegen-technical-committee) to review the pull request if your PR is targeting a particular programming language.
NOTE: There is no ObjC technical committee. Copying the Swift committee: @jgavris @ehyche @Edubits @jaz-ah

### Description of the PR

In the ObjC generator, replaced calls to the deprecated AFNetworking function `dataTaskWithRequest:completionHandler:` with the replacement function `dataTaskWithRequest:uploadProgress:downloadProgress:completionHandler:`.

The generator now incorporates the recommended migration path from AFNetworking, which is to simply call the replacement function, setting the two new parameters in the replacement function to `nil`.

The generated ObjC client no longer causes deprecation warnings in Xcode.

Fixes #7644 

