### PR TITLE
[PHP] Fix code example from README. Variable name was missing when using Basic auth.

### DIFF
--- a/modules/swagger-codegen/src/main/resources/php/README.mustache
+++ b/modules/swagger-codegen/src/main/resources/php/README.mustache
@@ -68,6 +68,7 @@ Please follow the [installation procedure](#installation--usage) and then run th
 require_once(__DIR__ . '/vendor/autoload.php');
 {{#apiInfo}}{{#apis}}{{#-first}}{{#operations}}{{#operation}}{{#-first}}{{#hasAuthMethods}}{{#authMethods}}{{#isBasic}}
 // Configure HTTP basic authorization: {{{name}}}
+$config = {{{invokerPackage}}}\Configuration::getDefaultConfiguration()
     ->setUsername('YOUR_USERNAME')
     ->setPassword('YOUR_PASSWORD');{{/isBasic}}{{#isApiKey}}
 // Configure API key authorization: {{{name}}}


### PR DESCRIPTION
Fix code example from README. Variable name was missing when using Basic auth.

### PR checklist

- [x] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [x] Filed the PR against the correct branch: `3.0.0` branch for changes related to OpenAPI spec 3.0. Default: `master`.
- [x] Copied the [technical committee](https://github.com/swagger-api/swagger-codegen/#swagger-codegen-technical-committee) to review the pull request if your PR is targeting a particular programming language.

@jebentier (2017/07) @dkarlovi (2017/07) @mandrean (2017/08) @jfastnacht (2017/09) @ackintosh (2017/09)

### Description of the PR

In the previous change (link in the description) $config variable was accidentally removed. So the generated README file had incorrect code example when using basic auth.
https://github.com/swagger-api/swagger-codegen/commit/9ca9887de471fb82488592298e5e3e544f278aa7#diff-48c9b5ad08e2cc9e563b3ac9da839117

I have restored variable name and checked the code example after generation.
