### PR TITLE
Fix for Visual Studio Project GUID

### DIFF
--- a/modules/swagger-codegen/src/main/resources/aspnetcore/Solution.mustache
+++ b/modules/swagger-codegen/src/main/resources/aspnetcore/Solution.mustache
@@ -2,7 +2,7 @@
 # Visual Studio 15
 VisualStudioVersion = 15.0.26114.2
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "{{packageName}}", "src\{{packageName}}\{{packageName}}.csproj", "{{packageGuid}}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "{{packageName}}", "src\{{packageName}}\{{packageName}}.csproj", "{{packageGuid}}"
 EndProject
 Global
         GlobalSection(SolutionConfigurationPlatforms) = preSolution


### PR DESCRIPTION
It appears that ASP Core is now using a new GUID for the project in visual studio. The old one {8BB2217D-0F2D-49D1-97BC-3654ED321F3B} does not load in VS2017. We should now be using {9A19103F-16F7-4668-BE54-9A1E7A4F7556}

Not sure if  @mandrean or @jimschubert maintain aspnetcore or not?

[CSharpProjectSystemPackage from dotnet github page ](https://github.com/dotnet/project-system/blob/master/src/Microsoft.VisualStudio.ProjectSystem.CSharp.VS/Packaging/CSharpProjectSystemPackage.cs)

```
    internal class CSharpProjectSystemPackage : AsyncPackage
    {
        public const string ProjectTypeGuid = "9A19103F-16F7-4668-BE54-9A1E7A4F7556";
        public const string LegacyProjectTypeGuid = "FAE04EC0-301F-11d3-BF4B-00C04F79EFBC";
        public const string PackageGuid = "860A27C0-B665-47F3-BC12-637E16A1050A";
        private const string ProjectTypeGuidFormatted = "{" + ProjectTypeGuid + "}";
...
```
