### PR TITLE
Adding qt project generation fix #7784

### DIFF
--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/Qt5CPPGenerator.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/Qt5CPPGenerator.java
@@ -197,6 +197,12 @@ public class Qt5CPPGenerator extends AbstractCppCodegen implements CodegenConfig
             importMapping.put("SWGHttpRequestInputFileElement", "#include \"" + modelNamePrefix + "HttpRequest.h\"");
             additionalProperties().put("prefix", modelNamePrefix);
         }
+
+        if (additionalProperties.containsKey(CodegenConstants.OPTIONAL_PROJECT_FILE)) {
+            setOptionalProjectFileFlag(convertPropertyToBooleanAndWriteBack(CodegenConstants.OPTIONAL_PROJECT_FILE));
+        } else {
+            additionalProperties.put(CodegenConstants.OPTIONAL_PROJECT_FILE, optionalProjectFileFlag);
+        }
     }
 
     /**

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/Qt5CPPGenerator.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/Qt5CPPGenerator.java
@@ -26,6 +26,7 @@ import java.util.Set;
 public class Qt5CPPGenerator extends AbstractCppCodegen implements CodegenConfig {
     public static final String CPP_NAMESPACE = "cppNamespace";
     public static final String CPP_NAMESPACE_DESC = "C++ namespace (convention: name::space::for::api).";
+    public static final String OPTIONAL_PROJECT_FILE_DESC = "Generate client.pri.";
 
     protected final String PREFIX = "SWG";
     protected Set<String> foundationClasses = new HashSet<String>();
@@ -35,6 +36,7 @@ public class Qt5CPPGenerator extends AbstractCppCodegen implements CodegenConfig
     protected Map<String, String> namespaces = new HashMap<String, String>();
     protected Set<String> systemIncludes = new HashSet<String>();
     protected String cppNamespace = "Swagger";
+    protected boolean optionalProjectFileFlag = true;
 
     public Qt5CPPGenerator() {
         super();
@@ -82,6 +84,7 @@ public class Qt5CPPGenerator extends AbstractCppCodegen implements CodegenConfig
 
         // CLI options
         addOption(CPP_NAMESPACE, CPP_NAMESPACE_DESC, this.cppNamespace);
+        addSwitch(CodegenConstants.OPTIONAL_PROJECT_FILE, OPTIONAL_PROJECT_FILE_DESC, this.optionalProjectFileFlag);
 
         /*
          * Additional Properties.  These values can be passed to the templates and
@@ -114,6 +117,9 @@ public class Qt5CPPGenerator extends AbstractCppCodegen implements CodegenConfig
         supportingFiles.add(new SupportingFile("HttpRequest.cpp.mustache", sourceFolder, PREFIX + "HttpRequest.cpp"));
         supportingFiles.add(new SupportingFile("modelFactory.mustache", sourceFolder, PREFIX + "ModelFactory.h"));
         supportingFiles.add(new SupportingFile("object.mustache", sourceFolder, PREFIX + "Object.h"));
+        if (optionalProjectFileFlag) {
+            supportingFiles.add(new SupportingFile("Project.mustache", "", "client.pri"));
+        }
 
         super.typeMapping = new HashMap<String, String>();
 
@@ -159,6 +165,14 @@ public class Qt5CPPGenerator extends AbstractCppCodegen implements CodegenConfig
             option.defaultValue(defaultValue);
         cliOptions.add(option);
     }
+
+    protected void addSwitch(String key, String description, Boolean defaultValue) {
+        CliOption option = CliOption.newBoolean(key, description);
+        if (defaultValue != null)
+           option.defaultValue(defaultValue.toString());
+        cliOptions.add(option);
+    }
+
 
     @Override
     public void processOpts() {
@@ -424,5 +438,9 @@ public class Qt5CPPGenerator extends AbstractCppCodegen implements CodegenConfig
     @Override
     public String escapeUnsafeCharacters(String input) {
         return input.replace("*/", "*_/").replace("/*", "/_*");
+    }
+
+    public void setOptionalProjectFileFlag(boolean flag) {
+        this.optionalProjectFileFlag = flag;
     }
 }

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/Qt5CPPGenerator.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/Qt5CPPGenerator.java
@@ -118,7 +118,7 @@ public class Qt5CPPGenerator extends AbstractCppCodegen implements CodegenConfig
         supportingFiles.add(new SupportingFile("modelFactory.mustache", sourceFolder, PREFIX + "ModelFactory.h"));
         supportingFiles.add(new SupportingFile("object.mustache", sourceFolder, PREFIX + "Object.h"));
         if (optionalProjectFileFlag) {
-            supportingFiles.add(new SupportingFile("Project.mustache", "", "client.pri"));
+            supportingFiles.add(new SupportingFile("Project.mustache", sourceFolder, "client.pri"));
         }
 
         super.typeMapping = new HashMap<String, String>();

--- a/modules/swagger-codegen/src/main/resources/qt5cpp/Project.mustache
+++ b/modules/swagger-codegen/src/main/resources/qt5cpp/Project.mustache
@@ -16,10 +16,10 @@ HEADERS += \
 {{/apis}}
 {{/apiInfo}}
 # Others
-    $${PWD}/SWGHelpers.h \
-    $${PWD}/SWGHttpRequest.h \
-    $${PWD}/SWGModelFactory.h \
-    $${PWD}/SWGObject.h
+    $${PWD}/{{prefix}}Helpers.h \
+    $${PWD}/{{prefix}}HttpRequest.h \
+    $${PWD}/{{prefix}}ModelFactory.h \
+    $${PWD}/{{prefix}}Object.h
 
 SOURCES += \
 # Models
@@ -37,6 +37,6 @@ SOURCES += \
 {{/apis}}
 {{/apiInfo}}
 # Others
-    $${PWD}/SWGHelpers.cpp \
-    $${PWD}/SWGHttpRequest.cpp
+    $${PWD}/{{prefix}}Helpers.cpp \
+    $${PWD}/{{prefix}}HttpRequest.cpp
 

--- a/modules/swagger-codegen/src/main/resources/qt5cpp/Project.mustache
+++ b/modules/swagger-codegen/src/main/resources/qt5cpp/Project.mustache
@@ -1,0 +1,2 @@
+QT += network
+

--- a/modules/swagger-codegen/src/main/resources/qt5cpp/Project.mustache
+++ b/modules/swagger-codegen/src/main/resources/qt5cpp/Project.mustache
@@ -1,2 +1,42 @@
 QT += network
 
+HEADERS += \
+# Models
+{{#models}}
+{{#model}}
+    $${PWD}/{{classname}}.h \
+{{/model}}
+{{/models}}
+# APIs
+{{#apiInfo}}
+{{#apis}}
+{{#operations}}
+    $${PWD}/{{classname}}.h \
+{{/operations}}
+{{/apis}}
+{{/apiInfo}}
+# Others
+    $${PWD}/SWGHelpers.h \
+    $${PWD}/SWGHttpRequest.h \
+    $${PWD}/SWGModelFactory.h \
+    $${PWD}/SWGObject.h
+
+SOURCES += \
+# Models
+{{#models}}
+{{#model}}
+    $${PWD}/{{classname}}.cpp \
+{{/model}}
+{{/models}}
+# APIs
+{{#apiInfo}}
+{{#apis}}
+{{#operations}}
+    $${PWD}/{{classname}}.cpp \
+{{/operations}}
+{{/apis}}
+{{/apiInfo}}
+# Others
+    $${PWD}/SWGHelpers.cpp \
+    $${PWD}/SWGHttpRequest.cpp
+

--- a/modules/swagger-codegen/src/test/java/io/swagger/codegen/options/Qt5CPPOptionsProvider.java
+++ b/modules/swagger-codegen/src/test/java/io/swagger/codegen/options/Qt5CPPOptionsProvider.java
@@ -12,6 +12,7 @@ public class Qt5CPPOptionsProvider implements OptionsProvider {
     public static final String ENSURE_UNIQUE_PARAMS_VALUE = "true";
     public static final String ALLOW_UNICODE_IDENTIFIERS_VALUE = "false";
     public static final String CPP_NAMESPACE_VALUE = "Swagger";
+    public static final String OPTIONAL_PROJECT_FILE_VALUE = "true";
 
 
     @Override
@@ -26,6 +27,7 @@ public class Qt5CPPOptionsProvider implements OptionsProvider {
                 .put(CodegenConstants.ENSURE_UNIQUE_PARAMS, ENSURE_UNIQUE_PARAMS_VALUE)
                 .put(CodegenConstants.ALLOW_UNICODE_IDENTIFIERS, ALLOW_UNICODE_IDENTIFIERS_VALUE)
                 .put(Qt5CPPGenerator.CPP_NAMESPACE, CPP_NAMESPACE_VALUE)
+                .put(CodegenConstants.OPTIONAL_PROJECT_FILE, OPTIONAL_PROJECT_FILE_VALUE)
                 .build();
     }
 

--- a/modules/swagger-codegen/src/test/java/io/swagger/codegen/qtfivecpp/Qt5CPPOptionsTest.java
+++ b/modules/swagger-codegen/src/test/java/io/swagger/codegen/qtfivecpp/Qt5CPPOptionsTest.java
@@ -28,6 +28,8 @@ public class Qt5CPPOptionsTest extends AbstractOptionsTest {
         new Expectations(clientCodegen) {{
             clientCodegen.setSortParamsByRequiredFlag(Boolean.valueOf(Qt5CPPOptionsProvider.SORT_PARAMS_VALUE));
             times = 1;
+            clientCodegen.setOptionalProjectFileFlag(true);
+            times = 1;
         }};
     }
 }

--- a/samples/client/petstore/qt5cpp/PetStore/PetStore.pro
+++ b/samples/client/petstore/qt5cpp/PetStore/PetStore.pro
@@ -16,33 +16,9 @@ CONFIG   += c++11
 
 TEMPLATE = app
 
+include(../client/client.pri)
 
 SOURCES += main.cpp \
-    ../client/SWGCategory.cpp \
-    ../client/SWGHelpers.cpp \
-    ../client/SWGHttpRequest.cpp \
-    ../client/SWGOrder.cpp \
-    ../client/SWGPet.cpp \
-    ../client/SWGPetApi.cpp \
-    ../client/SWGStoreApi.cpp \
-    ../client/SWGTag.cpp \
-    ../client/SWGUser.cpp \
-    ../client/SWGUserApi.cpp \
-    ../client/SWGApiResponse.cpp \
-    PetApiTests.cpp
+	PetApiTests.cpp
 
-HEADERS += \
-    ../client/SWGCategory.h \
-    ../client/SWGHelpers.h \
-    ../client/SWGHttpRequest.h \
-    ../client/SWGObject.h \
-    ../client/SWGOrder.h \
-    ../client/SWGPet.h \
-    ../client/SWGPetApi.h \
-    ../client/SWGStoreApi.h \
-    ../client/SWGTag.h \
-    ../client/SWGUser.h \
-    ../client/SWGUserApi.h \
-    PetApiTests.h \
-    ../client/SWGApiResponse.h \
-    ../client/SWGModelFactory.h
+HEADERS += PetApiTests.h

--- a/samples/client/petstore/qt5cpp/client/SWGHelpers.h
+++ b/samples/client/petstore/qt5cpp/client/SWGHelpers.h
@@ -13,6 +13,7 @@
 #ifndef SWG_HELPERS_H
 #define SWG_HELPERS_H
 
+#include <QJsonObject>
 #include <QJsonValue>
 #include <QList>
 #include <QMap>

--- a/samples/client/petstore/qt5cpp/client/SWGModelFactory.h
+++ b/samples/client/petstore/qt5cpp/client/SWGModelFactory.h
@@ -13,6 +13,7 @@
 #ifndef ModelFactory_H_
 #define ModelFactory_H_
 
+#include "SWGObject.h"
 
 #include "SWGApiResponse.h"
 #include "SWGCategory.h"

--- a/samples/client/petstore/qt5cpp/client/SWGObject.h
+++ b/samples/client/petstore/qt5cpp/client/SWGObject.h
@@ -13,7 +13,7 @@
 #ifndef _SWG_OBJECT_H_
 #define _SWG_OBJECT_H_
 
-#include <QJsonValue>
+#include <QJsonObject>
 
 namespace Swagger {
 

--- a/samples/client/petstore/qt5cpp/client/client.pri
+++ b/samples/client/petstore/qt5cpp/client/client.pri
@@ -1,0 +1,36 @@
+QT += network
+
+HEADERS += \
+# Models
+    $${PWD}/SWGApiResponse.h \
+    $${PWD}/SWGCategory.h \
+    $${PWD}/SWGOrder.h \
+    $${PWD}/SWGPet.h \
+    $${PWD}/SWGTag.h \
+    $${PWD}/SWGUser.h \
+# APIs
+    $${PWD}/SWGPetApi.h \
+    $${PWD}/SWGStoreApi.h \
+    $${PWD}/SWGUserApi.h \
+# Others
+    $${PWD}/SWGHelpers.h \
+    $${PWD}/SWGHttpRequest.h \
+    $${PWD}/SWGModelFactory.h \
+    $${PWD}/SWGObject.h
+
+SOURCES += \
+# Models
+    $${PWD}/SWGApiResponse.cpp \
+    $${PWD}/SWGCategory.cpp \
+    $${PWD}/SWGOrder.cpp \
+    $${PWD}/SWGPet.cpp \
+    $${PWD}/SWGTag.cpp \
+    $${PWD}/SWGUser.cpp \
+# APIs
+    $${PWD}/SWGPetApi.cpp \
+    $${PWD}/SWGStoreApi.cpp \
+    $${PWD}/SWGUserApi.cpp \
+# Others
+    $${PWD}/SWGHelpers.cpp \
+    $${PWD}/SWGHttpRequest.cpp
+


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [x] Filed the PR against the correct branch: `3.0.0` branch for changes related to OpenAPI spec 3.0. Default: `master`.
- [x] Copied the [technical committee](https://github.com/swagger-api/swagger-codegen/#swagger-codegen-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

I would like to fix #7784 by adding `client.pri` generation. This is a work in progress but I open this PR to address some problem I have with its implementation.

For the Pet Store example, the resulting file should look like this:

```
QT += network

HEADERS += \
	$${PWD}/SWGApiResponse.h \
	$${PWD}/SWGCategory.h \
	$${PWD}/SWGHelpers.h \
	$${PWD}/SWGHttpRequest.h \
	$${PWD}/SWGModelFactory.h \
	$${PWD}/SWGObject.h \
	$${PWD}/SWGOrder.h \
	$${PWD}/SWGPet.h \
	$${PWD}/SWGPetApi.h \
	$${PWD}/SWGStoreApi.h \
	$${PWD}/SWGTag.h \
	$${PWD}/SWGUser.h \
	$${PWD}/SWGUserApi.h

SOURCES += \
	$${PWD}/SWGApiResponse.cpp \
	$${PWD}/SWGCategory.cpp \
	$${PWD}/SWGHelpers.cpp \
	$${PWD}/SWGHttpRequest.cpp \
	$${PWD}/SWGOrder.cpp \
	$${PWD}/SWGPet.cpp \
	$${PWD}/SWGPetApi.cpp \
	$${PWD}/SWGStoreApi.cpp \
	$${PWD}/SWGTag.cpp \
	$${PWD}/SWGUser.cpp \
	$${PWD}/SWGUserApi.cpp
```

Here are the tasks to do:

- [x] Add `optionalProjectFile` switch to the command line
- [ ] Generate `client.pri`
- [ ] Add test

Ping @ravinikam @stkrwork  @fvarose