### PR TITLE
[Swift] Fix issue-7663

### DIFF
--- a/modules/swagger-codegen/src/main/resources/swift/api.mustache
+++ b/modules/swagger-codegen/src/main/resources/swift/api.mustache
@@ -96,9 +96,9 @@ public class {{classname}}: APIBase {
      - defaultResponse: {{defaultResponse}}{{/defaultResponse}}{{#authMethods}}
      - {{#isBasic}}BASIC{{/isBasic}}{{#isOAuth}}OAuth{{/isOAuth}}{{#isApiKey}}API Key{{/isApiKey}}:
        - type: {{type}}{{#keyParamName}} {{keyParamName}} {{#isKeyInQuery}}(QUERY){{/isKeyInQuery}}{{#isKeyInHeaer}}(HEADER){{/isKeyInHeaer}}{{/keyParamName}}
-       - name: {{name}}{{/authMethods}}{{#responseHeaders}}
-     - responseHeaders: {{responseHeaders}}{{/responseHeaders}}{{#examples}}
-     - examples: {{{examples}}}{{/examples}}{{#externalDocs}}
+       - name: {{name}}{{/authMethods}}{{^responseHeaders.isEmpty}}
+     - responseHeaders: {{responseHeaders}}{{/responseHeaders.isEmpty}}{{^examples.isEmpty}}
+     - examples: {{{examples}}}{{/examples.isEmpty}}{{#externalDocs}}
      - externalDocs: {{externalDocs}}{{/externalDocs}}{{#hasParams}}
      {{/hasParams}}{{#allParams}}
      - parameter {{paramName}}: ({{#isFormParam}}form{{/isFormParam}}{{#isQueryParam}}query{{/isQueryParam}}{{#isPathParam}}path{{/isPathParam}}{{#isHeaderParam}}header{{/isHeaderParam}}{{#isBodyParam}}body{{/isBodyParam}}) {{description}} {{^required}}(optional{{#defaultValue}}, default to {{{.}}}{{/defaultValue}}){{/required}}{{/allParams}}

--- a/modules/swagger-codegen/src/main/resources/swift3/api.mustache
+++ b/modules/swagger-codegen/src/main/resources/swift3/api.mustache
@@ -109,9 +109,9 @@ open class {{classname}}: APIBase {
      {{#authMethods}}
      - {{#isBasic}}BASIC{{/isBasic}}{{#isOAuth}}OAuth{{/isOAuth}}{{#isApiKey}}API Key{{/isApiKey}}:
        - type: {{type}}{{#keyParamName}} {{keyParamName}} {{#isKeyInQuery}}(QUERY){{/isKeyInQuery}}{{#isKeyInHeaer}}(HEADER){{/isKeyInHeaer}}{{/keyParamName}}
-       - name: {{name}}{{/authMethods}}{{#responseHeaders}}
-     - responseHeaders: {{responseHeaders}}{{/responseHeaders}}{{#examples}}
-     - examples: {{{examples}}}{{/examples}}{{#externalDocs}}
+       - name: {{name}}{{/authMethods}}{{^responseHeaders.isEmpty}}
+     - responseHeaders: {{responseHeaders}}{{/responseHeaders.isEmpty}}{{^examples.isEmpty}}
+     - examples: {{{examples}}}{{/examples.isEmpty}}{{#externalDocs}}
      - externalDocs: {{externalDocs}}{{/externalDocs}}
      {{#allParams}}
      - parameter {{paramName}}: ({{#isFormParam}}form{{/isFormParam}}{{#isQueryParam}}query{{/isQueryParam}}{{#isPathParam}}path{{/isPathParam}}{{#isHeaderParam}}header{{/isHeaderParam}}{{#isBodyParam}}body{{/isBodyParam}}) {{description}} {{^required}}(optional{{#defaultValue}}, default to {{{.}}}{{/defaultValue}}){{/required}}

--- a/modules/swagger-codegen/src/main/resources/swift4/api.mustache
+++ b/modules/swagger-codegen/src/main/resources/swift4/api.mustache
@@ -95,9 +95,9 @@ open class {{classname}} {
      - defaultResponse: {{defaultResponse}}{{/defaultResponse}}{{#authMethods}}
      - {{#isBasic}}BASIC{{/isBasic}}{{#isOAuth}}OAuth{{/isOAuth}}{{#isApiKey}}API Key{{/isApiKey}}:
        - type: {{type}}{{#keyParamName}} {{keyParamName}} {{#isKeyInQuery}}(QUERY){{/isKeyInQuery}}{{#isKeyInHeaer}}(HEADER){{/isKeyInHeaer}}{{/keyParamName}}
-       - name: {{name}}{{/authMethods}}{{#responseHeaders}}
-     - responseHeaders: {{responseHeaders}}{{/responseHeaders}}{{#examples}}
-     - examples: {{{examples}}}{{/examples}}{{#externalDocs}}
+       - name: {{name}}{{/authMethods}}{{^responseHeaders.isEmpty}}
+     - responseHeaders: {{responseHeaders}}{{/responseHeaders.isEmpty}}{{^examples.isEmpty}}
+     - examples: {{{examples}}}{{/examples.isEmpty}}{{#externalDocs}}
      - externalDocs: {{externalDocs}}{{/externalDocs}}{{#hasParams}}
      {{/hasParams}}{{#allParams}}
      - parameter {{paramName}}: ({{#isFormParam}}form{{/isFormParam}}{{#isQueryParam}}query{{/isQueryParam}}{{#isPathParam}}path{{/isPathParam}}{{#isHeaderParam}}header{{/isHeaderParam}}{{#isBodyParam}}body{{/isBodyParam}}) {{description}} {{^required}}(optional{{#defaultValue}}, default to {{{.}}}{{/defaultValue}}){{/required}}{{/allParams}}


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [x] Filed the PR against the correct branch: `3.0.0` branch for changes related to OpenAPI spec 3.0. Default: `master`.
- [x] Copied the [technical committee](https://github.com/swagger-api/swagger-codegen/#swagger-codegen-technical-committee) to review the pull request if your PR is targeting a particular programming language.

@jgavris (2017/07) @ehyche (2017/08) @Edubits (2017/09) @jaz-ah (2017/09)

### Description of the PR

This changes solves issue #7663

before outs:
```swift
    /**
     Logs user into the system
     - GET /user/login
     - 
     - responseHeaders: [X-Rate-Limit(Int32), X-Expires-After(NSDate)]
     - responseHeaders: [X-Rate-Limit(Int32), X-Expires-After(NSDate)]
     - examples: [{contentType=application/xml, example=aeiou}, {contentType=application/json, example="aeiou"}]
     - examples: [{contentType=application/xml, example=aeiou}, {contentType=application/json, example="aeiou"}]
     
     - parameter username: (query) The user name for login 
     - parameter password: (query) The password for login in clear text 

     - returns: RequestBuilder<String> 
     */
```

after outs:
```swift
    /**
     Logs user into the system
     - GET /user/login
     - 
     - responseHeaders: [X-Rate-Limit(Int32), X-Expires-After(NSDate)]
     - examples: [{contentType=application/xml, example=aeiou}, {contentType=application/json, example="aeiou"}]

     - parameter username: (query) The user name for login 
     - parameter password: (query) The password for login in clear text 

     - returns: RequestBuilder<String> 
     */
```

