### PR TITLE
[PHP] Non required enum property

### DIFF
--- a/modules/swagger-codegen/src/main/resources/php/model_generic.mustache
+++ b/modules/swagger-codegen/src/main/resources/php/model_generic.mustache
@@ -194,7 +194,7 @@ class {{classname}} {{#parentSchema}}extends {{{parent}}} {{/parentSchema}}{{^pa
         {{#isEnum}}
         {{^isContainer}}
         $allowedValues = $this->{{getter}}AllowableValues();
-        if (!in_array($this->container['{{name}}'], $allowedValues)) {
+        if ($this->container['{{name}}'] !== null && !in_array($this->container['{{name}}'], $allowedValues)) {
             $invalidProperties[] = sprintf(
                 "invalid value for '{{name}}', must be one of '%s'",
                 implode("', '", $allowedValues)
@@ -274,7 +274,7 @@ class {{classname}} {{#parentSchema}}extends {{{parent}}} {{/parentSchema}}{{^pa
         {{#isEnum}}
         {{^isContainer}}
         $allowedValues = $this->{{getter}}AllowableValues();
-        if (!in_array($this->container['{{name}}'], $allowedValues)) {
+        if ($this->container['{{name}}'] !== null && !in_array($this->container['{{name}}'], $allowedValues)) {
             return false;
         }
         {{/isContainer}}

--- a/modules/swagger-codegen/src/main/resources/php/model_generic.mustache
+++ b/modules/swagger-codegen/src/main/resources/php/model_generic.mustache
@@ -194,7 +194,7 @@ class {{classname}} {{#parentSchema}}extends {{{parent}}} {{/parentSchema}}{{^pa
         {{#isEnum}}
         {{^isContainer}}
         $allowedValues = $this->{{getter}}AllowableValues();
-        if ($this->container['{{name}}'] !== null && !in_array($this->container['{{name}}'], $allowedValues)) {
+        if (!is_null($this->container['{{name}}']) && !in_array($this->container['{{name}}'], $allowedValues)) {
             $invalidProperties[] = sprintf(
                 "invalid value for '{{name}}', must be one of '%s'",
                 implode("', '", $allowedValues)
@@ -274,7 +274,7 @@ class {{classname}} {{#parentSchema}}extends {{{parent}}} {{/parentSchema}}{{^pa
         {{#isEnum}}
         {{^isContainer}}
         $allowedValues = $this->{{getter}}AllowableValues();
-        if ($this->container['{{name}}'] !== null && !in_array($this->container['{{name}}'], $allowedValues)) {
+        if (!is_null($this->container['{{name}}']) && !in_array($this->container['{{name}}'], $allowedValues)) {
             return false;
         }
         {{/isContainer}}

--- a/modules/swagger-codegen/src/test/resources/2_0/petstore-with-fake-endpoints-models-for-testing.yaml
+++ b/modules/swagger-codegen/src/test/resources/2_0/petstore-with-fake-endpoints-models-for-testing.yaml
@@ -1225,8 +1225,16 @@ definitions:
       - (xyz)
   Enum_Test:
     type: object
+    required:
+      - enum_string_required
     properties:
       enum_string:
+        type: string
+        enum:
+          - UPPER
+          - lower
+          - ''
+      enum_string_required:
         type: string
         enum:
           - UPPER

--- a/samples/client/petstore/php/SwaggerClient-php/docs/Model/EnumTest.md
+++ b/samples/client/petstore/php/SwaggerClient-php/docs/Model/EnumTest.md
@@ -4,6 +4,7 @@
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **enum_string** | **string** |  | [optional] 
+**enum_string_required** | **string** |  | 
 **enum_integer** | **int** |  | [optional] 
 **enum_number** | **double** |  | [optional] 
 **outer_enum** | [**\Swagger\Client\Model\OuterEnum**](OuterEnum.md) |  | [optional] 

--- a/samples/client/petstore/php/SwaggerClient-php/lib/Model/EnumArrays.php
+++ b/samples/client/petstore/php/SwaggerClient-php/lib/Model/EnumArrays.php
@@ -226,7 +226,7 @@ class EnumArrays implements ModelInterface, ArrayAccess
         $invalidProperties = [];
 
         $allowedValues = $this->getJustSymbolAllowableValues();
-        if (!in_array($this->container['just_symbol'], $allowedValues)) {
+        if ($this->container['just_symbol'] !== null && !in_array($this->container['just_symbol'], $allowedValues)) {
             $invalidProperties[] = sprintf(
                 "invalid value for 'just_symbol', must be one of '%s'",
                 implode("', '", $allowedValues)
@@ -246,7 +246,7 @@ class EnumArrays implements ModelInterface, ArrayAccess
     {
 
         $allowedValues = $this->getJustSymbolAllowableValues();
-        if (!in_array($this->container['just_symbol'], $allowedValues)) {
+        if ($this->container['just_symbol'] !== null && !in_array($this->container['just_symbol'], $allowedValues)) {
             return false;
         }
         return true;

--- a/samples/client/petstore/php/SwaggerClient-php/lib/Model/EnumArrays.php
+++ b/samples/client/petstore/php/SwaggerClient-php/lib/Model/EnumArrays.php
@@ -226,7 +226,7 @@ class EnumArrays implements ModelInterface, ArrayAccess
         $invalidProperties = [];
 
         $allowedValues = $this->getJustSymbolAllowableValues();
-        if ($this->container['just_symbol'] !== null && !in_array($this->container['just_symbol'], $allowedValues)) {
+        if (!is_null($this->container['just_symbol']) && !in_array($this->container['just_symbol'], $allowedValues)) {
             $invalidProperties[] = sprintf(
                 "invalid value for 'just_symbol', must be one of '%s'",
                 implode("', '", $allowedValues)
@@ -246,7 +246,7 @@ class EnumArrays implements ModelInterface, ArrayAccess
     {
 
         $allowedValues = $this->getJustSymbolAllowableValues();
-        if ($this->container['just_symbol'] !== null && !in_array($this->container['just_symbol'], $allowedValues)) {
+        if (!is_null($this->container['just_symbol']) && !in_array($this->container['just_symbol'], $allowedValues)) {
             return false;
         }
         return true;

--- a/samples/client/petstore/php/SwaggerClient-php/lib/Model/EnumTest.php
+++ b/samples/client/petstore/php/SwaggerClient-php/lib/Model/EnumTest.php
@@ -278,7 +278,7 @@ class EnumTest implements ModelInterface, ArrayAccess
         $invalidProperties = [];
 
         $allowedValues = $this->getEnumStringAllowableValues();
-        if (!in_array($this->container['enum_string'], $allowedValues)) {
+        if ($this->container['enum_string'] !== null && !in_array($this->container['enum_string'], $allowedValues)) {
             $invalidProperties[] = sprintf(
                 "invalid value for 'enum_string', must be one of '%s'",
                 implode("', '", $allowedValues)
@@ -289,7 +289,7 @@ class EnumTest implements ModelInterface, ArrayAccess
             $invalidProperties[] = "'enum_string_required' can't be null";
         }
         $allowedValues = $this->getEnumStringRequiredAllowableValues();
-        if (!in_array($this->container['enum_string_required'], $allowedValues)) {
+        if ($this->container['enum_string_required'] !== null && !in_array($this->container['enum_string_required'], $allowedValues)) {
             $invalidProperties[] = sprintf(
                 "invalid value for 'enum_string_required', must be one of '%s'",
                 implode("', '", $allowedValues)
@@ -297,7 +297,7 @@ class EnumTest implements ModelInterface, ArrayAccess
         }
 
         $allowedValues = $this->getEnumIntegerAllowableValues();
-        if (!in_array($this->container['enum_integer'], $allowedValues)) {
+        if ($this->container['enum_integer'] !== null && !in_array($this->container['enum_integer'], $allowedValues)) {
             $invalidProperties[] = sprintf(
                 "invalid value for 'enum_integer', must be one of '%s'",
                 implode("', '", $allowedValues)
@@ -305,7 +305,7 @@ class EnumTest implements ModelInterface, ArrayAccess
         }
 
         $allowedValues = $this->getEnumNumberAllowableValues();
-        if (!in_array($this->container['enum_number'], $allowedValues)) {
+        if ($this->container['enum_number'] !== null && !in_array($this->container['enum_number'], $allowedValues)) {
             $invalidProperties[] = sprintf(
                 "invalid value for 'enum_number', must be one of '%s'",
                 implode("', '", $allowedValues)
@@ -325,22 +325,22 @@ class EnumTest implements ModelInterface, ArrayAccess
     {
 
         $allowedValues = $this->getEnumStringAllowableValues();
-        if (!in_array($this->container['enum_string'], $allowedValues)) {
+        if ($this->container['enum_string'] !== null && !in_array($this->container['enum_string'], $allowedValues)) {
             return false;
         }
         if ($this->container['enum_string_required'] === null) {
             return false;
         }
         $allowedValues = $this->getEnumStringRequiredAllowableValues();
-        if (!in_array($this->container['enum_string_required'], $allowedValues)) {
+        if ($this->container['enum_string_required'] !== null && !in_array($this->container['enum_string_required'], $allowedValues)) {
             return false;
         }
         $allowedValues = $this->getEnumIntegerAllowableValues();
-        if (!in_array($this->container['enum_integer'], $allowedValues)) {
+        if ($this->container['enum_integer'] !== null && !in_array($this->container['enum_integer'], $allowedValues)) {
             return false;
         }
         $allowedValues = $this->getEnumNumberAllowableValues();
-        if (!in_array($this->container['enum_number'], $allowedValues)) {
+        if ($this->container['enum_number'] !== null && !in_array($this->container['enum_number'], $allowedValues)) {
             return false;
         }
         return true;

--- a/samples/client/petstore/php/SwaggerClient-php/lib/Model/EnumTest.php
+++ b/samples/client/petstore/php/SwaggerClient-php/lib/Model/EnumTest.php
@@ -278,7 +278,7 @@ class EnumTest implements ModelInterface, ArrayAccess
         $invalidProperties = [];
 
         $allowedValues = $this->getEnumStringAllowableValues();
-        if ($this->container['enum_string'] !== null && !in_array($this->container['enum_string'], $allowedValues)) {
+        if (!is_null($this->container['enum_string']) && !in_array($this->container['enum_string'], $allowedValues)) {
             $invalidProperties[] = sprintf(
                 "invalid value for 'enum_string', must be one of '%s'",
                 implode("', '", $allowedValues)
@@ -289,7 +289,7 @@ class EnumTest implements ModelInterface, ArrayAccess
             $invalidProperties[] = "'enum_string_required' can't be null";
         }
         $allowedValues = $this->getEnumStringRequiredAllowableValues();
-        if ($this->container['enum_string_required'] !== null && !in_array($this->container['enum_string_required'], $allowedValues)) {
+        if (!is_null($this->container['enum_string_required']) && !in_array($this->container['enum_string_required'], $allowedValues)) {
             $invalidProperties[] = sprintf(
                 "invalid value for 'enum_string_required', must be one of '%s'",
                 implode("', '", $allowedValues)
@@ -297,7 +297,7 @@ class EnumTest implements ModelInterface, ArrayAccess
         }
 
         $allowedValues = $this->getEnumIntegerAllowableValues();
-        if ($this->container['enum_integer'] !== null && !in_array($this->container['enum_integer'], $allowedValues)) {
+        if (!is_null($this->container['enum_integer']) && !in_array($this->container['enum_integer'], $allowedValues)) {
             $invalidProperties[] = sprintf(
                 "invalid value for 'enum_integer', must be one of '%s'",
                 implode("', '", $allowedValues)
@@ -305,7 +305,7 @@ class EnumTest implements ModelInterface, ArrayAccess
         }
 
         $allowedValues = $this->getEnumNumberAllowableValues();
-        if ($this->container['enum_number'] !== null && !in_array($this->container['enum_number'], $allowedValues)) {
+        if (!is_null($this->container['enum_number']) && !in_array($this->container['enum_number'], $allowedValues)) {
             $invalidProperties[] = sprintf(
                 "invalid value for 'enum_number', must be one of '%s'",
                 implode("', '", $allowedValues)
@@ -325,22 +325,22 @@ class EnumTest implements ModelInterface, ArrayAccess
     {
 
         $allowedValues = $this->getEnumStringAllowableValues();
-        if ($this->container['enum_string'] !== null && !in_array($this->container['enum_string'], $allowedValues)) {
+        if (!is_null($this->container['enum_string']) && !in_array($this->container['enum_string'], $allowedValues)) {
             return false;
         }
         if ($this->container['enum_string_required'] === null) {
             return false;
         }
         $allowedValues = $this->getEnumStringRequiredAllowableValues();
-        if ($this->container['enum_string_required'] !== null && !in_array($this->container['enum_string_required'], $allowedValues)) {
+        if (!is_null($this->container['enum_string_required']) && !in_array($this->container['enum_string_required'], $allowedValues)) {
             return false;
         }
         $allowedValues = $this->getEnumIntegerAllowableValues();
-        if ($this->container['enum_integer'] !== null && !in_array($this->container['enum_integer'], $allowedValues)) {
+        if (!is_null($this->container['enum_integer']) && !in_array($this->container['enum_integer'], $allowedValues)) {
             return false;
         }
         $allowedValues = $this->getEnumNumberAllowableValues();
-        if ($this->container['enum_number'] !== null && !in_array($this->container['enum_number'], $allowedValues)) {
+        if (!is_null($this->container['enum_number']) && !in_array($this->container['enum_number'], $allowedValues)) {
             return false;
         }
         return true;

--- a/samples/client/petstore/php/SwaggerClient-php/lib/Model/EnumTest.php
+++ b/samples/client/petstore/php/SwaggerClient-php/lib/Model/EnumTest.php
@@ -58,6 +58,7 @@ class EnumTest implements ModelInterface, ArrayAccess
       */
     protected static $swaggerTypes = [
         'enum_string' => 'string',
+        'enum_string_required' => 'string',
         'enum_integer' => 'int',
         'enum_number' => 'double',
         'outer_enum' => '\Swagger\Client\Model\OuterEnum'
@@ -70,6 +71,7 @@ class EnumTest implements ModelInterface, ArrayAccess
       */
     protected static $swaggerFormats = [
         'enum_string' => null,
+        'enum_string_required' => null,
         'enum_integer' => 'int32',
         'enum_number' => 'double',
         'outer_enum' => null
@@ -103,6 +105,7 @@ class EnumTest implements ModelInterface, ArrayAccess
      */
     protected static $attributeMap = [
         'enum_string' => 'enum_string',
+        'enum_string_required' => 'enum_string_required',
         'enum_integer' => 'enum_integer',
         'enum_number' => 'enum_number',
         'outer_enum' => 'outerEnum'
@@ -115,6 +118,7 @@ class EnumTest implements ModelInterface, ArrayAccess
      */
     protected static $setters = [
         'enum_string' => 'setEnumString',
+        'enum_string_required' => 'setEnumStringRequired',
         'enum_integer' => 'setEnumInteger',
         'enum_number' => 'setEnumNumber',
         'outer_enum' => 'setOuterEnum'
@@ -127,6 +131,7 @@ class EnumTest implements ModelInterface, ArrayAccess
      */
     protected static $getters = [
         'enum_string' => 'getEnumString',
+        'enum_string_required' => 'getEnumStringRequired',
         'enum_integer' => 'getEnumInteger',
         'enum_number' => 'getEnumNumber',
         'outer_enum' => 'getOuterEnum'
@@ -176,6 +181,9 @@ class EnumTest implements ModelInterface, ArrayAccess
     const ENUM_STRING_UPPER = 'UPPER';
     const ENUM_STRING_LOWER = 'lower';
     const ENUM_STRING_EMPTY = '';
+    const ENUM_STRING_REQUIRED_UPPER = 'UPPER';
+    const ENUM_STRING_REQUIRED_LOWER = 'lower';
+    const ENUM_STRING_REQUIRED_EMPTY = '';
     const ENUM_INTEGER_1 = 1;
     const ENUM_INTEGER_MINUS_1 = -1;
     const ENUM_NUMBER_1_DOT_1 = 1.1;
@@ -194,6 +202,20 @@ class EnumTest implements ModelInterface, ArrayAccess
             self::ENUM_STRING_UPPER,
             self::ENUM_STRING_LOWER,
             self::ENUM_STRING_EMPTY,
+        ];
+    }
+    
+    /**
+     * Gets allowable values of the enum
+     *
+     * @return string[]
+     */
+    public function getEnumStringRequiredAllowableValues()
+    {
+        return [
+            self::ENUM_STRING_REQUIRED_UPPER,
+            self::ENUM_STRING_REQUIRED_LOWER,
+            self::ENUM_STRING_REQUIRED_EMPTY,
         ];
     }
     
@@ -240,6 +262,7 @@ class EnumTest implements ModelInterface, ArrayAccess
     public function __construct(array $data = null)
     {
         $this->container['enum_string'] = isset($data['enum_string']) ? $data['enum_string'] : null;
+        $this->container['enum_string_required'] = isset($data['enum_string_required']) ? $data['enum_string_required'] : null;
         $this->container['enum_integer'] = isset($data['enum_integer']) ? $data['enum_integer'] : null;
         $this->container['enum_number'] = isset($data['enum_number']) ? $data['enum_number'] : null;
         $this->container['outer_enum'] = isset($data['outer_enum']) ? $data['outer_enum'] : null;
@@ -258,6 +281,17 @@ class EnumTest implements ModelInterface, ArrayAccess
         if (!in_array($this->container['enum_string'], $allowedValues)) {
             $invalidProperties[] = sprintf(
                 "invalid value for 'enum_string', must be one of '%s'",
+                implode("', '", $allowedValues)
+            );
+        }
+
+        if ($this->container['enum_string_required'] === null) {
+            $invalidProperties[] = "'enum_string_required' can't be null";
+        }
+        $allowedValues = $this->getEnumStringRequiredAllowableValues();
+        if (!in_array($this->container['enum_string_required'], $allowedValues)) {
+            $invalidProperties[] = sprintf(
+                "invalid value for 'enum_string_required', must be one of '%s'",
                 implode("', '", $allowedValues)
             );
         }
@@ -292,6 +326,13 @@ class EnumTest implements ModelInterface, ArrayAccess
 
         $allowedValues = $this->getEnumStringAllowableValues();
         if (!in_array($this->container['enum_string'], $allowedValues)) {
+            return false;
+        }
+        if ($this->container['enum_string_required'] === null) {
+            return false;
+        }
+        $allowedValues = $this->getEnumStringRequiredAllowableValues();
+        if (!in_array($this->container['enum_string_required'], $allowedValues)) {
             return false;
         }
         $allowedValues = $this->getEnumIntegerAllowableValues();
@@ -335,6 +376,39 @@ class EnumTest implements ModelInterface, ArrayAccess
             );
         }
         $this->container['enum_string'] = $enum_string;
+
+        return $this;
+    }
+
+    /**
+     * Gets enum_string_required
+     *
+     * @return string
+     */
+    public function getEnumStringRequired()
+    {
+        return $this->container['enum_string_required'];
+    }
+
+    /**
+     * Sets enum_string_required
+     *
+     * @param string $enum_string_required enum_string_required
+     *
+     * @return $this
+     */
+    public function setEnumStringRequired($enum_string_required)
+    {
+        $allowedValues = $this->getEnumStringRequiredAllowableValues();
+        if (!in_array($enum_string_required, $allowedValues)) {
+            throw new \InvalidArgumentException(
+                sprintf(
+                    "Invalid value for 'enum_string_required', must be one of '%s'",
+                    implode("', '", $allowedValues)
+                )
+            );
+        }
+        $this->container['enum_string_required'] = $enum_string_required;
 
         return $this;
     }

--- a/samples/client/petstore/php/SwaggerClient-php/lib/Model/Order.php
+++ b/samples/client/petstore/php/SwaggerClient-php/lib/Model/Order.php
@@ -237,7 +237,7 @@ class Order implements ModelInterface, ArrayAccess
         $invalidProperties = [];
 
         $allowedValues = $this->getStatusAllowableValues();
-        if ($this->container['status'] !== null && !in_array($this->container['status'], $allowedValues)) {
+        if (!is_null($this->container['status']) && !in_array($this->container['status'], $allowedValues)) {
             $invalidProperties[] = sprintf(
                 "invalid value for 'status', must be one of '%s'",
                 implode("', '", $allowedValues)
@@ -257,7 +257,7 @@ class Order implements ModelInterface, ArrayAccess
     {
 
         $allowedValues = $this->getStatusAllowableValues();
-        if ($this->container['status'] !== null && !in_array($this->container['status'], $allowedValues)) {
+        if (!is_null($this->container['status']) && !in_array($this->container['status'], $allowedValues)) {
             return false;
         }
         return true;

--- a/samples/client/petstore/php/SwaggerClient-php/lib/Model/Order.php
+++ b/samples/client/petstore/php/SwaggerClient-php/lib/Model/Order.php
@@ -237,7 +237,7 @@ class Order implements ModelInterface, ArrayAccess
         $invalidProperties = [];
 
         $allowedValues = $this->getStatusAllowableValues();
-        if (!in_array($this->container['status'], $allowedValues)) {
+        if ($this->container['status'] !== null && !in_array($this->container['status'], $allowedValues)) {
             $invalidProperties[] = sprintf(
                 "invalid value for 'status', must be one of '%s'",
                 implode("', '", $allowedValues)
@@ -257,7 +257,7 @@ class Order implements ModelInterface, ArrayAccess
     {
 
         $allowedValues = $this->getStatusAllowableValues();
-        if (!in_array($this->container['status'], $allowedValues)) {
+        if ($this->container['status'] !== null && !in_array($this->container['status'], $allowedValues)) {
             return false;
         }
         return true;

--- a/samples/client/petstore/php/SwaggerClient-php/lib/Model/Pet.php
+++ b/samples/client/petstore/php/SwaggerClient-php/lib/Model/Pet.php
@@ -243,7 +243,7 @@ class Pet implements ModelInterface, ArrayAccess
             $invalidProperties[] = "'photo_urls' can't be null";
         }
         $allowedValues = $this->getStatusAllowableValues();
-        if (!in_array($this->container['status'], $allowedValues)) {
+        if ($this->container['status'] !== null && !in_array($this->container['status'], $allowedValues)) {
             $invalidProperties[] = sprintf(
                 "invalid value for 'status', must be one of '%s'",
                 implode("', '", $allowedValues)
@@ -269,7 +269,7 @@ class Pet implements ModelInterface, ArrayAccess
             return false;
         }
         $allowedValues = $this->getStatusAllowableValues();
-        if (!in_array($this->container['status'], $allowedValues)) {
+        if ($this->container['status'] !== null && !in_array($this->container['status'], $allowedValues)) {
             return false;
         }
         return true;

--- a/samples/client/petstore/php/SwaggerClient-php/lib/Model/Pet.php
+++ b/samples/client/petstore/php/SwaggerClient-php/lib/Model/Pet.php
@@ -243,7 +243,7 @@ class Pet implements ModelInterface, ArrayAccess
             $invalidProperties[] = "'photo_urls' can't be null";
         }
         $allowedValues = $this->getStatusAllowableValues();
-        if ($this->container['status'] !== null && !in_array($this->container['status'], $allowedValues)) {
+        if (!is_null($this->container['status']) && !in_array($this->container['status'], $allowedValues)) {
             $invalidProperties[] = sprintf(
                 "invalid value for 'status', must be one of '%s'",
                 implode("', '", $allowedValues)
@@ -269,7 +269,7 @@ class Pet implements ModelInterface, ArrayAccess
             return false;
         }
         $allowedValues = $this->getStatusAllowableValues();
-        if ($this->container['status'] !== null && !in_array($this->container['status'], $allowedValues)) {
+        if (!is_null($this->container['status']) && !in_array($this->container['status'], $allowedValues)) {
             return false;
         }
         return true;

--- a/samples/client/petstore/php/SwaggerClient-php/tests/EnumTestTest.php
+++ b/samples/client/petstore/php/SwaggerClient-php/tests/EnumTestTest.php
@@ -15,4 +15,20 @@ class EnumTestTest extends \PHPUnit_Framework_TestCase
         $this->assertSame(EnumTest::ENUM_NUMBER_1_DOT_1, 1.1);
         $this->assertSame(EnumTest::ENUM_NUMBER_MINUS_1_DOT_2, -1.2);
     }
+
+    public function testNonRequiredPropertyIsOptional()
+    {
+        $enum = new EnumTest([
+            'enum_string_required' => 'UPPER',
+        ]);
+        $this->assertSame([], $enum->listInvalidProperties());
+        $this->assertTrue($enum->valid());
+    }
+
+    public function testRequiredProperty()
+    {
+        $enum = new EnumTest();
+        $this->assertSame(["'enum_string_required' can't be null"], $enum->listInvalidProperties());
+        $this->assertFalse($enum->valid());
+    }
 }


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [x] Filed the PR against the correct branch: `3.0.0` branch for changes related to OpenAPI spec 3.0. Default: `master`.
- [x] Copied the [technical committee](https://github.com/swagger-api/swagger-codegen/#swagger-codegen-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

refs https://github.com/swagger-api/swagger-codegen/pull/7686#issuecomment-368200011
> 2. Non-required enum property is listed as invalid when omitted

This PR fixes the above problem.