### PR TITLE
Add templates for async client Retrofit2 in Java Play Framework 2.6

### DIFF
--- a/bin/java-petstore-retrofit2-all.sh
+++ b/bin/java-petstore-retrofit2-all.sh
@@ -2,6 +2,7 @@
 
 ./bin/java-petstore-retrofit2-play24.sh
 ./bin/java-petstore-retrofit2-play25.sh
+./bin/java-petstore-retrofit2-play26.sh
 ./bin/java-petstore-retrofit2.sh
 ./bin/java-petstore-retrofit2rx.sh
 ./bin/java-petstore-retrofit2rx2.sh

--- a/bin/java-petstore-retrofit2-play26.json
+++ b/bin/java-petstore-retrofit2-play26.json
@@ -1,0 +1,1 @@
+{"useBeanValidation":"true","enableBuilderSupport":"true","library":"retrofit2","usePlayWS":"true","playVersion":"play26"}

--- a/bin/java-petstore-retrofit2-play26.sh
+++ b/bin/java-petstore-retrofit2-play26.sh
@@ -1,0 +1,34 @@
+#!/bin/sh
+
+SCRIPT="$0"
+
+while [ -h "$SCRIPT" ] ; do
+  ls=`ls -ld "$SCRIPT"`
+  link=`expr "$ls" : '.*-> \(.*\)$'`
+  if expr "$link" : '/.*' > /dev/null; then
+    SCRIPT="$link"
+  else
+    SCRIPT=`dirname "$SCRIPT"`/"$link"
+  fi
+done
+
+if [ ! -d "${APP_DIR}" ]; then
+  APP_DIR=`dirname "$SCRIPT"`/..
+  APP_DIR=`cd "${APP_DIR}"; pwd`
+fi
+
+executable="./modules/swagger-codegen-cli/target/swagger-codegen-cli.jar"
+
+if [ ! -f "$executable" ]
+then
+  mvn clean package
+fi
+
+# if you've executed sbt assembly previously it will use that instead.
+export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
+ags="$@ generate -i modules/swagger-codegen/src/test/resources/2_0/petstore-with-fake-endpoints-models-for-testing.yaml -l java -c bin/java-petstore-retrofit2-play26.json -o samples/client/petstore/java/retrofit2-play26 -DhideGenerationTimestamp=true"
+
+echo "Removing files and folders under samples/client/petstore/java/retrofit2-play26/src/main"
+rm -rf samples/client/petstore/java/retrofit2-play26/src/main
+find samples/client/petstore/java/retrofit2-play26 -maxdepth 1 -type f ! -name "README.md" -exec rm {} +
+java $JAVA_OPTS -jar $executable $ags

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/JavaClientCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/JavaClientCodegen.java
@@ -36,6 +36,7 @@ public class JavaClientCodegen extends AbstractJavaCodegen
 
     public static final String PLAY_24 = "play24";
     public static final String PLAY_25 = "play25";
+    public static final String PLAY_26 = "play26";
 
     public static final String RETROFIT_1 = "retrofit";
     public static final String RETROFIT_2 = "retrofit2";
@@ -46,7 +47,7 @@ public class JavaClientCodegen extends AbstractJavaCodegen
     protected boolean useRxJava2 = false;
     protected boolean doNotUseRx = true; // backwards compatibility for swagger configs that specify neither rx1 nor rx2 (mustache does not allow for boolean operators so we need this extra field)
     protected boolean usePlayWS = false;
-    protected String playVersion = PLAY_25;
+    protected String playVersion = PLAY_26;
     protected boolean parcelableModel = false;
     protected boolean useBeanValidation = false;
     protected boolean performBeanValidation = false;
@@ -67,7 +68,7 @@ public class JavaClientCodegen extends AbstractJavaCodegen
         cliOptions.add(CliOption.newBoolean(USE_RX_JAVA2, "Whether to use the RxJava2 adapter with the retrofit2 library."));
         cliOptions.add(CliOption.newBoolean(PARCELABLE_MODEL, "Whether to generate models for Android that implement Parcelable with the okhttp-gson library."));
         cliOptions.add(CliOption.newBoolean(USE_PLAY_WS, "Use Play! Async HTTP client (Play WS API)"));
-        cliOptions.add(CliOption.newString(PLAY_VERSION, "Version of Play! Framework (possible values \"play24\", \"play25\")"));
+        cliOptions.add(CliOption.newString(PLAY_VERSION, "Version of Play! Framework (possible values \"play24\", \"play25\", \"play26\")"));
         cliOptions.add(CliOption.newBoolean(SUPPORT_JAVA6, "Whether to support Java6 with the Jersey1 library."));
         cliOptions.add(CliOption.newBoolean(USE_BEANVALIDATION, "Use BeanValidation API annotations"));
         cliOptions.add(CliOption.newBoolean(PERFORM_BEANVALIDATION, "Perform BeanValidation"));
@@ -279,7 +280,7 @@ public class JavaClientCodegen extends AbstractJavaCodegen
                 supportingFiles.add(new SupportingFile("play24/Play24CallFactory.mustache", invokerFolder, "Play24CallFactory.java"));
                 supportingFiles.add(new SupportingFile("play24/Play24CallAdapterFactory.mustache", invokerFolder,
                         "Play24CallAdapterFactory.java"));
-            } else {
+            } else if (PLAY_25.equals(playVersion)) {
                 additionalProperties.put(PLAY_25, true);
                 apiTemplateFiles.put("play25/api.mustache", ".java");
 
@@ -287,6 +288,15 @@ public class JavaClientCodegen extends AbstractJavaCodegen
                 supportingFiles.add(new SupportingFile("play25/Play25CallFactory.mustache", invokerFolder, "Play25CallFactory.java"));
                 supportingFiles.add(new SupportingFile("play25/Play25CallAdapterFactory.mustache", invokerFolder,
                         "Play25CallAdapterFactory.java"));
+                additionalProperties.put("java8", "true");
+            } else {
+                additionalProperties.put(PLAY_26, true);
+                apiTemplateFiles.put("play26/api.mustache", ".java");
+
+                supportingFiles.add(new SupportingFile("play26/ApiClient.mustache", invokerFolder, "ApiClient.java"));
+                supportingFiles.add(new SupportingFile("play26/Play26CallFactory.mustache", invokerFolder, "Play26CallFactory.java"));
+                supportingFiles.add(new SupportingFile("play26/Play26CallAdapterFactory.mustache", invokerFolder,
+                        "Play26CallAdapterFactory.java"));
                 additionalProperties.put("java8", "true");
             }
 

--- a/modules/swagger-codegen/src/main/resources/Java/libraries/retrofit2/build.gradle.mustache
+++ b/modules/swagger-codegen/src/main/resources/Java/libraries/retrofit2/build.gradle.mustache
@@ -111,6 +111,10 @@ ext {
     jackson_version = "2.7.8"
     play_version = "2.5.14"
     {{/play25}}
+    {{#play26}}
+    jackson_version = "2.7.8"
+    play_version = "2.5.14"
+    {{/play26}}
     {{/usePlayWS}}
     swagger_annotations_version = "1.5.17"
     junit_version = "4.12"

--- a/modules/swagger-codegen/src/main/resources/Java/libraries/retrofit2/build.sbt.mustache
+++ b/modules/swagger-codegen/src/main/resources/Java/libraries/retrofit2/build.sbt.mustache
@@ -27,6 +27,12 @@ lazy val root = (project in file(".")).
       "com.fasterxml.jackson.core" % "jackson-annotations" % "2.7.8" % "compile",
       "com.fasterxml.jackson.core" % "jackson-databind" % "2.7.8" % "compile",
       {{/play25}}
+      {{#play26}}
+      "com.typesafe.play" % "play-java-ws_2.11" % "2.5.15" % "compile",
+      "com.fasterxml.jackson.core" % "jackson-core" % "2.7.8" % "compile",
+      "com.fasterxml.jackson.core" % "jackson-annotations" % "2.7.8" % "compile",
+      "com.fasterxml.jackson.core" % "jackson-databind" % "2.7.8" % "compile",
+      {{/play26}}
       "com.squareup.retrofit2" % "converter-jackson" % "2.3.0" % "compile",
       {{/usePlayWS}}
       {{#useRxJava}}

--- a/modules/swagger-codegen/src/main/resources/Java/libraries/retrofit2/play26/ApiClient.mustache
+++ b/modules/swagger-codegen/src/main/resources/Java/libraries/retrofit2/play26/ApiClient.mustache
@@ -1,0 +1,136 @@
+package {{invokerPackage}};
+
+import java.io.IOException;
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Type;
+import java.util.*;
+
+import retrofit2.Retrofit;
+import retrofit2.converter.scalars.ScalarsConverterFactory;
+import retrofit2.converter.jackson.JacksonConverterFactory;
+
+import play.libs.Json;
+import play.libs.ws.WSClient;
+
+import {{invokerPackage}}.Play26CallAdapterFactory;
+import {{invokerPackage}}.Play26CallFactory;
+
+import okhttp3.Interceptor;
+import {{invokerPackage}}.auth.ApiKeyAuth;
+import {{invokerPackage}}.auth.Authentication;
+
+/**
+ * API client
+ */
+public class ApiClient {
+
+    /** Underlying HTTP-client */
+    private WSClient wsClient;
+
+    /** Supported auths */
+    private Map<String, Authentication> authentications;
+
+    /** API base path */
+    private String basePath = "{{{basePath}}}";
+
+    public ApiClient(WSClient wsClient) {
+        this();
+        this.wsClient = wsClient;
+    }
+
+    public ApiClient() {
+        // Setup authentications (key: authentication name, value: authentication).
+        authentications = new HashMap<>();{{#authMethods}}{{#isBasic}}
+        // authentications.put("{{name}}", new HttpBasicAuth());{{/isBasic}}{{#isApiKey}}
+        authentications.put("{{name}}", new ApiKeyAuth({{#isKeyInHeader}}"header"{{/isKeyInHeader}}{{^isKeyInHeader}}"query"{{/isKeyInHeader}}, "{{keyParamName}}"));{{/isApiKey}}{{#isOAuth}}
+        // authentications.put("{{name}}", new OAuth());{{/isOAuth}}{{/authMethods}}
+        // Prevent the authentications from being modified.
+        authentications = Collections.unmodifiableMap(authentications);
+
+    }
+
+    /**
+     * Creates a retrofit2 client for given API interface
+     */
+    public <S> S createService(Class<S> serviceClass) {
+        if(!basePath.endsWith("/")) {
+            basePath = basePath + "/";
+        }
+
+        Map<String, String> extraHeaders = new HashMap<>();
+        List<Pair> extraQueryParams = new ArrayList<>();
+
+        for (String authName : authentications.keySet()) {
+            Authentication auth = authentications.get(authName);
+            if (auth == null) throw new RuntimeException("Authentication undefined: " + authName);
+
+            auth.applyToParams(extraQueryParams, extraHeaders);
+        }
+
+        return new Retrofit.Builder()
+                       .baseUrl(basePath)
+                       .addConverterFactory(ScalarsConverterFactory.create())
+                       .addConverterFactory(JacksonConverterFactory.create(Json.mapper()))
+                       .callFactory(new Play26CallFactory(wsClient, extraHeaders, extraQueryParams))
+                       .addCallAdapterFactory(new Play26CallAdapterFactory())
+                       .build()
+                       .create(serviceClass);
+    }
+
+    /**
+     * Helper method to set API base path
+     */
+    public ApiClient setBasePath(String basePath) {
+        this.basePath = basePath;
+        return this;
+    }
+
+    /**
+     * Get authentications (key: authentication name, value: authentication).
+     */
+    public Map<String, Authentication> getAuthentications() {
+        return authentications;
+    }
+
+    /**
+     * Get authentication for the given name.
+     *
+     * @param authName The authentication name
+     * @return The authentication, null if not found
+     */
+    public Authentication getAuthentication(String authName) {
+        return authentications.get(authName);
+    }
+
+    /**
+     * Helper method to set API key value for the first API key authentication.
+     */
+    public ApiClient setApiKey(String apiKey) {
+        for (Authentication auth : authentications.values()) {
+            if (auth instanceof ApiKeyAuth) {
+                ((ApiKeyAuth) auth).setApiKey(apiKey);
+                return this;
+            }
+        }
+
+        throw new RuntimeException("No API key authentication configured!");
+    }
+
+    /**
+     * Helper method to set API key prefix for the first API key authentication.
+     */
+    public ApiClient setApiKeyPrefix(String apiKeyPrefix) {
+        for (Authentication auth : authentications.values()) {
+            if (auth instanceof ApiKeyAuth) {
+                ((ApiKeyAuth) auth).setApiKeyPrefix(apiKeyPrefix);
+                return this;
+            }
+        }
+
+        throw new RuntimeException("No API key authentication configured!");
+    }
+
+
+}
+
+

--- a/modules/swagger-codegen/src/main/resources/Java/libraries/retrofit2/play26/Play26CallAdapterFactory.mustache
+++ b/modules/swagger-codegen/src/main/resources/Java/libraries/retrofit2/play26/Play26CallAdapterFactory.mustache
@@ -1,0 +1,117 @@
+package {{invokerPackage}};
+
+import java.util.concurrent.CompletionStage;
+import retrofit2.*;
+
+import java.lang.annotation.Annotation;
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
+import java.lang.reflect.WildcardType;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+import java.util.function.Function;
+
+/**
+ * Creates {@link CallAdapter} instances that convert {@link Call} into {@link java.util.concurrent.CompletionStage}
+ */
+public class Play26CallAdapterFactory extends CallAdapter.Factory {
+
+    private Function<RuntimeException, RuntimeException> exceptionConverter = Function.identity();
+
+    public Play26CallAdapterFactory() {
+    }
+
+    public Play26CallAdapterFactory(
+            Function<RuntimeException, RuntimeException> exceptionConverter) {
+        this.exceptionConverter = exceptionConverter;
+    }
+
+    @Override
+    public CallAdapter<?, ?> get(Type returnType, Annotation[] annotations, Retrofit retrofit) {
+        if (!(returnType instanceof ParameterizedType)) {
+            return null;
+        }
+
+        ParameterizedType type = (ParameterizedType) returnType;
+        if (type.getRawType() != CompletionStage.class) {
+            return null;
+        }
+
+        return createAdapter((ParameterizedType) returnType);
+    }
+
+    private CallAdapter<?, CompletionStage<?>> createAdapter(ParameterizedType returnType) {
+        // Get CompletionStage type argument
+        Type[] types = returnType.getActualTypeArguments();
+        if (types.length != 1) {
+            throw new IllegalStateException("Must be exactly one type parameter");
+        }
+
+        Type resultType = types[0];
+        Class<?> rawTypeParam = getRawType(resultType);
+
+        boolean includeResponse = false;
+        if (rawTypeParam == Response.class) {
+            if (!(resultType instanceof ParameterizedType)) {
+                throw new IllegalStateException("Response must be parameterized"
+                        + " as Response<T>");
+            }
+            resultType = ((ParameterizedType) resultType).getActualTypeArguments()[0];
+            includeResponse = true;
+        }
+
+        return new ValueAdapter(resultType, includeResponse, exceptionConverter);
+    }
+
+    /**
+     * Adapter that coverts values returned by API interface into CompletionStage
+     */
+    private static final class ValueAdapter<R> implements CallAdapter<R, CompletionStage<R>> {
+
+        private final Type responseType;
+        private final boolean includeResponse;
+        private Function<RuntimeException, RuntimeException> exceptionConverter;
+
+        ValueAdapter(Type responseType, boolean includeResponse,
+                     Function<RuntimeException, RuntimeException> exceptionConverter) {
+            this.responseType = responseType;
+            this.includeResponse = includeResponse;
+            this.exceptionConverter = exceptionConverter;
+        }
+
+        @Override
+        public Type responseType() {
+            return responseType;
+        }
+
+        @Override
+        public CompletionStage<R> adapt(final Call<R> call) {
+            final CompletableFuture<R> promise = new CompletableFuture();
+
+            call.enqueue(new Callback<R>() {
+
+                @Override
+                public void onResponse(Call<R> call, Response<R> response) {
+                    if (response.isSuccessful()) {
+                        if (includeResponse) {
+                            promise.complete((R) response);
+                        } else {
+                            promise.complete(response.body());
+                        }
+                    } else {
+                        promise.completeExceptionally(exceptionConverter.apply(new HttpException(response)));
+                    }
+                }
+
+                @Override
+                public void onFailure(Call<R> call, Throwable t) {
+                    promise.completeExceptionally(t);
+                }
+
+            });
+
+            return promise;
+        }
+    }
+}
+

--- a/modules/swagger-codegen/src/main/resources/Java/libraries/retrofit2/play26/Play26CallFactory.mustache
+++ b/modules/swagger-codegen/src/main/resources/Java/libraries/retrofit2/play26/Play26CallFactory.mustache
@@ -1,0 +1,229 @@
+package {{invokerPackage}};
+
+import okhttp3.*;
+import okio.Buffer;
+import okio.BufferedSource;
+import play.libs.ws.WSClient;
+import play.libs.ws.WSRequest;
+import play.libs.ws.WSResponse;
+import play.libs.ws.WSRequestFilter;
+
+import java.io.IOException;
+import java.net.MalformedURLException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.CompletionStage;
+
+/**
+ * Creates {@link Call} instances that invoke underlying {@link WSClient}
+ */
+public class Play26CallFactory implements okhttp3.Call.Factory {
+
+    /** PlayWS http client */
+    private final WSClient wsClient;
+
+    /** Extra headers to add to request */
+    private Map<String, String> extraHeaders = new HashMap<>();
+
+    /** Extra query parameters to add to request */
+    private List<Pair> extraQueryParams = new ArrayList<>();
+    
+    /** Filters (interceptors) */
+    private List<WSRequestFilter> filters = new ArrayList<>();
+
+    public Play26CallFactory(WSClient wsClient) {
+        this.wsClient = wsClient;
+    }
+
+    public Play26CallFactory(WSClient wsClient, List<WSRequestFilter> filters) {
+        this(wsClient);
+        this.filters.addAll(filters);
+    }
+
+    public Play26CallFactory(WSClient wsClient, Map<String, String> extraHeaders,
+                             List<Pair> extraQueryParams) {
+        this(wsClient);
+
+        this.extraHeaders.putAll(extraHeaders);
+        this.extraQueryParams.addAll(extraQueryParams);
+    }
+
+    @Override
+    public Call newCall(Request request) {
+        // add extra headers
+        Request.Builder rb = request.newBuilder();
+        for (Map.Entry<String, String> header : this.extraHeaders.entrySet()) {
+            rb.addHeader(header.getKey(), header.getValue());
+        }
+
+        // add extra query params
+        if (!this.extraQueryParams.isEmpty()) {
+            String newQuery = request.url().uri().getQuery();
+            for (Pair queryParam : this.extraQueryParams) {
+                String param = String.format("%s=%s", queryParam.getName(), queryParam.getValue());
+                if (newQuery == null) {
+                    newQuery = param;
+                } else {
+                    newQuery += "&" + param;
+                }
+            }
+
+            URI newUri;
+            try {
+                newUri = new URI(request.url().uri().getScheme(), request.url().uri().getAuthority(),
+                        request.url().uri().getPath(), newQuery, request.url().uri().getFragment());
+                rb.url(newUri.toURL());
+            } catch (MalformedURLException | URISyntaxException e) {
+                throw new RuntimeException("Error while updating an url", e);
+            }
+        }
+
+        return new PlayWSCall(wsClient, this.filters, rb.build());
+    }
+
+    /**
+     * Call implementation that delegates to Play WS Client
+     */
+    static class PlayWSCall implements Call {
+
+        private final WSClient wsClient;
+        private WSRequest wsRequest;
+        private List<WSRequestFilter> filters;
+
+        private final Request request;
+
+        public PlayWSCall(WSClient wsClient, List<WSRequestFilter> filters, Request request) {
+            this.wsClient = wsClient;
+            this.request = request;
+            this.filters = filters;
+        }
+
+        @Override
+        public Request request() {
+            return request;
+        }
+
+        @Override
+        public void enqueue(final okhttp3.Callback responseCallback) {
+            final Call call = this;
+            final CompletionStage<WSResponse> promise = executeAsync();
+
+            promise.whenCompleteAsync((v, t) -> {
+                if (t != null) {
+                    if (t instanceof IOException) {
+                        responseCallback.onFailure(call, (IOException) t);
+                    } else {
+                        responseCallback.onFailure(call, new IOException(t));
+                    }
+                } else {
+                    try {
+                        responseCallback.onResponse(call, PlayWSCall.this.toWSResponse(v));
+                    } catch (IOException e) {
+                        throw new RuntimeException(e);
+                    }
+                }
+            }, play.libs.concurrent.HttpExecution.defaultContext());
+        }
+
+        CompletionStage<WSResponse> executeAsync() {
+            try {
+                wsRequest = wsClient.url(request.url().uri().toString());
+                addHeaders(wsRequest);
+                if (request.body() != null) {
+                    addBody(wsRequest);
+                }
+                filters.stream().forEach(f -> wsRequest.setRequestFilter(f));
+
+                return wsRequest.execute(request.method());
+            } catch (Exception e) {
+                throw new RuntimeException(e.getMessage(), e);
+            }
+        }
+
+        private void addHeaders(WSRequest wsRequest) {
+            for(Map.Entry<String, List<String>> entry : request.headers().toMultimap().entrySet()) {
+                List<String> values = entry.getValue();
+                for (String value : values) {
+                    wsRequest.setHeader(entry.getKey(), value);
+                }
+            }
+        }
+
+        private void addBody(WSRequest wsRequest) throws IOException {
+            Buffer buffer = new Buffer();
+            request.body().writeTo(buffer);
+            wsRequest.setBody(buffer.inputStream());
+
+            MediaType mediaType = request.body().contentType();
+            if (mediaType != null) {
+                wsRequest.setContentType(mediaType.toString());
+            }
+        }
+
+        private Response toWSResponse(final WSResponse r) {
+            final Response.Builder builder = new Response.Builder();
+            builder.request(request)
+                   .code(r.getStatus())
+                   .message("")
+                   .body(new ResponseBody() {
+
+                       @Override
+                       public MediaType contentType() {
+                           return r.getSingleHeader("Content-Type")
+                                          .map(MediaType::parse)
+                                          .orElse(null);
+                       }
+
+                       @Override
+                       public long contentLength() {
+                           return r.asByteArray().length;
+                       }
+
+                       @Override
+                       public BufferedSource source() {
+                           return new Buffer().write(r.asByteArray());
+                       }
+
+                   });
+                   
+            for (Map.Entry<String, List<String>> entry : r.getAllHeaders().entrySet()) {
+                for (String value : entry.getValue()) {
+                    builder.addHeader(entry.getKey(), value);
+                }
+            }
+
+            builder.protocol(Protocol.HTTP_1_1);
+            return builder.build();
+        }
+
+        @Override
+        public Response execute() throws IOException {
+            throw new UnsupportedOperationException("Not supported");
+        }
+
+        @Override
+        public void cancel() {
+            throw new UnsupportedOperationException("Not supported");
+        }
+
+        @Override
+        public PlayWSCall clone() {
+            throw new UnsupportedOperationException("Not supported");
+        }
+
+        @Override
+        public boolean isExecuted() {
+            return false;
+        }
+
+        @Override
+        public boolean isCanceled() {
+            return false;
+        }
+    }
+}

--- a/modules/swagger-codegen/src/main/resources/Java/libraries/retrofit2/play26/api.mustache
+++ b/modules/swagger-codegen/src/main/resources/Java/libraries/retrofit2/play26/api.mustache
@@ -1,0 +1,57 @@
+package {{package}};
+
+import {{invokerPackage}}.CollectionFormats.*;
+
+{{#useRxJava}}import rx.Observable;{{/useRxJava}}
+{{#useRxJava2}}import io.reactivex.Observable;{{/useRxJava2}}
+{{#doNotUseRx}}import retrofit2.Call;{{/doNotUseRx}}
+import retrofit2.http.*;
+
+import okhttp3.RequestBody;
+
+{{#imports}}import {{import}};
+{{/imports}}
+
+{{^fullJavaUtil}}
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+{{/fullJavaUtil}}
+
+import java.util.concurrent.*;
+import retrofit2.Response;
+
+{{#operations}}
+public interface {{classname}} {
+  {{#operation}}
+  /**
+   * {{summary}}
+   * {{notes}}
+{{#allParams}}
+   * @param {{paramName}} {{description}}{{#required}} (required){{/required}}{{^required}} (optional{{#defaultValue}}, default to {{{.}}}{{/defaultValue}}){{/required}}
+{{/allParams}}
+   * @return Call&lt;{{#returnType}}{{returnType}}{{/returnType}}{{^returnType}}Void{{/returnType}}&gt;
+   */
+  {{#formParams}}
+  {{#-first}}
+  {{#isMultipart}}@retrofit2.http.Multipart{{/isMultipart}}{{^isMultipart}}@retrofit2.http.FormUrlEncoded{{/isMultipart}}
+  {{/-first}}
+  {{/formParams}}
+  {{^formParams}}
+  {{#prioritizedContentTypes}}
+  {{#-first}}
+  @Headers({
+    "Content-Type:{{{mediaType}}}"
+  })
+  {{/-first}}
+  {{/prioritizedContentTypes}}
+  {{/formParams}}
+  @{{httpMethod}}("{{{path}}}")
+  CompletionStage<Response<{{#returnType}}{{{returnType}}}{{/returnType}}{{^returnType}}Void{{/returnType}}>> {{operationId}}({{^allParams}});{{/allParams}}
+    {{#allParams}}{{>libraries/retrofit2/queryParams}}{{>libraries/retrofit2/pathParams}}{{>libraries/retrofit2/headerParams}}{{>libraries/retrofit2/bodyParams}}{{>libraries/retrofit2/formParams}}{{#hasMore}}, {{/hasMore}}{{^hasMore}}
+  );{{/hasMore}}{{/allParams}}
+
+  {{/operation}}
+}
+{{/operations}}

--- a/modules/swagger-codegen/src/main/resources/Java/libraries/retrofit2/pom.mustache
+++ b/modules/swagger-codegen/src/main/resources/Java/libraries/retrofit2/pom.mustache
@@ -341,6 +341,10 @@
                 <jackson-version>2.7.8</jackson-version>
                 <play-version>2.5.15</play-version>
             {{/play25}}
+            {{#play26}}
+                <jackson-version>2.7.8</jackson-version>
+                <play-version>2.5.15</play-version>
+            {{/play26}}
         {{/usePlayWS}}
         <retrofit-version>2.3.0</retrofit-version>
         {{#useRxJava}}


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [ ] Filed the PR against the correct branch: `3.0.0` branch for changes related to OpenAPI spec 3.0. Default: `master`.
- [ ] Copied the [technical committee](https://github.com/swagger-api/swagger-codegen/#swagger-codegen-technical-committee) to review the pull request if your PR is targeting a particular programming language.

@bbdouglas @JFCote @sreeshas @jfiala @lukoyanov @cbornet @jeff9finger

### Description of the PR

Add templates to support Play Framework version 2.6 with async clients using Retrofit2

