### PR TITLE
[Java] fix connection leak on retrofit OAuth token renewal

### DIFF
--- a/modules/swagger-codegen/src/main/resources/Java/libraries/retrofit/auth/OAuth.mustache
+++ b/modules/swagger-codegen/src/main/resources/Java/libraries/retrofit/auth/OAuth.mustache
@@ -113,8 +113,14 @@ public class OAuth implements Interceptor {
     
             // 401/403 most likely indicates that access token has expired. Unless it happens two times in a row.
             if ( response != null && (response.code() == HTTP_UNAUTHORIZED || response.code() == HTTP_FORBIDDEN) && updateTokenAndRetryOnAuthorizationFailure ) {
-                if (updateAccessToken(requestAccessToken)) {
-                    return retryingIntercept( chain, false );
+                try {
+                    if (updateAccessToken(requestAccessToken)) {
+                        response.body().close();
+                        return retryingIntercept( chain, false );
+                    }
+                } catch (Exception e) {
+                    response.body().close();
+                    throw e;
                 }
             }
             return response;

--- a/modules/swagger-codegen/src/main/resources/Java/libraries/retrofit2/auth/OAuth.mustache
+++ b/modules/swagger-codegen/src/main/resources/Java/libraries/retrofit2/auth/OAuth.mustache
@@ -113,8 +113,14 @@ public class OAuth implements Interceptor {
 
             // 401/403 most likely indicates that access token has expired. Unless it happens two times in a row.
             if ( response != null && (response.code() == HTTP_UNAUTHORIZED || response.code() == HTTP_FORBIDDEN) && updateTokenAndRetryOnAuthorizationFailure ) {
-                if (updateAccessToken(requestAccessToken)) {
-                    return retryingIntercept( chain, false );
+                try {
+                    if (updateAccessToken(requestAccessToken)) {
+                        response.body().close();
+                        return retryingIntercept( chain, false );
+                    }
+                } catch (Exception e) {
+                    response.body().close();
+                    throw e;
                 }
             }
             return response;

--- a/samples/client/petstore/java/retrofit/src/main/java/io/swagger/client/auth/OAuth.java
+++ b/samples/client/petstore/java/retrofit/src/main/java/io/swagger/client/auth/OAuth.java
@@ -113,8 +113,14 @@ public class OAuth implements Interceptor {
     
             // 401/403 most likely indicates that access token has expired. Unless it happens two times in a row.
             if ( response != null && (response.code() == HTTP_UNAUTHORIZED || response.code() == HTTP_FORBIDDEN) && updateTokenAndRetryOnAuthorizationFailure ) {
-                if (updateAccessToken(requestAccessToken)) {
-                    return retryingIntercept( chain, false );
+                try {
+                    if (updateAccessToken(requestAccessToken)) {
+                        response.body().close();
+                        return retryingIntercept( chain, false );
+                    }
+                } catch (Exception e) {
+                    response.body().close();
+                    throw e;
                 }
             }
             return response;

--- a/samples/client/petstore/java/retrofit2/src/main/java/io/swagger/client/auth/OAuth.java
+++ b/samples/client/petstore/java/retrofit2/src/main/java/io/swagger/client/auth/OAuth.java
@@ -113,8 +113,14 @@ public class OAuth implements Interceptor {
 
             // 401/403 most likely indicates that access token has expired. Unless it happens two times in a row.
             if ( response != null && (response.code() == HTTP_UNAUTHORIZED || response.code() == HTTP_FORBIDDEN) && updateTokenAndRetryOnAuthorizationFailure ) {
-                if (updateAccessToken(requestAccessToken)) {
-                    return retryingIntercept( chain, false );
+                try {
+                    if (updateAccessToken(requestAccessToken)) {
+                        response.body().close();
+                        return retryingIntercept( chain, false );
+                    }
+                } catch (Exception e) {
+                    response.body().close();
+                    throw e;
                 }
             }
             return response;

--- a/samples/client/petstore/java/retrofit2rx/src/main/java/io/swagger/client/auth/OAuth.java
+++ b/samples/client/petstore/java/retrofit2rx/src/main/java/io/swagger/client/auth/OAuth.java
@@ -113,8 +113,14 @@ public class OAuth implements Interceptor {
 
             // 401/403 most likely indicates that access token has expired. Unless it happens two times in a row.
             if ( response != null && (response.code() == HTTP_UNAUTHORIZED || response.code() == HTTP_FORBIDDEN) && updateTokenAndRetryOnAuthorizationFailure ) {
-                if (updateAccessToken(requestAccessToken)) {
-                    return retryingIntercept( chain, false );
+                try {
+                    if (updateAccessToken(requestAccessToken)) {
+                        response.body().close();
+                        return retryingIntercept( chain, false );
+                    }
+                } catch (Exception e) {
+                    response.body().close();
+                    throw e;
                 }
             }
             return response;

--- a/samples/client/petstore/java/retrofit2rx2/src/main/java/io/swagger/client/auth/OAuth.java
+++ b/samples/client/petstore/java/retrofit2rx2/src/main/java/io/swagger/client/auth/OAuth.java
@@ -113,8 +113,14 @@ public class OAuth implements Interceptor {
 
             // 401/403 most likely indicates that access token has expired. Unless it happens two times in a row.
             if ( response != null && (response.code() == HTTP_UNAUTHORIZED || response.code() == HTTP_FORBIDDEN) && updateTokenAndRetryOnAuthorizationFailure ) {
-                if (updateAccessToken(requestAccessToken)) {
-                    return retryingIntercept( chain, false );
+                try {
+                    if (updateAccessToken(requestAccessToken)) {
+                        response.body().close();
+                        return retryingIntercept( chain, false );
+                    }
+                } catch (Exception e) {
+                    response.body().close();
+                    throw e;
                 }
             }
             return response;


### PR DESCRIPTION
### PR checklist

- [X] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [X] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [X] Filed the PR against the correct branch: `3.0.0` branch for changes related to OpenAPI spec 3.0. Default: `master`.
- [X] Copied the [technical committee](https://github.com/swagger-api/swagger-codegen/#swagger-codegen-technical-committee) to review the pull request if your PR is targeting a particular programming language. @jeff9finger

### Description of the PR
OAuth interceptors of retrofit 1 and 2 are causing a connection leak on token refresh.

When the initial request returns 401 or 403, the token is refreshed and - if successful - a new attempt to execute the initial request is made.
But the first response is never closed in that case and causes a connection leak that okhttp3 is even logging
```
2017-12-13 23:28:03.228 [WARN ] [com.squareup.okhttp.OkHttpClient    ] - A connection to https://api.whatever.com/ was leaked. Did you forget to close a response body?
```
I discovered that problem during the development of a tado-binding for OpenHAB. The related discussion is [in the OpenHAB forum](https://community.openhab.org/t/tado-binding/37000).

To prevent the connection leak, the OAuth interceptor is now manually closing the initial response whenever another response is returned from the interceptor. That's why the initial response is not closed if `updateAccessToken` is not successful.