### PR TITLE
Bring run-in-docker.sh to date for 3.0

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -10,7 +10,7 @@ cli="${GEN_DIR}/modules/swagger-codegen-cli"
 codegen="${cli}/target/swagger-codegen-cli.jar"
 cmdsrc="${cli}/src/main/java/io/swagger/codegen/cmd"
 
-pattern="@Command(name = \"$1\""
+pattern="${1^} implements Runnable"
 if expr "x$1" : 'x[a-z][a-z-]*$' > /dev/null && fgrep -qe "$pattern" "$cmdsrc"/*.java || expr "$1" = 'help' > /dev/null; then
     # If ${GEN_DIR} has been mapped elsewhere from default, and that location has not been built
     if [[ ! -f "${codegen}" ]]; then

--- a/run-in-docker.sh
+++ b/run-in-docker.sh
@@ -15,4 +15,4 @@ docker run --rm -it \
         -v "${PWD}:/gen" \
         -v "${maven_cache_repo}:/var/maven/.m2/repository" \
         --entrypoint /gen/docker-entrypoint.sh \
-        maven:3-jdk-7 "$@"
+        maven:3-jdk-8 "$@"


### PR DESCRIPTION
- Update run-in-docker.sh to use jdk-8
- Update docker-entrypoint.sh for 3.0 style commands

### PR checklist

- [X] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [ ] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [X] Filed the PR against the correct branch: `3.0.0` branch for changes related to OpenAPI spec 3.0. Default: `master`.
- [X] Copied the [technical committee](https://github.com/swagger-api/swagger-codegen/#swagger-codegen-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

https://github.com/swagger-api/swagger-codegen/issues/7678
