### PR TITLE
[Swift] Add public initializer for modelObject.

### DIFF
--- a/modules/swagger-codegen/src/main/resources/swift4/modelObject.mustache
+++ b/modules/swagger-codegen/src/main/resources/swift4/modelObject.mustache
@@ -22,6 +22,14 @@ public struct {{classname}}: Codable {
 {{/isEnum}}
 {{/allVars}}
 
+    {{#hasVars}}
+    public init({{#vars}}{{name}}: {{{datatypeWithEnum}}}{{^required}}?{{/required}}{{#hasMore}}, {{/hasMore}}{{/vars}}) {
+        {{#vars}}
+        self.{{name}} = {{name}}
+        {{/vars}}
+    }
+    {{/hasVars}}
+
 {{#additionalPropertiesType}}
     public var additionalProperties: [String:{{{additionalPropertiesType}}}] = [:]
 

--- a/modules/swagger-codegen/src/main/resources/swift4/modelObject.mustache
+++ b/modules/swagger-codegen/src/main/resources/swift4/modelObject.mustache
@@ -22,13 +22,13 @@ public struct {{classname}}: Codable {
 {{/isEnum}}
 {{/allVars}}
 
-    {{#hasVars}}
+{{#hasVars}}
     public init({{#allVars}}{{name}}: {{{datatypeWithEnum}}}{{^required}}?{{/required}}{{#hasMore}}, {{/hasMore}}{{/allVars}}) {
         {{#allVars}}
         self.{{name}} = {{name}}
         {{/allVars}}
     }
-    {{/hasVars}}
+{{/hasVars}}
 
 {{#additionalPropertiesType}}
     public var additionalProperties: [String:{{{additionalPropertiesType}}}] = [:]

--- a/modules/swagger-codegen/src/main/resources/swift4/modelObject.mustache
+++ b/modules/swagger-codegen/src/main/resources/swift4/modelObject.mustache
@@ -23,10 +23,10 @@ public struct {{classname}}: Codable {
 {{/allVars}}
 
     {{#hasVars}}
-    public init({{#vars}}{{name}}: {{{datatypeWithEnum}}}{{^required}}?{{/required}}{{#hasMore}}, {{/hasMore}}{{/vars}}) {
-        {{#vars}}
+    public init({{#allVars}}{{name}}: {{{datatypeWithEnum}}}{{^required}}?{{/required}}{{#hasMore}}, {{/hasMore}}{{/allVars}}) {
+        {{#allVars}}
         self.{{name}} = {{name}}
-        {{/vars}}
+        {{/allVars}}
     }
     {{/hasVars}}
 

--- a/samples/client/petstore/swift4/default/PetstoreClient/Classes/Swaggers/APIs/UserAPI.swift
+++ b/samples/client/petstore/swift4/default/PetstoreClient/Classes/Swaggers/APIs/UserAPI.swift
@@ -157,7 +157,7 @@ open class UserAPI {
     /**
      Get user by user name
      
-     - parameter username: (path) The name that needs to be fetched. Use user1 for testing.  
+     - parameter username: (path) The name that needs to be fetched. Use user1 for testing. 
      - parameter completion: completion handler to receive the data and the error objects
      */
     open class func getUserByName(username: String, completion: @escaping ((_ data: User?,_ error: Error?) -> Void)) {
@@ -210,7 +210,7 @@ open class UserAPI {
   "username" : "username"
 }}]
      
-     - parameter username: (path) The name that needs to be fetched. Use user1 for testing.  
+     - parameter username: (path) The name that needs to be fetched. Use user1 for testing. 
 
      - returns: RequestBuilder<User> 
      */

--- a/samples/client/petstore/swift4/default/PetstoreClient/Classes/Swaggers/Models/AdditionalPropertiesClass.swift
+++ b/samples/client/petstore/swift4/default/PetstoreClient/Classes/Swaggers/Models/AdditionalPropertiesClass.swift
@@ -14,6 +14,11 @@ public struct AdditionalPropertiesClass: Codable {
     public var mapProperty: [String:String]?
     public var mapOfMapProperty: [String:[String:String]]?
 
+    public init(mapProperty: [String:String]?, mapOfMapProperty: [String:[String:String]]?) {
+        self.mapProperty = mapProperty
+        self.mapOfMapProperty = mapOfMapProperty
+    }
+
 
     public enum CodingKeys: String, CodingKey { 
         case mapProperty = "map_property"

--- a/samples/client/petstore/swift4/default/PetstoreClient/Classes/Swaggers/Models/Animal.swift
+++ b/samples/client/petstore/swift4/default/PetstoreClient/Classes/Swaggers/Models/Animal.swift
@@ -14,6 +14,11 @@ public struct Animal: Codable {
     public var className: String
     public var color: String?
 
+    public init(className: String, color: String?) {
+        self.className = className
+        self.color = color
+    }
+
 
 
 }

--- a/samples/client/petstore/swift4/default/PetstoreClient/Classes/Swaggers/Models/ApiResponse.swift
+++ b/samples/client/petstore/swift4/default/PetstoreClient/Classes/Swaggers/Models/ApiResponse.swift
@@ -15,6 +15,12 @@ public struct ApiResponse: Codable {
     public var type: String?
     public var message: String?
 
+    public init(code: Int?, type: String?, message: String?) {
+        self.code = code
+        self.type = type
+        self.message = message
+    }
+
 
 
 }

--- a/samples/client/petstore/swift4/default/PetstoreClient/Classes/Swaggers/Models/ArrayOfArrayOfNumberOnly.swift
+++ b/samples/client/petstore/swift4/default/PetstoreClient/Classes/Swaggers/Models/ArrayOfArrayOfNumberOnly.swift
@@ -13,6 +13,10 @@ public struct ArrayOfArrayOfNumberOnly: Codable {
 
     public var arrayArrayNumber: [[Double]]?
 
+    public init(arrayArrayNumber: [[Double]]?) {
+        self.arrayArrayNumber = arrayArrayNumber
+    }
+
 
     public enum CodingKeys: String, CodingKey { 
         case arrayArrayNumber = "ArrayArrayNumber"

--- a/samples/client/petstore/swift4/default/PetstoreClient/Classes/Swaggers/Models/ArrayOfNumberOnly.swift
+++ b/samples/client/petstore/swift4/default/PetstoreClient/Classes/Swaggers/Models/ArrayOfNumberOnly.swift
@@ -13,6 +13,10 @@ public struct ArrayOfNumberOnly: Codable {
 
     public var arrayNumber: [Double]?
 
+    public init(arrayNumber: [Double]?) {
+        self.arrayNumber = arrayNumber
+    }
+
 
     public enum CodingKeys: String, CodingKey { 
         case arrayNumber = "ArrayNumber"

--- a/samples/client/petstore/swift4/default/PetstoreClient/Classes/Swaggers/Models/ArrayTest.swift
+++ b/samples/client/petstore/swift4/default/PetstoreClient/Classes/Swaggers/Models/ArrayTest.swift
@@ -15,6 +15,12 @@ public struct ArrayTest: Codable {
     public var arrayArrayOfInteger: [[Int64]]?
     public var arrayArrayOfModel: [[ReadOnlyFirst]]?
 
+    public init(arrayOfString: [String]?, arrayArrayOfInteger: [[Int64]]?, arrayArrayOfModel: [[ReadOnlyFirst]]?) {
+        self.arrayOfString = arrayOfString
+        self.arrayArrayOfInteger = arrayArrayOfInteger
+        self.arrayArrayOfModel = arrayArrayOfModel
+    }
+
 
     public enum CodingKeys: String, CodingKey { 
         case arrayOfString = "array_of_string"

--- a/samples/client/petstore/swift4/default/PetstoreClient/Classes/Swaggers/Models/Capitalization.swift
+++ b/samples/client/petstore/swift4/default/PetstoreClient/Classes/Swaggers/Models/Capitalization.swift
@@ -19,6 +19,15 @@ public struct Capitalization: Codable {
     /** Name of the pet  */
     public var ATT_NAME: String?
 
+    public init(smallCamel: String?, capitalCamel: String?, smallSnake: String?, capitalSnake: String?, sCAETHFlowPoints: String?, ATT_NAME: String?) {
+        self.smallCamel = smallCamel
+        self.capitalCamel = capitalCamel
+        self.smallSnake = smallSnake
+        self.capitalSnake = capitalSnake
+        self.sCAETHFlowPoints = sCAETHFlowPoints
+        self.ATT_NAME = ATT_NAME
+    }
+
 
     public enum CodingKeys: String, CodingKey { 
         case smallCamel

--- a/samples/client/petstore/swift4/default/PetstoreClient/Classes/Swaggers/Models/Cat.swift
+++ b/samples/client/petstore/swift4/default/PetstoreClient/Classes/Swaggers/Models/Cat.swift
@@ -15,6 +15,10 @@ public struct Cat: Codable {
     public var color: String?
     public var declawed: Bool?
 
+    public init(declawed: Bool?) {
+        self.declawed = declawed
+    }
+
 
 
 }

--- a/samples/client/petstore/swift4/default/PetstoreClient/Classes/Swaggers/Models/Cat.swift
+++ b/samples/client/petstore/swift4/default/PetstoreClient/Classes/Swaggers/Models/Cat.swift
@@ -15,7 +15,9 @@ public struct Cat: Codable {
     public var color: String?
     public var declawed: Bool?
 
-    public init(declawed: Bool?) {
+    public init(className: String, color: String?, declawed: Bool?) {
+        self.className = className
+        self.color = color
         self.declawed = declawed
     }
 

--- a/samples/client/petstore/swift4/default/PetstoreClient/Classes/Swaggers/Models/Category.swift
+++ b/samples/client/petstore/swift4/default/PetstoreClient/Classes/Swaggers/Models/Category.swift
@@ -14,6 +14,11 @@ public struct Category: Codable {
     public var _id: Int64?
     public var name: String?
 
+    public init(_id: Int64?, name: String?) {
+        self._id = _id
+        self.name = name
+    }
+
 
     public enum CodingKeys: String, CodingKey { 
         case _id = "id"

--- a/samples/client/petstore/swift4/default/PetstoreClient/Classes/Swaggers/Models/ClassModel.swift
+++ b/samples/client/petstore/swift4/default/PetstoreClient/Classes/Swaggers/Models/ClassModel.swift
@@ -14,6 +14,10 @@ public struct ClassModel: Codable {
 
     public var _class: String?
 
+    public init(_class: String?) {
+        self._class = _class
+    }
+
 
 
 }

--- a/samples/client/petstore/swift4/default/PetstoreClient/Classes/Swaggers/Models/Client.swift
+++ b/samples/client/petstore/swift4/default/PetstoreClient/Classes/Swaggers/Models/Client.swift
@@ -13,6 +13,10 @@ public struct Client: Codable {
 
     public var client: String?
 
+    public init(client: String?) {
+        self.client = client
+    }
+
 
 
 }

--- a/samples/client/petstore/swift4/default/PetstoreClient/Classes/Swaggers/Models/Dog.swift
+++ b/samples/client/petstore/swift4/default/PetstoreClient/Classes/Swaggers/Models/Dog.swift
@@ -15,7 +15,9 @@ public struct Dog: Codable {
     public var color: String?
     public var breed: String?
 
-    public init(breed: String?) {
+    public init(className: String, color: String?, breed: String?) {
+        self.className = className
+        self.color = color
         self.breed = breed
     }
 

--- a/samples/client/petstore/swift4/default/PetstoreClient/Classes/Swaggers/Models/Dog.swift
+++ b/samples/client/petstore/swift4/default/PetstoreClient/Classes/Swaggers/Models/Dog.swift
@@ -15,6 +15,10 @@ public struct Dog: Codable {
     public var color: String?
     public var breed: String?
 
+    public init(breed: String?) {
+        self.breed = breed
+    }
+
 
 
 }

--- a/samples/client/petstore/swift4/default/PetstoreClient/Classes/Swaggers/Models/EnumArrays.swift
+++ b/samples/client/petstore/swift4/default/PetstoreClient/Classes/Swaggers/Models/EnumArrays.swift
@@ -22,6 +22,11 @@ public struct EnumArrays: Codable {
     public var justSymbol: JustSymbol?
     public var arrayEnum: [ArrayEnum]?
 
+    public init(justSymbol: JustSymbol?, arrayEnum: [ArrayEnum]?) {
+        self.justSymbol = justSymbol
+        self.arrayEnum = arrayEnum
+    }
+
 
     public enum CodingKeys: String, CodingKey { 
         case justSymbol = "just_symbol"

--- a/samples/client/petstore/swift4/default/PetstoreClient/Classes/Swaggers/Models/EnumTest.swift
+++ b/samples/client/petstore/swift4/default/PetstoreClient/Classes/Swaggers/Models/EnumTest.swift
@@ -29,6 +29,13 @@ public struct EnumTest: Codable {
     public var enumNumber: EnumNumber?
     public var outerEnum: OuterEnum?
 
+    public init(enumString: EnumString?, enumInteger: EnumInteger?, enumNumber: EnumNumber?, outerEnum: OuterEnum?) {
+        self.enumString = enumString
+        self.enumInteger = enumInteger
+        self.enumNumber = enumNumber
+        self.outerEnum = outerEnum
+    }
+
 
     public enum CodingKeys: String, CodingKey { 
         case enumString = "enum_string"

--- a/samples/client/petstore/swift4/default/PetstoreClient/Classes/Swaggers/Models/FormatTest.swift
+++ b/samples/client/petstore/swift4/default/PetstoreClient/Classes/Swaggers/Models/FormatTest.swift
@@ -25,6 +25,22 @@ public struct FormatTest: Codable {
     public var uuid: UUID?
     public var password: String
 
+    public init(integer: Int?, int32: Int?, int64: Int64?, number: Double, float: Float?, double: Double?, string: String?, byte: Data, binary: Data?, date: Date, dateTime: Date?, uuid: UUID?, password: String) {
+        self.integer = integer
+        self.int32 = int32
+        self.int64 = int64
+        self.number = number
+        self.float = float
+        self.double = double
+        self.string = string
+        self.byte = byte
+        self.binary = binary
+        self.date = date
+        self.dateTime = dateTime
+        self.uuid = uuid
+        self.password = password
+    }
+
 
 
 }

--- a/samples/client/petstore/swift4/default/PetstoreClient/Classes/Swaggers/Models/HasOnlyReadOnly.swift
+++ b/samples/client/petstore/swift4/default/PetstoreClient/Classes/Swaggers/Models/HasOnlyReadOnly.swift
@@ -14,6 +14,11 @@ public struct HasOnlyReadOnly: Codable {
     public var bar: String?
     public var foo: String?
 
+    public init(bar: String?, foo: String?) {
+        self.bar = bar
+        self.foo = foo
+    }
+
 
 
 }

--- a/samples/client/petstore/swift4/default/PetstoreClient/Classes/Swaggers/Models/List.swift
+++ b/samples/client/petstore/swift4/default/PetstoreClient/Classes/Swaggers/Models/List.swift
@@ -13,6 +13,10 @@ public struct List: Codable {
 
     public var _123List: String?
 
+    public init(_123List: String?) {
+        self._123List = _123List
+    }
+
 
     public enum CodingKeys: String, CodingKey { 
         case _123List = "123-list"

--- a/samples/client/petstore/swift4/default/PetstoreClient/Classes/Swaggers/Models/MapTest.swift
+++ b/samples/client/petstore/swift4/default/PetstoreClient/Classes/Swaggers/Models/MapTest.swift
@@ -18,6 +18,11 @@ public struct MapTest: Codable {
     public var mapMapOfString: [String:[String:String]]?
     public var mapOfEnumString: [String:String]?
 
+    public init(mapMapOfString: [String:[String:String]]?, mapOfEnumString: [String:String]?) {
+        self.mapMapOfString = mapMapOfString
+        self.mapOfEnumString = mapOfEnumString
+    }
+
 
     public enum CodingKeys: String, CodingKey { 
         case mapMapOfString = "map_map_of_string"

--- a/samples/client/petstore/swift4/default/PetstoreClient/Classes/Swaggers/Models/MixedPropertiesAndAdditionalPropertiesClass.swift
+++ b/samples/client/petstore/swift4/default/PetstoreClient/Classes/Swaggers/Models/MixedPropertiesAndAdditionalPropertiesClass.swift
@@ -15,6 +15,12 @@ public struct MixedPropertiesAndAdditionalPropertiesClass: Codable {
     public var dateTime: Date?
     public var map: [String:Animal]?
 
+    public init(uuid: UUID?, dateTime: Date?, map: [String:Animal]?) {
+        self.uuid = uuid
+        self.dateTime = dateTime
+        self.map = map
+    }
+
 
 
 }

--- a/samples/client/petstore/swift4/default/PetstoreClient/Classes/Swaggers/Models/Model200Response.swift
+++ b/samples/client/petstore/swift4/default/PetstoreClient/Classes/Swaggers/Models/Model200Response.swift
@@ -15,6 +15,11 @@ public struct Model200Response: Codable {
     public var name: Int?
     public var _class: String?
 
+    public init(name: Int?, _class: String?) {
+        self.name = name
+        self._class = _class
+    }
+
 
     public enum CodingKeys: String, CodingKey { 
         case name

--- a/samples/client/petstore/swift4/default/PetstoreClient/Classes/Swaggers/Models/Name.swift
+++ b/samples/client/petstore/swift4/default/PetstoreClient/Classes/Swaggers/Models/Name.swift
@@ -17,6 +17,13 @@ public struct Name: Codable {
     public var property: String?
     public var _123Number: Int?
 
+    public init(name: Int, snakeCase: Int?, property: String?, _123Number: Int?) {
+        self.name = name
+        self.snakeCase = snakeCase
+        self.property = property
+        self._123Number = _123Number
+    }
+
 
     public enum CodingKeys: String, CodingKey { 
         case name

--- a/samples/client/petstore/swift4/default/PetstoreClient/Classes/Swaggers/Models/NumberOnly.swift
+++ b/samples/client/petstore/swift4/default/PetstoreClient/Classes/Swaggers/Models/NumberOnly.swift
@@ -13,6 +13,10 @@ public struct NumberOnly: Codable {
 
     public var justNumber: Double?
 
+    public init(justNumber: Double?) {
+        self.justNumber = justNumber
+    }
+
 
     public enum CodingKeys: String, CodingKey { 
         case justNumber = "JustNumber"

--- a/samples/client/petstore/swift4/default/PetstoreClient/Classes/Swaggers/Models/Order.swift
+++ b/samples/client/petstore/swift4/default/PetstoreClient/Classes/Swaggers/Models/Order.swift
@@ -24,6 +24,15 @@ public struct Order: Codable {
     public var status: Status?
     public var complete: Bool?
 
+    public init(_id: Int64?, petId: Int64?, quantity: Int?, shipDate: Date?, status: Status?, complete: Bool?) {
+        self._id = _id
+        self.petId = petId
+        self.quantity = quantity
+        self.shipDate = shipDate
+        self.status = status
+        self.complete = complete
+    }
+
 
     public enum CodingKeys: String, CodingKey { 
         case _id = "id"

--- a/samples/client/petstore/swift4/default/PetstoreClient/Classes/Swaggers/Models/OuterBoolean.swift
+++ b/samples/client/petstore/swift4/default/PetstoreClient/Classes/Swaggers/Models/OuterBoolean.swift
@@ -14,5 +14,6 @@ public struct OuterBoolean: Codable {
 
 
 
+
 }
 

--- a/samples/client/petstore/swift4/default/PetstoreClient/Classes/Swaggers/Models/OuterComposite.swift
+++ b/samples/client/petstore/swift4/default/PetstoreClient/Classes/Swaggers/Models/OuterComposite.swift
@@ -15,6 +15,12 @@ public struct OuterComposite: Codable {
     public var myString: OuterString?
     public var myBoolean: OuterBoolean?
 
+    public init(myNumber: OuterNumber?, myString: OuterString?, myBoolean: OuterBoolean?) {
+        self.myNumber = myNumber
+        self.myString = myString
+        self.myBoolean = myBoolean
+    }
+
 
     public enum CodingKeys: String, CodingKey { 
         case myNumber = "my_number"

--- a/samples/client/petstore/swift4/default/PetstoreClient/Classes/Swaggers/Models/OuterNumber.swift
+++ b/samples/client/petstore/swift4/default/PetstoreClient/Classes/Swaggers/Models/OuterNumber.swift
@@ -14,5 +14,6 @@ public struct OuterNumber: Codable {
 
 
 
+
 }
 

--- a/samples/client/petstore/swift4/default/PetstoreClient/Classes/Swaggers/Models/OuterString.swift
+++ b/samples/client/petstore/swift4/default/PetstoreClient/Classes/Swaggers/Models/OuterString.swift
@@ -14,5 +14,6 @@ public struct OuterString: Codable {
 
 
 
+
 }
 

--- a/samples/client/petstore/swift4/default/PetstoreClient/Classes/Swaggers/Models/Pet.swift
+++ b/samples/client/petstore/swift4/default/PetstoreClient/Classes/Swaggers/Models/Pet.swift
@@ -24,6 +24,15 @@ public struct Pet: Codable {
     /** pet status in the store */
     public var status: Status?
 
+    public init(_id: Int64?, category: Category?, name: String, photoUrls: [String], tags: [Tag]?, status: Status?) {
+        self._id = _id
+        self.category = category
+        self.name = name
+        self.photoUrls = photoUrls
+        self.tags = tags
+        self.status = status
+    }
+
 
     public enum CodingKeys: String, CodingKey { 
         case _id = "id"

--- a/samples/client/petstore/swift4/default/PetstoreClient/Classes/Swaggers/Models/ReadOnlyFirst.swift
+++ b/samples/client/petstore/swift4/default/PetstoreClient/Classes/Swaggers/Models/ReadOnlyFirst.swift
@@ -14,6 +14,11 @@ public struct ReadOnlyFirst: Codable {
     public var bar: String?
     public var baz: String?
 
+    public init(bar: String?, baz: String?) {
+        self.bar = bar
+        self.baz = baz
+    }
+
 
 
 }

--- a/samples/client/petstore/swift4/default/PetstoreClient/Classes/Swaggers/Models/Return.swift
+++ b/samples/client/petstore/swift4/default/PetstoreClient/Classes/Swaggers/Models/Return.swift
@@ -14,6 +14,10 @@ public struct Return: Codable {
 
     public var _return: Int?
 
+    public init(_return: Int?) {
+        self._return = _return
+    }
+
 
     public enum CodingKeys: String, CodingKey { 
         case _return = "return"

--- a/samples/client/petstore/swift4/default/PetstoreClient/Classes/Swaggers/Models/SpecialModelName.swift
+++ b/samples/client/petstore/swift4/default/PetstoreClient/Classes/Swaggers/Models/SpecialModelName.swift
@@ -13,6 +13,10 @@ public struct SpecialModelName: Codable {
 
     public var specialPropertyName: Int64?
 
+    public init(specialPropertyName: Int64?) {
+        self.specialPropertyName = specialPropertyName
+    }
+
 
     public enum CodingKeys: String, CodingKey { 
         case specialPropertyName = "$special[property.name]"

--- a/samples/client/petstore/swift4/default/PetstoreClient/Classes/Swaggers/Models/Tag.swift
+++ b/samples/client/petstore/swift4/default/PetstoreClient/Classes/Swaggers/Models/Tag.swift
@@ -14,6 +14,11 @@ public struct Tag: Codable {
     public var _id: Int64?
     public var name: String?
 
+    public init(_id: Int64?, name: String?) {
+        self._id = _id
+        self.name = name
+    }
+
 
     public enum CodingKeys: String, CodingKey { 
         case _id = "id"

--- a/samples/client/petstore/swift4/default/PetstoreClient/Classes/Swaggers/Models/User.swift
+++ b/samples/client/petstore/swift4/default/PetstoreClient/Classes/Swaggers/Models/User.swift
@@ -21,6 +21,17 @@ public struct User: Codable {
     /** User Status */
     public var userStatus: Int?
 
+    public init(_id: Int64?, username: String?, firstName: String?, lastName: String?, email: String?, password: String?, phone: String?, userStatus: Int?) {
+        self._id = _id
+        self.username = username
+        self.firstName = firstName
+        self.lastName = lastName
+        self.email = email
+        self.password = password
+        self.phone = phone
+        self.userStatus = userStatus
+    }
+
 
     public enum CodingKeys: String, CodingKey { 
         case _id = "id"

--- a/samples/client/petstore/swift4/objcCompatible/PetstoreClient/Classes/Swaggers/APIs.swift
+++ b/samples/client/petstore/swift4/objcCompatible/PetstoreClient/Classes/Swaggers/APIs.swift
@@ -16,10 +16,10 @@ open class PetstoreClientAPI {
 open class RequestBuilder<T> {
     var credential: URLCredential?
     var headers: [String:String]
-    let parameters: [String:Any]?
-    let isBody: Bool
-    let method: String
-    let URLString: String
+    public let parameters: [String:Any]?
+    public let isBody: Bool
+    public let method: String
+    public let URLString: String
 
     /// Optional block to obtain a reference to the request's progress instance when available.
     public var onProgressReady: ((Progress) -> ())?

--- a/samples/client/petstore/swift4/objcCompatible/PetstoreClient/Classes/Swaggers/APIs/PetAPI.swift
+++ b/samples/client/petstore/swift4/objcCompatible/PetstoreClient/Classes/Swaggers/APIs/PetAPI.swift
@@ -78,7 +78,9 @@ open class PetAPI {
      */
     open class func deletePetWithRequestBuilder(petId: Int64, apiKey: String? = nil) -> RequestBuilder<Void> {
         var path = "/pet/{petId}"
-        path = path.replacingOccurrences(of: "{petId}", with: "\(petId)", options: .literal, range: nil)
+        let petIdPreEscape = "\(petId)"
+        let petIdPostEscape = petIdPreEscape.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? ""
+        path = path.replacingOccurrences(of: "{petId}", with: petIdPostEscape, options: .literal, range: nil)
         let URLString = PetstoreClientAPI.basePath + path
         let parameters: [String:Any]? = nil
 
@@ -432,7 +434,9 @@ open class PetAPI {
      */
     open class func getPetByIdWithRequestBuilder(petId: Int64) -> RequestBuilder<Pet> {
         var path = "/pet/{petId}"
-        path = path.replacingOccurrences(of: "{petId}", with: "\(petId)", options: .literal, range: nil)
+        let petIdPreEscape = "\(petId)"
+        let petIdPostEscape = petIdPreEscape.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? ""
+        path = path.replacingOccurrences(of: "{petId}", with: petIdPostEscape, options: .literal, range: nil)
         let URLString = PetstoreClientAPI.basePath + path
         let parameters: [String:Any]? = nil
 
@@ -513,7 +517,9 @@ open class PetAPI {
      */
     open class func updatePetWithFormWithRequestBuilder(petId: Int64, name: String? = nil, status: String? = nil) -> RequestBuilder<Void> {
         var path = "/pet/{petId}"
-        path = path.replacingOccurrences(of: "{petId}", with: "\(petId)", options: .literal, range: nil)
+        let petIdPreEscape = "\(petId)"
+        let petIdPostEscape = petIdPreEscape.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? ""
+        path = path.replacingOccurrences(of: "{petId}", with: petIdPostEscape, options: .literal, range: nil)
         let URLString = PetstoreClientAPI.basePath + path
         let formParams: [String:Any?] = [
             "name": name,
@@ -567,7 +573,9 @@ open class PetAPI {
      */
     open class func uploadFileWithRequestBuilder(petId: Int64, additionalMetadata: String? = nil, file: URL? = nil) -> RequestBuilder<ApiResponse> {
         var path = "/pet/{petId}/uploadImage"
-        path = path.replacingOccurrences(of: "{petId}", with: "\(petId)", options: .literal, range: nil)
+        let petIdPreEscape = "\(petId)"
+        let petIdPostEscape = petIdPreEscape.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? ""
+        path = path.replacingOccurrences(of: "{petId}", with: petIdPostEscape, options: .literal, range: nil)
         let URLString = PetstoreClientAPI.basePath + path
         let formParams: [String:Any?] = [
             "additionalMetadata": additionalMetadata,

--- a/samples/client/petstore/swift4/objcCompatible/PetstoreClient/Classes/Swaggers/APIs/StoreAPI.swift
+++ b/samples/client/petstore/swift4/objcCompatible/PetstoreClient/Classes/Swaggers/APIs/StoreAPI.swift
@@ -35,7 +35,9 @@ open class StoreAPI {
      */
     open class func deleteOrderWithRequestBuilder(orderId: String) -> RequestBuilder<Void> {
         var path = "/store/order/{order_id}"
-        path = path.replacingOccurrences(of: "{order_id}", with: "\(orderId)", options: .literal, range: nil)
+        let orderIdPreEscape = "\(orderId)"
+        let orderIdPostEscape = orderIdPreEscape.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? ""
+        path = path.replacingOccurrences(of: "{order_id}", with: orderIdPostEscape, options: .literal, range: nil)
         let URLString = PetstoreClientAPI.basePath + path
         let parameters: [String:Any]? = nil
 
@@ -139,7 +141,9 @@ open class StoreAPI {
      */
     open class func getOrderByIdWithRequestBuilder(orderId: Int64) -> RequestBuilder<Order> {
         var path = "/store/order/{order_id}"
-        path = path.replacingOccurrences(of: "{order_id}", with: "\(orderId)", options: .literal, range: nil)
+        let orderIdPreEscape = "\(orderId)"
+        let orderIdPostEscape = orderIdPreEscape.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? ""
+        path = path.replacingOccurrences(of: "{order_id}", with: orderIdPostEscape, options: .literal, range: nil)
         let URLString = PetstoreClientAPI.basePath + path
         let parameters: [String:Any]? = nil
 

--- a/samples/client/petstore/swift4/objcCompatible/PetstoreClient/Classes/Swaggers/APIs/UserAPI.swift
+++ b/samples/client/petstore/swift4/objcCompatible/PetstoreClient/Classes/Swaggers/APIs/UserAPI.swift
@@ -140,7 +140,9 @@ open class UserAPI {
      */
     open class func deleteUserWithRequestBuilder(username: String) -> RequestBuilder<Void> {
         var path = "/user/{username}"
-        path = path.replacingOccurrences(of: "{username}", with: "\(username)", options: .literal, range: nil)
+        let usernamePreEscape = "\(username)"
+        let usernamePostEscape = usernamePreEscape.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? ""
+        path = path.replacingOccurrences(of: "{username}", with: usernamePostEscape, options: .literal, range: nil)
         let URLString = PetstoreClientAPI.basePath + path
         let parameters: [String:Any]? = nil
 
@@ -155,7 +157,7 @@ open class UserAPI {
     /**
      Get user by user name
      
-     - parameter username: (path) The name that needs to be fetched. Use user1 for testing.  
+     - parameter username: (path) The name that needs to be fetched. Use user1 for testing. 
      - parameter completion: completion handler to receive the data and the error objects
      */
     open class func getUserByName(username: String, completion: @escaping ((_ data: User?,_ error: Error?) -> Void)) {
@@ -208,13 +210,15 @@ open class UserAPI {
   "username" : "username"
 }}]
      
-     - parameter username: (path) The name that needs to be fetched. Use user1 for testing.  
+     - parameter username: (path) The name that needs to be fetched. Use user1 for testing. 
 
      - returns: RequestBuilder<User> 
      */
     open class func getUserByNameWithRequestBuilder(username: String) -> RequestBuilder<User> {
         var path = "/user/{username}"
-        path = path.replacingOccurrences(of: "{username}", with: "\(username)", options: .literal, range: nil)
+        let usernamePreEscape = "\(username)"
+        let usernamePostEscape = usernamePreEscape.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? ""
+        path = path.replacingOccurrences(of: "{username}", with: usernamePostEscape, options: .literal, range: nil)
         let URLString = PetstoreClientAPI.basePath + path
         let parameters: [String:Any]? = nil
 
@@ -329,7 +333,9 @@ open class UserAPI {
      */
     open class func updateUserWithRequestBuilder(username: String, body: User) -> RequestBuilder<Void> {
         var path = "/user/{username}"
-        path = path.replacingOccurrences(of: "{username}", with: "\(username)", options: .literal, range: nil)
+        let usernamePreEscape = "\(username)"
+        let usernamePostEscape = usernamePreEscape.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? ""
+        path = path.replacingOccurrences(of: "{username}", with: usernamePostEscape, options: .literal, range: nil)
         let URLString = PetstoreClientAPI.basePath + path
         let parameters = JSONEncodingHelper.encodingParameters(forEncodableObject: body)
 

--- a/samples/client/petstore/swift4/objcCompatible/PetstoreClient/Classes/Swaggers/Models/AdditionalPropertiesClass.swift
+++ b/samples/client/petstore/swift4/objcCompatible/PetstoreClient/Classes/Swaggers/Models/AdditionalPropertiesClass.swift
@@ -14,6 +14,11 @@ public struct AdditionalPropertiesClass: Codable {
     public var mapProperty: [String:String]?
     public var mapOfMapProperty: [String:[String:String]]?
 
+    public init(mapProperty: [String:String]?, mapOfMapProperty: [String:[String:String]]?) {
+        self.mapProperty = mapProperty
+        self.mapOfMapProperty = mapOfMapProperty
+    }
+
 
     public enum CodingKeys: String, CodingKey { 
         case mapProperty = "map_property"

--- a/samples/client/petstore/swift4/objcCompatible/PetstoreClient/Classes/Swaggers/Models/Animal.swift
+++ b/samples/client/petstore/swift4/objcCompatible/PetstoreClient/Classes/Swaggers/Models/Animal.swift
@@ -14,6 +14,11 @@ public struct Animal: Codable {
     public var className: String
     public var color: String?
 
+    public init(className: String, color: String?) {
+        self.className = className
+        self.color = color
+    }
+
 
 
 }

--- a/samples/client/petstore/swift4/objcCompatible/PetstoreClient/Classes/Swaggers/Models/ApiResponse.swift
+++ b/samples/client/petstore/swift4/objcCompatible/PetstoreClient/Classes/Swaggers/Models/ApiResponse.swift
@@ -20,6 +20,12 @@ public struct ApiResponse: Codable {
     public var type: String?
     public var message: String?
 
+    public init(code: Int?, type: String?, message: String?) {
+        self.code = code
+        self.type = type
+        self.message = message
+    }
+
 
 
 }

--- a/samples/client/petstore/swift4/objcCompatible/PetstoreClient/Classes/Swaggers/Models/ArrayOfArrayOfNumberOnly.swift
+++ b/samples/client/petstore/swift4/objcCompatible/PetstoreClient/Classes/Swaggers/Models/ArrayOfArrayOfNumberOnly.swift
@@ -13,6 +13,10 @@ public struct ArrayOfArrayOfNumberOnly: Codable {
 
     public var arrayArrayNumber: [[Double]]?
 
+    public init(arrayArrayNumber: [[Double]]?) {
+        self.arrayArrayNumber = arrayArrayNumber
+    }
+
 
     public enum CodingKeys: String, CodingKey { 
         case arrayArrayNumber = "ArrayArrayNumber"

--- a/samples/client/petstore/swift4/objcCompatible/PetstoreClient/Classes/Swaggers/Models/ArrayOfNumberOnly.swift
+++ b/samples/client/petstore/swift4/objcCompatible/PetstoreClient/Classes/Swaggers/Models/ArrayOfNumberOnly.swift
@@ -13,6 +13,10 @@ public struct ArrayOfNumberOnly: Codable {
 
     public var arrayNumber: [Double]?
 
+    public init(arrayNumber: [Double]?) {
+        self.arrayNumber = arrayNumber
+    }
+
 
     public enum CodingKeys: String, CodingKey { 
         case arrayNumber = "ArrayNumber"

--- a/samples/client/petstore/swift4/objcCompatible/PetstoreClient/Classes/Swaggers/Models/ArrayTest.swift
+++ b/samples/client/petstore/swift4/objcCompatible/PetstoreClient/Classes/Swaggers/Models/ArrayTest.swift
@@ -15,6 +15,12 @@ public struct ArrayTest: Codable {
     public var arrayArrayOfInteger: [[Int64]]?
     public var arrayArrayOfModel: [[ReadOnlyFirst]]?
 
+    public init(arrayOfString: [String]?, arrayArrayOfInteger: [[Int64]]?, arrayArrayOfModel: [[ReadOnlyFirst]]?) {
+        self.arrayOfString = arrayOfString
+        self.arrayArrayOfInteger = arrayArrayOfInteger
+        self.arrayArrayOfModel = arrayArrayOfModel
+    }
+
 
     public enum CodingKeys: String, CodingKey { 
         case arrayOfString = "array_of_string"

--- a/samples/client/petstore/swift4/objcCompatible/PetstoreClient/Classes/Swaggers/Models/Capitalization.swift
+++ b/samples/client/petstore/swift4/objcCompatible/PetstoreClient/Classes/Swaggers/Models/Capitalization.swift
@@ -19,6 +19,15 @@ public struct Capitalization: Codable {
     /** Name of the pet  */
     public var ATT_NAME: String?
 
+    public init(smallCamel: String?, capitalCamel: String?, smallSnake: String?, capitalSnake: String?, sCAETHFlowPoints: String?, ATT_NAME: String?) {
+        self.smallCamel = smallCamel
+        self.capitalCamel = capitalCamel
+        self.smallSnake = smallSnake
+        self.capitalSnake = capitalSnake
+        self.sCAETHFlowPoints = sCAETHFlowPoints
+        self.ATT_NAME = ATT_NAME
+    }
+
 
     public enum CodingKeys: String, CodingKey { 
         case smallCamel

--- a/samples/client/petstore/swift4/objcCompatible/PetstoreClient/Classes/Swaggers/Models/Cat.swift
+++ b/samples/client/petstore/swift4/objcCompatible/PetstoreClient/Classes/Swaggers/Models/Cat.swift
@@ -20,6 +20,10 @@ public struct Cat: Codable {
         }
     }
 
+    public init(declawed: Bool?) {
+        self.declawed = declawed
+    }
+
 
 
 }

--- a/samples/client/petstore/swift4/objcCompatible/PetstoreClient/Classes/Swaggers/Models/Cat.swift
+++ b/samples/client/petstore/swift4/objcCompatible/PetstoreClient/Classes/Swaggers/Models/Cat.swift
@@ -20,7 +20,9 @@ public struct Cat: Codable {
         }
     }
 
-    public init(declawed: Bool?) {
+    public init(className: String, color: String?, declawed: Bool?) {
+        self.className = className
+        self.color = color
         self.declawed = declawed
     }
 

--- a/samples/client/petstore/swift4/objcCompatible/PetstoreClient/Classes/Swaggers/Models/Category.swift
+++ b/samples/client/petstore/swift4/objcCompatible/PetstoreClient/Classes/Swaggers/Models/Category.swift
@@ -19,6 +19,11 @@ public struct Category: Codable {
     }
     public var name: String?
 
+    public init(_id: Int64?, name: String?) {
+        self._id = _id
+        self.name = name
+    }
+
 
     public enum CodingKeys: String, CodingKey { 
         case _id = "id"

--- a/samples/client/petstore/swift4/objcCompatible/PetstoreClient/Classes/Swaggers/Models/ClassModel.swift
+++ b/samples/client/petstore/swift4/objcCompatible/PetstoreClient/Classes/Swaggers/Models/ClassModel.swift
@@ -14,6 +14,10 @@ public struct ClassModel: Codable {
 
     public var _class: String?
 
+    public init(_class: String?) {
+        self._class = _class
+    }
+
 
 
 }

--- a/samples/client/petstore/swift4/objcCompatible/PetstoreClient/Classes/Swaggers/Models/Client.swift
+++ b/samples/client/petstore/swift4/objcCompatible/PetstoreClient/Classes/Swaggers/Models/Client.swift
@@ -13,6 +13,10 @@ public struct Client: Codable {
 
     public var client: String?
 
+    public init(client: String?) {
+        self.client = client
+    }
+
 
 
 }

--- a/samples/client/petstore/swift4/objcCompatible/PetstoreClient/Classes/Swaggers/Models/Dog.swift
+++ b/samples/client/petstore/swift4/objcCompatible/PetstoreClient/Classes/Swaggers/Models/Dog.swift
@@ -15,7 +15,9 @@ public struct Dog: Codable {
     public var color: String?
     public var breed: String?
 
-    public init(breed: String?) {
+    public init(className: String, color: String?, breed: String?) {
+        self.className = className
+        self.color = color
         self.breed = breed
     }
 

--- a/samples/client/petstore/swift4/objcCompatible/PetstoreClient/Classes/Swaggers/Models/Dog.swift
+++ b/samples/client/petstore/swift4/objcCompatible/PetstoreClient/Classes/Swaggers/Models/Dog.swift
@@ -15,6 +15,10 @@ public struct Dog: Codable {
     public var color: String?
     public var breed: String?
 
+    public init(breed: String?) {
+        self.breed = breed
+    }
+
 
 
 }

--- a/samples/client/petstore/swift4/objcCompatible/PetstoreClient/Classes/Swaggers/Models/EnumArrays.swift
+++ b/samples/client/petstore/swift4/objcCompatible/PetstoreClient/Classes/Swaggers/Models/EnumArrays.swift
@@ -22,6 +22,11 @@ public struct EnumArrays: Codable {
     public var justSymbol: JustSymbol?
     public var arrayEnum: [ArrayEnum]?
 
+    public init(justSymbol: JustSymbol?, arrayEnum: [ArrayEnum]?) {
+        self.justSymbol = justSymbol
+        self.arrayEnum = arrayEnum
+    }
+
 
     public enum CodingKeys: String, CodingKey { 
         case justSymbol = "just_symbol"

--- a/samples/client/petstore/swift4/objcCompatible/PetstoreClient/Classes/Swaggers/Models/EnumTest.swift
+++ b/samples/client/petstore/swift4/objcCompatible/PetstoreClient/Classes/Swaggers/Models/EnumTest.swift
@@ -29,6 +29,13 @@ public struct EnumTest: Codable {
     public var enumNumber: EnumNumber?
     public var outerEnum: OuterEnum?
 
+    public init(enumString: EnumString?, enumInteger: EnumInteger?, enumNumber: EnumNumber?, outerEnum: OuterEnum?) {
+        self.enumString = enumString
+        self.enumInteger = enumInteger
+        self.enumNumber = enumNumber
+        self.outerEnum = outerEnum
+    }
+
 
     public enum CodingKeys: String, CodingKey { 
         case enumString = "enum_string"

--- a/samples/client/petstore/swift4/objcCompatible/PetstoreClient/Classes/Swaggers/Models/FormatTest.swift
+++ b/samples/client/petstore/swift4/objcCompatible/PetstoreClient/Classes/Swaggers/Models/FormatTest.swift
@@ -50,6 +50,22 @@ public struct FormatTest: Codable {
     public var uuid: UUID?
     public var password: String
 
+    public init(integer: Int?, int32: Int?, int64: Int64?, number: Double, float: Float?, double: Double?, string: String?, byte: Data, binary: Data?, date: Date, dateTime: Date?, uuid: UUID?, password: String) {
+        self.integer = integer
+        self.int32 = int32
+        self.int64 = int64
+        self.number = number
+        self.float = float
+        self.double = double
+        self.string = string
+        self.byte = byte
+        self.binary = binary
+        self.date = date
+        self.dateTime = dateTime
+        self.uuid = uuid
+        self.password = password
+    }
+
 
 
 }

--- a/samples/client/petstore/swift4/objcCompatible/PetstoreClient/Classes/Swaggers/Models/HasOnlyReadOnly.swift
+++ b/samples/client/petstore/swift4/objcCompatible/PetstoreClient/Classes/Swaggers/Models/HasOnlyReadOnly.swift
@@ -14,6 +14,11 @@ public struct HasOnlyReadOnly: Codable {
     public var bar: String?
     public var foo: String?
 
+    public init(bar: String?, foo: String?) {
+        self.bar = bar
+        self.foo = foo
+    }
+
 
 
 }

--- a/samples/client/petstore/swift4/objcCompatible/PetstoreClient/Classes/Swaggers/Models/List.swift
+++ b/samples/client/petstore/swift4/objcCompatible/PetstoreClient/Classes/Swaggers/Models/List.swift
@@ -13,6 +13,10 @@ public struct List: Codable {
 
     public var _123List: String?
 
+    public init(_123List: String?) {
+        self._123List = _123List
+    }
+
 
     public enum CodingKeys: String, CodingKey { 
         case _123List = "123-list"

--- a/samples/client/petstore/swift4/objcCompatible/PetstoreClient/Classes/Swaggers/Models/MapTest.swift
+++ b/samples/client/petstore/swift4/objcCompatible/PetstoreClient/Classes/Swaggers/Models/MapTest.swift
@@ -18,6 +18,11 @@ public struct MapTest: Codable {
     public var mapMapOfString: [String:[String:String]]?
     public var mapOfEnumString: [String:String]?
 
+    public init(mapMapOfString: [String:[String:String]]?, mapOfEnumString: [String:String]?) {
+        self.mapMapOfString = mapMapOfString
+        self.mapOfEnumString = mapOfEnumString
+    }
+
 
     public enum CodingKeys: String, CodingKey { 
         case mapMapOfString = "map_map_of_string"

--- a/samples/client/petstore/swift4/objcCompatible/PetstoreClient/Classes/Swaggers/Models/MixedPropertiesAndAdditionalPropertiesClass.swift
+++ b/samples/client/petstore/swift4/objcCompatible/PetstoreClient/Classes/Swaggers/Models/MixedPropertiesAndAdditionalPropertiesClass.swift
@@ -15,6 +15,12 @@ public struct MixedPropertiesAndAdditionalPropertiesClass: Codable {
     public var dateTime: Date?
     public var map: [String:Animal]?
 
+    public init(uuid: UUID?, dateTime: Date?, map: [String:Animal]?) {
+        self.uuid = uuid
+        self.dateTime = dateTime
+        self.map = map
+    }
+
 
 
 }

--- a/samples/client/petstore/swift4/objcCompatible/PetstoreClient/Classes/Swaggers/Models/Model200Response.swift
+++ b/samples/client/petstore/swift4/objcCompatible/PetstoreClient/Classes/Swaggers/Models/Model200Response.swift
@@ -20,6 +20,11 @@ public struct Model200Response: Codable {
     }
     public var _class: String?
 
+    public init(name: Int?, _class: String?) {
+        self.name = name
+        self._class = _class
+    }
+
 
     public enum CodingKeys: String, CodingKey { 
         case name

--- a/samples/client/petstore/swift4/objcCompatible/PetstoreClient/Classes/Swaggers/Models/Name.swift
+++ b/samples/client/petstore/swift4/objcCompatible/PetstoreClient/Classes/Swaggers/Models/Name.swift
@@ -32,6 +32,13 @@ public struct Name: Codable {
         }
     }
 
+    public init(name: Int, snakeCase: Int?, property: String?, _123Number: Int?) {
+        self.name = name
+        self.snakeCase = snakeCase
+        self.property = property
+        self._123Number = _123Number
+    }
+
 
     public enum CodingKeys: String, CodingKey { 
         case name

--- a/samples/client/petstore/swift4/objcCompatible/PetstoreClient/Classes/Swaggers/Models/NumberOnly.swift
+++ b/samples/client/petstore/swift4/objcCompatible/PetstoreClient/Classes/Swaggers/Models/NumberOnly.swift
@@ -13,6 +13,10 @@ public struct NumberOnly: Codable {
 
     public var justNumber: Double?
 
+    public init(justNumber: Double?) {
+        self.justNumber = justNumber
+    }
+
 
     public enum CodingKeys: String, CodingKey { 
         case justNumber = "JustNumber"

--- a/samples/client/petstore/swift4/objcCompatible/PetstoreClient/Classes/Swaggers/Models/Order.swift
+++ b/samples/client/petstore/swift4/objcCompatible/PetstoreClient/Classes/Swaggers/Models/Order.swift
@@ -44,6 +44,15 @@ public struct Order: Codable {
         }
     }
 
+    public init(_id: Int64?, petId: Int64?, quantity: Int?, shipDate: Date?, status: Status?, complete: Bool?) {
+        self._id = _id
+        self.petId = petId
+        self.quantity = quantity
+        self.shipDate = shipDate
+        self.status = status
+        self.complete = complete
+    }
+
 
     public enum CodingKeys: String, CodingKey { 
         case _id = "id"

--- a/samples/client/petstore/swift4/objcCompatible/PetstoreClient/Classes/Swaggers/Models/OuterBoolean.swift
+++ b/samples/client/petstore/swift4/objcCompatible/PetstoreClient/Classes/Swaggers/Models/OuterBoolean.swift
@@ -14,5 +14,6 @@ public struct OuterBoolean: Codable {
 
 
 
+
 }
 

--- a/samples/client/petstore/swift4/objcCompatible/PetstoreClient/Classes/Swaggers/Models/OuterComposite.swift
+++ b/samples/client/petstore/swift4/objcCompatible/PetstoreClient/Classes/Swaggers/Models/OuterComposite.swift
@@ -15,6 +15,12 @@ public struct OuterComposite: Codable {
     public var myString: OuterString?
     public var myBoolean: OuterBoolean?
 
+    public init(myNumber: OuterNumber?, myString: OuterString?, myBoolean: OuterBoolean?) {
+        self.myNumber = myNumber
+        self.myString = myString
+        self.myBoolean = myBoolean
+    }
+
 
     public enum CodingKeys: String, CodingKey { 
         case myNumber = "my_number"

--- a/samples/client/petstore/swift4/objcCompatible/PetstoreClient/Classes/Swaggers/Models/OuterNumber.swift
+++ b/samples/client/petstore/swift4/objcCompatible/PetstoreClient/Classes/Swaggers/Models/OuterNumber.swift
@@ -14,5 +14,6 @@ public struct OuterNumber: Codable {
 
 
 
+
 }
 

--- a/samples/client/petstore/swift4/objcCompatible/PetstoreClient/Classes/Swaggers/Models/OuterString.swift
+++ b/samples/client/petstore/swift4/objcCompatible/PetstoreClient/Classes/Swaggers/Models/OuterString.swift
@@ -14,5 +14,6 @@ public struct OuterString: Codable {
 
 
 
+
 }
 

--- a/samples/client/petstore/swift4/objcCompatible/PetstoreClient/Classes/Swaggers/Models/Pet.swift
+++ b/samples/client/petstore/swift4/objcCompatible/PetstoreClient/Classes/Swaggers/Models/Pet.swift
@@ -29,6 +29,15 @@ public struct Pet: Codable {
     /** pet status in the store */
     public var status: Status?
 
+    public init(_id: Int64?, category: Category?, name: String, photoUrls: [String], tags: [Tag]?, status: Status?) {
+        self._id = _id
+        self.category = category
+        self.name = name
+        self.photoUrls = photoUrls
+        self.tags = tags
+        self.status = status
+    }
+
 
     public enum CodingKeys: String, CodingKey { 
         case _id = "id"

--- a/samples/client/petstore/swift4/objcCompatible/PetstoreClient/Classes/Swaggers/Models/ReadOnlyFirst.swift
+++ b/samples/client/petstore/swift4/objcCompatible/PetstoreClient/Classes/Swaggers/Models/ReadOnlyFirst.swift
@@ -14,6 +14,11 @@ public struct ReadOnlyFirst: Codable {
     public var bar: String?
     public var baz: String?
 
+    public init(bar: String?, baz: String?) {
+        self.bar = bar
+        self.baz = baz
+    }
+
 
 
 }

--- a/samples/client/petstore/swift4/objcCompatible/PetstoreClient/Classes/Swaggers/Models/Return.swift
+++ b/samples/client/petstore/swift4/objcCompatible/PetstoreClient/Classes/Swaggers/Models/Return.swift
@@ -19,6 +19,10 @@ public struct Return: Codable {
         }
     }
 
+    public init(_return: Int?) {
+        self._return = _return
+    }
+
 
     public enum CodingKeys: String, CodingKey { 
         case _return = "return"

--- a/samples/client/petstore/swift4/objcCompatible/PetstoreClient/Classes/Swaggers/Models/SpecialModelName.swift
+++ b/samples/client/petstore/swift4/objcCompatible/PetstoreClient/Classes/Swaggers/Models/SpecialModelName.swift
@@ -18,6 +18,10 @@ public struct SpecialModelName: Codable {
         }
     }
 
+    public init(specialPropertyName: Int64?) {
+        self.specialPropertyName = specialPropertyName
+    }
+
 
     public enum CodingKeys: String, CodingKey { 
         case specialPropertyName = "$special[property.name]"

--- a/samples/client/petstore/swift4/objcCompatible/PetstoreClient/Classes/Swaggers/Models/Tag.swift
+++ b/samples/client/petstore/swift4/objcCompatible/PetstoreClient/Classes/Swaggers/Models/Tag.swift
@@ -19,6 +19,11 @@ public struct Tag: Codable {
     }
     public var name: String?
 
+    public init(_id: Int64?, name: String?) {
+        self._id = _id
+        self.name = name
+    }
+
 
     public enum CodingKeys: String, CodingKey { 
         case _id = "id"

--- a/samples/client/petstore/swift4/objcCompatible/PetstoreClient/Classes/Swaggers/Models/User.swift
+++ b/samples/client/petstore/swift4/objcCompatible/PetstoreClient/Classes/Swaggers/Models/User.swift
@@ -31,6 +31,17 @@ public struct User: Codable {
         }
     }
 
+    public init(_id: Int64?, username: String?, firstName: String?, lastName: String?, email: String?, password: String?, phone: String?, userStatus: Int?) {
+        self._id = _id
+        self.username = username
+        self.firstName = firstName
+        self.lastName = lastName
+        self.email = email
+        self.password = password
+        self.phone = phone
+        self.userStatus = userStatus
+    }
+
 
     public enum CodingKeys: String, CodingKey { 
         case _id = "id"

--- a/samples/client/petstore/swift4/promisekit/PetstoreClient/Classes/Swaggers/APIs.swift
+++ b/samples/client/petstore/swift4/promisekit/PetstoreClient/Classes/Swaggers/APIs.swift
@@ -16,10 +16,10 @@ open class PetstoreClientAPI {
 open class RequestBuilder<T> {
     var credential: URLCredential?
     var headers: [String:String]
-    let parameters: [String:Any]?
-    let isBody: Bool
-    let method: String
-    let URLString: String
+    public let parameters: [String:Any]?
+    public let isBody: Bool
+    public let method: String
+    public let URLString: String
 
     /// Optional block to obtain a reference to the request's progress instance when available.
     public var onProgressReady: ((Progress) -> ())?

--- a/samples/client/petstore/swift4/promisekit/PetstoreClient/Classes/Swaggers/APIs/PetAPI.swift
+++ b/samples/client/petstore/swift4/promisekit/PetstoreClient/Classes/Swaggers/APIs/PetAPI.swift
@@ -114,7 +114,9 @@ open class PetAPI {
      */
     open class func deletePetWithRequestBuilder(petId: Int64, apiKey: String? = nil) -> RequestBuilder<Void> {
         var path = "/pet/{petId}"
-        path = path.replacingOccurrences(of: "{petId}", with: "\(petId)", options: .literal, range: nil)
+        let petIdPreEscape = "\(petId)"
+        let petIdPostEscape = petIdPreEscape.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? ""
+        path = path.replacingOccurrences(of: "{petId}", with: petIdPostEscape, options: .literal, range: nil)
         let URLString = PetstoreClientAPI.basePath + path
         let parameters: [String:Any]? = nil
 
@@ -519,7 +521,9 @@ open class PetAPI {
      */
     open class func getPetByIdWithRequestBuilder(petId: Int64) -> RequestBuilder<Pet> {
         var path = "/pet/{petId}"
-        path = path.replacingOccurrences(of: "{petId}", with: "\(petId)", options: .literal, range: nil)
+        let petIdPreEscape = "\(petId)"
+        let petIdPostEscape = petIdPreEscape.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? ""
+        path = path.replacingOccurrences(of: "{petId}", with: petIdPostEscape, options: .literal, range: nil)
         let URLString = PetstoreClientAPI.basePath + path
         let parameters: [String:Any]? = nil
 
@@ -636,7 +640,9 @@ open class PetAPI {
      */
     open class func updatePetWithFormWithRequestBuilder(petId: Int64, name: String? = nil, status: String? = nil) -> RequestBuilder<Void> {
         var path = "/pet/{petId}"
-        path = path.replacingOccurrences(of: "{petId}", with: "\(petId)", options: .literal, range: nil)
+        let petIdPreEscape = "\(petId)"
+        let petIdPostEscape = petIdPreEscape.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? ""
+        path = path.replacingOccurrences(of: "{petId}", with: petIdPostEscape, options: .literal, range: nil)
         let URLString = PetstoreClientAPI.basePath + path
         let formParams: [String:Any?] = [
             "name": name,
@@ -709,7 +715,9 @@ open class PetAPI {
      */
     open class func uploadFileWithRequestBuilder(petId: Int64, additionalMetadata: String? = nil, file: URL? = nil) -> RequestBuilder<ApiResponse> {
         var path = "/pet/{petId}/uploadImage"
-        path = path.replacingOccurrences(of: "{petId}", with: "\(petId)", options: .literal, range: nil)
+        let petIdPreEscape = "\(petId)"
+        let petIdPostEscape = petIdPreEscape.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? ""
+        path = path.replacingOccurrences(of: "{petId}", with: petIdPostEscape, options: .literal, range: nil)
         let URLString = PetstoreClientAPI.basePath + path
         let formParams: [String:Any?] = [
             "additionalMetadata": additionalMetadata,

--- a/samples/client/petstore/swift4/promisekit/PetstoreClient/Classes/Swaggers/APIs/StoreAPI.swift
+++ b/samples/client/petstore/swift4/promisekit/PetstoreClient/Classes/Swaggers/APIs/StoreAPI.swift
@@ -53,7 +53,9 @@ open class StoreAPI {
      */
     open class func deleteOrderWithRequestBuilder(orderId: String) -> RequestBuilder<Void> {
         var path = "/store/order/{order_id}"
-        path = path.replacingOccurrences(of: "{order_id}", with: "\(orderId)", options: .literal, range: nil)
+        let orderIdPreEscape = "\(orderId)"
+        let orderIdPostEscape = orderIdPreEscape.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? ""
+        path = path.replacingOccurrences(of: "{order_id}", with: orderIdPostEscape, options: .literal, range: nil)
         let URLString = PetstoreClientAPI.basePath + path
         let parameters: [String:Any]? = nil
 
@@ -190,7 +192,9 @@ open class StoreAPI {
      */
     open class func getOrderByIdWithRequestBuilder(orderId: Int64) -> RequestBuilder<Order> {
         var path = "/store/order/{order_id}"
-        path = path.replacingOccurrences(of: "{order_id}", with: "\(orderId)", options: .literal, range: nil)
+        let orderIdPreEscape = "\(orderId)"
+        let orderIdPostEscape = orderIdPreEscape.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? ""
+        path = path.replacingOccurrences(of: "{order_id}", with: orderIdPostEscape, options: .literal, range: nil)
         let URLString = PetstoreClientAPI.basePath + path
         let parameters: [String:Any]? = nil
 

--- a/samples/client/petstore/swift4/promisekit/PetstoreClient/Classes/Swaggers/APIs/UserAPI.swift
+++ b/samples/client/petstore/swift4/promisekit/PetstoreClient/Classes/Swaggers/APIs/UserAPI.swift
@@ -209,7 +209,9 @@ open class UserAPI {
      */
     open class func deleteUserWithRequestBuilder(username: String) -> RequestBuilder<Void> {
         var path = "/user/{username}"
-        path = path.replacingOccurrences(of: "{username}", with: "\(username)", options: .literal, range: nil)
+        let usernamePreEscape = "\(username)"
+        let usernamePostEscape = usernamePreEscape.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? ""
+        path = path.replacingOccurrences(of: "{username}", with: usernamePostEscape, options: .literal, range: nil)
         let URLString = PetstoreClientAPI.basePath + path
         let parameters: [String:Any]? = nil
 
@@ -224,7 +226,7 @@ open class UserAPI {
     /**
      Get user by user name
      
-     - parameter username: (path) The name that needs to be fetched. Use user1 for testing.  
+     - parameter username: (path) The name that needs to be fetched. Use user1 for testing. 
      - parameter completion: completion handler to receive the data and the error objects
      */
     open class func getUserByName(username: String, completion: @escaping ((_ data: User?,_ error: Error?) -> Void)) {
@@ -236,7 +238,7 @@ open class UserAPI {
     /**
      Get user by user name
      
-     - parameter username: (path) The name that needs to be fetched. Use user1 for testing.  
+     - parameter username: (path) The name that needs to be fetched. Use user1 for testing. 
      - returns: Promise<User>
      */
     open class func getUserByName( username: String) -> Promise<User> {
@@ -294,13 +296,15 @@ open class UserAPI {
   "username" : "username"
 }}]
      
-     - parameter username: (path) The name that needs to be fetched. Use user1 for testing.  
+     - parameter username: (path) The name that needs to be fetched. Use user1 for testing. 
 
      - returns: RequestBuilder<User> 
      */
     open class func getUserByNameWithRequestBuilder(username: String) -> RequestBuilder<User> {
         var path = "/user/{username}"
-        path = path.replacingOccurrences(of: "{username}", with: "\(username)", options: .literal, range: nil)
+        let usernamePreEscape = "\(username)"
+        let usernamePostEscape = usernamePreEscape.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? ""
+        path = path.replacingOccurrences(of: "{username}", with: usernamePostEscape, options: .literal, range: nil)
         let URLString = PetstoreClientAPI.basePath + path
         let parameters: [String:Any]? = nil
 
@@ -467,7 +471,9 @@ open class UserAPI {
      */
     open class func updateUserWithRequestBuilder(username: String, body: User) -> RequestBuilder<Void> {
         var path = "/user/{username}"
-        path = path.replacingOccurrences(of: "{username}", with: "\(username)", options: .literal, range: nil)
+        let usernamePreEscape = "\(username)"
+        let usernamePostEscape = usernamePreEscape.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? ""
+        path = path.replacingOccurrences(of: "{username}", with: usernamePostEscape, options: .literal, range: nil)
         let URLString = PetstoreClientAPI.basePath + path
         let parameters = JSONEncodingHelper.encodingParameters(forEncodableObject: body)
 

--- a/samples/client/petstore/swift4/promisekit/PetstoreClient/Classes/Swaggers/Models/AdditionalPropertiesClass.swift
+++ b/samples/client/petstore/swift4/promisekit/PetstoreClient/Classes/Swaggers/Models/AdditionalPropertiesClass.swift
@@ -14,6 +14,11 @@ public struct AdditionalPropertiesClass: Codable {
     public var mapProperty: [String:String]?
     public var mapOfMapProperty: [String:[String:String]]?
 
+    public init(mapProperty: [String:String]?, mapOfMapProperty: [String:[String:String]]?) {
+        self.mapProperty = mapProperty
+        self.mapOfMapProperty = mapOfMapProperty
+    }
+
 
     public enum CodingKeys: String, CodingKey { 
         case mapProperty = "map_property"

--- a/samples/client/petstore/swift4/promisekit/PetstoreClient/Classes/Swaggers/Models/Animal.swift
+++ b/samples/client/petstore/swift4/promisekit/PetstoreClient/Classes/Swaggers/Models/Animal.swift
@@ -14,6 +14,11 @@ public struct Animal: Codable {
     public var className: String
     public var color: String?
 
+    public init(className: String, color: String?) {
+        self.className = className
+        self.color = color
+    }
+
 
 
 }

--- a/samples/client/petstore/swift4/promisekit/PetstoreClient/Classes/Swaggers/Models/ApiResponse.swift
+++ b/samples/client/petstore/swift4/promisekit/PetstoreClient/Classes/Swaggers/Models/ApiResponse.swift
@@ -15,6 +15,12 @@ public struct ApiResponse: Codable {
     public var type: String?
     public var message: String?
 
+    public init(code: Int?, type: String?, message: String?) {
+        self.code = code
+        self.type = type
+        self.message = message
+    }
+
 
 
 }

--- a/samples/client/petstore/swift4/promisekit/PetstoreClient/Classes/Swaggers/Models/ArrayOfArrayOfNumberOnly.swift
+++ b/samples/client/petstore/swift4/promisekit/PetstoreClient/Classes/Swaggers/Models/ArrayOfArrayOfNumberOnly.swift
@@ -13,6 +13,10 @@ public struct ArrayOfArrayOfNumberOnly: Codable {
 
     public var arrayArrayNumber: [[Double]]?
 
+    public init(arrayArrayNumber: [[Double]]?) {
+        self.arrayArrayNumber = arrayArrayNumber
+    }
+
 
     public enum CodingKeys: String, CodingKey { 
         case arrayArrayNumber = "ArrayArrayNumber"

--- a/samples/client/petstore/swift4/promisekit/PetstoreClient/Classes/Swaggers/Models/ArrayOfNumberOnly.swift
+++ b/samples/client/petstore/swift4/promisekit/PetstoreClient/Classes/Swaggers/Models/ArrayOfNumberOnly.swift
@@ -13,6 +13,10 @@ public struct ArrayOfNumberOnly: Codable {
 
     public var arrayNumber: [Double]?
 
+    public init(arrayNumber: [Double]?) {
+        self.arrayNumber = arrayNumber
+    }
+
 
     public enum CodingKeys: String, CodingKey { 
         case arrayNumber = "ArrayNumber"

--- a/samples/client/petstore/swift4/promisekit/PetstoreClient/Classes/Swaggers/Models/ArrayTest.swift
+++ b/samples/client/petstore/swift4/promisekit/PetstoreClient/Classes/Swaggers/Models/ArrayTest.swift
@@ -15,6 +15,12 @@ public struct ArrayTest: Codable {
     public var arrayArrayOfInteger: [[Int64]]?
     public var arrayArrayOfModel: [[ReadOnlyFirst]]?
 
+    public init(arrayOfString: [String]?, arrayArrayOfInteger: [[Int64]]?, arrayArrayOfModel: [[ReadOnlyFirst]]?) {
+        self.arrayOfString = arrayOfString
+        self.arrayArrayOfInteger = arrayArrayOfInteger
+        self.arrayArrayOfModel = arrayArrayOfModel
+    }
+
 
     public enum CodingKeys: String, CodingKey { 
         case arrayOfString = "array_of_string"

--- a/samples/client/petstore/swift4/promisekit/PetstoreClient/Classes/Swaggers/Models/Capitalization.swift
+++ b/samples/client/petstore/swift4/promisekit/PetstoreClient/Classes/Swaggers/Models/Capitalization.swift
@@ -19,6 +19,15 @@ public struct Capitalization: Codable {
     /** Name of the pet  */
     public var ATT_NAME: String?
 
+    public init(smallCamel: String?, capitalCamel: String?, smallSnake: String?, capitalSnake: String?, sCAETHFlowPoints: String?, ATT_NAME: String?) {
+        self.smallCamel = smallCamel
+        self.capitalCamel = capitalCamel
+        self.smallSnake = smallSnake
+        self.capitalSnake = capitalSnake
+        self.sCAETHFlowPoints = sCAETHFlowPoints
+        self.ATT_NAME = ATT_NAME
+    }
+
 
     public enum CodingKeys: String, CodingKey { 
         case smallCamel

--- a/samples/client/petstore/swift4/promisekit/PetstoreClient/Classes/Swaggers/Models/Cat.swift
+++ b/samples/client/petstore/swift4/promisekit/PetstoreClient/Classes/Swaggers/Models/Cat.swift
@@ -15,6 +15,10 @@ public struct Cat: Codable {
     public var color: String?
     public var declawed: Bool?
 
+    public init(declawed: Bool?) {
+        self.declawed = declawed
+    }
+
 
 
 }

--- a/samples/client/petstore/swift4/promisekit/PetstoreClient/Classes/Swaggers/Models/Cat.swift
+++ b/samples/client/petstore/swift4/promisekit/PetstoreClient/Classes/Swaggers/Models/Cat.swift
@@ -15,7 +15,9 @@ public struct Cat: Codable {
     public var color: String?
     public var declawed: Bool?
 
-    public init(declawed: Bool?) {
+    public init(className: String, color: String?, declawed: Bool?) {
+        self.className = className
+        self.color = color
         self.declawed = declawed
     }
 

--- a/samples/client/petstore/swift4/promisekit/PetstoreClient/Classes/Swaggers/Models/Category.swift
+++ b/samples/client/petstore/swift4/promisekit/PetstoreClient/Classes/Swaggers/Models/Category.swift
@@ -14,6 +14,11 @@ public struct Category: Codable {
     public var _id: Int64?
     public var name: String?
 
+    public init(_id: Int64?, name: String?) {
+        self._id = _id
+        self.name = name
+    }
+
 
     public enum CodingKeys: String, CodingKey { 
         case _id = "id"

--- a/samples/client/petstore/swift4/promisekit/PetstoreClient/Classes/Swaggers/Models/ClassModel.swift
+++ b/samples/client/petstore/swift4/promisekit/PetstoreClient/Classes/Swaggers/Models/ClassModel.swift
@@ -14,6 +14,10 @@ public struct ClassModel: Codable {
 
     public var _class: String?
 
+    public init(_class: String?) {
+        self._class = _class
+    }
+
 
 
 }

--- a/samples/client/petstore/swift4/promisekit/PetstoreClient/Classes/Swaggers/Models/Client.swift
+++ b/samples/client/petstore/swift4/promisekit/PetstoreClient/Classes/Swaggers/Models/Client.swift
@@ -13,6 +13,10 @@ public struct Client: Codable {
 
     public var client: String?
 
+    public init(client: String?) {
+        self.client = client
+    }
+
 
 
 }

--- a/samples/client/petstore/swift4/promisekit/PetstoreClient/Classes/Swaggers/Models/Dog.swift
+++ b/samples/client/petstore/swift4/promisekit/PetstoreClient/Classes/Swaggers/Models/Dog.swift
@@ -15,7 +15,9 @@ public struct Dog: Codable {
     public var color: String?
     public var breed: String?
 
-    public init(breed: String?) {
+    public init(className: String, color: String?, breed: String?) {
+        self.className = className
+        self.color = color
         self.breed = breed
     }
 

--- a/samples/client/petstore/swift4/promisekit/PetstoreClient/Classes/Swaggers/Models/Dog.swift
+++ b/samples/client/petstore/swift4/promisekit/PetstoreClient/Classes/Swaggers/Models/Dog.swift
@@ -15,6 +15,10 @@ public struct Dog: Codable {
     public var color: String?
     public var breed: String?
 
+    public init(breed: String?) {
+        self.breed = breed
+    }
+
 
 
 }

--- a/samples/client/petstore/swift4/promisekit/PetstoreClient/Classes/Swaggers/Models/EnumArrays.swift
+++ b/samples/client/petstore/swift4/promisekit/PetstoreClient/Classes/Swaggers/Models/EnumArrays.swift
@@ -22,6 +22,11 @@ public struct EnumArrays: Codable {
     public var justSymbol: JustSymbol?
     public var arrayEnum: [ArrayEnum]?
 
+    public init(justSymbol: JustSymbol?, arrayEnum: [ArrayEnum]?) {
+        self.justSymbol = justSymbol
+        self.arrayEnum = arrayEnum
+    }
+
 
     public enum CodingKeys: String, CodingKey { 
         case justSymbol = "just_symbol"

--- a/samples/client/petstore/swift4/promisekit/PetstoreClient/Classes/Swaggers/Models/EnumTest.swift
+++ b/samples/client/petstore/swift4/promisekit/PetstoreClient/Classes/Swaggers/Models/EnumTest.swift
@@ -29,6 +29,13 @@ public struct EnumTest: Codable {
     public var enumNumber: EnumNumber?
     public var outerEnum: OuterEnum?
 
+    public init(enumString: EnumString?, enumInteger: EnumInteger?, enumNumber: EnumNumber?, outerEnum: OuterEnum?) {
+        self.enumString = enumString
+        self.enumInteger = enumInteger
+        self.enumNumber = enumNumber
+        self.outerEnum = outerEnum
+    }
+
 
     public enum CodingKeys: String, CodingKey { 
         case enumString = "enum_string"

--- a/samples/client/petstore/swift4/promisekit/PetstoreClient/Classes/Swaggers/Models/FormatTest.swift
+++ b/samples/client/petstore/swift4/promisekit/PetstoreClient/Classes/Swaggers/Models/FormatTest.swift
@@ -25,6 +25,22 @@ public struct FormatTest: Codable {
     public var uuid: UUID?
     public var password: String
 
+    public init(integer: Int?, int32: Int?, int64: Int64?, number: Double, float: Float?, double: Double?, string: String?, byte: Data, binary: Data?, date: Date, dateTime: Date?, uuid: UUID?, password: String) {
+        self.integer = integer
+        self.int32 = int32
+        self.int64 = int64
+        self.number = number
+        self.float = float
+        self.double = double
+        self.string = string
+        self.byte = byte
+        self.binary = binary
+        self.date = date
+        self.dateTime = dateTime
+        self.uuid = uuid
+        self.password = password
+    }
+
 
 
 }

--- a/samples/client/petstore/swift4/promisekit/PetstoreClient/Classes/Swaggers/Models/HasOnlyReadOnly.swift
+++ b/samples/client/petstore/swift4/promisekit/PetstoreClient/Classes/Swaggers/Models/HasOnlyReadOnly.swift
@@ -14,6 +14,11 @@ public struct HasOnlyReadOnly: Codable {
     public var bar: String?
     public var foo: String?
 
+    public init(bar: String?, foo: String?) {
+        self.bar = bar
+        self.foo = foo
+    }
+
 
 
 }

--- a/samples/client/petstore/swift4/promisekit/PetstoreClient/Classes/Swaggers/Models/List.swift
+++ b/samples/client/petstore/swift4/promisekit/PetstoreClient/Classes/Swaggers/Models/List.swift
@@ -13,6 +13,10 @@ public struct List: Codable {
 
     public var _123List: String?
 
+    public init(_123List: String?) {
+        self._123List = _123List
+    }
+
 
     public enum CodingKeys: String, CodingKey { 
         case _123List = "123-list"

--- a/samples/client/petstore/swift4/promisekit/PetstoreClient/Classes/Swaggers/Models/MapTest.swift
+++ b/samples/client/petstore/swift4/promisekit/PetstoreClient/Classes/Swaggers/Models/MapTest.swift
@@ -18,6 +18,11 @@ public struct MapTest: Codable {
     public var mapMapOfString: [String:[String:String]]?
     public var mapOfEnumString: [String:String]?
 
+    public init(mapMapOfString: [String:[String:String]]?, mapOfEnumString: [String:String]?) {
+        self.mapMapOfString = mapMapOfString
+        self.mapOfEnumString = mapOfEnumString
+    }
+
 
     public enum CodingKeys: String, CodingKey { 
         case mapMapOfString = "map_map_of_string"

--- a/samples/client/petstore/swift4/promisekit/PetstoreClient/Classes/Swaggers/Models/MixedPropertiesAndAdditionalPropertiesClass.swift
+++ b/samples/client/petstore/swift4/promisekit/PetstoreClient/Classes/Swaggers/Models/MixedPropertiesAndAdditionalPropertiesClass.swift
@@ -15,6 +15,12 @@ public struct MixedPropertiesAndAdditionalPropertiesClass: Codable {
     public var dateTime: Date?
     public var map: [String:Animal]?
 
+    public init(uuid: UUID?, dateTime: Date?, map: [String:Animal]?) {
+        self.uuid = uuid
+        self.dateTime = dateTime
+        self.map = map
+    }
+
 
 
 }

--- a/samples/client/petstore/swift4/promisekit/PetstoreClient/Classes/Swaggers/Models/Model200Response.swift
+++ b/samples/client/petstore/swift4/promisekit/PetstoreClient/Classes/Swaggers/Models/Model200Response.swift
@@ -15,6 +15,11 @@ public struct Model200Response: Codable {
     public var name: Int?
     public var _class: String?
 
+    public init(name: Int?, _class: String?) {
+        self.name = name
+        self._class = _class
+    }
+
 
     public enum CodingKeys: String, CodingKey { 
         case name

--- a/samples/client/petstore/swift4/promisekit/PetstoreClient/Classes/Swaggers/Models/Name.swift
+++ b/samples/client/petstore/swift4/promisekit/PetstoreClient/Classes/Swaggers/Models/Name.swift
@@ -17,6 +17,13 @@ public struct Name: Codable {
     public var property: String?
     public var _123Number: Int?
 
+    public init(name: Int, snakeCase: Int?, property: String?, _123Number: Int?) {
+        self.name = name
+        self.snakeCase = snakeCase
+        self.property = property
+        self._123Number = _123Number
+    }
+
 
     public enum CodingKeys: String, CodingKey { 
         case name

--- a/samples/client/petstore/swift4/promisekit/PetstoreClient/Classes/Swaggers/Models/NumberOnly.swift
+++ b/samples/client/petstore/swift4/promisekit/PetstoreClient/Classes/Swaggers/Models/NumberOnly.swift
@@ -13,6 +13,10 @@ public struct NumberOnly: Codable {
 
     public var justNumber: Double?
 
+    public init(justNumber: Double?) {
+        self.justNumber = justNumber
+    }
+
 
     public enum CodingKeys: String, CodingKey { 
         case justNumber = "JustNumber"

--- a/samples/client/petstore/swift4/promisekit/PetstoreClient/Classes/Swaggers/Models/Order.swift
+++ b/samples/client/petstore/swift4/promisekit/PetstoreClient/Classes/Swaggers/Models/Order.swift
@@ -24,6 +24,15 @@ public struct Order: Codable {
     public var status: Status?
     public var complete: Bool?
 
+    public init(_id: Int64?, petId: Int64?, quantity: Int?, shipDate: Date?, status: Status?, complete: Bool?) {
+        self._id = _id
+        self.petId = petId
+        self.quantity = quantity
+        self.shipDate = shipDate
+        self.status = status
+        self.complete = complete
+    }
+
 
     public enum CodingKeys: String, CodingKey { 
         case _id = "id"

--- a/samples/client/petstore/swift4/promisekit/PetstoreClient/Classes/Swaggers/Models/OuterBoolean.swift
+++ b/samples/client/petstore/swift4/promisekit/PetstoreClient/Classes/Swaggers/Models/OuterBoolean.swift
@@ -14,5 +14,6 @@ public struct OuterBoolean: Codable {
 
 
 
+
 }
 

--- a/samples/client/petstore/swift4/promisekit/PetstoreClient/Classes/Swaggers/Models/OuterComposite.swift
+++ b/samples/client/petstore/swift4/promisekit/PetstoreClient/Classes/Swaggers/Models/OuterComposite.swift
@@ -15,6 +15,12 @@ public struct OuterComposite: Codable {
     public var myString: OuterString?
     public var myBoolean: OuterBoolean?
 
+    public init(myNumber: OuterNumber?, myString: OuterString?, myBoolean: OuterBoolean?) {
+        self.myNumber = myNumber
+        self.myString = myString
+        self.myBoolean = myBoolean
+    }
+
 
     public enum CodingKeys: String, CodingKey { 
         case myNumber = "my_number"

--- a/samples/client/petstore/swift4/promisekit/PetstoreClient/Classes/Swaggers/Models/OuterNumber.swift
+++ b/samples/client/petstore/swift4/promisekit/PetstoreClient/Classes/Swaggers/Models/OuterNumber.swift
@@ -14,5 +14,6 @@ public struct OuterNumber: Codable {
 
 
 
+
 }
 

--- a/samples/client/petstore/swift4/promisekit/PetstoreClient/Classes/Swaggers/Models/OuterString.swift
+++ b/samples/client/petstore/swift4/promisekit/PetstoreClient/Classes/Swaggers/Models/OuterString.swift
@@ -14,5 +14,6 @@ public struct OuterString: Codable {
 
 
 
+
 }
 

--- a/samples/client/petstore/swift4/promisekit/PetstoreClient/Classes/Swaggers/Models/Pet.swift
+++ b/samples/client/petstore/swift4/promisekit/PetstoreClient/Classes/Swaggers/Models/Pet.swift
@@ -24,6 +24,15 @@ public struct Pet: Codable {
     /** pet status in the store */
     public var status: Status?
 
+    public init(_id: Int64?, category: Category?, name: String, photoUrls: [String], tags: [Tag]?, status: Status?) {
+        self._id = _id
+        self.category = category
+        self.name = name
+        self.photoUrls = photoUrls
+        self.tags = tags
+        self.status = status
+    }
+
 
     public enum CodingKeys: String, CodingKey { 
         case _id = "id"

--- a/samples/client/petstore/swift4/promisekit/PetstoreClient/Classes/Swaggers/Models/ReadOnlyFirst.swift
+++ b/samples/client/petstore/swift4/promisekit/PetstoreClient/Classes/Swaggers/Models/ReadOnlyFirst.swift
@@ -14,6 +14,11 @@ public struct ReadOnlyFirst: Codable {
     public var bar: String?
     public var baz: String?
 
+    public init(bar: String?, baz: String?) {
+        self.bar = bar
+        self.baz = baz
+    }
+
 
 
 }

--- a/samples/client/petstore/swift4/promisekit/PetstoreClient/Classes/Swaggers/Models/Return.swift
+++ b/samples/client/petstore/swift4/promisekit/PetstoreClient/Classes/Swaggers/Models/Return.swift
@@ -14,6 +14,10 @@ public struct Return: Codable {
 
     public var _return: Int?
 
+    public init(_return: Int?) {
+        self._return = _return
+    }
+
 
     public enum CodingKeys: String, CodingKey { 
         case _return = "return"

--- a/samples/client/petstore/swift4/promisekit/PetstoreClient/Classes/Swaggers/Models/SpecialModelName.swift
+++ b/samples/client/petstore/swift4/promisekit/PetstoreClient/Classes/Swaggers/Models/SpecialModelName.swift
@@ -13,6 +13,10 @@ public struct SpecialModelName: Codable {
 
     public var specialPropertyName: Int64?
 
+    public init(specialPropertyName: Int64?) {
+        self.specialPropertyName = specialPropertyName
+    }
+
 
     public enum CodingKeys: String, CodingKey { 
         case specialPropertyName = "$special[property.name]"

--- a/samples/client/petstore/swift4/promisekit/PetstoreClient/Classes/Swaggers/Models/Tag.swift
+++ b/samples/client/petstore/swift4/promisekit/PetstoreClient/Classes/Swaggers/Models/Tag.swift
@@ -14,6 +14,11 @@ public struct Tag: Codable {
     public var _id: Int64?
     public var name: String?
 
+    public init(_id: Int64?, name: String?) {
+        self._id = _id
+        self.name = name
+    }
+
 
     public enum CodingKeys: String, CodingKey { 
         case _id = "id"

--- a/samples/client/petstore/swift4/promisekit/PetstoreClient/Classes/Swaggers/Models/User.swift
+++ b/samples/client/petstore/swift4/promisekit/PetstoreClient/Classes/Swaggers/Models/User.swift
@@ -21,6 +21,17 @@ public struct User: Codable {
     /** User Status */
     public var userStatus: Int?
 
+    public init(_id: Int64?, username: String?, firstName: String?, lastName: String?, email: String?, password: String?, phone: String?, userStatus: Int?) {
+        self._id = _id
+        self.username = username
+        self.firstName = firstName
+        self.lastName = lastName
+        self.email = email
+        self.password = password
+        self.phone = phone
+        self.userStatus = userStatus
+    }
+
 
     public enum CodingKeys: String, CodingKey { 
         case _id = "id"

--- a/samples/client/petstore/swift4/rxswift/PetstoreClient/Classes/Swaggers/APIs.swift
+++ b/samples/client/petstore/swift4/rxswift/PetstoreClient/Classes/Swaggers/APIs.swift
@@ -16,10 +16,10 @@ open class PetstoreClientAPI {
 open class RequestBuilder<T> {
     var credential: URLCredential?
     var headers: [String:String]
-    let parameters: [String:Any]?
-    let isBody: Bool
-    let method: String
-    let URLString: String
+    public let parameters: [String:Any]?
+    public let isBody: Bool
+    public let method: String
+    public let URLString: String
 
     /// Optional block to obtain a reference to the request's progress instance when available.
     public var onProgressReady: ((Progress) -> ())?

--- a/samples/client/petstore/swift4/rxswift/PetstoreClient/Classes/Swaggers/APIs/PetAPI.swift
+++ b/samples/client/petstore/swift4/rxswift/PetstoreClient/Classes/Swaggers/APIs/PetAPI.swift
@@ -118,7 +118,9 @@ open class PetAPI {
      */
     open class func deletePetWithRequestBuilder(petId: Int64, apiKey: String? = nil) -> RequestBuilder<Void> {
         var path = "/pet/{petId}"
-        path = path.replacingOccurrences(of: "{petId}", with: "\(petId)", options: .literal, range: nil)
+        let petIdPreEscape = "\(petId)"
+        let petIdPostEscape = petIdPreEscape.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? ""
+        path = path.replacingOccurrences(of: "{petId}", with: petIdPostEscape, options: .literal, range: nil)
         let URLString = PetstoreClientAPI.basePath + path
         let parameters: [String:Any]? = nil
 
@@ -529,7 +531,9 @@ open class PetAPI {
      */
     open class func getPetByIdWithRequestBuilder(petId: Int64) -> RequestBuilder<Pet> {
         var path = "/pet/{petId}"
-        path = path.replacingOccurrences(of: "{petId}", with: "\(petId)", options: .literal, range: nil)
+        let petIdPreEscape = "\(petId)"
+        let petIdPostEscape = petIdPreEscape.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? ""
+        path = path.replacingOccurrences(of: "{petId}", with: petIdPostEscape, options: .literal, range: nil)
         let URLString = PetstoreClientAPI.basePath + path
         let parameters: [String:Any]? = nil
 
@@ -650,7 +654,9 @@ open class PetAPI {
      */
     open class func updatePetWithFormWithRequestBuilder(petId: Int64, name: String? = nil, status: String? = nil) -> RequestBuilder<Void> {
         var path = "/pet/{petId}"
-        path = path.replacingOccurrences(of: "{petId}", with: "\(petId)", options: .literal, range: nil)
+        let petIdPreEscape = "\(petId)"
+        let petIdPostEscape = petIdPreEscape.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? ""
+        path = path.replacingOccurrences(of: "{petId}", with: petIdPostEscape, options: .literal, range: nil)
         let URLString = PetstoreClientAPI.basePath + path
         let formParams: [String:Any?] = [
             "name": name,
@@ -725,7 +731,9 @@ open class PetAPI {
      */
     open class func uploadFileWithRequestBuilder(petId: Int64, additionalMetadata: String? = nil, file: URL? = nil) -> RequestBuilder<ApiResponse> {
         var path = "/pet/{petId}/uploadImage"
-        path = path.replacingOccurrences(of: "{petId}", with: "\(petId)", options: .literal, range: nil)
+        let petIdPreEscape = "\(petId)"
+        let petIdPostEscape = petIdPreEscape.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? ""
+        path = path.replacingOccurrences(of: "{petId}", with: petIdPostEscape, options: .literal, range: nil)
         let URLString = PetstoreClientAPI.basePath + path
         let formParams: [String:Any?] = [
             "additionalMetadata": additionalMetadata,

--- a/samples/client/petstore/swift4/rxswift/PetstoreClient/Classes/Swaggers/APIs/StoreAPI.swift
+++ b/samples/client/petstore/swift4/rxswift/PetstoreClient/Classes/Swaggers/APIs/StoreAPI.swift
@@ -55,7 +55,9 @@ open class StoreAPI {
      */
     open class func deleteOrderWithRequestBuilder(orderId: String) -> RequestBuilder<Void> {
         var path = "/store/order/{order_id}"
-        path = path.replacingOccurrences(of: "{order_id}", with: "\(orderId)", options: .literal, range: nil)
+        let orderIdPreEscape = "\(orderId)"
+        let orderIdPostEscape = orderIdPreEscape.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? ""
+        path = path.replacingOccurrences(of: "{order_id}", with: orderIdPostEscape, options: .literal, range: nil)
         let URLString = PetstoreClientAPI.basePath + path
         let parameters: [String:Any]? = nil
 
@@ -196,7 +198,9 @@ open class StoreAPI {
      */
     open class func getOrderByIdWithRequestBuilder(orderId: Int64) -> RequestBuilder<Order> {
         var path = "/store/order/{order_id}"
-        path = path.replacingOccurrences(of: "{order_id}", with: "\(orderId)", options: .literal, range: nil)
+        let orderIdPreEscape = "\(orderId)"
+        let orderIdPostEscape = orderIdPreEscape.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? ""
+        path = path.replacingOccurrences(of: "{order_id}", with: orderIdPostEscape, options: .literal, range: nil)
         let URLString = PetstoreClientAPI.basePath + path
         let parameters: [String:Any]? = nil
 

--- a/samples/client/petstore/swift4/rxswift/PetstoreClient/Classes/Swaggers/APIs/UserAPI.swift
+++ b/samples/client/petstore/swift4/rxswift/PetstoreClient/Classes/Swaggers/APIs/UserAPI.swift
@@ -217,7 +217,9 @@ open class UserAPI {
      */
     open class func deleteUserWithRequestBuilder(username: String) -> RequestBuilder<Void> {
         var path = "/user/{username}"
-        path = path.replacingOccurrences(of: "{username}", with: "\(username)", options: .literal, range: nil)
+        let usernamePreEscape = "\(username)"
+        let usernamePostEscape = usernamePreEscape.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? ""
+        path = path.replacingOccurrences(of: "{username}", with: usernamePostEscape, options: .literal, range: nil)
         let URLString = PetstoreClientAPI.basePath + path
         let parameters: [String:Any]? = nil
 
@@ -232,7 +234,7 @@ open class UserAPI {
     /**
      Get user by user name
      
-     - parameter username: (path) The name that needs to be fetched. Use user1 for testing.  
+     - parameter username: (path) The name that needs to be fetched. Use user1 for testing. 
      - parameter completion: completion handler to receive the data and the error objects
      */
     open class func getUserByName(username: String, completion: @escaping ((_ data: User?,_ error: Error?) -> Void)) {
@@ -244,7 +246,7 @@ open class UserAPI {
     /**
      Get user by user name
      
-     - parameter username: (path) The name that needs to be fetched. Use user1 for testing.  
+     - parameter username: (path) The name that needs to be fetched. Use user1 for testing. 
      - returns: Observable<User>
      */
     open class func getUserByName(username: String) -> Observable<User> {
@@ -304,13 +306,15 @@ open class UserAPI {
   "username" : "username"
 }}]
      
-     - parameter username: (path) The name that needs to be fetched. Use user1 for testing.  
+     - parameter username: (path) The name that needs to be fetched. Use user1 for testing. 
 
      - returns: RequestBuilder<User> 
      */
     open class func getUserByNameWithRequestBuilder(username: String) -> RequestBuilder<User> {
         var path = "/user/{username}"
-        path = path.replacingOccurrences(of: "{username}", with: "\(username)", options: .literal, range: nil)
+        let usernamePreEscape = "\(username)"
+        let usernamePostEscape = usernamePreEscape.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? ""
+        path = path.replacingOccurrences(of: "{username}", with: usernamePostEscape, options: .literal, range: nil)
         let URLString = PetstoreClientAPI.basePath + path
         let parameters: [String:Any]? = nil
 
@@ -483,7 +487,9 @@ open class UserAPI {
      */
     open class func updateUserWithRequestBuilder(username: String, body: User) -> RequestBuilder<Void> {
         var path = "/user/{username}"
-        path = path.replacingOccurrences(of: "{username}", with: "\(username)", options: .literal, range: nil)
+        let usernamePreEscape = "\(username)"
+        let usernamePostEscape = usernamePreEscape.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? ""
+        path = path.replacingOccurrences(of: "{username}", with: usernamePostEscape, options: .literal, range: nil)
         let URLString = PetstoreClientAPI.basePath + path
         let parameters = JSONEncodingHelper.encodingParameters(forEncodableObject: body)
 

--- a/samples/client/petstore/swift4/rxswift/PetstoreClient/Classes/Swaggers/Models/AdditionalPropertiesClass.swift
+++ b/samples/client/petstore/swift4/rxswift/PetstoreClient/Classes/Swaggers/Models/AdditionalPropertiesClass.swift
@@ -14,6 +14,11 @@ public struct AdditionalPropertiesClass: Codable {
     public var mapProperty: [String:String]?
     public var mapOfMapProperty: [String:[String:String]]?
 
+    public init(mapProperty: [String:String]?, mapOfMapProperty: [String:[String:String]]?) {
+        self.mapProperty = mapProperty
+        self.mapOfMapProperty = mapOfMapProperty
+    }
+
 
     public enum CodingKeys: String, CodingKey { 
         case mapProperty = "map_property"

--- a/samples/client/petstore/swift4/rxswift/PetstoreClient/Classes/Swaggers/Models/Animal.swift
+++ b/samples/client/petstore/swift4/rxswift/PetstoreClient/Classes/Swaggers/Models/Animal.swift
@@ -14,6 +14,11 @@ public struct Animal: Codable {
     public var className: String
     public var color: String?
 
+    public init(className: String, color: String?) {
+        self.className = className
+        self.color = color
+    }
+
 
 
 }

--- a/samples/client/petstore/swift4/rxswift/PetstoreClient/Classes/Swaggers/Models/ApiResponse.swift
+++ b/samples/client/petstore/swift4/rxswift/PetstoreClient/Classes/Swaggers/Models/ApiResponse.swift
@@ -15,6 +15,12 @@ public struct ApiResponse: Codable {
     public var type: String?
     public var message: String?
 
+    public init(code: Int?, type: String?, message: String?) {
+        self.code = code
+        self.type = type
+        self.message = message
+    }
+
 
 
 }

--- a/samples/client/petstore/swift4/rxswift/PetstoreClient/Classes/Swaggers/Models/ArrayOfArrayOfNumberOnly.swift
+++ b/samples/client/petstore/swift4/rxswift/PetstoreClient/Classes/Swaggers/Models/ArrayOfArrayOfNumberOnly.swift
@@ -13,6 +13,10 @@ public struct ArrayOfArrayOfNumberOnly: Codable {
 
     public var arrayArrayNumber: [[Double]]?
 
+    public init(arrayArrayNumber: [[Double]]?) {
+        self.arrayArrayNumber = arrayArrayNumber
+    }
+
 
     public enum CodingKeys: String, CodingKey { 
         case arrayArrayNumber = "ArrayArrayNumber"

--- a/samples/client/petstore/swift4/rxswift/PetstoreClient/Classes/Swaggers/Models/ArrayOfNumberOnly.swift
+++ b/samples/client/petstore/swift4/rxswift/PetstoreClient/Classes/Swaggers/Models/ArrayOfNumberOnly.swift
@@ -13,6 +13,10 @@ public struct ArrayOfNumberOnly: Codable {
 
     public var arrayNumber: [Double]?
 
+    public init(arrayNumber: [Double]?) {
+        self.arrayNumber = arrayNumber
+    }
+
 
     public enum CodingKeys: String, CodingKey { 
         case arrayNumber = "ArrayNumber"

--- a/samples/client/petstore/swift4/rxswift/PetstoreClient/Classes/Swaggers/Models/ArrayTest.swift
+++ b/samples/client/petstore/swift4/rxswift/PetstoreClient/Classes/Swaggers/Models/ArrayTest.swift
@@ -15,6 +15,12 @@ public struct ArrayTest: Codable {
     public var arrayArrayOfInteger: [[Int64]]?
     public var arrayArrayOfModel: [[ReadOnlyFirst]]?
 
+    public init(arrayOfString: [String]?, arrayArrayOfInteger: [[Int64]]?, arrayArrayOfModel: [[ReadOnlyFirst]]?) {
+        self.arrayOfString = arrayOfString
+        self.arrayArrayOfInteger = arrayArrayOfInteger
+        self.arrayArrayOfModel = arrayArrayOfModel
+    }
+
 
     public enum CodingKeys: String, CodingKey { 
         case arrayOfString = "array_of_string"

--- a/samples/client/petstore/swift4/rxswift/PetstoreClient/Classes/Swaggers/Models/Capitalization.swift
+++ b/samples/client/petstore/swift4/rxswift/PetstoreClient/Classes/Swaggers/Models/Capitalization.swift
@@ -19,6 +19,15 @@ public struct Capitalization: Codable {
     /** Name of the pet  */
     public var ATT_NAME: String?
 
+    public init(smallCamel: String?, capitalCamel: String?, smallSnake: String?, capitalSnake: String?, sCAETHFlowPoints: String?, ATT_NAME: String?) {
+        self.smallCamel = smallCamel
+        self.capitalCamel = capitalCamel
+        self.smallSnake = smallSnake
+        self.capitalSnake = capitalSnake
+        self.sCAETHFlowPoints = sCAETHFlowPoints
+        self.ATT_NAME = ATT_NAME
+    }
+
 
     public enum CodingKeys: String, CodingKey { 
         case smallCamel

--- a/samples/client/petstore/swift4/rxswift/PetstoreClient/Classes/Swaggers/Models/Cat.swift
+++ b/samples/client/petstore/swift4/rxswift/PetstoreClient/Classes/Swaggers/Models/Cat.swift
@@ -15,6 +15,10 @@ public struct Cat: Codable {
     public var color: String?
     public var declawed: Bool?
 
+    public init(declawed: Bool?) {
+        self.declawed = declawed
+    }
+
 
 
 }

--- a/samples/client/petstore/swift4/rxswift/PetstoreClient/Classes/Swaggers/Models/Cat.swift
+++ b/samples/client/petstore/swift4/rxswift/PetstoreClient/Classes/Swaggers/Models/Cat.swift
@@ -15,7 +15,9 @@ public struct Cat: Codable {
     public var color: String?
     public var declawed: Bool?
 
-    public init(declawed: Bool?) {
+    public init(className: String, color: String?, declawed: Bool?) {
+        self.className = className
+        self.color = color
         self.declawed = declawed
     }
 

--- a/samples/client/petstore/swift4/rxswift/PetstoreClient/Classes/Swaggers/Models/Category.swift
+++ b/samples/client/petstore/swift4/rxswift/PetstoreClient/Classes/Swaggers/Models/Category.swift
@@ -14,6 +14,11 @@ public struct Category: Codable {
     public var _id: Int64?
     public var name: String?
 
+    public init(_id: Int64?, name: String?) {
+        self._id = _id
+        self.name = name
+    }
+
 
     public enum CodingKeys: String, CodingKey { 
         case _id = "id"

--- a/samples/client/petstore/swift4/rxswift/PetstoreClient/Classes/Swaggers/Models/ClassModel.swift
+++ b/samples/client/petstore/swift4/rxswift/PetstoreClient/Classes/Swaggers/Models/ClassModel.swift
@@ -14,6 +14,10 @@ public struct ClassModel: Codable {
 
     public var _class: String?
 
+    public init(_class: String?) {
+        self._class = _class
+    }
+
 
 
 }

--- a/samples/client/petstore/swift4/rxswift/PetstoreClient/Classes/Swaggers/Models/Client.swift
+++ b/samples/client/petstore/swift4/rxswift/PetstoreClient/Classes/Swaggers/Models/Client.swift
@@ -13,6 +13,10 @@ public struct Client: Codable {
 
     public var client: String?
 
+    public init(client: String?) {
+        self.client = client
+    }
+
 
 
 }

--- a/samples/client/petstore/swift4/rxswift/PetstoreClient/Classes/Swaggers/Models/Dog.swift
+++ b/samples/client/petstore/swift4/rxswift/PetstoreClient/Classes/Swaggers/Models/Dog.swift
@@ -15,7 +15,9 @@ public struct Dog: Codable {
     public var color: String?
     public var breed: String?
 
-    public init(breed: String?) {
+    public init(className: String, color: String?, breed: String?) {
+        self.className = className
+        self.color = color
         self.breed = breed
     }
 

--- a/samples/client/petstore/swift4/rxswift/PetstoreClient/Classes/Swaggers/Models/Dog.swift
+++ b/samples/client/petstore/swift4/rxswift/PetstoreClient/Classes/Swaggers/Models/Dog.swift
@@ -15,6 +15,10 @@ public struct Dog: Codable {
     public var color: String?
     public var breed: String?
 
+    public init(breed: String?) {
+        self.breed = breed
+    }
+
 
 
 }

--- a/samples/client/petstore/swift4/rxswift/PetstoreClient/Classes/Swaggers/Models/EnumArrays.swift
+++ b/samples/client/petstore/swift4/rxswift/PetstoreClient/Classes/Swaggers/Models/EnumArrays.swift
@@ -22,6 +22,11 @@ public struct EnumArrays: Codable {
     public var justSymbol: JustSymbol?
     public var arrayEnum: [ArrayEnum]?
 
+    public init(justSymbol: JustSymbol?, arrayEnum: [ArrayEnum]?) {
+        self.justSymbol = justSymbol
+        self.arrayEnum = arrayEnum
+    }
+
 
     public enum CodingKeys: String, CodingKey { 
         case justSymbol = "just_symbol"

--- a/samples/client/petstore/swift4/rxswift/PetstoreClient/Classes/Swaggers/Models/EnumTest.swift
+++ b/samples/client/petstore/swift4/rxswift/PetstoreClient/Classes/Swaggers/Models/EnumTest.swift
@@ -29,6 +29,13 @@ public struct EnumTest: Codable {
     public var enumNumber: EnumNumber?
     public var outerEnum: OuterEnum?
 
+    public init(enumString: EnumString?, enumInteger: EnumInteger?, enumNumber: EnumNumber?, outerEnum: OuterEnum?) {
+        self.enumString = enumString
+        self.enumInteger = enumInteger
+        self.enumNumber = enumNumber
+        self.outerEnum = outerEnum
+    }
+
 
     public enum CodingKeys: String, CodingKey { 
         case enumString = "enum_string"

--- a/samples/client/petstore/swift4/rxswift/PetstoreClient/Classes/Swaggers/Models/FormatTest.swift
+++ b/samples/client/petstore/swift4/rxswift/PetstoreClient/Classes/Swaggers/Models/FormatTest.swift
@@ -25,6 +25,22 @@ public struct FormatTest: Codable {
     public var uuid: UUID?
     public var password: String
 
+    public init(integer: Int?, int32: Int?, int64: Int64?, number: Double, float: Float?, double: Double?, string: String?, byte: Data, binary: Data?, date: Date, dateTime: Date?, uuid: UUID?, password: String) {
+        self.integer = integer
+        self.int32 = int32
+        self.int64 = int64
+        self.number = number
+        self.float = float
+        self.double = double
+        self.string = string
+        self.byte = byte
+        self.binary = binary
+        self.date = date
+        self.dateTime = dateTime
+        self.uuid = uuid
+        self.password = password
+    }
+
 
 
 }

--- a/samples/client/petstore/swift4/rxswift/PetstoreClient/Classes/Swaggers/Models/HasOnlyReadOnly.swift
+++ b/samples/client/petstore/swift4/rxswift/PetstoreClient/Classes/Swaggers/Models/HasOnlyReadOnly.swift
@@ -14,6 +14,11 @@ public struct HasOnlyReadOnly: Codable {
     public var bar: String?
     public var foo: String?
 
+    public init(bar: String?, foo: String?) {
+        self.bar = bar
+        self.foo = foo
+    }
+
 
 
 }

--- a/samples/client/petstore/swift4/rxswift/PetstoreClient/Classes/Swaggers/Models/List.swift
+++ b/samples/client/petstore/swift4/rxswift/PetstoreClient/Classes/Swaggers/Models/List.swift
@@ -13,6 +13,10 @@ public struct List: Codable {
 
     public var _123List: String?
 
+    public init(_123List: String?) {
+        self._123List = _123List
+    }
+
 
     public enum CodingKeys: String, CodingKey { 
         case _123List = "123-list"

--- a/samples/client/petstore/swift4/rxswift/PetstoreClient/Classes/Swaggers/Models/MapTest.swift
+++ b/samples/client/petstore/swift4/rxswift/PetstoreClient/Classes/Swaggers/Models/MapTest.swift
@@ -18,6 +18,11 @@ public struct MapTest: Codable {
     public var mapMapOfString: [String:[String:String]]?
     public var mapOfEnumString: [String:String]?
 
+    public init(mapMapOfString: [String:[String:String]]?, mapOfEnumString: [String:String]?) {
+        self.mapMapOfString = mapMapOfString
+        self.mapOfEnumString = mapOfEnumString
+    }
+
 
     public enum CodingKeys: String, CodingKey { 
         case mapMapOfString = "map_map_of_string"

--- a/samples/client/petstore/swift4/rxswift/PetstoreClient/Classes/Swaggers/Models/MixedPropertiesAndAdditionalPropertiesClass.swift
+++ b/samples/client/petstore/swift4/rxswift/PetstoreClient/Classes/Swaggers/Models/MixedPropertiesAndAdditionalPropertiesClass.swift
@@ -15,6 +15,12 @@ public struct MixedPropertiesAndAdditionalPropertiesClass: Codable {
     public var dateTime: Date?
     public var map: [String:Animal]?
 
+    public init(uuid: UUID?, dateTime: Date?, map: [String:Animal]?) {
+        self.uuid = uuid
+        self.dateTime = dateTime
+        self.map = map
+    }
+
 
 
 }

--- a/samples/client/petstore/swift4/rxswift/PetstoreClient/Classes/Swaggers/Models/Model200Response.swift
+++ b/samples/client/petstore/swift4/rxswift/PetstoreClient/Classes/Swaggers/Models/Model200Response.swift
@@ -15,6 +15,11 @@ public struct Model200Response: Codable {
     public var name: Int?
     public var _class: String?
 
+    public init(name: Int?, _class: String?) {
+        self.name = name
+        self._class = _class
+    }
+
 
     public enum CodingKeys: String, CodingKey { 
         case name

--- a/samples/client/petstore/swift4/rxswift/PetstoreClient/Classes/Swaggers/Models/Name.swift
+++ b/samples/client/petstore/swift4/rxswift/PetstoreClient/Classes/Swaggers/Models/Name.swift
@@ -17,6 +17,13 @@ public struct Name: Codable {
     public var property: String?
     public var _123Number: Int?
 
+    public init(name: Int, snakeCase: Int?, property: String?, _123Number: Int?) {
+        self.name = name
+        self.snakeCase = snakeCase
+        self.property = property
+        self._123Number = _123Number
+    }
+
 
     public enum CodingKeys: String, CodingKey { 
         case name

--- a/samples/client/petstore/swift4/rxswift/PetstoreClient/Classes/Swaggers/Models/NumberOnly.swift
+++ b/samples/client/petstore/swift4/rxswift/PetstoreClient/Classes/Swaggers/Models/NumberOnly.swift
@@ -13,6 +13,10 @@ public struct NumberOnly: Codable {
 
     public var justNumber: Double?
 
+    public init(justNumber: Double?) {
+        self.justNumber = justNumber
+    }
+
 
     public enum CodingKeys: String, CodingKey { 
         case justNumber = "JustNumber"

--- a/samples/client/petstore/swift4/rxswift/PetstoreClient/Classes/Swaggers/Models/Order.swift
+++ b/samples/client/petstore/swift4/rxswift/PetstoreClient/Classes/Swaggers/Models/Order.swift
@@ -24,6 +24,15 @@ public struct Order: Codable {
     public var status: Status?
     public var complete: Bool?
 
+    public init(_id: Int64?, petId: Int64?, quantity: Int?, shipDate: Date?, status: Status?, complete: Bool?) {
+        self._id = _id
+        self.petId = petId
+        self.quantity = quantity
+        self.shipDate = shipDate
+        self.status = status
+        self.complete = complete
+    }
+
 
     public enum CodingKeys: String, CodingKey { 
         case _id = "id"

--- a/samples/client/petstore/swift4/rxswift/PetstoreClient/Classes/Swaggers/Models/OuterBoolean.swift
+++ b/samples/client/petstore/swift4/rxswift/PetstoreClient/Classes/Swaggers/Models/OuterBoolean.swift
@@ -14,5 +14,6 @@ public struct OuterBoolean: Codable {
 
 
 
+
 }
 

--- a/samples/client/petstore/swift4/rxswift/PetstoreClient/Classes/Swaggers/Models/OuterComposite.swift
+++ b/samples/client/petstore/swift4/rxswift/PetstoreClient/Classes/Swaggers/Models/OuterComposite.swift
@@ -15,6 +15,12 @@ public struct OuterComposite: Codable {
     public var myString: OuterString?
     public var myBoolean: OuterBoolean?
 
+    public init(myNumber: OuterNumber?, myString: OuterString?, myBoolean: OuterBoolean?) {
+        self.myNumber = myNumber
+        self.myString = myString
+        self.myBoolean = myBoolean
+    }
+
 
     public enum CodingKeys: String, CodingKey { 
         case myNumber = "my_number"

--- a/samples/client/petstore/swift4/rxswift/PetstoreClient/Classes/Swaggers/Models/OuterNumber.swift
+++ b/samples/client/petstore/swift4/rxswift/PetstoreClient/Classes/Swaggers/Models/OuterNumber.swift
@@ -14,5 +14,6 @@ public struct OuterNumber: Codable {
 
 
 
+
 }
 

--- a/samples/client/petstore/swift4/rxswift/PetstoreClient/Classes/Swaggers/Models/OuterString.swift
+++ b/samples/client/petstore/swift4/rxswift/PetstoreClient/Classes/Swaggers/Models/OuterString.swift
@@ -14,5 +14,6 @@ public struct OuterString: Codable {
 
 
 
+
 }
 

--- a/samples/client/petstore/swift4/rxswift/PetstoreClient/Classes/Swaggers/Models/Pet.swift
+++ b/samples/client/petstore/swift4/rxswift/PetstoreClient/Classes/Swaggers/Models/Pet.swift
@@ -24,6 +24,15 @@ public struct Pet: Codable {
     /** pet status in the store */
     public var status: Status?
 
+    public init(_id: Int64?, category: Category?, name: String, photoUrls: [String], tags: [Tag]?, status: Status?) {
+        self._id = _id
+        self.category = category
+        self.name = name
+        self.photoUrls = photoUrls
+        self.tags = tags
+        self.status = status
+    }
+
 
     public enum CodingKeys: String, CodingKey { 
         case _id = "id"

--- a/samples/client/petstore/swift4/rxswift/PetstoreClient/Classes/Swaggers/Models/ReadOnlyFirst.swift
+++ b/samples/client/petstore/swift4/rxswift/PetstoreClient/Classes/Swaggers/Models/ReadOnlyFirst.swift
@@ -14,6 +14,11 @@ public struct ReadOnlyFirst: Codable {
     public var bar: String?
     public var baz: String?
 
+    public init(bar: String?, baz: String?) {
+        self.bar = bar
+        self.baz = baz
+    }
+
 
 
 }

--- a/samples/client/petstore/swift4/rxswift/PetstoreClient/Classes/Swaggers/Models/Return.swift
+++ b/samples/client/petstore/swift4/rxswift/PetstoreClient/Classes/Swaggers/Models/Return.swift
@@ -14,6 +14,10 @@ public struct Return: Codable {
 
     public var _return: Int?
 
+    public init(_return: Int?) {
+        self._return = _return
+    }
+
 
     public enum CodingKeys: String, CodingKey { 
         case _return = "return"

--- a/samples/client/petstore/swift4/rxswift/PetstoreClient/Classes/Swaggers/Models/SpecialModelName.swift
+++ b/samples/client/petstore/swift4/rxswift/PetstoreClient/Classes/Swaggers/Models/SpecialModelName.swift
@@ -13,6 +13,10 @@ public struct SpecialModelName: Codable {
 
     public var specialPropertyName: Int64?
 
+    public init(specialPropertyName: Int64?) {
+        self.specialPropertyName = specialPropertyName
+    }
+
 
     public enum CodingKeys: String, CodingKey { 
         case specialPropertyName = "$special[property.name]"

--- a/samples/client/petstore/swift4/rxswift/PetstoreClient/Classes/Swaggers/Models/Tag.swift
+++ b/samples/client/petstore/swift4/rxswift/PetstoreClient/Classes/Swaggers/Models/Tag.swift
@@ -14,6 +14,11 @@ public struct Tag: Codable {
     public var _id: Int64?
     public var name: String?
 
+    public init(_id: Int64?, name: String?) {
+        self._id = _id
+        self.name = name
+    }
+
 
     public enum CodingKeys: String, CodingKey { 
         case _id = "id"

--- a/samples/client/petstore/swift4/rxswift/PetstoreClient/Classes/Swaggers/Models/User.swift
+++ b/samples/client/petstore/swift4/rxswift/PetstoreClient/Classes/Swaggers/Models/User.swift
@@ -21,6 +21,17 @@ public struct User: Codable {
     /** User Status */
     public var userStatus: Int?
 
+    public init(_id: Int64?, username: String?, firstName: String?, lastName: String?, email: String?, password: String?, phone: String?, userStatus: Int?) {
+        self._id = _id
+        self.username = username
+        self.firstName = firstName
+        self.lastName = lastName
+        self.email = email
+        self.password = password
+        self.phone = phone
+        self.userStatus = userStatus
+    }
+
 
     public enum CodingKeys: String, CodingKey { 
         case _id = "id"

--- a/samples/client/test/swift4/default/TestClient/Classes/Swaggers/APIs.swift
+++ b/samples/client/test/swift4/default/TestClient/Classes/Swaggers/APIs.swift
@@ -16,10 +16,10 @@ open class TestClientAPI {
 open class RequestBuilder<T> {
     var credential: URLCredential?
     var headers: [String:String]
-    let parameters: [String:Any]?
-    let isBody: Bool
-    let method: String
-    let URLString: String
+    public let parameters: [String:Any]?
+    public let isBody: Bool
+    public let method: String
+    public let URLString: String
 
     /// Optional block to obtain a reference to the request's progress instance when available.
     public var onProgressReady: ((Progress) -> ())?

--- a/samples/client/test/swift4/default/TestClient/Classes/Swaggers/Models/AllPrimitives.swift
+++ b/samples/client/test/swift4/default/TestClient/Classes/Swaggers/Models/AllPrimitives.swift
@@ -43,6 +43,34 @@ public struct AllPrimitives: Codable {
     public var myStringEnumArray: [StringEnum]?
     public var myInlineStringEnum: MyInlineStringEnum?
 
+    public init(myInteger: Int?, myIntegerArray: [Int]?, myLong: Int64?, myLongArray: [Int64]?, myFloat: Float?, myFloatArray: [Float]?, myDouble: Double?, myDoubleArray: [Double]?, myString: String?, myStringArray: [String]?, myBytes: Data?, myBytesArray: [Data]?, myBoolean: Bool?, myBooleanArray: [Bool]?, myDate: Date?, myDateArray: [Date]?, myDateTime: Date?, myDateTimeArray: [Date]?, myFile: URL?, myFileArray: [URL]?, myUUID: UUID?, myUUIDArray: [UUID]?, myStringEnum: StringEnum?, myStringEnumArray: [StringEnum]?, myInlineStringEnum: MyInlineStringEnum?) {
+        self.myInteger = myInteger
+        self.myIntegerArray = myIntegerArray
+        self.myLong = myLong
+        self.myLongArray = myLongArray
+        self.myFloat = myFloat
+        self.myFloatArray = myFloatArray
+        self.myDouble = myDouble
+        self.myDoubleArray = myDoubleArray
+        self.myString = myString
+        self.myStringArray = myStringArray
+        self.myBytes = myBytes
+        self.myBytesArray = myBytesArray
+        self.myBoolean = myBoolean
+        self.myBooleanArray = myBooleanArray
+        self.myDate = myDate
+        self.myDateArray = myDateArray
+        self.myDateTime = myDateTime
+        self.myDateTimeArray = myDateTimeArray
+        self.myFile = myFile
+        self.myFileArray = myFileArray
+        self.myUUID = myUUID
+        self.myUUIDArray = myUUIDArray
+        self.myStringEnum = myStringEnum
+        self.myStringEnumArray = myStringEnumArray
+        self.myInlineStringEnum = myInlineStringEnum
+    }
+
 
 
 }

--- a/samples/client/test/swift4/default/TestClient/Classes/Swaggers/Models/BaseCard.swift
+++ b/samples/client/test/swift4/default/TestClient/Classes/Swaggers/Models/BaseCard.swift
@@ -14,6 +14,10 @@ public struct BaseCard: Codable {
 
     public var cardType: String
 
+    public init(cardType: String) {
+        self.cardType = cardType
+    }
+
 
 
 }

--- a/samples/client/test/swift4/default/TestClient/Classes/Swaggers/Models/ErrorInfo.swift
+++ b/samples/client/test/swift4/default/TestClient/Classes/Swaggers/Models/ErrorInfo.swift
@@ -16,6 +16,12 @@ public struct ErrorInfo: Codable {
     public var message: String?
     public var details: [String]?
 
+    public init(code: Int?, message: String?, details: [String]?) {
+        self.code = code
+        self.message = message
+        self.details = details
+    }
+
 
 
 }

--- a/samples/client/test/swift4/default/TestClient/Classes/Swaggers/Models/GetAllModelsResult.swift
+++ b/samples/client/test/swift4/default/TestClient/Classes/Swaggers/Models/GetAllModelsResult.swift
@@ -16,6 +16,12 @@ public struct GetAllModelsResult: Codable {
     public var myPrimitive: AllPrimitives?
     public var myVariableNameTest: VariableNameTest?
 
+    public init(myPrimitiveArray: [AllPrimitives]?, myPrimitive: AllPrimitives?, myVariableNameTest: VariableNameTest?) {
+        self.myPrimitiveArray = myPrimitiveArray
+        self.myPrimitive = myPrimitive
+        self.myVariableNameTest = myVariableNameTest
+    }
+
 
 
 }

--- a/samples/client/test/swift4/default/TestClient/Classes/Swaggers/Models/ModelWithIntAdditionalPropertiesOnly.swift
+++ b/samples/client/test/swift4/default/TestClient/Classes/Swaggers/Models/ModelWithIntAdditionalPropertiesOnly.swift
@@ -13,6 +13,7 @@ import Foundation
 public struct ModelWithIntAdditionalPropertiesOnly: Codable {
 
 
+
     public var additionalProperties: [String:Int] = [:]
 
     public subscript(key: String) -> Int? {

--- a/samples/client/test/swift4/default/TestClient/Classes/Swaggers/Models/ModelWithPropertiesAndAdditionalProperties.swift
+++ b/samples/client/test/swift4/default/TestClient/Classes/Swaggers/Models/ModelWithPropertiesAndAdditionalProperties.swift
@@ -21,6 +21,17 @@ public struct ModelWithPropertiesAndAdditionalProperties: Codable {
     public var myPrimitiveArrayReq: [AllPrimitives]
     public var myPrimitiveArrayOpt: [AllPrimitives]?
 
+    public init(myIntegerReq: Int, myIntegerOpt: Int?, myPrimitiveReq: AllPrimitives, myPrimitiveOpt: AllPrimitives?, myStringArrayReq: [String], myStringArrayOpt: [String]?, myPrimitiveArrayReq: [AllPrimitives], myPrimitiveArrayOpt: [AllPrimitives]?) {
+        self.myIntegerReq = myIntegerReq
+        self.myIntegerOpt = myIntegerOpt
+        self.myPrimitiveReq = myPrimitiveReq
+        self.myPrimitiveOpt = myPrimitiveOpt
+        self.myStringArrayReq = myStringArrayReq
+        self.myStringArrayOpt = myStringArrayOpt
+        self.myPrimitiveArrayReq = myPrimitiveArrayReq
+        self.myPrimitiveArrayOpt = myPrimitiveArrayOpt
+    }
+
     public var additionalProperties: [String:String] = [:]
 
     public subscript(key: String) -> String? {

--- a/samples/client/test/swift4/default/TestClient/Classes/Swaggers/Models/ModelWithStringAdditionalPropertiesOnly.swift
+++ b/samples/client/test/swift4/default/TestClient/Classes/Swaggers/Models/ModelWithStringAdditionalPropertiesOnly.swift
@@ -13,6 +13,7 @@ import Foundation
 public struct ModelWithStringAdditionalPropertiesOnly: Codable {
 
 
+
     public var additionalProperties: [String:String] = [:]
 
     public subscript(key: String) -> String? {

--- a/samples/client/test/swift4/default/TestClient/Classes/Swaggers/Models/PersonCard.swift
+++ b/samples/client/test/swift4/default/TestClient/Classes/Swaggers/Models/PersonCard.swift
@@ -16,6 +16,11 @@ public struct PersonCard: Codable {
     public var firstName: String?
     public var lastName: String?
 
+    public init(firstName: String?, lastName: String?) {
+        self.firstName = firstName
+        self.lastName = lastName
+    }
+
 
 
 }

--- a/samples/client/test/swift4/default/TestClient/Classes/Swaggers/Models/PersonCard.swift
+++ b/samples/client/test/swift4/default/TestClient/Classes/Swaggers/Models/PersonCard.swift
@@ -16,7 +16,8 @@ public struct PersonCard: Codable {
     public var firstName: String?
     public var lastName: String?
 
-    public init(firstName: String?, lastName: String?) {
+    public init(cardType: String, firstName: String?, lastName: String?) {
+        self.cardType = cardType
         self.firstName = firstName
         self.lastName = lastName
     }

--- a/samples/client/test/swift4/default/TestClient/Classes/Swaggers/Models/PlaceCard.swift
+++ b/samples/client/test/swift4/default/TestClient/Classes/Swaggers/Models/PlaceCard.swift
@@ -16,6 +16,11 @@ public struct PlaceCard: Codable {
     public var placeName: String?
     public var placeAddress: String?
 
+    public init(placeName: String?, placeAddress: String?) {
+        self.placeName = placeName
+        self.placeAddress = placeAddress
+    }
+
 
 
 }

--- a/samples/client/test/swift4/default/TestClient/Classes/Swaggers/Models/PlaceCard.swift
+++ b/samples/client/test/swift4/default/TestClient/Classes/Swaggers/Models/PlaceCard.swift
@@ -16,7 +16,8 @@ public struct PlaceCard: Codable {
     public var placeName: String?
     public var placeAddress: String?
 
-    public init(placeName: String?, placeAddress: String?) {
+    public init(cardType: String, placeName: String?, placeAddress: String?) {
+        self.cardType = cardType
         self.placeName = placeName
         self.placeAddress = placeAddress
     }

--- a/samples/client/test/swift4/default/TestClient/Classes/Swaggers/Models/SampleBase.swift
+++ b/samples/client/test/swift4/default/TestClient/Classes/Swaggers/Models/SampleBase.swift
@@ -15,6 +15,11 @@ public struct SampleBase: Codable {
     public var baseClassStringProp: String?
     public var baseClassIntegerProp: Int?
 
+    public init(baseClassStringProp: String?, baseClassIntegerProp: Int?) {
+        self.baseClassStringProp = baseClassStringProp
+        self.baseClassIntegerProp = baseClassIntegerProp
+    }
+
 
 
 }

--- a/samples/client/test/swift4/default/TestClient/Classes/Swaggers/Models/SampleSubClass.swift
+++ b/samples/client/test/swift4/default/TestClient/Classes/Swaggers/Models/SampleSubClass.swift
@@ -17,6 +17,13 @@ public struct SampleSubClass: Codable {
     public var subClassStringProp: String?
     public var subClassIntegerProp: Int?
 
+    public init(baseClassStringProp: String?, baseClassIntegerProp: Int?, subClassStringProp: String?, subClassIntegerProp: Int?) {
+        self.baseClassStringProp = baseClassStringProp
+        self.baseClassIntegerProp = baseClassIntegerProp
+        self.subClassStringProp = subClassStringProp
+        self.subClassIntegerProp = subClassIntegerProp
+    }
+
 
 
 }

--- a/samples/client/test/swift4/default/TestClient/Classes/Swaggers/Models/VariableNameTest.swift
+++ b/samples/client/test/swift4/default/TestClient/Classes/Swaggers/Models/VariableNameTest.swift
@@ -19,6 +19,12 @@ public struct VariableNameTest: Codable {
     /** This model object property name should be unchanged from the JSON property name. */
     public var normalName: String?
 
+    public init(exampleName: String?, _for: String?, normalName: String?) {
+        self.exampleName = exampleName
+        self._for = _for
+        self.normalName = normalName
+    }
+
 
     public enum CodingKeys: String, CodingKey { 
         case exampleName = "example_name"


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [x] Filed the PR against the correct branch: `3.0.0` branch for changes related to OpenAPI spec 3.0. Default: `master`.
- [x] Copied the [technical committee](https://github.com/swagger-api/swagger-codegen/#swagger-codegen-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

https://github.com/swagger-api/swagger-codegen/issues/6941

Add explicit public initializer again for modelObject.mustache.

Initializers are no longer see from other Xcode targets after merged the above issue. Swift struct can omit explicit initializer, but is necessary if reference it from outer packages.

In my case, I usually generate a CocoaTouch Framework from generated codes and reuse it via Carthage.