### PR TITLE
[CPPRest] Adapt templates to correctly generate code regarding the "Object" class

### DIFF
--- a/modules/swagger-codegen/src/main/resources/cpprest/model-header.mustache
+++ b/modules/swagger-codegen/src/main/resources/cpprest/model-header.mustache
@@ -5,12 +5,13 @@
  * {{description}}
  */
 
-#ifndef {{modelHeaderGuardPrefix}}_{{classname}}_H_
-#define {{modelHeaderGuardPrefix}}_{{classname}}_H_
+#ifndef {{classname}}_H_
+#define {{classname}}_H_
 
 {{^parent}}
 {{{defaultInclude}}}
-#include "../ModelBase.h"
+#include "ModelBase.h"
+#include "Object.h"
 {{/parent}}
 
 {{#imports}}{{{this}}}
@@ -50,11 +51,24 @@ public:
     /// {{description}}
     /// </summary>
     {{^isNotContainer}}{{{datatype}}}& {{getter}}();
-    {{/isNotContainer}}{{#isNotContainer}}{{{datatype}}} {{getter}}() const;
+    {{/isNotContainer}}{{#isNotContainer}}{{{datatype}}} {{getter}}() const;    
     {{/isNotContainer}}{{^required}}bool {{nameInCamelCase}}IsSet() const;
     void unset{{name}}();
     {{/required}}
     void {{setter}}({{{datatype}}} value);
+    
+    {{#isString}}
+    {{{datatype}}}* getNew{{nameInCamelCase}}Instance();
+    {{/isString}}
+    {{#isContainer}}
+    {{{datatype}}}* getNew{{nameInCamelCase}}Instance();
+    {{/isContainer}}
+    {{^isString}}
+    {{^isContainer}}
+    {{baseType}}* getNew{{nameInCamelCase}}Instance();
+    {{/isContainer}}
+    {{/isString}}
+       
     {{/isInherited}}
     {{/vars}}
 
@@ -72,6 +86,7 @@ protected:
 }
 {{/modelNamespaceDeclarations}}
 
-#endif /* {{modelHeaderGuardPrefix}}_{{classname}}_H_ */
+#endif /* {{classname}}_H_ */
 {{/model}}
 {{/models}}
+

--- a/modules/swagger-codegen/src/main/resources/cpprest/model-source.mustache
+++ b/modules/swagger-codegen/src/main/resources/cpprest/model-source.mustache
@@ -2,6 +2,7 @@
 {{#models}}{{#model}}
 
 #include "{{classname}}.h"
+#include "Object.h"
 
 {{#modelNamespaceDeclarations}}
 namespace {{this}} {
@@ -198,39 +199,73 @@ void {{classname}}::fromJson(web::json::value& val)
         if(val.has_field(utility::conversions::to_string_t("{{baseName}}")))
         {
         {{/required}}
-        for( auto& item : val[utility::conversions::to_string_t("{{baseName}}")].as_array() )
-        {  
-            utility::string_t key;
-            if(item.has_field(utility::conversions::to_string_t("key")))
-            {
-                key = ModelBase::stringFromJson(item[utility::conversions::to_string_t("key")]);
-            }
-            {{#items.isPrimitiveType}}
-            m_{{name}}.insert(std::pair<utility::string_t,{{{items.datatype}}}>( key, ModelBase::{{items.baseType}}FromJson(item[utility::conversions::to_string_t("value")])));
-            {{/items.isPrimitiveType}}
-            {{^items.isPrimitiveType}}
-            {{#items.isString}}
-            m_{{name}}.insert(std::pair<utility::string_t,{{{items.datatype}}}>( key, ModelBase::stringFromJson(item[utility::conversions::to_string_t("value")])));
-            {{/items.isString}}
-            {{^items.isString}}
-            {{#items.isDateTime}}
-            m_{{name}}.insert(std::pair<utility::string_t,{{{items.datatype}}}>( key, ModelBase::dateFromJson(item[utility::conversions::to_string_t("value")])));
-            {{/items.isDateTime}}
-            {{^items.isDateTime}}
-            if(item.is_null())
-            {
-                m_{{name}}.insert(std::pair<utility::string_t,{{{items.datatype}}}>( key, {{{items.datatype}}}(nullptr) ));
-            }
-            else
-            {
-                {{{items.datatype}}} newItem({{{items.defaultValue}}});
-                newItem->fromJson(item[utility::conversions::to_string_t("value")]);
-                m_{{name}}.insert(std::pair<utility::string_t,{{{items.datatype}}}>( key, newItem ));
-            }
-            {{/items.isDateTime}}
-            {{/items.isString}}
-            {{/items.isPrimitiveType}}
-        }
+
+		try{
+		    for( auto& item : val[utility::conversions::to_string_t("{{baseName}}")].as_array() )
+		    {  
+		        utility::string_t key;
+		        if(item.has_field(utility::conversions::to_string_t("key")))
+		        {
+		            key = ModelBase::stringFromJson(item[utility::conversions::to_string_t("key")]);
+		        }
+		        {{#items.isPrimitiveType}}
+		        m_{{name}}.insert(std::pair<utility::string_t,{{{items.datatype}}}>( key, ModelBase::{{items.baseType}}FromJson(item[utility::conversions::to_string_t("value")])));
+		        {{/items.isPrimitiveType}}
+		        {{^items.isPrimitiveType}}
+		        {{#items.isString}}
+		        m_{{name}}.insert(std::pair<utility::string_t,{{{items.datatype}}}>( key, ModelBase::stringFromJson(item[utility::conversions::to_string_t("value")])));
+		        {{/items.isString}}
+		        {{^items.isString}}
+		        {{#items.isDateTime}}
+		        m_{{name}}.insert(std::pair<utility::string_t,{{{items.datatype}}}>( key, ModelBase::dateFromJson(item[utility::conversions::to_string_t("value")])));
+		        {{/items.isDateTime}}
+		        {{^items.isDateTime}}
+		        if(item.is_null())
+		        {
+		            m_{{name}}.insert(std::pair<utility::string_t,{{{items.datatype}}}>( key, {{{items.datatype}}}({{{items.defaultValue}}}) ));
+		        }
+		        else
+		        {
+		            {{{items.datatype}}} newItem({{{items.defaultValue}}});
+		            newItem->fromJson(item[utility::conversions::to_string_t("value")]);
+		            m_{{name}}.insert(std::pair<utility::string_t,{{{items.datatype}}}>( key, newItem ));
+		        }
+		        {{/items.isDateTime}}
+		        {{/items.isString}}
+		        {{/items.isPrimitiveType}}
+		    }
+		} catch(std::exception& e) {
+		    for( auto& item : val[utility::conversions::to_string_t("{{baseName}}")].as_object() )
+		    {  
+		        {{#items.isPrimitiveType}}
+		        m_{{name}}.insert(std::pair<utility::string_t,{{{items.datatype}}}>( item.first, ModelBase::{{items.baseType}}FromJson(item.second)));
+		        {{/items.isPrimitiveType}}
+		        {{^items.isPrimitiveType}}
+		        {{#items.isString}}
+		        m_{{name}}.insert(std::pair<utility::string_t,{{{items.datatype}}}>( item.first, item.second.serialize() ));
+		        {{/items.isString}}
+		        {{^items.isString}}
+		        {{#items.isDateTime}}
+		        m_{{name}}.insert(std::pair<utility::string_t,{{{items.datatype}}}>( item.first, ModelBase::dateFromJson(item.second)));
+		        {{/items.isDateTime}}
+		        {{^items.isDateTime}}
+		        if(item.second.is_null())
+		        {
+		            m_{{name}}.insert(std::pair<utility::string_t,{{{items.datatype}}}>( item.first, {{{items.datatype}}}({{{items.defaultValue}}}) ));
+		        }
+		        else
+		        {
+		            {{{items.datatype}}} newItem({{{items.defaultValue}}});
+		            newItem->fromJson(item.second);
+		            m_{{name}}.insert(std::pair<utility::string_t,{{{items.datatype}}}>( item.first, newItem ));
+		        }
+		        {{/items.isDateTime}}
+		        {{/items.isString}}
+		        {{/items.isPrimitiveType}}
+		        
+		    }
+		}
+
         {{^required}}
         }
         {{/required}}
@@ -251,13 +286,15 @@ void {{classname}}::fromJson(web::json::value& val)
         {{/isDateTime}}
         {{^isDateTime}}
         if(!val[utility::conversions::to_string_t("{{baseName}}")].is_null())
-        {
-            {{{datatype}}} newItem({{{defaultValue}}});
-            newItem->fromJson(val[utility::conversions::to_string_t("{{baseName}}")]);
-            {{setter}}( newItem );
+        {        	
+           	{{{datatype}}} newItem(getNew{{nameInCamelCase}}Instance());
+           	           	
+           	newItem->fromJson(val[utility::conversions::to_string_t("{{baseName}}")]);
+           	{{setter}}( newItem );      
         }
         {{/isDateTime}}
         {{/isString}}
+
     }
     {{/required}}
     {{#required}}
@@ -286,6 +323,7 @@ void {{classname}}::fromJson(web::json::value& val)
     {{/isListContainer}}
     {{/isInherited}}
     {{/vars}}
+
 }
 
 void {{classname}}::toMultipart(std::shared_ptr<MultipartFormData> multipart, const utility::string_t& prefix) const
@@ -461,39 +499,72 @@ void {{classname}}::fromMultiPart(std::shared_ptr<MultipartFormData> multipart, 
         {{/required}}
 
         web::json::value jsonArray = web::json::value::parse(ModelBase::stringFromHttpContent(multipart->getContent(utility::conversions::to_string_t("{{baseName}}"))));
-        for( auto& item : jsonArray.as_array() )
-        {
-            utility::string_t key;
-            if(item.has_field(utility::conversions::to_string_t("key")))
-            {
-                key = ModelBase::stringFromJson(item[utility::conversions::to_string_t("key")]);
-            }
-            {{#items.isPrimitiveType}}
-            m_{{name}}.insert(std::pair<utility::string_t,{{{items.datatype}}}>( key, ModelBase::{{items.baseType}}FromJson(item[utility::conversions::to_string_t("value")])));
-            {{/items.isPrimitiveType}}
-            {{^items.isPrimitiveType}}
-            {{#items.isString}}
-            m_{{name}}.insert(std::pair<utility::string_t,{{{items.datatype}}}>( key, ModelBase::stringFromJson(item[utility::conversions::to_string_t("value")])));
-            {{/items.isString}}
-            {{^items.isString}}
-            {{#items.isDateTime}}
-            m_{{name}}.insert(std::pair<utility::string_t,{{{items.datatype}}}>( key, ModelBase::dateFromJson(item[utility::conversions::to_string_t("value")])));
-            {{/items.isDateTime}}
-            {{^items.isDateTime}}
-            if(item.is_null())
-            {
-                m_{{name}}.insert(std::pair<utility::string_t,{{{items.datatype}}}>( key, {{{items.datatype}}}(nullptr) ));
-            }
-            else
-            {
-                {{{items.datatype}}} newItem({{{items.defaultValue}}});
-                newItem->fromJson(item[utility::conversions::to_string_t("value")]);
-                m_{{name}}.insert(std::pair<utility::string_t,{{{items.datatype}}}>( key, newItem ));
-            }
-            {{/items.isDateTime}}
-            {{/items.isString}}
-            {{/items.isPrimitiveType}}
-        }
+
+		try {
+		    for( auto& item : jsonArray.as_array() )
+		    {
+		        utility::string_t key;
+		        if(item.has_field(utility::conversions::to_string_t("key")))
+		        {
+		            key = ModelBase::stringFromJson(item[utility::conversions::to_string_t("key")]);
+		        }
+		        {{#items.isPrimitiveType}}
+		        m_{{name}}.insert(std::pair<utility::string_t,{{{items.datatype}}}>( key, ModelBase::{{items.baseType}}FromJson(item[utility::conversions::to_string_t("value")])));
+		        {{/items.isPrimitiveType}}
+		        {{^items.isPrimitiveType}}
+		        {{#items.isString}}
+		        m_{{name}}.insert(std::pair<utility::string_t,{{{items.datatype}}}>( key, ModelBase::stringFromJson(item[utility::conversions::to_string_t("value")])));
+		        {{/items.isString}}
+		        {{^items.isString}}
+		        {{#items.isDateTime}}
+		        m_{{name}}.insert(std::pair<utility::string_t,{{{items.datatype}}}>( key, ModelBase::dateFromJson(item[utility::conversions::to_string_t("value")])));
+		        {{/items.isDateTime}}
+		        {{^items.isDateTime}}
+		        if(item.is_null())
+		        {
+		            m_{{name}}.insert(std::pair<utility::string_t,{{{items.datatype}}}>( key, {{{items.datatype}}}(nullptr) ));
+		        }
+		        else
+		        {
+		            {{{items.datatype}}} newItem({{{items.defaultValue}}});
+		            newItem->fromJson(item[utility::conversions::to_string_t("value")]);
+		            m_{{name}}.insert(std::pair<utility::string_t,{{{items.datatype}}}>( key, newItem ));
+		        }
+		        {{/items.isDateTime}}
+		        {{/items.isString}}
+		        {{/items.isPrimitiveType}}
+		    }
+		} catch(std::exception& e){
+		    for( auto& item : jsonArray.as_object() )
+		    {
+		        {{#items.isPrimitiveType}}
+		        m_{{name}}.insert(std::pair<utility::string_t,{{{items.datatype}}}>( item.first, ModelBase::{{items.baseType}}FromJson(item.second)));
+		        {{/items.isPrimitiveType}}
+		        {{^items.isPrimitiveType}}
+		        {{#items.isString}}
+		        m_{{name}}.insert(std::pair<utility::string_t,{{{items.datatype}}}>( item.first, item.second.serialize()));
+		        {{/items.isString}}
+		        {{^items.isString}}
+		        {{#items.isDateTime}}
+		        m_{{name}}.insert(std::pair<utility::string_t,{{{items.datatype}}}>( item.first, ModelBase::dateFromJson(item.second)));
+		        {{/items.isDateTime}}
+		        {{^items.isDateTime}}
+		        if(item.second.is_null())
+		        {
+		            m_{{name}}.insert(std::pair<utility::string_t,{{{items.datatype}}}>( item.first, {{{items.datatype}}}({{{items.defaultValue}}}) ));
+		        }
+		        else
+		        {
+		            {{{items.datatype}}} newItem({{{items.defaultValue}}});
+		            newItem->fromJson(item.second);
+		            m_{{name}}.insert(std::pair<utility::string_t,{{{items.datatype}}}>( item.first, newItem ));
+		        }
+		        {{/items.isDateTime}}
+		        {{/items.isString}}
+		        {{/items.isPrimitiveType}}
+		    }
+		}
+
         {{^required}}
         }
         {{/required}}
@@ -562,6 +633,7 @@ void {{classname}}::{{setter}}({{{datatype}}} value)
     m_{{name}} = value;
     {{^required}}m_{{name}}IsSet = true;{{/required}}
 }
+
 {{/isNotContainer}}
 {{#isNotContainer}}
 {{{datatype}}} {{classname}}::{{getter}}() const
@@ -575,6 +647,7 @@ void {{classname}}::{{setter}}({{{datatype}}} value)
     m_{{name}} = value;
     {{^required}}m_{{name}}IsSet = true;{{/required}}
 }
+
 {{/isNotContainer}}
 {{^required}}
 bool {{classname}}::{{nameInCamelCase}}IsSet() const
@@ -587,6 +660,28 @@ void {{classname}}::unset{{name}}()
     m_{{name}}IsSet = false;
 }
 
+{{#isString}}
+{{{datatype}}}* {{classname}}::getNew{{nameInCamelCase}}Instance()
+{
+	return new {{{datatype}}}();
+}
+{{/isString}}
+{{#isContainer}}
+{{{datatype}}}* {{classname}}::getNew{{nameInCamelCase}}Instance()
+{
+	return new {{{datatype}}}();
+}
+{{/isContainer}}
+{{^isString}}
+{{^isContainer}}
+{{baseType}}* {{classname}}::getNew{{nameInCamelCase}}Instance()
+{
+	return new {{baseType}}();
+}
+{{/isContainer}}
+{{/isString}}
+
+
 {{/required}}
 {{/isInherited}}
 {{/vars}}
@@ -596,3 +691,4 @@ void {{classname}}::unset{{name}}()
 
 {{/model}}
 {{/models}}
+


### PR DESCRIPTION
Modify model-source.mustache and model-header.mustache to correctly deal with Object objects by removing use of nullptr and instead creating a new Object object which eliminates the segmentation fault described in issue #7557. This is done by creating methods for each possible datatype that returns a new object of the corresponding type.

### PR checklist

- [] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [ ] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [] Filed the PR against the correct branch: `3.0.0` branch for changes related to OpenAPI spec 3.0. Default: `master`.
- [ ] Copied the [technical committee](https://github.com/swagger-api/swagger-codegen/#swagger-codegen-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

Based on issue #7557 this pull request fixes problems when using the "Object" class in C++/CPPRest. Prior to this objects of type "Object" were created in ``fromJson`` function using a ``nullptr`` which led to a segmentation fault upon every execution. Now a new object is generated and used so the error is fixed. This is done by generating a method for each possible datatype that returns a new instance of said type. Also the ``fromJson`` function can now deal with a JSON object containing other objects compared to the prior version which would throw an ``not an array`` error in the same situation.

[Issue #7557 ](https://github.com/swagger-api/swagger-codegen/issues/7557)

