### PR TITLE
Fix performance linting problem with maps in java ApiClient template

### DIFF
--- a/modules/swagger-codegen/src/main/resources/Java/ApiClient.mustache
+++ b/modules/swagger-codegen/src/main/resources/Java/ApiClient.mustache
@@ -651,7 +651,7 @@ public class ApiClient {
     }
     for (Map.Entry<String,String> keyValue : defaultHeaderMap.entrySet()) {
       if (!headerParams.containsKey(keyValue.getKey())) {
-        builder = builder.header(keyValue.getKey(), defaultHeaderMap.get(keyValue.getValue()));
+        builder = builder.header(keyValue.getKey(), keyValue.getValue());
       }
     }
 

--- a/modules/swagger-codegen/src/main/resources/Java/ApiClient.mustache
+++ b/modules/swagger-codegen/src/main/resources/Java/ApiClient.mustache
@@ -646,12 +646,12 @@ public class ApiClient {
       builder = httpClient.resource(url).accept(accept);
     }
 
-    for (String key : headerParams.keySet()) {
-      builder = builder.header(key, headerParams.get(key));
+    for (Entry<String, String> keyValue : headerParams.entrySet()) {
+      builder = builder.header(keyValue.getKey(), keyValue.getValue());
     }
-    for (String key : defaultHeaderMap.keySet()) {
-      if (!headerParams.containsKey(key)) {
-        builder = builder.header(key, defaultHeaderMap.get(key));
+    for (Map.Entry<String,String> keyValue : defaultHeaderMap.entrySet()) {
+      if (!headerParams.containsKey(keyValue.getKey())) {
+        builder = builder.header(keyValue.getKey(), defaultHeaderMap.get(keyValue.getValue()));
       }
     }
 


### PR DESCRIPTION
I just fixed a little map performance Problem, because our linter keeps finding this and we'd like to use upstream template and not custom ones.

