### PR TITLE
[PHP] Improve validation on empty arrays

### DIFF
--- a/modules/swagger-codegen/src/main/resources/php/api.mustache
+++ b/modules/swagger-codegen/src/main/resources/php/api.mustache
@@ -299,7 +299,7 @@ use {{invokerPackage}}\ObjectSerializer;
         {{#allParams}}
         {{#required}}
         // verify the required parameter '{{paramName}}' is set
-        if (${{paramName}} === null) {
+        if (${{paramName}} === null || (is_array(${{paramName}}) && count(${{paramName}}) === 0)) {
             throw new \InvalidArgumentException(
                 'Missing the required parameter ${{paramName}} when calling {{operationId}}'
             );

--- a/samples/client/petstore/php/SwaggerClient-php/docs/Api/FakeClassnameTags123Api.md
+++ b/samples/client/petstore/php/SwaggerClient-php/docs/Api/FakeClassnameTags123Api.md
@@ -12,6 +12,8 @@ Method | HTTP request | Description
 
 To test class name in snake case
 
+To test class name in snake case
+
 ### Example
 ```php
 <?php

--- a/samples/client/petstore/php/SwaggerClient-php/lib/Api/AnotherFakeApi.php
+++ b/samples/client/petstore/php/SwaggerClient-php/lib/Api/AnotherFakeApi.php
@@ -262,7 +262,7 @@ class AnotherFakeApi
     protected function testSpecialTagsRequest($body)
     {
         // verify the required parameter 'body' is set
-        if ($body === null) {
+        if ($body === null || (is_array($body) && count($body) === 0)) {
             throw new \InvalidArgumentException(
                 'Missing the required parameter $body when calling testSpecialTags'
             );

--- a/samples/client/petstore/php/SwaggerClient-php/lib/Api/FakeApi.php
+++ b/samples/client/petstore/php/SwaggerClient-php/lib/Api/FakeApi.php
@@ -1250,7 +1250,7 @@ class FakeApi
     protected function testClientModelRequest($body)
     {
         // verify the required parameter 'body' is set
-        if ($body === null) {
+        if ($body === null || (is_array($body) && count($body) === 0)) {
             throw new \InvalidArgumentException(
                 'Missing the required parameter $body when calling testClientModel'
             );
@@ -1535,7 +1535,7 @@ class FakeApi
     protected function testEndpointParametersRequest($number, $double, $pattern_without_delimiter, $byte, $integer = null, $int32 = null, $int64 = null, $float = null, $string = null, $binary = null, $date = null, $date_time = null, $password = null, $callback = null)
     {
         // verify the required parameter 'number' is set
-        if ($number === null) {
+        if ($number === null || (is_array($number) && count($number) === 0)) {
             throw new \InvalidArgumentException(
                 'Missing the required parameter $number when calling testEndpointParameters'
             );
@@ -1548,7 +1548,7 @@ class FakeApi
         }
 
         // verify the required parameter 'double' is set
-        if ($double === null) {
+        if ($double === null || (is_array($double) && count($double) === 0)) {
             throw new \InvalidArgumentException(
                 'Missing the required parameter $double when calling testEndpointParameters'
             );
@@ -1561,7 +1561,7 @@ class FakeApi
         }
 
         // verify the required parameter 'pattern_without_delimiter' is set
-        if ($pattern_without_delimiter === null) {
+        if ($pattern_without_delimiter === null || (is_array($pattern_without_delimiter) && count($pattern_without_delimiter) === 0)) {
             throw new \InvalidArgumentException(
                 'Missing the required parameter $pattern_without_delimiter when calling testEndpointParameters'
             );
@@ -1571,7 +1571,7 @@ class FakeApi
         }
 
         // verify the required parameter 'byte' is set
-        if ($byte === null) {
+        if ($byte === null || (is_array($byte) && count($byte) === 0)) {
             throw new \InvalidArgumentException(
                 'Missing the required parameter $byte when calling testEndpointParameters'
             );
@@ -2161,7 +2161,7 @@ class FakeApi
     protected function testInlineAdditionalPropertiesRequest($param)
     {
         // verify the required parameter 'param' is set
-        if ($param === null) {
+        if ($param === null || (is_array($param) && count($param) === 0)) {
             throw new \InvalidArgumentException(
                 'Missing the required parameter $param when calling testInlineAdditionalProperties'
             );
@@ -2386,13 +2386,13 @@ class FakeApi
     protected function testJsonFormDataRequest($param, $param2)
     {
         // verify the required parameter 'param' is set
-        if ($param === null) {
+        if ($param === null || (is_array($param) && count($param) === 0)) {
             throw new \InvalidArgumentException(
                 'Missing the required parameter $param when calling testJsonFormData'
             );
         }
         // verify the required parameter 'param2' is set
-        if ($param2 === null) {
+        if ($param2 === null || (is_array($param2) && count($param2) === 0)) {
             throw new \InvalidArgumentException(
                 'Missing the required parameter $param2 when calling testJsonFormData'
             );

--- a/samples/client/petstore/php/SwaggerClient-php/lib/Api/FakeClassnameTags123Api.php
+++ b/samples/client/petstore/php/SwaggerClient-php/lib/Api/FakeClassnameTags123Api.php
@@ -262,7 +262,7 @@ class FakeClassnameTags123Api
     protected function testClassnameRequest($body)
     {
         // verify the required parameter 'body' is set
-        if ($body === null) {
+        if ($body === null || (is_array($body) && count($body) === 0)) {
             throw new \InvalidArgumentException(
                 'Missing the required parameter $body when calling testClassname'
             );

--- a/samples/client/petstore/php/SwaggerClient-php/lib/Api/PetApi.php
+++ b/samples/client/petstore/php/SwaggerClient-php/lib/Api/PetApi.php
@@ -225,7 +225,7 @@ class PetApi
     protected function addPetRequest($body)
     {
         // verify the required parameter 'body' is set
-        if ($body === null) {
+        if ($body === null || (is_array($body) && count($body) === 0)) {
             throw new \InvalidArgumentException(
                 'Missing the required parameter $body when calling addPet'
             );
@@ -454,7 +454,7 @@ class PetApi
     protected function deletePetRequest($pet_id, $api_key = null)
     {
         // verify the required parameter 'pet_id' is set
-        if ($pet_id === null) {
+        if ($pet_id === null || (is_array($pet_id) && count($pet_id) === 0)) {
             throw new \InvalidArgumentException(
                 'Missing the required parameter $pet_id when calling deletePet'
             );
@@ -724,7 +724,7 @@ class PetApi
     protected function findPetsByStatusRequest($status)
     {
         // verify the required parameter 'status' is set
-        if ($status === null) {
+        if ($status === null || (is_array($status) && count($status) === 0)) {
             throw new \InvalidArgumentException(
                 'Missing the required parameter $status when calling findPetsByStatus'
             );
@@ -989,7 +989,7 @@ class PetApi
     protected function findPetsByTagsRequest($tags)
     {
         // verify the required parameter 'tags' is set
-        if ($tags === null) {
+        if ($tags === null || (is_array($tags) && count($tags) === 0)) {
             throw new \InvalidArgumentException(
                 'Missing the required parameter $tags when calling findPetsByTags'
             );
@@ -1254,7 +1254,7 @@ class PetApi
     protected function getPetByIdRequest($pet_id)
     {
         // verify the required parameter 'pet_id' is set
-        if ($pet_id === null) {
+        if ($pet_id === null || (is_array($pet_id) && count($pet_id) === 0)) {
             throw new \InvalidArgumentException(
                 'Missing the required parameter $pet_id when calling getPetById'
             );
@@ -1484,7 +1484,7 @@ class PetApi
     protected function updatePetRequest($body)
     {
         // verify the required parameter 'body' is set
-        if ($body === null) {
+        if ($body === null || (is_array($body) && count($body) === 0)) {
             throw new \InvalidArgumentException(
                 'Missing the required parameter $body when calling updatePet'
             );
@@ -1718,7 +1718,7 @@ class PetApi
     protected function updatePetWithFormRequest($pet_id, $name = null, $status = null)
     {
         // verify the required parameter 'pet_id' is set
-        if ($pet_id === null) {
+        if ($pet_id === null || (is_array($pet_id) && count($pet_id) === 0)) {
             throw new \InvalidArgumentException(
                 'Missing the required parameter $pet_id when calling updatePetWithForm'
             );
@@ -2002,7 +2002,7 @@ class PetApi
     protected function uploadFileRequest($pet_id, $additional_metadata = null, $file = null)
     {
         // verify the required parameter 'pet_id' is set
-        if ($pet_id === null) {
+        if ($pet_id === null || (is_array($pet_id) && count($pet_id) === 0)) {
             throw new \InvalidArgumentException(
                 'Missing the required parameter $pet_id when calling uploadFile'
             );

--- a/samples/client/petstore/php/SwaggerClient-php/lib/Api/StoreApi.php
+++ b/samples/client/petstore/php/SwaggerClient-php/lib/Api/StoreApi.php
@@ -225,7 +225,7 @@ class StoreApi
     protected function deleteOrderRequest($order_id)
     {
         // verify the required parameter 'order_id' is set
-        if ($order_id === null) {
+        if ($order_id === null || (is_array($order_id) && count($order_id) === 0)) {
             throw new \InvalidArgumentException(
                 'Missing the required parameter $order_id when calling deleteOrder'
             );
@@ -735,7 +735,7 @@ class StoreApi
     protected function getOrderByIdRequest($order_id)
     {
         // verify the required parameter 'order_id' is set
-        if ($order_id === null) {
+        if ($order_id === null || (is_array($order_id) && count($order_id) === 0)) {
             throw new \InvalidArgumentException(
                 'Missing the required parameter $order_id when calling getOrderById'
             );
@@ -1004,7 +1004,7 @@ class StoreApi
     protected function placeOrderRequest($body)
     {
         // verify the required parameter 'body' is set
-        if ($body === null) {
+        if ($body === null || (is_array($body) && count($body) === 0)) {
             throw new \InvalidArgumentException(
                 'Missing the required parameter $body when calling placeOrder'
             );

--- a/samples/client/petstore/php/SwaggerClient-php/lib/Api/UserApi.php
+++ b/samples/client/petstore/php/SwaggerClient-php/lib/Api/UserApi.php
@@ -225,7 +225,7 @@ class UserApi
     protected function createUserRequest($body)
     {
         // verify the required parameter 'body' is set
-        if ($body === null) {
+        if ($body === null || (is_array($body) && count($body) === 0)) {
             throw new \InvalidArgumentException(
                 'Missing the required parameter $body when calling createUser'
             );
@@ -445,7 +445,7 @@ class UserApi
     protected function createUsersWithArrayInputRequest($body)
     {
         // verify the required parameter 'body' is set
-        if ($body === null) {
+        if ($body === null || (is_array($body) && count($body) === 0)) {
             throw new \InvalidArgumentException(
                 'Missing the required parameter $body when calling createUsersWithArrayInput'
             );
@@ -665,7 +665,7 @@ class UserApi
     protected function createUsersWithListInputRequest($body)
     {
         // verify the required parameter 'body' is set
-        if ($body === null) {
+        if ($body === null || (is_array($body) && count($body) === 0)) {
             throw new \InvalidArgumentException(
                 'Missing the required parameter $body when calling createUsersWithListInput'
             );
@@ -885,7 +885,7 @@ class UserApi
     protected function deleteUserRequest($username)
     {
         // verify the required parameter 'username' is set
-        if ($username === null) {
+        if ($username === null || (is_array($username) && count($username) === 0)) {
             throw new \InvalidArgumentException(
                 'Missing the required parameter $username when calling deleteUser'
             );
@@ -1147,7 +1147,7 @@ class UserApi
     protected function getUserByNameRequest($username)
     {
         // verify the required parameter 'username' is set
-        if ($username === null) {
+        if ($username === null || (is_array($username) && count($username) === 0)) {
             throw new \InvalidArgumentException(
                 'Missing the required parameter $username when calling getUserByName'
             );
@@ -1414,13 +1414,13 @@ class UserApi
     protected function loginUserRequest($username, $password)
     {
         // verify the required parameter 'username' is set
-        if ($username === null) {
+        if ($username === null || (is_array($username) && count($username) === 0)) {
             throw new \InvalidArgumentException(
                 'Missing the required parameter $username when calling loginUser'
             );
         }
         // verify the required parameter 'password' is set
-        if ($password === null) {
+        if ($password === null || (is_array($password) && count($password) === 0)) {
             throw new \InvalidArgumentException(
                 'Missing the required parameter $password when calling loginUser'
             );
@@ -1856,13 +1856,13 @@ class UserApi
     protected function updateUserRequest($username, $body)
     {
         // verify the required parameter 'username' is set
-        if ($username === null) {
+        if ($username === null || (is_array($username) && count($username) === 0)) {
             throw new \InvalidArgumentException(
                 'Missing the required parameter $username when calling updateUser'
             );
         }
         // verify the required parameter 'body' is set
-        if ($body === null) {
+        if ($body === null || (is_array($body) && count($body) === 0)) {
             throw new \InvalidArgumentException(
                 'Missing the required parameter $body when calling updateUser'
             );

--- a/samples/client/petstore/php/SwaggerClient-php/tests/PetApiTest.php
+++ b/samples/client/petstore/php/SwaggerClient-php/tests/PetApiTest.php
@@ -377,6 +377,7 @@ class PetApiTest extends \PHPUnit_Framework_TestCase
      * test invalid argument
      *
      * @expectedException \InvalidArgumentException
+     * @expectedExceptionMessage Missing the required parameter $status when calling findPetsByStatus
      */
     public function testInvalidArgument()
     {


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [x] Filed the PR against the correct branch: `3.0.0` branch for changes related to OpenAPI spec 3.0. Default: `master`.
- [x] Copied the [technical committee](https://github.com/swagger-api/swagger-codegen/#swagger-codegen-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

refs https://github.com/swagger-api/swagger-codegen/pull/7675#issuecomment-366658641

> PetApi::findPetsByStatus() should throw an exception if an empty array is passed.
