### PR TITLE
[3.0.0] Migrate guava logic to java 8

### DIFF
--- a/modules/swagger-codegen/src/main/java/config/Config.java
+++ b/modules/swagger-codegen/src/main/java/config/Config.java
@@ -1,7 +1,6 @@
 package config;
 
-import com.google.common.collect.ImmutableMap;
-
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -17,7 +16,7 @@ public class Config {
     }
 
     public Map<String, String> getOptions() {
-        return ImmutableMap.copyOf(options);
+        return Collections.unmodifiableMap(options);
     }
 
     public boolean hasOption(String opt) {

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/DefaultCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/DefaultCodegen.java
@@ -1,8 +1,6 @@
 package io.swagger.codegen;
 
 import com.github.jknack.handlebars.Handlebars;
-import com.google.common.base.Function;
-import com.google.common.collect.Lists;
 import com.samskivert.mustache.Mustache.Compiler;
 import io.swagger.codegen.languages.helpers.HasHelper;
 import io.swagger.codegen.languages.helpers.HasNotHelper;
@@ -41,14 +39,11 @@ import io.swagger.v3.oas.models.security.OAuthFlow;
 import io.swagger.v3.oas.models.security.OAuthFlows;
 import io.swagger.v3.oas.models.security.SecurityScheme;
 import io.swagger.v3.parser.util.SchemaTypeUtil;
-import org.apache.commons.lang3.ArrayUtils;
 import org.apache.commons.lang3.ObjectUtils;
 import org.apache.commons.lang3.StringEscapeUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import javax.annotation.Nullable;
 import java.io.File;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -66,15 +61,15 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
-import static io.swagger.codegen.CodegenHelper.getDefaultIncludes;
-import static io.swagger.codegen.CodegenHelper.getImportMappings;
-import static io.swagger.codegen.CodegenHelper.getTypeMappings;
-import static io.swagger.codegen.CodegenHelper.initalizeSpecialCharacterMapping;
 import static io.swagger.codegen.CodegenConstants.HAS_ONLY_READ_ONLY_EXT_NAME;
 import static io.swagger.codegen.CodegenConstants.HAS_OPTIONAL_EXT_NAME;
 import static io.swagger.codegen.CodegenConstants.HAS_REQUIRED_EXT_NAME;
 import static io.swagger.codegen.CodegenConstants.IS_ARRAY_MODEL_EXT_NAME;
 import static io.swagger.codegen.CodegenConstants.IS_ENUM_EXT_NAME;
+import static io.swagger.codegen.CodegenHelper.getDefaultIncludes;
+import static io.swagger.codegen.CodegenHelper.getImportMappings;
+import static io.swagger.codegen.CodegenHelper.getTypeMappings;
+import static io.swagger.codegen.CodegenHelper.initalizeSpecialCharacterMapping;
 import static io.swagger.codegen.languages.helpers.ExtensionHelper.getBooleanValue;
 import static io.swagger.codegen.utils.ModelUtils.processCodegenModels;
 import static io.swagger.codegen.utils.ModelUtils.processModelEnums;
@@ -2818,13 +2813,9 @@ public class DefaultCodegen implements CodegenConfig {
      * @return camelized string
      */
     protected String removeNonNameElementToCamelCase(final String name, final String nonNameElementPattern) {
-        String result = StringUtils.join(Lists.transform(Lists.newArrayList(name.split(nonNameElementPattern)), new Function<String, String>() {
-            @Nullable
-            @Override
-            public String apply(String input) {
-                return StringUtils.capitalize(input);
-            }
-        }), "");
+        String result = Arrays.stream(name.split(nonNameElementPattern))
+                .map(StringUtils::capitalize)
+                .collect(Collectors.joining(""));
         if (result.length() > 0) {
             result = result.substring(0, 1).toLowerCase() + result.substring(1);
         }

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/ignore/CodegenIgnoreProcessor.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/ignore/CodegenIgnoreProcessor.java
@@ -1,14 +1,16 @@
 package io.swagger.codegen.ignore;
 
-import com.google.common.collect.ImmutableList;
 import io.swagger.codegen.ignore.rules.DirectoryRule;
 import io.swagger.codegen.ignore.rules.Rule;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.*;
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.FileReader;
+import java.io.IOException;
 import java.util.ArrayList;
-import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
 
 /**
@@ -173,10 +175,10 @@ public class CodegenIgnoreProcessor {
     /**
      * Allows a consumer to manually inspect explicit "inclusion rules". That is, patterns in the ignore file which have been negated.
      *
-     * @return A {@link ImmutableList#copyOf(Collection)} of rules which possibly negate exclusion rules in the ignore file.
+     * @return A unmodifiable {@link java.util.List} of rules which possibly negate exclusion rules in the ignore file.
      */
     public List<Rule> getInclusionRules() {
-        return ImmutableList.copyOf(inclusionRules);
+        return Collections.unmodifiableList(inclusionRules);
     }
 
     /**
@@ -185,9 +187,9 @@ public class CodegenIgnoreProcessor {
      *
      * NOTE: Existence in this list doesn't mean a file is excluded. The rule can be overridden by {@link CodegenIgnoreProcessor#getInclusionRules()} rules.
      *
-     * @return A {@link ImmutableList#copyOf(Collection)} of rules which define exclusions by patterns in the ignore file.
+     * @return A unmodifiable {@link java.util.List} of rules which define exclusions by patterns in the ignore file.
      */
     public List<Rule> getExclusionRules() {
-        return ImmutableList.copyOf(exclusionRules);
+        return Collections.unmodifiableList(exclusionRules);
     }
 }


### PR DESCRIPTION
With https://github.com/swagger-api/swagger-codegen-generators/issues/5 we have started to remove guava from `swagger-codegen-generators`.

This is useless if the code used by `swagger-codegen-generators` in `swagger-codegen` is still using Guava.

This pull request removes the guava imports from the code, except in the `io.swagger.codegen.languages` package (that contains already dead code => code that is no longer used and present for legacy reason until the migration is over).

The goal is to be able to use `swagger-codegen-generators` in a project configured as follow:

    <dependency>
      <groupId>io.swagger</groupId>
      <artifactId>swagger-codegen-generators</artifactId>
      <version>1.0.0-SNAPSHOT</version>
      <exclusions>
        <exclusion>
          <groupId>com.google.guava</groupId>
          <artifactId>guava</artifactId>
        </exclusion>
        <!-- ... + additional exclusions, depending on the use case -->
      </exclusions>
    </dependency>