### PR TITLE
Fix python / tornado body handling

### DIFF
--- a/modules/swagger-codegen/src/main/resources/python/tornado/rest.mustache
+++ b/modules/swagger-codegen/src/main/resources/python/tornado/rest.mustache
@@ -20,11 +20,19 @@ logger = logging.getLogger(__name__)
 
 class RESTResponse(io.IOBase):
 
-    def __init__(self, resp, data):
+    def __init__(self, resp):
         self.tornado_response = resp
         self.status = resp.code
         self.reason = resp.reason
-        self.data = data
+
+        if resp.body:
+            # In Python 3, the response body is utf-8 encoded bytes.
+            if six.PY3:
+                self.data = resp.body.decode('utf-8')
+            else:
+                self.data = resp.body
+        else:
+            self.data = None
 
     def getheaders(self):
         """Returns a CIMultiDictProxy of the response headers."""
@@ -83,7 +91,8 @@ class RESTClientObject(object):
                 "body parameter cannot be used with post_params parameter."
             )
 
-        request = httpclient.HTTPRequest(url, allow_nonstandard_methods=True)
+        request = httpclient.HTTPRequest(url)
+        request.allow_nonstandard_methods = True
         request.ca_certs = self.ca_certs
         request.client_key = self.client_key
         request.client_cert = self.client_cert
@@ -128,11 +137,7 @@ class RESTClientObject(object):
 
         if _preload_content:
 
-            r = RESTResponse(r, r.body)
-            # In the python 3, the response.data is bytes.
-            # we need to decode it to string.
-            if six.PY3:
-                r.data = r.data.decode('utf8')
+            r = RESTResponse(r)
 
             # log response body
             logger.debug("response body: %s", r.data)

--- a/samples/client/petstore/python-tornado/petstore_api/rest.py
+++ b/samples/client/petstore/python-tornado/petstore_api/rest.py
@@ -29,11 +29,19 @@ logger = logging.getLogger(__name__)
 
 class RESTResponse(io.IOBase):
 
-    def __init__(self, resp, data):
+    def __init__(self, resp):
         self.tornado_response = resp
         self.status = resp.code
         self.reason = resp.reason
-        self.data = data
+
+        if resp.body:
+            # In Python 3, the response body is utf-8 encoded bytes.
+            if six.PY3:
+                self.data = resp.body.decode('utf-8')
+            else:
+                self.data = resp.body
+        else:
+            self.data = None
 
     def getheaders(self):
         """Returns a CIMultiDictProxy of the response headers."""
@@ -92,7 +100,8 @@ class RESTClientObject(object):
                 "body parameter cannot be used with post_params parameter."
             )
 
-        request = httpclient.HTTPRequest(url, allow_nonstandard_methods=True)
+        request = httpclient.HTTPRequest(url)
+        request.allow_nonstandard_methods = True
         request.ca_certs = self.ca_certs
         request.client_key = self.client_key
         request.client_cert = self.client_cert
@@ -137,11 +146,7 @@ class RESTClientObject(object):
 
         if _preload_content:
 
-            r = RESTResponse(r, r.body)
-            # In the python 3, the response.data is bytes.
-            # we need to decode it to string.
-            if six.PY3:
-                r.data = r.data.decode('utf8')
+            r = RESTResponse(r)
 
             # log response body
             logger.debug("response body: %s", r.data)


### PR DESCRIPTION
### PR checklist

- [X] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [X] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [X] Filed the PR against the correct branch: `3.0.0` branch for changes related to OpenAPI spec 3.0. Default: `master`.
- [X] Copied the [technical committee](https://github.com/swagger-api/swagger-codegen/#swagger-codegen-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

Fixes #7737 

A response from tornado may contain a body of `None`, most usually in the case of a timeout. This needs to be handled when attempting to decode the response body.

@taxpon 
@frol 
@mbohlool 
@cbornet 
@kenjones-cisco 



