### PR TITLE
added async_req parameter (default to True) to ApiClient constructor

### DIFF
--- a/modules/swagger-codegen/src/main/resources/python/api_client.mustache
+++ b/modules/swagger-codegen/src/main/resources/python/api_client.mustache
@@ -40,6 +40,7 @@ class ApiClient(object):
         the API.
     :param cookie: a cookie to include in the header when making calls
         to the API
+    :param async_req: use either synchronous or asynchronous requests
     """
 
     PRIMITIVE_TYPES = (float, bool, bytes, six.text_type) + six.integer_types
@@ -55,12 +56,14 @@ class ApiClient(object):
     }
 
     def __init__(self, configuration=None, header_name=None, header_value=None,
-                 cookie=None):
+                 cookie=None, async_req=True):
         if configuration is None:
             configuration = Configuration()
         self.configuration = configuration
 
-        self.pool = ThreadPool()
+        self.async_req = async_req
+        if async_req:
+            self.pool = ThreadPool()
         self.rest_client = rest.RESTClientObject(configuration)
         self.default_headers = {}
         if header_name is not None:
@@ -70,8 +73,9 @@ class ApiClient(object):
         self.user_agent = '{{#httpUserAgent}}{{{.}}}{{/httpUserAgent}}{{^httpUserAgent}}Swagger-Codegen/{{{packageVersion}}}/python{{/httpUserAgent}}'
 
     def __del__(self):
-        self.pool.close()
-        self.pool.join()
+        if self.async_req:
+            self.pool.close()
+            self.pool.join()
 
     @property
     def user_agent(self):
@@ -319,7 +323,7 @@ class ApiClient(object):
             If parameter async is False or missing,
             then the method will return the response directly.
         """
-        if not async:
+        if not async or not self.async_req:
             return self.__call_api(resource_path, method,
                                    path_params, query_params, header_params,
                                    body, post_params, files,

--- a/samples/client/petstore/python/docs/EnumTest.md
+++ b/samples/client/petstore/python/docs/EnumTest.md
@@ -4,6 +4,7 @@
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **enum_string** | **str** |  | [optional] 
+**enum_string_required** | **str** |  | 
 **enum_integer** | **int** |  | [optional] 
 **enum_number** | **float** |  | [optional] 
 **outer_enum** | [**OuterEnum**](OuterEnum.md) |  | [optional] 

--- a/samples/client/petstore/python/petstore_api/models/enum_test.py
+++ b/samples/client/petstore/python/petstore_api/models/enum_test.py
@@ -34,6 +34,7 @@ class EnumTest(object):
     """
     swagger_types = {
         'enum_string': 'str',
+        'enum_string_required': 'str',
         'enum_integer': 'int',
         'enum_number': 'float',
         'outer_enum': 'OuterEnum'
@@ -41,15 +42,17 @@ class EnumTest(object):
 
     attribute_map = {
         'enum_string': 'enum_string',
+        'enum_string_required': 'enum_string_required',
         'enum_integer': 'enum_integer',
         'enum_number': 'enum_number',
         'outer_enum': 'outerEnum'
     }
 
-    def __init__(self, enum_string=None, enum_integer=None, enum_number=None, outer_enum=None):  # noqa: E501
+    def __init__(self, enum_string=None, enum_string_required=None, enum_integer=None, enum_number=None, outer_enum=None):  # noqa: E501
         """EnumTest - a model defined in Swagger"""  # noqa: E501
 
         self._enum_string = None
+        self._enum_string_required = None
         self._enum_integer = None
         self._enum_number = None
         self._outer_enum = None
@@ -57,6 +60,7 @@ class EnumTest(object):
 
         if enum_string is not None:
             self.enum_string = enum_string
+        self.enum_string_required = enum_string_required
         if enum_integer is not None:
             self.enum_integer = enum_integer
         if enum_number is not None:
@@ -90,6 +94,35 @@ class EnumTest(object):
             )
 
         self._enum_string = enum_string
+
+    @property
+    def enum_string_required(self):
+        """Gets the enum_string_required of this EnumTest.  # noqa: E501
+
+
+        :return: The enum_string_required of this EnumTest.  # noqa: E501
+        :rtype: str
+        """
+        return self._enum_string_required
+
+    @enum_string_required.setter
+    def enum_string_required(self, enum_string_required):
+        """Sets the enum_string_required of this EnumTest.
+
+
+        :param enum_string_required: The enum_string_required of this EnumTest.  # noqa: E501
+        :type: str
+        """
+        if enum_string_required is None:
+            raise ValueError("Invalid value for `enum_string_required`, must not be `None`")  # noqa: E501
+        allowed_values = ["UPPER", "lower", ""]  # noqa: E501
+        if enum_string_required not in allowed_values:
+            raise ValueError(
+                "Invalid value for `enum_string_required` ({0}), must be one of {1}"  # noqa: E501
+                .format(enum_string_required, allowed_values)
+            )
+
+        self._enum_string_required = enum_string_required
 
     @property
     def enum_integer(self):


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [x] Filed the PR against the correct branch: `3.0.0` branch for changes related to OpenAPI spec 3.0. Default: `master`.
- [ ] Copied the [technical committee](https://github.com/swagger-api/swagger-codegen/#swagger-codegen-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

This is to resolve the issue described in https://github.com/kubernetes-client/python/issues/471.
From my PR https://github.com/kubernetes-client/python/pull/473, it was suggested that I should open a PR here instead.