### PR TITLE
[3.0.0] Cleanup work after migration of JaxRS Codegen classes

### DIFF
--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/AbstractJavaJAXRSServerCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/AbstractJavaJAXRSServerCodegen.java
@@ -24,6 +24,11 @@ import java.util.Map;
 
 import static io.swagger.codegen.languages.helpers.ExtensionHelper.getBooleanValue;
 
+/**
+ * new version of this class can be found on: https://github.com/swagger-api/swagger-codegen-generators
+ * @deprecated use <code>io.swagger.codegen.languages.java.AbstractJavaJAXRSServerCodegen</code> instead.
+ */
+@Deprecated
 public abstract class AbstractJavaJAXRSServerCodegen extends AbstractJavaCodegen implements BeanValidationFeatures {
     /**
      * Name of the sub-directory in "src/main/resource" where to find the

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/JavaCXFServerCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/JavaCXFServerCodegen.java
@@ -18,6 +18,11 @@ import io.swagger.codegen.languages.features.GzipTestFeatures;
 import io.swagger.codegen.languages.features.LoggingTestFeatures;
 import io.swagger.codegen.languages.features.UseGenericResponseFeatures;
 
+/**
+ * new version of this class can be found on: https://github.com/swagger-api/swagger-codegen-generators
+ * @deprecated use <code>io.swagger.codegen.languages.java.JavaCXFServerCodegen</code> instead.
+ */
+@Deprecated
 public class JavaCXFServerCodegen extends AbstractJavaJAXRSServerCodegen
         implements CXFServerFeatures, GzipTestFeatures, LoggingTestFeatures, UseGenericResponseFeatures
 {

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/JavaJAXRSCXFCDIServerCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/JavaJAXRSCXFCDIServerCodegen.java
@@ -14,7 +14,11 @@ import java.io.File;
  * Similar to the original JAXRS generator, this creates API and Service classes
  * in /src/gen/java and a sample ServiceImpl in /src/main/java. The API uses CDI
  * to get an instance of ServiceImpl that implements the Service interface.
+ * 
+ * new version of this class can be found on: https://github.com/swagger-api/swagger-codegen-generators
+ * @deprecated use <code>io.swagger.codegen.languages.java.JavaJAXRSCXFCDIServerCodegen</code> instead.
  */
+@Deprecated
 public class JavaJAXRSCXFCDIServerCodegen extends JavaJAXRSSpecServerCodegen implements BeanValidationFeatures {
     
     protected boolean useBeanValidation = true;

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/JavaJAXRSSpecServerCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/JavaJAXRSSpecServerCodegen.java
@@ -19,6 +19,11 @@ import io.swagger.codegen.CodegenProperty;
 import io.swagger.codegen.SupportingFile;
 import io.swagger.v3.core.util.Json;
 
+/**
+ * new version of this class can be found on: https://github.com/swagger-api/swagger-codegen-generators
+ * @deprecated use <code>io.swagger.codegen.languages.java.JavaJAXRSSpecServerCodegen</code> instead.
+ */
+@Deprecated
 public class JavaJAXRSSpecServerCodegen extends AbstractJavaJAXRSServerCodegen
 {
 

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/JavaJerseyServerCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/JavaJerseyServerCodegen.java
@@ -16,6 +16,11 @@ import static io.swagger.codegen.CodegenConstants.HAS_ENUMS_EXT_NAME;
 import static io.swagger.codegen.CodegenConstants.IS_ENUM_EXT_NAME;
 import static io.swagger.codegen.languages.helpers.ExtensionHelper.getBooleanValue;
 
+/**
+ * new version of this class can be found on: https://github.com/swagger-api/swagger-codegen-generators
+ * @deprecated use <code>io.swagger.codegen.languages.java.JavaJerseyServerCodegen</code> instead.
+ */
+@Deprecated
 public class JavaJerseyServerCodegen extends AbstractJavaJAXRSServerCodegen {
 
     protected static final String LIBRARY_JERSEY1 = "jersey1";

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/JavaResteasyEapServerCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/JavaResteasyEapServerCodegen.java
@@ -22,6 +22,11 @@ import static io.swagger.codegen.CodegenConstants.HAS_ENUMS_EXT_NAME;
 import static io.swagger.codegen.CodegenConstants.IS_ENUM_EXT_NAME;
 import static io.swagger.codegen.languages.helpers.ExtensionHelper.getBooleanValue;
 
+/**
+ * new version of this class can be found on: https://github.com/swagger-api/swagger-codegen-generators
+ * @deprecated use <code>io.swagger.codegen.languages.java.JavaResteasyEapServerCodegen</code> instead.
+ */
+@Deprecated
 public class JavaResteasyEapServerCodegen extends AbstractJavaJAXRSServerCodegen
         implements JbossFeature, BeanValidationFeatures, SwaggerFeatures {
 

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/JavaResteasyServerCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/JavaResteasyServerCodegen.java
@@ -19,6 +19,11 @@ import static io.swagger.codegen.CodegenConstants.HAS_ENUMS_EXT_NAME;
 import static io.swagger.codegen.CodegenConstants.IS_ENUM_EXT_NAME;
 import static io.swagger.codegen.languages.helpers.ExtensionHelper.getBooleanValue;
 
+/**
+ * new version of this class can be found on: https://github.com/swagger-api/swagger-codegen-generators
+ * @deprecated use <code>io.swagger.codegen.languages.java.JavaResteasyServerCodegen</code> instead.
+ */
+@Deprecated
 public class JavaResteasyServerCodegen extends AbstractJavaJAXRSServerCodegen implements JbossFeature {
 
     protected boolean generateJbossDeploymentDescriptor = true;


### PR DESCRIPTION
Now that JaxRS Codegen classes were migrated to `swagger-codegen-generators` (see https://github.com/swagger-api/swagger-codegen-generators/pull/29), some [cleanup tasks](https://github.com/swagger-api/swagger-codegen/wiki/Swagger-Codegen-migration-(swagger-codegen-generators-repository)#cleanup-work-in-the-swagger-codegen-repository) are requested in this repository:

* Add `@deprecated` on the old classes (incl. Javadoc comment)

---

Additional steps are requested, but I propose to delay them in order to keep the CI Build running.

* Update the `bin/*.sh` and `bin/windows/*.bat` scripts
* Run all the `bin/jaxrs-*.sh` to update the examples.

When I have updated the examples, I have noticed some errors (`HandlebarsException` ...). I will raise issues and propose fixes in the `swagger-codegen-generators` project. Then the samples can be generated again.

This part is work in progress on a separated branch: [patch-9](https://github.com/jmini/swagger-codegen/tree/patch-9)