### PR TITLE
[Java] Fix ignored resteasy default HTTP headers

### DIFF
--- a/modules/swagger-codegen/src/main/resources/Java/libraries/resteasy/ApiClient.mustache
+++ b/modules/swagger-codegen/src/main/resources/Java/libraries/resteasy/ApiClient.mustache
@@ -596,11 +596,11 @@ public class ApiClient {
       }
     }
 
-    for (Entry<String, String> defaultHeaderEnrty: defaultHeaderMap.entrySet()) {
-      if (!headerParams.containsKey(defaultHeaderEnrty.getKey())) {
-        String value = defaultHeaderEnrty.getKey();
+    for (Entry<String, String> entry: defaultHeaderMap.entrySet()) {
+      if (!headerParams.containsKey(entry.getKey())) {
+        String value = entry.getValue();
         if (value != null) {
-          invocationBuilder = invocationBuilder.header(defaultHeaderEnrty.getKey(), value);
+          invocationBuilder = invocationBuilder.header(entry.getKey(), value);
         }
       }
     }


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [x] Filed the PR against the correct branch: `3.0.0` branch for changes related to OpenAPI spec 3.0. Default: `master`.
- [x] Copied the [technical committee](https://github.com/swagger-api/swagger-codegen/#swagger-codegen-technical-committee) to review the pull request if your PR is targeting a particular programming language. @jeff9finger

### Description of the PR

Renamed misspelled variable and read the header value from getValue() instead of getKey().

https://github.com/swagger-api/swagger-codegen/issues/7758


