### PR TITLE
[3.0.0] Fix typo: 'Values' instead of 'Valiues'

### DIFF
--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/CodegenConfig.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/CodegenConfig.java
@@ -222,5 +222,5 @@ public interface CodegenConfig {
 
     List<CodegenArgument> getLanguageArguments();
 
-    void processArgumentsValiues(List<CodegenArgument> codegenArguments);
+    void processArgumentsValues(List<CodegenArgument> codegenArguments);
 }

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/DefaultCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/DefaultCodegen.java
@@ -3170,7 +3170,7 @@ public class DefaultCodegen implements CodegenConfig {
     }
 
     @Override
-    public void processArgumentsValiues(List<CodegenArgument> codegenArguments){
+    public void processArgumentsValues(List<CodegenArgument> codegenArguments){
     }
 
     /**

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/config/CodegenConfigurator.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/config/CodegenConfigurator.java
@@ -416,7 +416,7 @@ public class CodegenConfigurator implements Serializable {
         config.languageSpecificPrimitives().addAll(languageSpecificPrimitives);
         config.reservedWordsMappings().putAll(reservedWordMappings);
 
-        config.processArgumentsValiues(codegenArguments);
+        config.processArgumentsValues(codegenArguments);
 
         checkAndSetAdditionalProperty(apiPackage, CodegenConstants.API_PACKAGE);
         checkAndSetAdditionalProperty(modelPackage, CodegenConstants.MODEL_PACKAGE);
@@ -478,7 +478,7 @@ public class CodegenConfigurator implements Serializable {
         config.languageSpecificPrimitives().addAll(languageSpecificPrimitives);
         config.reservedWordsMappings().putAll(reservedWordMappings);
 
-        config.processArgumentsValiues(codegenArguments);
+        config.processArgumentsValues(codegenArguments);
 
         checkAndSetAdditionalProperty(apiPackage, CodegenConstants.API_PACKAGE);
         checkAndSetAdditionalProperty(modelPackage, CodegenConstants.MODEL_PACKAGE);


### PR DESCRIPTION
With commit ab1c5f3e38d9736d34711d74ff652bc7c9d3fe15, @HugoMario has introduced a new method. With this pull request the name is fixed: `processArgumentsValues` instead of `processArgumentsValiues`