### PR TITLE
[3.0.0] Remove "joda-time" dependency

### DIFF
--- a/modules/swagger-codegen/pom.xml
+++ b/modules/swagger-codegen/pom.xml
@@ -269,11 +269,6 @@
             <version>${commons-cli-version}</version>
         </dependency>
         <dependency>
-            <groupId>joda-time</groupId>
-            <artifactId>joda-time</artifactId>
-            <version>2.9.7</version>
-        </dependency>
-        <dependency>
             <groupId>org.testng</groupId>
             <artifactId>testng</artifactId>
 <!--             <version>${testng-version}</version> -->

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/DefaultGenerator.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/DefaultGenerator.java
@@ -9,6 +9,7 @@ import java.io.OutputStream;
 import java.io.Reader;
 import java.net.MalformedURLException;
 import java.net.URL;
+import java.time.ZonedDateTime;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -55,8 +56,6 @@ import io.swagger.v3.oas.models.tags.Tag;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.ObjectUtils;
 import org.apache.commons.lang3.StringUtils;
-
-import org.joda.time.DateTime;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -204,8 +203,8 @@ public class DefaultGenerator extends AbstractGenerator implements Generator {
         config.processOpts();
         config.preprocessOpenAPI(this.openAPI);
         config.additionalProperties().put("generatorVersion", ImplementationVersion.read());
-        config.additionalProperties().put("generatedDate", DateTime.now().toString());
-        config.additionalProperties().put("generatedYear", String.valueOf(DateTime.now().getYear()));
+        config.additionalProperties().put("generatedDate", ZonedDateTime.now().toString());
+        config.additionalProperties().put("generatedYear", String.valueOf(ZonedDateTime.now().getYear()));
         config.additionalProperties().put("generatorClass", config.getClass().getName());
         config.additionalProperties().put("inputSpec", config.getInputSpec());
         if (this.openAPI.getExtensions() != null) {


### PR DESCRIPTION
The `3.0.0` branch uses Java 8. `java.time.*` can be used instead of `org.joda.time.*`.

Migration guide: http://blog.joda.org/2014/11/converting-from-joda-time-to-javatime.html