### PR TITLE
Remove reading the response body in case of HTTP error

### DIFF
--- a/modules/swagger-codegen/src/main/resources/go/api.mustache
+++ b/modules/swagger-codegen/src/main/resources/go/api.mustache
@@ -209,10 +209,8 @@ func (a *{{{classname}}}Service) {{{nickname}}}(ctx context.Context{{#hasParams}
 	if err != nil || localVarHttpResponse == nil {
 		return {{#returnType}}successPayload, {{/returnType}}localVarHttpResponse, err
 	}
-	defer localVarHttpResponse.Body.Close()
 	if localVarHttpResponse.StatusCode >= 300 {
-		bodyBytes, _ := ioutil.ReadAll(localVarHttpResponse.Body)
-		return {{#returnType}}successPayload, {{/returnType}}localVarHttpResponse, reportError("Status: %v, Body: %s", localVarHttpResponse.Status, bodyBytes)
+		return {{#returnType}}successPayload, {{/returnType}}localVarHttpResponse, reportError("Status: %v", localVarHttpResponse.Status)
 	}
 {{#returnType}}
 	{{#withXml}}

--- a/samples/client/petstore/go/go-petstore/api/swagger.yaml
+++ b/samples/client/petstore/go/go-petstore/api/swagger.yaml
@@ -107,11 +107,11 @@ paths:
         type: "array"
         items:
           type: "string"
+          default: "available"
           enum:
           - "available"
           - "pending"
           - "sold"
-          default: "available"
         collectionFormat: "csv"
         x-exportParamName: "Status"
       responses:
@@ -528,7 +528,7 @@ paths:
       parameters:
       - name: "username"
         in: "path"
-        description: "The name that needs to be fetched. Use user1 for testing. "
+        description: "The name that needs to be fetched. Use user1 for testing."
         required: true
         type: "string"
         x-exportParamName: "Username"
@@ -595,6 +595,7 @@ paths:
       tags:
       - "fake_classname_tags 123#$%^"
       summary: "To test class name in snake case"
+      description: "To test class name in snake case"
       operationId: "testClassname"
       consumes:
       - "application/json"
@@ -634,10 +635,10 @@ paths:
         type: "array"
         items:
           type: "string"
+          default: "$"
           enum:
           - ">"
           - "$"
-          default: "$"
         x-exportParamName: "EnumFormStringArray"
       - name: "enum_form_string"
         in: "formData"
@@ -657,10 +658,10 @@ paths:
         type: "array"
         items:
           type: "string"
+          default: "$"
           enum:
           - ">"
           - "$"
-          default: "$"
         x-exportParamName: "EnumHeaderStringArray"
       - name: "enum_header_string"
         in: "header"
@@ -680,10 +681,10 @@ paths:
         type: "array"
         items:
           type: "string"
+          default: "$"
           enum:
           - ">"
           - "$"
-          default: "$"
         x-exportParamName: "EnumQueryStringArray"
       - name: "enum_query_string"
         in: "query"
@@ -1344,8 +1345,16 @@ definitions:
     default: "-efg"
   Enum_Test:
     type: "object"
+    required:
+    - "enum_string_required"
     properties:
       enum_string:
+        type: "string"
+        enum:
+        - "UPPER"
+        - "lower"
+        - ""
+      enum_string_required:
         type: "string"
         enum:
         - "UPPER"

--- a/samples/client/petstore/go/go-petstore/api_another_fake.go
+++ b/samples/client/petstore/go/go-petstore/api_another_fake.go
@@ -75,10 +75,8 @@ func (a *AnotherFakeApiService) TestSpecialTags(ctx context.Context, body Client
 	if err != nil || localVarHttpResponse == nil {
 		return successPayload, localVarHttpResponse, err
 	}
-	defer localVarHttpResponse.Body.Close()
 	if localVarHttpResponse.StatusCode >= 300 {
-		bodyBytes, _ := ioutil.ReadAll(localVarHttpResponse.Body)
-		return successPayload, localVarHttpResponse, reportError("Status: %v, Body: %s", localVarHttpResponse.Status, bodyBytes)
+		return successPayload, localVarHttpResponse, reportError("Status: %v", localVarHttpResponse.Status)
 	}
 
 	if err = json.NewDecoder(localVarHttpResponse.Body).Decode(&successPayload); err != nil {
@@ -87,3 +85,4 @@ func (a *AnotherFakeApiService) TestSpecialTags(ctx context.Context, body Client
 
 	return successPayload, localVarHttpResponse, err
 }
+

--- a/samples/client/petstore/go/go-petstore/api_fake.go
+++ b/samples/client/petstore/go/go-petstore/api_fake.go
@@ -79,10 +79,8 @@ func (a *FakeApiService) FakeOuterBooleanSerialize(ctx context.Context, localVar
 	if err != nil || localVarHttpResponse == nil {
 		return successPayload, localVarHttpResponse, err
 	}
-	defer localVarHttpResponse.Body.Close()
 	if localVarHttpResponse.StatusCode >= 300 {
-		bodyBytes, _ := ioutil.ReadAll(localVarHttpResponse.Body)
-		return successPayload, localVarHttpResponse, reportError("Status: %v, Body: %s", localVarHttpResponse.Status, bodyBytes)
+		return successPayload, localVarHttpResponse, reportError("Status: %v", localVarHttpResponse.Status)
 	}
 
 	if err = json.NewDecoder(localVarHttpResponse.Body).Decode(&successPayload); err != nil {
@@ -144,10 +142,8 @@ func (a *FakeApiService) FakeOuterCompositeSerialize(ctx context.Context, localV
 	if err != nil || localVarHttpResponse == nil {
 		return successPayload, localVarHttpResponse, err
 	}
-	defer localVarHttpResponse.Body.Close()
 	if localVarHttpResponse.StatusCode >= 300 {
-		bodyBytes, _ := ioutil.ReadAll(localVarHttpResponse.Body)
-		return successPayload, localVarHttpResponse, reportError("Status: %v, Body: %s", localVarHttpResponse.Status, bodyBytes)
+		return successPayload, localVarHttpResponse, reportError("Status: %v", localVarHttpResponse.Status)
 	}
 
 	if err = json.NewDecoder(localVarHttpResponse.Body).Decode(&successPayload); err != nil {
@@ -209,10 +205,8 @@ func (a *FakeApiService) FakeOuterNumberSerialize(ctx context.Context, localVarO
 	if err != nil || localVarHttpResponse == nil {
 		return successPayload, localVarHttpResponse, err
 	}
-	defer localVarHttpResponse.Body.Close()
 	if localVarHttpResponse.StatusCode >= 300 {
-		bodyBytes, _ := ioutil.ReadAll(localVarHttpResponse.Body)
-		return successPayload, localVarHttpResponse, reportError("Status: %v, Body: %s", localVarHttpResponse.Status, bodyBytes)
+		return successPayload, localVarHttpResponse, reportError("Status: %v", localVarHttpResponse.Status)
 	}
 
 	if err = json.NewDecoder(localVarHttpResponse.Body).Decode(&successPayload); err != nil {
@@ -274,10 +268,8 @@ func (a *FakeApiService) FakeOuterStringSerialize(ctx context.Context, localVarO
 	if err != nil || localVarHttpResponse == nil {
 		return successPayload, localVarHttpResponse, err
 	}
-	defer localVarHttpResponse.Body.Close()
 	if localVarHttpResponse.StatusCode >= 300 {
-		bodyBytes, _ := ioutil.ReadAll(localVarHttpResponse.Body)
-		return successPayload, localVarHttpResponse, reportError("Status: %v, Body: %s", localVarHttpResponse.Status, bodyBytes)
+		return successPayload, localVarHttpResponse, reportError("Status: %v", localVarHttpResponse.Status)
 	}
 
 	if err = json.NewDecoder(localVarHttpResponse.Body).Decode(&successPayload); err != nil {
@@ -336,10 +328,8 @@ func (a *FakeApiService) TestClientModel(ctx context.Context, body Client) (Clie
 	if err != nil || localVarHttpResponse == nil {
 		return successPayload, localVarHttpResponse, err
 	}
-	defer localVarHttpResponse.Body.Close()
 	if localVarHttpResponse.StatusCode >= 300 {
-		bodyBytes, _ := ioutil.ReadAll(localVarHttpResponse.Body)
-		return successPayload, localVarHttpResponse, reportError("Status: %v, Body: %s", localVarHttpResponse.Status, bodyBytes)
+		return successPayload, localVarHttpResponse, reportError("Status: %v", localVarHttpResponse.Status)
 	}
 
 	if err = json.NewDecoder(localVarHttpResponse.Body).Decode(&successPayload); err != nil {
@@ -485,10 +475,8 @@ func (a *FakeApiService) TestEndpointParameters(ctx context.Context, number floa
 	if err != nil || localVarHttpResponse == nil {
 		return localVarHttpResponse, err
 	}
-	defer localVarHttpResponse.Body.Close()
 	if localVarHttpResponse.StatusCode >= 300 {
-		bodyBytes, _ := ioutil.ReadAll(localVarHttpResponse.Body)
-		return localVarHttpResponse, reportError("Status: %v, Body: %s", localVarHttpResponse.Status, bodyBytes)
+		return localVarHttpResponse, reportError("Status: %v", localVarHttpResponse.Status)
 	}
 	return localVarHttpResponse, err
 }
@@ -586,10 +574,8 @@ func (a *FakeApiService) TestEnumParameters(ctx context.Context, localVarOptiona
 	if err != nil || localVarHttpResponse == nil {
 		return localVarHttpResponse, err
 	}
-	defer localVarHttpResponse.Body.Close()
 	if localVarHttpResponse.StatusCode >= 300 {
-		bodyBytes, _ := ioutil.ReadAll(localVarHttpResponse.Body)
-		return localVarHttpResponse, reportError("Status: %v, Body: %s", localVarHttpResponse.Status, bodyBytes)
+		return localVarHttpResponse, reportError("Status: %v", localVarHttpResponse.Status)
 	}
 	return localVarHttpResponse, err
 }
@@ -642,10 +628,8 @@ func (a *FakeApiService) TestInlineAdditionalProperties(ctx context.Context, par
 	if err != nil || localVarHttpResponse == nil {
 		return localVarHttpResponse, err
 	}
-	defer localVarHttpResponse.Body.Close()
 	if localVarHttpResponse.StatusCode >= 300 {
-		bodyBytes, _ := ioutil.ReadAll(localVarHttpResponse.Body)
-		return localVarHttpResponse, reportError("Status: %v, Body: %s", localVarHttpResponse.Status, bodyBytes)
+		return localVarHttpResponse, reportError("Status: %v", localVarHttpResponse.Status)
 	}
 	return localVarHttpResponse, err
 }
@@ -699,10 +683,9 @@ func (a *FakeApiService) TestJsonFormData(ctx context.Context, param string, par
 	if err != nil || localVarHttpResponse == nil {
 		return localVarHttpResponse, err
 	}
-	defer localVarHttpResponse.Body.Close()
 	if localVarHttpResponse.StatusCode >= 300 {
-		bodyBytes, _ := ioutil.ReadAll(localVarHttpResponse.Body)
-		return localVarHttpResponse, reportError("Status: %v, Body: %s", localVarHttpResponse.Status, bodyBytes)
+		return localVarHttpResponse, reportError("Status: %v", localVarHttpResponse.Status)
 	}
 	return localVarHttpResponse, err
 }
+

--- a/samples/client/petstore/go/go-petstore/api_fake_classname_tags123.go
+++ b/samples/client/petstore/go/go-petstore/api_fake_classname_tags123.go
@@ -27,6 +27,7 @@ var (
 type FakeClassnameTags123ApiService service
 
 /* FakeClassnameTags123ApiService To test class name in snake case
+To test class name in snake case
  * @param ctx context.Context for authentication, logging, tracing, etc.
 @param body client model
 @return Client*/
@@ -86,10 +87,8 @@ func (a *FakeClassnameTags123ApiService) TestClassname(ctx context.Context, body
 	if err != nil || localVarHttpResponse == nil {
 		return successPayload, localVarHttpResponse, err
 	}
-	defer localVarHttpResponse.Body.Close()
 	if localVarHttpResponse.StatusCode >= 300 {
-		bodyBytes, _ := ioutil.ReadAll(localVarHttpResponse.Body)
-		return successPayload, localVarHttpResponse, reportError("Status: %v, Body: %s", localVarHttpResponse.Status, bodyBytes)
+		return successPayload, localVarHttpResponse, reportError("Status: %v", localVarHttpResponse.Status)
 	}
 
 	if err = json.NewDecoder(localVarHttpResponse.Body).Decode(&successPayload); err != nil {
@@ -98,3 +97,4 @@ func (a *FakeClassnameTags123ApiService) TestClassname(ctx context.Context, body
 
 	return successPayload, localVarHttpResponse, err
 }
+

--- a/samples/client/petstore/go/go-petstore/api_pet.go
+++ b/samples/client/petstore/go/go-petstore/api_pet.go
@@ -76,10 +76,8 @@ func (a *PetApiService) AddPet(ctx context.Context, body Pet) (*http.Response, e
 	if err != nil || localVarHttpResponse == nil {
 		return localVarHttpResponse, err
 	}
-	defer localVarHttpResponse.Body.Close()
 	if localVarHttpResponse.StatusCode >= 300 {
-		bodyBytes, _ := ioutil.ReadAll(localVarHttpResponse.Body)
-		return localVarHttpResponse, reportError("Status: %v, Body: %s", localVarHttpResponse.Status, bodyBytes)
+		return localVarHttpResponse, reportError("Status: %v", localVarHttpResponse.Status)
 	}
 	return localVarHttpResponse, err
 }
@@ -139,10 +137,8 @@ func (a *PetApiService) DeletePet(ctx context.Context, petId int64, localVarOpti
 	if err != nil || localVarHttpResponse == nil {
 		return localVarHttpResponse, err
 	}
-	defer localVarHttpResponse.Body.Close()
 	if localVarHttpResponse.StatusCode >= 300 {
-		bodyBytes, _ := ioutil.ReadAll(localVarHttpResponse.Body)
-		return localVarHttpResponse, reportError("Status: %v, Body: %s", localVarHttpResponse.Status, bodyBytes)
+		return localVarHttpResponse, reportError("Status: %v", localVarHttpResponse.Status)
 	}
 	return localVarHttpResponse, err
 }
@@ -195,10 +191,8 @@ func (a *PetApiService) FindPetsByStatus(ctx context.Context, status []string) (
 	if err != nil || localVarHttpResponse == nil {
 		return successPayload, localVarHttpResponse, err
 	}
-	defer localVarHttpResponse.Body.Close()
 	if localVarHttpResponse.StatusCode >= 300 {
-		bodyBytes, _ := ioutil.ReadAll(localVarHttpResponse.Body)
-		return successPayload, localVarHttpResponse, reportError("Status: %v, Body: %s", localVarHttpResponse.Status, bodyBytes)
+		return successPayload, localVarHttpResponse, reportError("Status: %v", localVarHttpResponse.Status)
 	}
 
 	if err = json.NewDecoder(localVarHttpResponse.Body).Decode(&successPayload); err != nil {
@@ -256,10 +250,8 @@ func (a *PetApiService) FindPetsByTags(ctx context.Context, tags []string) ([]Pe
 	if err != nil || localVarHttpResponse == nil {
 		return successPayload, localVarHttpResponse, err
 	}
-	defer localVarHttpResponse.Body.Close()
 	if localVarHttpResponse.StatusCode >= 300 {
-		bodyBytes, _ := ioutil.ReadAll(localVarHttpResponse.Body)
-		return successPayload, localVarHttpResponse, reportError("Status: %v, Body: %s", localVarHttpResponse.Status, bodyBytes)
+		return successPayload, localVarHttpResponse, reportError("Status: %v", localVarHttpResponse.Status)
 	}
 
 	if err = json.NewDecoder(localVarHttpResponse.Body).Decode(&successPayload); err != nil {
@@ -329,10 +321,8 @@ func (a *PetApiService) GetPetById(ctx context.Context, petId int64) (Pet, *http
 	if err != nil || localVarHttpResponse == nil {
 		return successPayload, localVarHttpResponse, err
 	}
-	defer localVarHttpResponse.Body.Close()
 	if localVarHttpResponse.StatusCode >= 300 {
-		bodyBytes, _ := ioutil.ReadAll(localVarHttpResponse.Body)
-		return successPayload, localVarHttpResponse, reportError("Status: %v, Body: %s", localVarHttpResponse.Status, bodyBytes)
+		return successPayload, localVarHttpResponse, reportError("Status: %v", localVarHttpResponse.Status)
 	}
 
 	if err = json.NewDecoder(localVarHttpResponse.Body).Decode(&successPayload); err != nil {
@@ -390,10 +380,8 @@ func (a *PetApiService) UpdatePet(ctx context.Context, body Pet) (*http.Response
 	if err != nil || localVarHttpResponse == nil {
 		return localVarHttpResponse, err
 	}
-	defer localVarHttpResponse.Body.Close()
 	if localVarHttpResponse.StatusCode >= 300 {
-		bodyBytes, _ := ioutil.ReadAll(localVarHttpResponse.Body)
-		return localVarHttpResponse, reportError("Status: %v, Body: %s", localVarHttpResponse.Status, bodyBytes)
+		return localVarHttpResponse, reportError("Status: %v", localVarHttpResponse.Status)
 	}
 	return localVarHttpResponse, err
 }
@@ -460,10 +448,8 @@ func (a *PetApiService) UpdatePetWithForm(ctx context.Context, petId int64, loca
 	if err != nil || localVarHttpResponse == nil {
 		return localVarHttpResponse, err
 	}
-	defer localVarHttpResponse.Body.Close()
 	if localVarHttpResponse.StatusCode >= 300 {
-		bodyBytes, _ := ioutil.ReadAll(localVarHttpResponse.Body)
-		return localVarHttpResponse, reportError("Status: %v, Body: %s", localVarHttpResponse.Status, bodyBytes)
+		return localVarHttpResponse, reportError("Status: %v", localVarHttpResponse.Status)
 	}
 	return localVarHttpResponse, err
 }
@@ -535,10 +521,8 @@ func (a *PetApiService) UploadFile(ctx context.Context, petId int64, localVarOpt
 	if err != nil || localVarHttpResponse == nil {
 		return successPayload, localVarHttpResponse, err
 	}
-	defer localVarHttpResponse.Body.Close()
 	if localVarHttpResponse.StatusCode >= 300 {
-		bodyBytes, _ := ioutil.ReadAll(localVarHttpResponse.Body)
-		return successPayload, localVarHttpResponse, reportError("Status: %v, Body: %s", localVarHttpResponse.Status, bodyBytes)
+		return successPayload, localVarHttpResponse, reportError("Status: %v", localVarHttpResponse.Status)
 	}
 
 	if err = json.NewDecoder(localVarHttpResponse.Body).Decode(&successPayload); err != nil {
@@ -547,3 +531,4 @@ func (a *PetApiService) UploadFile(ctx context.Context, petId int64, localVarOpt
 
 	return successPayload, localVarHttpResponse, err
 }
+

--- a/samples/client/petstore/go/go-petstore/api_store.go
+++ b/samples/client/petstore/go/go-petstore/api_store.go
@@ -74,10 +74,8 @@ func (a *StoreApiService) DeleteOrder(ctx context.Context, orderId string) (*htt
 	if err != nil || localVarHttpResponse == nil {
 		return localVarHttpResponse, err
 	}
-	defer localVarHttpResponse.Body.Close()
 	if localVarHttpResponse.StatusCode >= 300 {
-		bodyBytes, _ := ioutil.ReadAll(localVarHttpResponse.Body)
-		return localVarHttpResponse, reportError("Status: %v, Body: %s", localVarHttpResponse.Status, bodyBytes)
+		return localVarHttpResponse, reportError("Status: %v", localVarHttpResponse.Status)
 	}
 	return localVarHttpResponse, err
 }
@@ -140,10 +138,8 @@ func (a *StoreApiService) GetInventory(ctx context.Context) (map[string]int32, *
 	if err != nil || localVarHttpResponse == nil {
 		return successPayload, localVarHttpResponse, err
 	}
-	defer localVarHttpResponse.Body.Close()
 	if localVarHttpResponse.StatusCode >= 300 {
-		bodyBytes, _ := ioutil.ReadAll(localVarHttpResponse.Body)
-		return successPayload, localVarHttpResponse, reportError("Status: %v, Body: %s", localVarHttpResponse.Status, bodyBytes)
+		return successPayload, localVarHttpResponse, reportError("Status: %v", localVarHttpResponse.Status)
 	}
 
 	if err = json.NewDecoder(localVarHttpResponse.Body).Decode(&successPayload); err != nil {
@@ -207,10 +203,8 @@ func (a *StoreApiService) GetOrderById(ctx context.Context, orderId int64) (Orde
 	if err != nil || localVarHttpResponse == nil {
 		return successPayload, localVarHttpResponse, err
 	}
-	defer localVarHttpResponse.Body.Close()
 	if localVarHttpResponse.StatusCode >= 300 {
-		bodyBytes, _ := ioutil.ReadAll(localVarHttpResponse.Body)
-		return successPayload, localVarHttpResponse, reportError("Status: %v, Body: %s", localVarHttpResponse.Status, bodyBytes)
+		return successPayload, localVarHttpResponse, reportError("Status: %v", localVarHttpResponse.Status)
 	}
 
 	if err = json.NewDecoder(localVarHttpResponse.Body).Decode(&successPayload); err != nil {
@@ -269,10 +263,8 @@ func (a *StoreApiService) PlaceOrder(ctx context.Context, body Order) (Order, *h
 	if err != nil || localVarHttpResponse == nil {
 		return successPayload, localVarHttpResponse, err
 	}
-	defer localVarHttpResponse.Body.Close()
 	if localVarHttpResponse.StatusCode >= 300 {
-		bodyBytes, _ := ioutil.ReadAll(localVarHttpResponse.Body)
-		return successPayload, localVarHttpResponse, reportError("Status: %v, Body: %s", localVarHttpResponse.Status, bodyBytes)
+		return successPayload, localVarHttpResponse, reportError("Status: %v", localVarHttpResponse.Status)
 	}
 
 	if err = json.NewDecoder(localVarHttpResponse.Body).Decode(&successPayload); err != nil {
@@ -281,3 +273,4 @@ func (a *StoreApiService) PlaceOrder(ctx context.Context, body Order) (Order, *h
 
 	return successPayload, localVarHttpResponse, err
 }
+

--- a/samples/client/petstore/go/go-petstore/api_user.go
+++ b/samples/client/petstore/go/go-petstore/api_user.go
@@ -75,10 +75,8 @@ func (a *UserApiService) CreateUser(ctx context.Context, body User) (*http.Respo
 	if err != nil || localVarHttpResponse == nil {
 		return localVarHttpResponse, err
 	}
-	defer localVarHttpResponse.Body.Close()
 	if localVarHttpResponse.StatusCode >= 300 {
-		bodyBytes, _ := ioutil.ReadAll(localVarHttpResponse.Body)
-		return localVarHttpResponse, reportError("Status: %v, Body: %s", localVarHttpResponse.Status, bodyBytes)
+		return localVarHttpResponse, reportError("Status: %v", localVarHttpResponse.Status)
 	}
 	return localVarHttpResponse, err
 }
@@ -131,10 +129,8 @@ func (a *UserApiService) CreateUsersWithArrayInput(ctx context.Context, body []U
 	if err != nil || localVarHttpResponse == nil {
 		return localVarHttpResponse, err
 	}
-	defer localVarHttpResponse.Body.Close()
 	if localVarHttpResponse.StatusCode >= 300 {
-		bodyBytes, _ := ioutil.ReadAll(localVarHttpResponse.Body)
-		return localVarHttpResponse, reportError("Status: %v, Body: %s", localVarHttpResponse.Status, bodyBytes)
+		return localVarHttpResponse, reportError("Status: %v", localVarHttpResponse.Status)
 	}
 	return localVarHttpResponse, err
 }
@@ -187,10 +183,8 @@ func (a *UserApiService) CreateUsersWithListInput(ctx context.Context, body []Us
 	if err != nil || localVarHttpResponse == nil {
 		return localVarHttpResponse, err
 	}
-	defer localVarHttpResponse.Body.Close()
 	if localVarHttpResponse.StatusCode >= 300 {
-		bodyBytes, _ := ioutil.ReadAll(localVarHttpResponse.Body)
-		return localVarHttpResponse, reportError("Status: %v, Body: %s", localVarHttpResponse.Status, bodyBytes)
+		return localVarHttpResponse, reportError("Status: %v", localVarHttpResponse.Status)
 	}
 	return localVarHttpResponse, err
 }
@@ -242,10 +236,8 @@ func (a *UserApiService) DeleteUser(ctx context.Context, username string) (*http
 	if err != nil || localVarHttpResponse == nil {
 		return localVarHttpResponse, err
 	}
-	defer localVarHttpResponse.Body.Close()
 	if localVarHttpResponse.StatusCode >= 300 {
-		bodyBytes, _ := ioutil.ReadAll(localVarHttpResponse.Body)
-		return localVarHttpResponse, reportError("Status: %v, Body: %s", localVarHttpResponse.Status, bodyBytes)
+		return localVarHttpResponse, reportError("Status: %v", localVarHttpResponse.Status)
 	}
 	return localVarHttpResponse, err
 }
@@ -253,7 +245,7 @@ func (a *UserApiService) DeleteUser(ctx context.Context, username string) (*http
 /* UserApiService Get user by user name
 
  * @param ctx context.Context for authentication, logging, tracing, etc.
-@param username The name that needs to be fetched. Use user1 for testing. 
+@param username The name that needs to be fetched. Use user1 for testing.
 @return User*/
 func (a *UserApiService) GetUserByName(ctx context.Context, username string) (User, *http.Response, error) {
 	var (
@@ -298,10 +290,8 @@ func (a *UserApiService) GetUserByName(ctx context.Context, username string) (Us
 	if err != nil || localVarHttpResponse == nil {
 		return successPayload, localVarHttpResponse, err
 	}
-	defer localVarHttpResponse.Body.Close()
 	if localVarHttpResponse.StatusCode >= 300 {
-		bodyBytes, _ := ioutil.ReadAll(localVarHttpResponse.Body)
-		return successPayload, localVarHttpResponse, reportError("Status: %v, Body: %s", localVarHttpResponse.Status, bodyBytes)
+		return successPayload, localVarHttpResponse, reportError("Status: %v", localVarHttpResponse.Status)
 	}
 
 	if err = json.NewDecoder(localVarHttpResponse.Body).Decode(&successPayload); err != nil {
@@ -361,10 +351,8 @@ func (a *UserApiService) LoginUser(ctx context.Context, username string, passwor
 	if err != nil || localVarHttpResponse == nil {
 		return successPayload, localVarHttpResponse, err
 	}
-	defer localVarHttpResponse.Body.Close()
 	if localVarHttpResponse.StatusCode >= 300 {
-		bodyBytes, _ := ioutil.ReadAll(localVarHttpResponse.Body)
-		return successPayload, localVarHttpResponse, reportError("Status: %v, Body: %s", localVarHttpResponse.Status, bodyBytes)
+		return successPayload, localVarHttpResponse, reportError("Status: %v", localVarHttpResponse.Status)
 	}
 
 	if err = json.NewDecoder(localVarHttpResponse.Body).Decode(&successPayload); err != nil {
@@ -419,10 +407,8 @@ func (a *UserApiService) LogoutUser(ctx context.Context) (*http.Response, error)
 	if err != nil || localVarHttpResponse == nil {
 		return localVarHttpResponse, err
 	}
-	defer localVarHttpResponse.Body.Close()
 	if localVarHttpResponse.StatusCode >= 300 {
-		bodyBytes, _ := ioutil.ReadAll(localVarHttpResponse.Body)
-		return localVarHttpResponse, reportError("Status: %v, Body: %s", localVarHttpResponse.Status, bodyBytes)
+		return localVarHttpResponse, reportError("Status: %v", localVarHttpResponse.Status)
 	}
 	return localVarHttpResponse, err
 }
@@ -477,10 +463,9 @@ func (a *UserApiService) UpdateUser(ctx context.Context, username string, body U
 	if err != nil || localVarHttpResponse == nil {
 		return localVarHttpResponse, err
 	}
-	defer localVarHttpResponse.Body.Close()
 	if localVarHttpResponse.StatusCode >= 300 {
-		bodyBytes, _ := ioutil.ReadAll(localVarHttpResponse.Body)
-		return localVarHttpResponse, reportError("Status: %v, Body: %s", localVarHttpResponse.Status, bodyBytes)
+		return localVarHttpResponse, reportError("Status: %v", localVarHttpResponse.Status)
 	}
 	return localVarHttpResponse, err
 }
+

--- a/samples/client/petstore/go/go-petstore/docs/EnumTest.md
+++ b/samples/client/petstore/go/go-petstore/docs/EnumTest.md
@@ -4,6 +4,7 @@
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **EnumString** | **string** |  | [optional] [default to null]
+**EnumStringRequired** | **string** |  | [default to null]
 **EnumInteger** | **int32** |  | [optional] [default to null]
 **EnumNumber** | **float64** |  | [optional] [default to null]
 **OuterEnum** | [***OuterEnum**](OuterEnum.md) |  | [optional] [default to null]

--- a/samples/client/petstore/go/go-petstore/docs/FakeClassnameTags123Api.md
+++ b/samples/client/petstore/go/go-petstore/docs/FakeClassnameTags123Api.md
@@ -11,6 +11,8 @@ Method | HTTP request | Description
 > Client TestClassname(ctx, body)
 To test class name in snake case
 
+To test class name in snake case
+
 ### Required Parameters
 
 Name | Type | Description  | Notes

--- a/samples/client/petstore/go/go-petstore/docs/UserApi.md
+++ b/samples/client/petstore/go/go-petstore/docs/UserApi.md
@@ -137,7 +137,7 @@ Get user by user name
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
  **ctx** | **context.Context** | context for logging, tracing, authentication, etc.
-  **username** | **string**| The name that needs to be fetched. Use user1 for testing.  | 
+  **username** | **string**| The name that needs to be fetched. Use user1 for testing. | 
 
 ### Return type
 

--- a/samples/client/petstore/go/go-petstore/model_enum_test.go
+++ b/samples/client/petstore/go/go-petstore/model_enum_test.go
@@ -13,6 +13,8 @@ package petstore
 type EnumTest struct {
 	EnumString string `json:"enum_string,omitempty"`
 
+	EnumStringRequired string `json:"enum_string_required"`
+
 	EnumInteger int32 `json:"enum_integer,omitempty"`
 
 	EnumNumber float64 `json:"enum_number,omitempty"`


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change.
- [x] Filed the PR against the correct branch: `3.0.0` branch for changes related to OpenAPI spec 3.0. Default: `master`.
- [x] Copied the [technical committee](https://github.com/swagger-api/swagger-codegen/#swagger-codegen-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

Addresses #7809 by not reading the response body in case of an HTTP status larger than / equal to 300, to make the body accessible to callers.

### Unrelated changes

Refreshing the generated code for the petstore example yielded some changes which don't seem to be related to the template change in this PR (EnumStringRequired etc.)

CC @antihax @bvwells