### PR TITLE
Issue 7638

### DIFF
--- a/modules/swagger-codegen-cli/src/main/java/io/swagger/codegen/cmd/Generate.java
+++ b/modules/swagger-codegen-cli/src/main/java/io/swagger/codegen/cmd/Generate.java
@@ -172,6 +172,10 @@ public class Generate implements Runnable {
             description = CodegenConstants.REMOVE_OPERATION_ID_PREFIX_DESC)
     private Boolean removeOperationIdPrefix;
 
+    @Option(name = {"--boolean-getter-prefix"}, title = "overwrite the boolean getter prefix",
+            description = CodegenConstants.BOOLEAN_GETTER_PREFIX_DESC)
+    private String booleanGetterPrefix;
+
     @Override
     public void run() {
 
@@ -271,6 +275,10 @@ public class Generate implements Runnable {
 
         if (removeOperationIdPrefix != null) {
             configurator.setRemoveOperationIdPrefix(removeOperationIdPrefix);
+        }
+
+        if (booleanGetterPrefix != null) {
+            configurator.setBooleanGetterPrefix(booleanGetterPrefix);
         }
 
         applySystemPropertiesKvpList(systemProperties, configurator);

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/CodegenConfig.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/CodegenConfig.java
@@ -87,6 +87,10 @@ public interface CodegenConfig {
 
     void setOutputDir(String dir);
 
+    String getBooleanGetterPrefix();
+
+    void setBooleanGetterPrefix(String prefix);
+
     CodegenModel fromModel(String name, Model model);
 
     CodegenModel fromModel(String name, Model model, Map<String, Model> allDefinitions);

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/CodegenConstants.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/CodegenConstants.java
@@ -226,6 +226,9 @@ public class CodegenConstants {
     public static final String REMOVE_OPERATION_ID_PREFIX = "removeOperationIdPrefix";
     public static final String REMOVE_OPERATION_ID_PREFIX_DESC = "Remove prefix of operationId, e.g. config_getId => getId";
 
+    public static final String BOOLEAN_GETTER_PREFIX = "booleanGetterPrefix";
+    public static final String BOOLEAN_GETTER_PREFIX_DESC = "overwrite the boolean getter prefix";
+
     public static final String STRIP_PACKAGE_NAME = "stripPackageName";
     public static final String STRIP_PACKAGE_NAME_DESC = "Whether to strip leading dot-separated packages from generated model classes";
 }

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/DefaultCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/DefaultCodegen.java
@@ -92,6 +92,7 @@ public class DefaultCodegen {
     protected List<CliOption> cliOptions = new ArrayList<CliOption>();
     protected boolean skipOverwrite;
     protected boolean removeOperationIdPrefix;
+    protected String booleanGetterPrefix;
     protected boolean supportsInheritance;
     protected boolean supportsMixins;
     protected Map<String, String> supportedLibraries = new LinkedHashMap<String, String>();
@@ -154,6 +155,11 @@ public class DefaultCodegen {
         if (additionalProperties.containsKey(CodegenConstants.REMOVE_OPERATION_ID_PREFIX)) {
             this.setRemoveOperationIdPrefix(Boolean.valueOf(additionalProperties
                     .get(CodegenConstants.REMOVE_OPERATION_ID_PREFIX).toString()));
+        }
+
+        if (additionalProperties.containsKey(CodegenConstants.BOOLEAN_GETTER_PREFIX)) {
+            this.setRemoveOperationIdPrefix(Boolean.valueOf(additionalProperties
+                    .get(CodegenConstants.BOOLEAN_GETTER_PREFIX).toString()));
         }
     }
 
@@ -1232,7 +1238,9 @@ public class DefaultCodegen {
      * @return getter name based on naming convention
      */
     public String toBooleanGetter(String name) {
-        return "get" + getterAndSetterCapitalize(name);
+        return getBooleanGetterPrefix() == null
+                ? toGetter(name)
+                : getBooleanGetterPrefix() + getterAndSetterCapitalize(name);
     }
 
     /**
@@ -3367,6 +3375,16 @@ public class DefaultCodegen {
 
     public void setRemoveOperationIdPrefix(boolean removeOperationIdPrefix) {
         this.removeOperationIdPrefix = removeOperationIdPrefix;
+    }
+
+    public String getBooleanGetterPrefix() {
+        return booleanGetterPrefix;
+    }
+
+    public void setBooleanGetterPrefix(String prefix) {
+        if (prefix != null) {
+            this.booleanGetterPrefix = prefix;
+        }
     }
 
     /**

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/config/CodegenConfigurator.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/config/CodegenConfigurator.java
@@ -52,6 +52,7 @@ public class CodegenConfigurator implements Serializable {
     private String invokerPackage;
     private String modelNamePrefix;
     private String modelNameSuffix;
+    private String booleanGetterPrefix;
     private String groupId;
     private String artifactId;
     private String artifactVersion;
@@ -132,6 +133,15 @@ public class CodegenConfigurator implements Serializable {
 
     public CodegenConfigurator setModelNameSuffix(String suffix) {
         this.modelNameSuffix = suffix;
+        return this;
+    }
+
+    public String getBooleanGetterPrefix() {
+        return booleanGetterPrefix;
+    }
+
+    public CodegenConfigurator setBooleanGetterPrefix(String booleanGetterPrefix) {
+        this.booleanGetterPrefix = booleanGetterPrefix;
         return this;
     }
 
@@ -394,6 +404,7 @@ public class CodegenConfigurator implements Serializable {
         config.setSkipOverwrite(skipOverwrite);
         config.setIgnoreFilePathOverride(ignoreFileOverride);
         config.setRemoveOperationIdPrefix(removeOperationIdPrefix);
+        config.setBooleanGetterPrefix(booleanGetterPrefix);
 
         config.instantiationTypes().putAll(instantiationTypes);
         config.typeMapping().putAll(typeMappings);

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/AbstractCppCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/AbstractCppCodegen.java
@@ -104,6 +104,7 @@ abstract public class AbstractCppCodegen extends DefaultCodegen implements Codeg
                         "xor",
                         "xor_eq")
         );
+        setBooleanGetterPrefix("is");
     }
 
     @Override
@@ -166,14 +167,5 @@ abstract public class AbstractCppCodegen extends DefaultCodegen implements Codeg
         property.nameInCamelCase = nameInCamelCase;
         return property;
     }
-    
-    /**
-     * Output the Getter name for boolean property, e.g. isActive
-     *
-     * @param name the name of the property
-     * @return getter name based on naming convention
-     */
-    public String toBooleanGetter(String name) {
-        return "is" + getterAndSetterCapitalize(name);
-    }
+
 }

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/AbstractJavaCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/AbstractJavaCodegen.java
@@ -1268,16 +1268,6 @@ public abstract class AbstractJavaCodegen extends DefaultCodegen implements Code
         additionalProperties.put(propertyKey, value);
     }
 
-    /**
-     * Output the partial Getter name for boolean property, e.g. Active
-     *
-     * @param name the name of the property
-     * @return partial getter name based on naming convention
-     */
-    public String toBooleanGetter(String name) {
-        return getterAndSetterCapitalize(name);
-    }
-
     @Override
     public String sanitizeTag(String tag) {
         tag = camelize(underscore(sanitizeName(tag)));

--- a/modules/swagger-codegen/src/main/resources/Java/pojo.mustache
+++ b/modules/swagger-codegen/src/main/resources/Java/pojo.mustache
@@ -125,7 +125,7 @@ public class {{classname}} {{#parent}}extends {{{parent}}} {{/parent}}{{#parcela
 {{#vendorExtensions.extraAnnotation}}
   {{{vendorExtensions.extraAnnotation}}}
 {{/vendorExtensions.extraAnnotation}}
-  public {{{datatypeWithEnum}}} {{#isBoolean}}is{{/isBoolean}}{{getter}}() {
+  public {{{datatypeWithEnum}}} {{getter}}() {
     return {{name}};
   }
   {{^isReadOnly}}

--- a/modules/swagger-codegen/src/main/resources/JavaInflector/pojo.mustache
+++ b/modules/swagger-codegen/src/main/resources/JavaInflector/pojo.mustache
@@ -42,7 +42,7 @@ public class {{classname}} {{#parent}}extends {{{parent}}}{{/parent}} {{#seriali
   {{#vendorExtensions.extraAnnotation}}{{{vendorExtensions.extraAnnotation}}}{{/vendorExtensions.extraAnnotation}}
   @ApiModelProperty({{#example}}example = "{{{example}}}", {{/example}}{{#required}}required = {{required}}, {{/required}}value = "{{{description}}}")
   @JsonProperty("{{baseName}}")
-  public {{{datatypeWithEnum}}} {{#isBoolean}}is{{/isBoolean}}{{getter}}() {
+  public {{{datatypeWithEnum}}} {{getter}}() {
     return {{name}};
   }
   public void {{setter}}({{{datatypeWithEnum}}} {{name}}) {

--- a/modules/swagger-codegen/src/main/resources/JavaJaxRS/cxf-cdi/pojo.mustache
+++ b/modules/swagger-codegen/src/main/resources/JavaJaxRS/cxf-cdi/pojo.mustache
@@ -33,7 +33,7 @@ public class {{classname}} {{#parent}}extends {{{parent}}}{{/parent}} {{#seriali
   {{#vendorExtensions.extraAnnotation}}{{{vendorExtensions.extraAnnotation}}}{{/vendorExtensions.extraAnnotation}}
   @ApiModelProperty({{#example}}example = "{{{example}}}", {{/example}}{{#required}}required = {{required}}, {{/required}}value = "{{{description}}}")
   @JsonProperty("{{baseName}}")
-{{#useBeanValidation}}{{>beanValidation}}{{/useBeanValidation}}  public {{{datatypeWithEnum}}} {{#isBoolean}}is{{/isBoolean}}{{getter}}() {
+{{#useBeanValidation}}{{>beanValidation}}{{/useBeanValidation}}  public {{{datatypeWithEnum}}} {{getter}}() {
     return {{name}};
   }
   public void {{setter}}({{{datatypeWithEnum}}} {{name}}) {

--- a/modules/swagger-codegen/src/main/resources/JavaJaxRS/cxf/pojo.mustache
+++ b/modules/swagger-codegen/src/main/resources/JavaJaxRS/cxf/pojo.mustache
@@ -64,16 +64,16 @@ public class {{classname}} {{#parent}}extends {{{parent}}}{{/parent}} {
 {{#vendorExtensions.extraAnnotation}}
   {{{vendorExtensions.extraAnnotation}}}
 {{/vendorExtensions.extraAnnotation}}
-{{#useBeanValidation}}{{>beanValidation}}{{/useBeanValidation}}  {{#isEnum}}{{^isListContainer}}{{^isMapContainer}}public {{datatype}} {{#isBoolean}}is{{/isBoolean}}{{getter}}() {
+{{#useBeanValidation}}{{>beanValidation}}{{/useBeanValidation}}  {{#isEnum}}{{^isListContainer}}{{^isMapContainer}}public {{datatype}} {{getter}}() {
     if ({{name}} == null) {
       return null;
     }
     return {{name}}.value();
-  }{{/isMapContainer}}{{/isListContainer}}{{/isEnum}}{{#isEnum}}{{#isListContainer}}public {{{datatypeWithEnum}}} {{#isBoolean}}is{{/isBoolean}}{{getter}}() {
+  }{{/isMapContainer}}{{/isListContainer}}{{/isEnum}}{{#isEnum}}{{#isListContainer}}public {{{datatypeWithEnum}}} {{getter}}() {
     return {{name}};
-  }{{/isListContainer}}{{/isEnum}}{{#isEnum}}{{#isMapContainer}}public {{{datatypeWithEnum}}} {{#isBoolean}}is{{/isBoolean}}{{getter}}() {
+  }{{/isListContainer}}{{/isEnum}}{{#isEnum}}{{#isMapContainer}}public {{{datatypeWithEnum}}} {{getter}}() {
     return {{name}};
-  }{{/isMapContainer}}{{/isEnum}}{{^isEnum}}public {{{datatypeWithEnum}}} {{#isBoolean}}is{{/isBoolean}}{{getter}}() {
+  }{{/isMapContainer}}{{/isEnum}}{{^isEnum}}public {{{datatypeWithEnum}}} {{getter}}() {
     return {{name}};
   }{{/isEnum}}
 

--- a/modules/swagger-codegen/src/main/resources/JavaJaxRS/pojo.mustache
+++ b/modules/swagger-codegen/src/main/resources/JavaJaxRS/pojo.mustache
@@ -85,7 +85,7 @@ public class {{classname}} {{#parent}}extends {{{parent}}}{{/parent}} {{#seriali
   @JsonProperty("{{baseName}}")
   {{/jackson}}
   @ApiModelProperty({{#example}}example = "{{{example}}}", {{/example}}{{#required}}required = {{required}}, {{/required}}value = "{{{description}}}")
-{{#useBeanValidation}}{{>beanValidation}}{{/useBeanValidation}}  public {{{datatypeWithEnum}}} {{#isBoolean}}is{{/isBoolean}}{{getter}}() {
+{{#useBeanValidation}}{{>beanValidation}}{{/useBeanValidation}}  public {{{datatypeWithEnum}}} {{getter}}() {
     return {{name}};
   }
   {{^isReadOnly}}

--- a/modules/swagger-codegen/src/main/resources/JavaJaxRS/resteasy/eap/pojo.mustache
+++ b/modules/swagger-codegen/src/main/resources/JavaJaxRS/resteasy/eap/pojo.mustache
@@ -28,7 +28,7 @@ public class {{classname}} {{#parent}}extends {{{parent}}}{{/parent}} {{#seriali
   {{#vendorExtensions.extraAnnotation}}{{{vendorExtensions.extraAnnotation}}}{{/vendorExtensions.extraAnnotation}}
   @ApiModelProperty({{#example}}example = "{{{example}}}", {{/example}}{{#required}}required = {{required}}, {{/required}}value = "{{{description}}}")
   @JsonProperty("{{baseName}}")
-{{#useBeanValidation}}{{>beanValidation}}{{/useBeanValidation}}  public {{{datatypeWithEnum}}} {{#isBoolean}}is{{/isBoolean}}{{getter}}() {
+{{#useBeanValidation}}{{>beanValidation}}{{/useBeanValidation}}  public {{{datatypeWithEnum}}} {{getter}}() {
     return {{name}};
   }
   public void {{setter}}({{{datatypeWithEnum}}} {{name}}) {

--- a/modules/swagger-codegen/src/main/resources/JavaJaxRS/resteasy/pojo.mustache
+++ b/modules/swagger-codegen/src/main/resources/JavaJaxRS/resteasy/pojo.mustache
@@ -28,7 +28,7 @@ public class {{classname}} {{#parent}}extends {{{parent}}}{{/parent}} {{#seriali
   {{#vendorExtensions.extraAnnotation}}{{{vendorExtensions.extraAnnotation}}}{{/vendorExtensions.extraAnnotation}}
   @ApiModelProperty({{#example}}example = "{{{example}}}", {{/example}}{{#required}}required = {{required}}, {{/required}}value = "{{{description}}}")
   @JsonProperty("{{baseName}}")
-{{#useBeanValidation}}{{>beanValidation}}{{/useBeanValidation}}  public {{{datatypeWithEnum}}} {{#isBoolean}}is{{/isBoolean}}{{getter}}() {
+{{#useBeanValidation}}{{>beanValidation}}{{/useBeanValidation}}  public {{{datatypeWithEnum}}} {{getter}}() {
     return {{name}};
   }
   public void {{setter}}({{{datatypeWithEnum}}} {{name}}) {

--- a/modules/swagger-codegen/src/main/resources/JavaJaxRS/spec/pojo.mustache
+++ b/modules/swagger-codegen/src/main/resources/JavaJaxRS/spec/pojo.mustache
@@ -31,7 +31,7 @@ public class {{classname}} {{#parent}}extends {{{parent}}}{{/parent}} {{#seriali
   {{#vendorExtensions.extraAnnotation}}{{{vendorExtensions.extraAnnotation}}}{{/vendorExtensions.extraAnnotation}}
   @ApiModelProperty({{#example}}example = "{{{example}}}", {{/example}}{{#required}}required = {{required}}, {{/required}}value = "{{{description}}}")
   @JsonProperty("{{baseName}}")
-{{#useBeanValidation}}{{>beanValidation}}{{/useBeanValidation}}  public {{{datatypeWithEnum}}} {{#isBoolean}}is{{/isBoolean}}{{getter}}() {
+{{#useBeanValidation}}{{>beanValidation}}{{/useBeanValidation}}  public {{{datatypeWithEnum}}} {{getter}}() {
     return {{name}};
   }
   public void {{setter}}({{{datatypeWithEnum}}} {{name}}) {

--- a/modules/swagger-codegen/src/main/resources/JavaPlayFramework/pojo.mustache
+++ b/modules/swagger-codegen/src/main/resources/JavaPlayFramework/pojo.mustache
@@ -83,7 +83,7 @@ public class {{classname}} {{#parent}}extends {{{parent}}}{{/parent}} {{#seriali
  {{#vendorExtensions.extraAnnotation}}
   {{{vendorExtensions.extraAnnotation}}}
   {{/vendorExtensions.extraAnnotation}}
-  {{#useBeanValidation}}{{>beanValidation}}{{/useBeanValidation}}  public {{{datatypeWithEnum}}} {{#isBoolean}}is{{/isBoolean}}{{getter}}() {
+  {{#useBeanValidation}}{{>beanValidation}}{{/useBeanValidation}}  public {{{datatypeWithEnum}}} {{getter}}() {
     return {{name}};
   }
 

--- a/modules/swagger-codegen/src/main/resources/JavaSpring/pojo.mustache
+++ b/modules/swagger-codegen/src/main/resources/JavaSpring/pojo.mustache
@@ -87,7 +87,7 @@ public class {{classname}} {{#parent}}extends {{{parent}}}{{/parent}} {{#seriali
   {{{vendorExtensions.extraAnnotation}}}
   {{/vendorExtensions.extraAnnotation}}
   @ApiModelProperty({{#example}}example = "{{{example}}}", {{/example}}{{#required}}required = {{required}}, {{/required}}{{#isReadOnly}}readOnly = {{{isReadOnly}}}, {{/isReadOnly}}value = "{{{description}}}")
-{{#useBeanValidation}}{{>beanValidation}}{{/useBeanValidation}}  public {{{datatypeWithEnum}}} {{#isBoolean}}is{{/isBoolean}}{{getter}}() {
+{{#useBeanValidation}}{{>beanValidation}}{{/useBeanValidation}}  public {{{datatypeWithEnum}}} {{getter}}() {
     return {{name}};
   }
 

--- a/modules/swagger-codegen/src/main/resources/JavaVertXServer/pojo.mustache
+++ b/modules/swagger-codegen/src/main/resources/JavaVertXServer/pojo.mustache
@@ -20,7 +20,7 @@ public class {{classname}} {{#parent}}extends {{{parent}}}{{/parent}} {{#seriali
   {{#vars}}
     {{#vendorExtensions.extraAnnotation}}{{vendorExtensions.extraAnnotation}}{{/vendorExtensions.extraAnnotation}}
   @JsonProperty("{{baseName}}")
-  public {{{datatypeWithEnum}}} {{#isBoolean}}is{{/isBoolean}}{{getter}}() {
+  public {{{datatypeWithEnum}}} {{getter}}() {
     return {{name}};
   }
   public void {{setter}}({{{datatypeWithEnum}}} {{name}}) {

--- a/modules/swagger-codegen/src/main/resources/MSF4J/pojo.mustache
+++ b/modules/swagger-codegen/src/main/resources/MSF4J/pojo.mustache
@@ -82,7 +82,7 @@ public class {{classname}} {{#parent}}extends {{{parent}}}{{/parent}} {{#seriali
   {{{vendorExtensions.extraAnnotation}}}
   {{/vendorExtensions.extraAnnotation}}
   @ApiModelProperty({{#example}}example = "{{{example}}}", {{/example}}{{#required}}required = {{required}}, {{/required}}value = "{{{description}}}")
-  public {{{datatypeWithEnum}}} {{#isBoolean}}is{{/isBoolean}}{{getter}}() {
+  public {{{datatypeWithEnum}}} {{getter}}() {
     return {{name}};
   }
   {{^isReadOnly}}

--- a/modules/swagger-codegen/src/main/resources/java-pkmst/pojo.mustache
+++ b/modules/swagger-codegen/src/main/resources/java-pkmst/pojo.mustache
@@ -87,7 +87,7 @@ public class {{classname}} {{#parent}}extends {{{parent}}}{{/parent}} {{#seriali
   {{{vendorExtensions.extraAnnotation}}}
   {{/vendorExtensions.extraAnnotation}}
   @ApiModelProperty({{#example}}example = "{{{example}}}", {{/example}}{{#required}}required = {{required}}, {{/required}}{{#isReadOnly}}readOnly = {{{isReadOnly}}}, {{/isReadOnly}}value = "{{{description}}}")
-{{#useBeanValidation}}{{>beanValidation}}{{/useBeanValidation}}  public {{{datatypeWithEnum}}} {{#isBoolean}}is{{/isBoolean}}{{getter}}() {
+{{#useBeanValidation}}{{>beanValidation}}{{/useBeanValidation}}  public {{{datatypeWithEnum}}} {{getter}}() {
     return {{name}};
   }
 

--- a/modules/swagger-codegen/src/main/resources/undertow/pojo.mustache
+++ b/modules/swagger-codegen/src/main/resources/undertow/pojo.mustache
@@ -22,7 +22,7 @@ public class {{classname}} {{#parent}}extends {{{parent}}}{{/parent}} {{#seriali
   {{#vendorExtensions.extraAnnotation}}{{{vendorExtensions.extraAnnotation}}}{{/vendorExtensions.extraAnnotation}}
   @ApiModelProperty({{#example}}example = "{{{example}}}", {{/example}}{{#required}}required = {{required}}, {{/required}}value = "{{{description}}}")
   @JsonProperty("{{baseName}}")
-  public {{{datatypeWithEnum}}} {{#isBoolean}}is{{/isBoolean}}{{getter}}() {
+  public {{{datatypeWithEnum}}} {{getter}}() {
     return {{name}};
   }
   public void {{setter}}({{{datatypeWithEnum}}} {{name}}) {

--- a/modules/swagger-codegen/src/test/java/io/swagger/codegen/java/JavaModelTest.java
+++ b/modules/swagger-codegen/src/test/java/io/swagger/codegen/java/JavaModelTest.java
@@ -715,7 +715,23 @@ public class JavaModelTest {
         Assert.assertEquals(cp.baseType, "Boolean");
         Assert.assertTrue(cp.isNotContainer);
         Assert.assertTrue(cp.isBoolean);
-        Assert.assertEquals(cp.getter, "Property");
+        Assert.assertEquals(cp.getter, "getProperty");
+    }
+
+    @Test(description = "choose a custom boolean prefix, where default is 'get'")
+    public void booleanParameterWithCustomBooleanPrefixTest() {
+        final BooleanProperty property = new BooleanProperty();
+        final DefaultCodegen codegen = new JavaClientCodegen();
+        codegen.setBooleanGetterPrefix("is");
+        final CodegenProperty cp = codegen.fromProperty("property", property);
+
+        Assert.assertEquals(cp.baseName, "property");
+        Assert.assertEquals(cp.datatype, "Boolean");
+        Assert.assertEquals(cp.name, "property");
+        Assert.assertEquals(cp.baseType, "Boolean");
+        Assert.assertTrue(cp.isNotContainer);
+        Assert.assertTrue(cp.isBoolean);
+        Assert.assertEquals(cp.getter, "isProperty");
     }
 
 }

--- a/samples/client/petstore/java/feign/src/main/java/io/swagger/client/model/Cat.java
+++ b/samples/client/petstore/java/feign/src/main/java/io/swagger/client/model/Cat.java
@@ -40,7 +40,7 @@ public class Cat extends Animal {
    * @return declawed
   **/
   @ApiModelProperty(value = "")
-  public Boolean isDeclawed() {
+  public Boolean getDeclawed() {
     return declawed;
   }
 

--- a/samples/client/petstore/java/feign/src/main/java/io/swagger/client/model/Order.java
+++ b/samples/client/petstore/java/feign/src/main/java/io/swagger/client/model/Order.java
@@ -182,7 +182,7 @@ public class Order {
    * @return complete
   **/
   @ApiModelProperty(value = "")
-  public Boolean isComplete() {
+  public Boolean getComplete() {
     return complete;
   }
 

--- a/samples/client/petstore/java/google-api-client/src/main/java/io/swagger/client/model/Cat.java
+++ b/samples/client/petstore/java/google-api-client/src/main/java/io/swagger/client/model/Cat.java
@@ -40,7 +40,7 @@ public class Cat extends Animal {
    * @return declawed
   **/
   @ApiModelProperty(value = "")
-  public Boolean isDeclawed() {
+  public Boolean getDeclawed() {
     return declawed;
   }
 

--- a/samples/client/petstore/java/google-api-client/src/main/java/io/swagger/client/model/Order.java
+++ b/samples/client/petstore/java/google-api-client/src/main/java/io/swagger/client/model/Order.java
@@ -182,7 +182,7 @@ public class Order {
    * @return complete
   **/
   @ApiModelProperty(value = "")
-  public Boolean isComplete() {
+  public Boolean getComplete() {
     return complete;
   }
 

--- a/samples/client/petstore/java/jersey1/src/main/java/io/swagger/client/model/Cat.java
+++ b/samples/client/petstore/java/jersey1/src/main/java/io/swagger/client/model/Cat.java
@@ -40,7 +40,7 @@ public class Cat extends Animal {
    * @return declawed
   **/
   @ApiModelProperty(value = "")
-  public Boolean isDeclawed() {
+  public Boolean getDeclawed() {
     return declawed;
   }
 

--- a/samples/client/petstore/java/jersey1/src/main/java/io/swagger/client/model/Order.java
+++ b/samples/client/petstore/java/jersey1/src/main/java/io/swagger/client/model/Order.java
@@ -182,7 +182,7 @@ public class Order {
    * @return complete
   **/
   @ApiModelProperty(value = "")
-  public Boolean isComplete() {
+  public Boolean getComplete() {
     return complete;
   }
 

--- a/samples/client/petstore/java/jersey2-java6/src/main/java/io/swagger/client/model/Cat.java
+++ b/samples/client/petstore/java/jersey2-java6/src/main/java/io/swagger/client/model/Cat.java
@@ -39,7 +39,7 @@ public class Cat extends Animal {
    * @return declawed
   **/
   @ApiModelProperty(value = "")
-  public Boolean isDeclawed() {
+  public Boolean getDeclawed() {
     return declawed;
   }
 

--- a/samples/client/petstore/java/jersey2-java6/src/main/java/io/swagger/client/model/Order.java
+++ b/samples/client/petstore/java/jersey2-java6/src/main/java/io/swagger/client/model/Order.java
@@ -181,7 +181,7 @@ public class Order {
    * @return complete
   **/
   @ApiModelProperty(value = "")
-  public Boolean isComplete() {
+  public Boolean getComplete() {
     return complete;
   }
 

--- a/samples/client/petstore/java/jersey2-java8/src/main/java/io/swagger/client/model/Cat.java
+++ b/samples/client/petstore/java/jersey2-java8/src/main/java/io/swagger/client/model/Cat.java
@@ -40,7 +40,7 @@ public class Cat extends Animal {
    * @return declawed
   **/
   @ApiModelProperty(value = "")
-  public Boolean isDeclawed() {
+  public Boolean getDeclawed() {
     return declawed;
   }
 

--- a/samples/client/petstore/java/jersey2-java8/src/main/java/io/swagger/client/model/Order.java
+++ b/samples/client/petstore/java/jersey2-java8/src/main/java/io/swagger/client/model/Order.java
@@ -182,7 +182,7 @@ public class Order {
    * @return complete
   **/
   @ApiModelProperty(value = "")
-  public Boolean isComplete() {
+  public Boolean getComplete() {
     return complete;
   }
 

--- a/samples/client/petstore/java/jersey2/src/main/java/io/swagger/client/model/Cat.java
+++ b/samples/client/petstore/java/jersey2/src/main/java/io/swagger/client/model/Cat.java
@@ -40,7 +40,7 @@ public class Cat extends Animal {
    * @return declawed
   **/
   @ApiModelProperty(value = "")
-  public Boolean isDeclawed() {
+  public Boolean getDeclawed() {
     return declawed;
   }
 

--- a/samples/client/petstore/java/jersey2/src/main/java/io/swagger/client/model/Order.java
+++ b/samples/client/petstore/java/jersey2/src/main/java/io/swagger/client/model/Order.java
@@ -182,7 +182,7 @@ public class Order {
    * @return complete
   **/
   @ApiModelProperty(value = "")
-  public Boolean isComplete() {
+  public Boolean getComplete() {
     return complete;
   }
 

--- a/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/io/swagger/client/model/Cat.java
+++ b/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/io/swagger/client/model/Cat.java
@@ -45,7 +45,7 @@ public class Cat extends Animal implements Parcelable {
    * @return declawed
   **/
   @ApiModelProperty(value = "")
-  public Boolean isDeclawed() {
+  public Boolean getDeclawed() {
     return declawed;
   }
 

--- a/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/io/swagger/client/model/Order.java
+++ b/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/io/swagger/client/model/Order.java
@@ -199,7 +199,7 @@ public class Order implements Parcelable {
    * @return complete
   **/
   @ApiModelProperty(value = "")
-  public Boolean isComplete() {
+  public Boolean getComplete() {
     return complete;
   }
 

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/io/swagger/client/model/Cat.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/io/swagger/client/model/Cat.java
@@ -43,7 +43,7 @@ public class Cat extends Animal {
    * @return declawed
   **/
   @ApiModelProperty(value = "")
-  public Boolean isDeclawed() {
+  public Boolean getDeclawed() {
     return declawed;
   }
 

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/io/swagger/client/model/Order.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/io/swagger/client/model/Order.java
@@ -197,7 +197,7 @@ public class Order {
    * @return complete
   **/
   @ApiModelProperty(value = "")
-  public Boolean isComplete() {
+  public Boolean getComplete() {
     return complete;
   }
 

--- a/samples/client/petstore/java/rest-assured/src/main/java/io/swagger/client/model/Cat.java
+++ b/samples/client/petstore/java/rest-assured/src/main/java/io/swagger/client/model/Cat.java
@@ -43,7 +43,7 @@ public class Cat extends Animal {
    * @return declawed
   **/
   @ApiModelProperty(value = "")
-  public Boolean isDeclawed() {
+  public Boolean getDeclawed() {
     return declawed;
   }
 

--- a/samples/client/petstore/java/rest-assured/src/main/java/io/swagger/client/model/Order.java
+++ b/samples/client/petstore/java/rest-assured/src/main/java/io/swagger/client/model/Order.java
@@ -197,7 +197,7 @@ public class Order {
    * @return complete
   **/
   @ApiModelProperty(value = "")
-  public Boolean isComplete() {
+  public Boolean getComplete() {
     return complete;
   }
 

--- a/samples/client/petstore/java/resteasy/src/main/java/io/swagger/client/model/Cat.java
+++ b/samples/client/petstore/java/resteasy/src/main/java/io/swagger/client/model/Cat.java
@@ -40,7 +40,7 @@ public class Cat extends Animal {
    * @return declawed
   **/
   @ApiModelProperty(value = "")
-  public Boolean isDeclawed() {
+  public Boolean getDeclawed() {
     return declawed;
   }
 

--- a/samples/client/petstore/java/resteasy/src/main/java/io/swagger/client/model/Order.java
+++ b/samples/client/petstore/java/resteasy/src/main/java/io/swagger/client/model/Order.java
@@ -182,7 +182,7 @@ public class Order {
    * @return complete
   **/
   @ApiModelProperty(value = "")
-  public Boolean isComplete() {
+  public Boolean getComplete() {
     return complete;
   }
 

--- a/samples/client/petstore/java/resttemplate-withXml/src/main/java/io/swagger/client/model/Cat.java
+++ b/samples/client/petstore/java/resttemplate-withXml/src/main/java/io/swagger/client/model/Cat.java
@@ -47,7 +47,7 @@ public class Cat extends Animal {
    * @return declawed
   **/
   @ApiModelProperty(value = "")
-  public Boolean isDeclawed() {
+  public Boolean getDeclawed() {
     return declawed;
   }
 

--- a/samples/client/petstore/java/resttemplate-withXml/src/main/java/io/swagger/client/model/Order.java
+++ b/samples/client/petstore/java/resttemplate-withXml/src/main/java/io/swagger/client/model/Order.java
@@ -199,7 +199,7 @@ public class Order {
    * @return complete
   **/
   @ApiModelProperty(value = "")
-  public Boolean isComplete() {
+  public Boolean getComplete() {
     return complete;
   }
 

--- a/samples/client/petstore/java/resttemplate/src/main/java/io/swagger/client/model/Cat.java
+++ b/samples/client/petstore/java/resttemplate/src/main/java/io/swagger/client/model/Cat.java
@@ -40,7 +40,7 @@ public class Cat extends Animal {
    * @return declawed
   **/
   @ApiModelProperty(value = "")
-  public Boolean isDeclawed() {
+  public Boolean getDeclawed() {
     return declawed;
   }
 

--- a/samples/client/petstore/java/resttemplate/src/main/java/io/swagger/client/model/Order.java
+++ b/samples/client/petstore/java/resttemplate/src/main/java/io/swagger/client/model/Order.java
@@ -182,7 +182,7 @@ public class Order {
    * @return complete
   **/
   @ApiModelProperty(value = "")
-  public Boolean isComplete() {
+  public Boolean getComplete() {
     return complete;
   }
 

--- a/samples/client/petstore/java/retrofit/src/main/java/io/swagger/client/model/Cat.java
+++ b/samples/client/petstore/java/retrofit/src/main/java/io/swagger/client/model/Cat.java
@@ -43,7 +43,7 @@ public class Cat extends Animal {
    * @return declawed
   **/
   @ApiModelProperty(value = "")
-  public Boolean isDeclawed() {
+  public Boolean getDeclawed() {
     return declawed;
   }
 

--- a/samples/client/petstore/java/retrofit/src/main/java/io/swagger/client/model/Order.java
+++ b/samples/client/petstore/java/retrofit/src/main/java/io/swagger/client/model/Order.java
@@ -197,7 +197,7 @@ public class Order {
    * @return complete
   **/
   @ApiModelProperty(value = "")
-  public Boolean isComplete() {
+  public Boolean getComplete() {
     return complete;
   }
 

--- a/samples/client/petstore/java/retrofit2-play24/src/main/java/io/swagger/client/model/Cat.java
+++ b/samples/client/petstore/java/retrofit2-play24/src/main/java/io/swagger/client/model/Cat.java
@@ -42,7 +42,7 @@ public class Cat extends Animal {
    * @return declawed
   **/
   @ApiModelProperty(value = "")
-  public Boolean isDeclawed() {
+  public Boolean getDeclawed() {
     return declawed;
   }
 

--- a/samples/client/petstore/java/retrofit2-play24/src/main/java/io/swagger/client/model/Order.java
+++ b/samples/client/petstore/java/retrofit2-play24/src/main/java/io/swagger/client/model/Order.java
@@ -185,7 +185,7 @@ public class Order {
    * @return complete
   **/
   @ApiModelProperty(value = "")
-  public Boolean isComplete() {
+  public Boolean getComplete() {
     return complete;
   }
 

--- a/samples/client/petstore/java/retrofit2/src/main/java/io/swagger/client/model/Cat.java
+++ b/samples/client/petstore/java/retrofit2/src/main/java/io/swagger/client/model/Cat.java
@@ -43,7 +43,7 @@ public class Cat extends Animal {
    * @return declawed
   **/
   @ApiModelProperty(value = "")
-  public Boolean isDeclawed() {
+  public Boolean getDeclawed() {
     return declawed;
   }
 

--- a/samples/client/petstore/java/retrofit2/src/main/java/io/swagger/client/model/Order.java
+++ b/samples/client/petstore/java/retrofit2/src/main/java/io/swagger/client/model/Order.java
@@ -197,7 +197,7 @@ public class Order {
    * @return complete
   **/
   @ApiModelProperty(value = "")
-  public Boolean isComplete() {
+  public Boolean getComplete() {
     return complete;
   }
 

--- a/samples/client/petstore/java/retrofit2rx/src/main/java/io/swagger/client/model/Cat.java
+++ b/samples/client/petstore/java/retrofit2rx/src/main/java/io/swagger/client/model/Cat.java
@@ -43,7 +43,7 @@ public class Cat extends Animal {
    * @return declawed
   **/
   @ApiModelProperty(value = "")
-  public Boolean isDeclawed() {
+  public Boolean getDeclawed() {
     return declawed;
   }
 

--- a/samples/client/petstore/java/retrofit2rx/src/main/java/io/swagger/client/model/Order.java
+++ b/samples/client/petstore/java/retrofit2rx/src/main/java/io/swagger/client/model/Order.java
@@ -197,7 +197,7 @@ public class Order {
    * @return complete
   **/
   @ApiModelProperty(value = "")
-  public Boolean isComplete() {
+  public Boolean getComplete() {
     return complete;
   }
 

--- a/samples/client/petstore/java/retrofit2rx2/src/main/java/io/swagger/client/model/Cat.java
+++ b/samples/client/petstore/java/retrofit2rx2/src/main/java/io/swagger/client/model/Cat.java
@@ -43,7 +43,7 @@ public class Cat extends Animal {
    * @return declawed
   **/
   @ApiModelProperty(value = "")
-  public Boolean isDeclawed() {
+  public Boolean getDeclawed() {
     return declawed;
   }
 

--- a/samples/client/petstore/java/retrofit2rx2/src/main/java/io/swagger/client/model/Order.java
+++ b/samples/client/petstore/java/retrofit2rx2/src/main/java/io/swagger/client/model/Order.java
@@ -197,7 +197,7 @@ public class Order {
    * @return complete
   **/
   @ApiModelProperty(value = "")
-  public Boolean isComplete() {
+  public Boolean getComplete() {
     return complete;
   }
 


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [x] Filed the PR against the correct branch: `master`.
- [x] Copied the [technical committee](https://github.com/swagger-api/swagger-codegen/#swagger-codegen-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

As described in Issue 7638 there is now the option to define the getter-prefix for `Boolean`s. For those who favor `isValid` (or maybe `hasValue`) instead of `getValid`. Default is `get`.
Option example: `--boolean-getter-prefix is` or `--boolean-getter-prefix has`

@bbdouglas, @JFCote, @sreeshas, @jfiala, @lukoyanov, @cbornet, @jeff9finger: Please verify

I have have not changed the generation in `AbstractCppCodegen` which is still by default `is`. Same is true for `SymfonyServerCodegen` (PHP). Maybe it would be good to clean up these exceptional cases or keep it like i did in `AbstractCppCodegen` (C++).

Last remark: Note that it would even be better to have `is`-prefix for primitive `boolean` and `get`-prefix for `Boolean` type.