### PR TITLE
[3.0.0] fix in META-INF/services/io.swagger.codegen.CodegenConfig 

### DIFF
--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/AbstractJavaCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/AbstractJavaCodegen.java
@@ -48,7 +48,8 @@ import static io.swagger.codegen.CodegenConstants.IS_ENUM_EXT_NAME;
 import static io.swagger.codegen.languages.helpers.ExtensionHelper.getBooleanValue;
 
 /**
- * new version of this class can be found on: https://github.com/swagger-api/swagger-codegen-templates
+ * new version of this class can be found on: https://github.com/swagger-api/swagger-codegen-generators
+ * @deprecated use <code>io.swagger.codegen.languages.java.AbstractJavaCodegen</code> instead.
  */
 @Deprecated
 public abstract class AbstractJavaCodegen extends DefaultCodegen implements CodegenConfig {

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/JavaClientCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/JavaClientCodegen.java
@@ -21,7 +21,8 @@ import java.util.*;
 import java.util.regex.Pattern;
 
 /**
- * new version of this class can be found on: https://github.com/swagger-api/swagger-codegen-templates
+ * new version of this class can be found on: https://github.com/swagger-api/swagger-codegen-generators
+ * @deprecated use <code>io.swagger.codegen.languages.java.JavaClientCodegen</code> instead.
  */
 @Deprecated
 public class JavaClientCodegen extends AbstractJavaCodegen

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/JavaInflectorServerCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/JavaInflectorServerCodegen.java
@@ -23,7 +23,8 @@ import static io.swagger.codegen.CodegenConstants.IS_ENUM_EXT_NAME;
 import static io.swagger.codegen.languages.helpers.ExtensionHelper.getBooleanValue;
 
 /**
- * new version of this class can be found on: https://github.com/swagger-api/swagger-codegen-templates
+ * new version of this class can be found on: https://github.com/swagger-api/swagger-codegen-generators
+ * @deprecated use <code>io.swagger.codegen.languages.java.JavaInflectorServerCodegen</code> instead.
  */
 @Deprecated
 public class JavaInflectorServerCodegen extends AbstractJavaCodegen {

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/utils/Markdown.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/utils/Markdown.java
@@ -18,7 +18,7 @@ public class Markdown {
     /** 
      * Convert input markdown text to HTML.
      * Simple text is not wrapped in <p>...</p>.
-     * @param markdown text with Markdown styles. If <code>null<code>, </code>""</code> is returned.
+     * @param markdown text with Markdown styles. If <code>null</code>, <code>""</code> is returned.
      * @return HTML rendering from the Markdown
      */
     public String toHtml(String markdown) {

--- a/modules/swagger-codegen/src/main/resources/META-INF/services/io.swagger.codegen.CodegenConfig
+++ b/modules/swagger-codegen/src/main/resources/META-INF/services/io.swagger.codegen.CodegenConfig
@@ -28,8 +28,6 @@ io.swagger.codegen.languages.HaskellServantCodegen
 io.swagger.codegen.languages.JMeterCodegen
 io.swagger.codegen.languages.JavaCXFClientCodegen
 io.swagger.codegen.languages.JavaCXFServerCodegen
-io.swagger.codegen.languages.java.JavaClientCodegen
-io.swagger.codegen.languages.java.JavaInflectorServerCodegen
 io.swagger.codegen.languages.JavaJAXRSCXFCDIServerCodegen
 io.swagger.codegen.languages.JavaJAXRSSpecServerCodegen
 io.swagger.codegen.languages.JavaJerseyServerCodegen


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [ ] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [x] Filed the PR against the correct branch: `3.0.0` branch for changes related to OpenAPI spec 3.0. Default: `master`.
- [x] Copied the [technical committee](https://github.com/swagger-api/swagger-codegen/#swagger-codegen-technical-committee) to review the pull request if your PR is targeting a particular programming language.

I do not think that I need to run something in the `./bin/` script folder. I did not change anything to the generators.

cc: @HugoMario 
cc technical-committee: @bbdouglas (2017/07) @JFCote (2017/08) @sreeshas (2017/08) @jfiala (2017/08) @lukoyanov (2017/09) @cbornet (2017/09) @jeff9finger (2018/01)

### Description of the PR

On the `3.0.0` the generators for `java` and `inflector` were moved to an other repository : http://github.com/swagger-api/swagger-codegen-generators/

The Service registry was updated, but now references classes that are not present in this jar. 
```
io.swagger.codegen.languages.java.JavaClientCodegen
io.swagger.codegen.languages.java.JavaInflectorServerCodegen
```
They needs to be removed from this list and added in the other jar (I will file an other pull request for that).
=> see commit 7732083a1bee0604d2c030b41e3d8c98c07548ee

In addition I have improved the javadoc, because the repository was renamed => commit b6fe102c21a6949d0e58b81aa7fc703151724412

And I also had to fix an other javadoc in order to be able to run the maven build locally => commit b48378154119bee2fbd3950ec0681992806d08e6

