### PR TITLE
[3.0.0] Rename "jaxrs" to "jaxrs-jersey"

### DIFF
--- a/bin/jaxrs-jersey1-petstore-server.sh
+++ b/bin/jaxrs-jersey1-petstore-server.sh
@@ -26,7 +26,7 @@ fi
 
 # if you've executed sbt assembly previously it will use that instead.
 export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
-ags="$@ generate -t modules/swagger-codegen/src/main/resources/JavaJaxRS -i modules/swagger-codegen/src/test/resources/2_0/petstore-with-fake-endpoints-models-for-testing.yaml -l jaxrs -o samples/server/petstore/jaxrs/jersey1 -DhideGenerationTimestamp=true,serverPort=8080 --library=jersey1 --artifact-id=swagger-jaxrs-jersey1-server"
+ags="$@ generate -t modules/swagger-codegen/src/main/resources/JavaJaxRS -i modules/swagger-codegen/src/test/resources/2_0/petstore-with-fake-endpoints-models-for-testing.yaml -l jaxrs-jersey -o samples/server/petstore/jaxrs/jersey1 -DhideGenerationTimestamp=true,serverPort=8080 --library=jersey1 --artifact-id=swagger-jaxrs-jersey1-server"
 
 echo "Removing files and folders under samples/server/petstore/jaxrs/jersey1/src/main"
 rm -rf samples/server/petstore/jaxrs/jersey1/src/main

--- a/bin/jaxrs-petstore-server.sh
+++ b/bin/jaxrs-petstore-server.sh
@@ -26,7 +26,7 @@ fi
 
 # if you've executed sbt assembly previously it will use that instead.
 export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
-ags="$@ generate -t modules/swagger-codegen/src/main/resources/JavaJaxRS -i modules/swagger-codegen/src/test/resources/2_0/petstore-with-fake-endpoints-models-for-testing.yaml -l jaxrs -o samples/server/petstore/jaxrs/jersey2 -DhideGenerationTimestamp=true,serverPort=8080"
+ags="$@ generate -t modules/swagger-codegen/src/main/resources/JavaJaxRS -i modules/swagger-codegen/src/test/resources/2_0/petstore-with-fake-endpoints-models-for-testing.yaml -l jaxrs-jersey -o samples/server/petstore/jaxrs/jersey2 -DhideGenerationTimestamp=true,serverPort=8080"
 
 echo "Removing files and folders under samples/server/petstore/jaxrs/jersey2/src/main"
 rm -rf samples/server/petstore/jaxrs/jersey2/src/main

--- a/bin/jaxrs-usetags-petstore-server.sh
+++ b/bin/jaxrs-usetags-petstore-server.sh
@@ -26,7 +26,7 @@ fi
 
 # if you've executed sbt assembly previously it will use that instead.
 export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
-ags="$@ generate -t modules/swagger-codegen/src/main/resources/JavaJaxRS -i modules/swagger-codegen/src/test/resources/2_0/petstore-with-fake-endpoints-models-for-testing.yaml -l jaxrs -o samples/server/petstore/jaxrs/jersey2-useTags -DhideGenerationTimestamp=true,serverPort=8080 --artifact-id=swagger-jaxrs-jersey2-useTags --additional-properties useTags=true"
+ags="$@ generate -t modules/swagger-codegen/src/main/resources/JavaJaxRS -i modules/swagger-codegen/src/test/resources/2_0/petstore-with-fake-endpoints-models-for-testing.yaml -l jaxrs-jersey -o samples/server/petstore/jaxrs/jersey2-useTags -DhideGenerationTimestamp=true,serverPort=8080 --artifact-id=swagger-jaxrs-jersey2-useTags --additional-properties useTags=true"
 
 echo "Removing files and folders under samples/server/petstore/jaxrs/jersey2-useTags/src/main"
 rm -rf samples/server/petstore/jaxrs/jersey2-useTags/src/main

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/JavaJerseyServerCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/JavaJerseyServerCodegen.java
@@ -62,7 +62,7 @@ public class JavaJerseyServerCodegen extends AbstractJavaJAXRSServerCodegen {
     @Override
     public String getName()
     {
-        return "jaxrs"; // TODO should be renamed as "jaxrs-jersey"
+        return "jaxrs-jersey";
     }
 
     @Override


### PR DESCRIPTION
In the `JavaJerseyServerCodegen` class there is a `TODO` indicating that `jaxrs` should be renamed to `jaxrs-jersey`.

With the switch from version 2 to version 3, such a change can be made.

Of course on the long term, JaxRS generators will be moved to `swagger-codegen-generator`. See #7622

cc: @HugoMario