### PR TITLE
Doc extension

### DIFF
--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/CodegenConfig.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/CodegenConfig.java
@@ -204,6 +204,10 @@ public interface CodegenConfig {
 
     String getHttpUserAgent();
 
+    void setDocExtension(String docExtension);
+
+    String getDocExtension();
+
     String getCommonTemplateDir();
 
     void setIgnoreFilePathOverride(String ignoreFileOverride);

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/CodegenConstants.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/CodegenConstants.java
@@ -228,4 +228,7 @@ public class CodegenConstants {
 
     public static final String STRIP_PACKAGE_NAME = "stripPackageName";
     public static final String STRIP_PACKAGE_NAME_DESC = "Whether to strip leading dot-separated packages from generated model classes";
+
+    public static final String DOCEXTENSION = "docExtension";
+    public static final String DOCEXTENSION_DESC = "The extension of the generated documentation files, defaults to markdown, .md";
 }

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/DefaultCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/DefaultCodegen.java
@@ -108,6 +108,8 @@ public class DefaultCodegen {
     protected Map<String, String> specialCharReplacements = new HashMap<String, String>();
     // When a model is an alias for a simple type
     protected Map<String, String> typeAliases = null;
+    // The extension of the generated documentation files (defaults to markdown .md)
+    protected String docExtension = ".md";
 
     protected String ignoreFilePathOverride;
 
@@ -154,6 +156,11 @@ public class DefaultCodegen {
         if (additionalProperties.containsKey(CodegenConstants.REMOVE_OPERATION_ID_PREFIX)) {
             this.setRemoveOperationIdPrefix(Boolean.valueOf(additionalProperties
                     .get(CodegenConstants.REMOVE_OPERATION_ID_PREFIX).toString()));
+        }
+
+        if (additionalProperties.containsKey(CodegenConstants.DOCEXTENSION)){
+            this.setDocExtension(String.valueOf(additionalProperties
+                    .get(CodegenConstants.DOCEXTENSION).toString()));
         }
     }
 
@@ -3460,6 +3467,25 @@ public class DefaultCodegen {
     public String getReleaseNote() {
         return releaseNote;
     }
+
+    /**
+     * Documentation files extension
+     *
+     * @return Documentation files extension
+     */
+    public String getDocExtension() {
+        return docExtension;
+    }
+
+    /**
+     * Set Documentation files extension
+     *
+     * @param userDocExtension documentation files extension
+     */
+    public void setDocExtension(String userDocExtension) {
+        this.docExtension = userDocExtension;
+    }
+
 
     /**
      * Set HTTP user agent.

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/DefaultCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/DefaultCodegen.java
@@ -109,7 +109,7 @@ public class DefaultCodegen {
     // When a model is an alias for a simple type
     protected Map<String, String> typeAliases = null;
     // The extension of the generated documentation files (defaults to markdown .md)
-    protected String docExtension = ".md";
+    protected String docExtension;
 
     protected String ignoreFilePathOverride;
 
@@ -3339,7 +3339,8 @@ public class DefaultCodegen {
      * @return the API documentation file name with full path
      */
     public String apiDocFilename(String templateName, String tag) {
-        String suffix = apiDocTemplateFiles().get(templateName);
+        String docExtension = getDocExtension();
+        String suffix = docExtension != null ? docExtension: apiDocTemplateFiles().get(templateName);
         return apiDocFileFolder() + '/' + toApiDocFilename(tag) + suffix;
     }
 

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/DefaultGenerator.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/DefaultGenerator.java
@@ -262,7 +262,8 @@ public class DefaultGenerator extends AbstractGenerator implements Generator {
 
     private void generateModelDocumentation(List<File> files, Map<String, Object> models, String modelName) throws IOException {
         for (String templateName : config.modelDocTemplateFiles().keySet()) {
-            String suffix = config.modelDocTemplateFiles().get(templateName);
+            String docExtension = config.getDocExtension();
+            String suffix = docExtension!=null ? docExtension : config.modelDocTemplateFiles().get(templateName);
             String filename = config.modelDocFileFolder() + File.separator + config.toModelDocFilename(modelName) + suffix;
             if (!config.shouldOverwrite(filename)) {
                 LOGGER.info("Skipped overwriting " + filename);


### PR DESCRIPTION
### PR checklist

- [X ] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
----> not sure here, I ran some bin/*petstore*.sh files, but it only added a few spaces here and there, replaced petstore.swagger.io with localhost in documentation and other things. Does these really need to be commited and put in the PR ? 

- [X ] Filed the PR against the correct branch: `3.0.0` branch for changes related to OpenAPI spec 3.0. Default: `master`.
- [ ] Copied the [technical committee](https://github.com/swagger-api/swagger-codegen/#swagger-codegen-technical-committee) to review the pull request if your PR is targeting a particular programming language.
-----> I technically modified *all* languages generators, but with a really minor change, what's the modus operandi?

### Description of the PR

Implements the change mentioned in #7680 regarding the possibility to generate some supporting files, namely documentation, with a different file extension

