### PR TITLE
Check date value before calling to_iso8601

### DIFF
--- a/modules/swagger-codegen/src/main/resources/elixir/deserializer.ex.mustache
+++ b/modules/swagger-codegen/src/main/resources/elixir/deserializer.ex.mustache
@@ -24,7 +24,7 @@ defmodule {{moduleName}}.Deserializer do
     value = Map.get(model, field)
     case is_binary(value) do
       true -> case DateTime.from_iso8601(value) do
-                {:ok, datetime} ->
+                {:ok, datetime, _offset} ->
                   Map.put(model, field, datetime)
                 _ ->
                   model

--- a/modules/swagger-codegen/src/main/resources/elixir/deserializer.ex.mustache
+++ b/modules/swagger-codegen/src/main/resources/elixir/deserializer.ex.mustache
@@ -21,11 +21,15 @@ defmodule {{moduleName}}.Deserializer do
     |> Map.update!(field, &(Map.new(&1, fn {key, val} -> {key, Poison.Decode.decode(val, Keyword.merge(options, [as: struct(mod)]))} end)))
   end
   def deserialize(model, field, :date, _, _options) do
-    case DateTime.from_iso8601(Map.get(model, field)) do
-      {:ok, datetime} ->
-        Map.put(model, field, datetime)
-      _ ->
-        model
+    value = Map.get(model, field)
+    case is_binary(value) do
+      true -> case DateTime.from_iso8601(value) do
+                {:ok, datetime} ->
+                  Map.put(model, field, datetime)
+                _ ->
+                  model
+              end
+      false -> model
     end
   end
 end


### PR DESCRIPTION
When deserializing a date value the value has to be a string when calling to_iso8601. Otherwise it fails with a match error due to a is_binary() guard.