### PR TITLE
[C++][pistache-server] Optional integer query parameter is not supported

### DIFF
--- a/modules/swagger-codegen/src/main/resources/pistache-server/api-header.mustache
+++ b/modules/swagger-codegen/src/main/resources/pistache-server/api-header.mustache
@@ -13,6 +13,9 @@
 #include <pistache/http.h>
 #include <pistache/router.h>
 #include <pistache/http_headers.h>
+{{#hasOptional}}
+##include <pistache/optional.h>
+{{/hasOptional}}
 
 {{#imports}}{{{import}}}
 {{/imports}}
@@ -21,7 +24,7 @@
 namespace {{this}} {
 {{/apiNamespaceDeclarations}}
 
-using namespace {{modelNamespace}};
+//using namespace {{modelNamespace}};
 
 class {{declspec}} {{classname}} {
 public:

--- a/modules/swagger-codegen/src/main/resources/pistache-server/api-impl-header.mustache
+++ b/modules/swagger-codegen/src/main/resources/pistache-server/api-impl-header.mustache
@@ -13,6 +13,9 @@
 #include <pistache/endpoint.h>
 #include <pistache/http.h>
 #include <pistache/router.h>
+{{#hasOptional}}
+##include <pistache/optional.h>
+{{/hasOptional}}
 #include <memory>
 
 #include <{{classname}}.h>
@@ -24,7 +27,7 @@
 namespace {{this}} {
 {{/apiNamespaceDeclarations}}
 
-using namespace {{modelNamespace}};
+//using namespace {{modelNamespace}};
 
 class {{classname}}Impl : public {{apiNamespace}}::{{classname}} {
 public:

--- a/modules/swagger-codegen/src/main/resources/pistache-server/api-impl-source.mustache
+++ b/modules/swagger-codegen/src/main/resources/pistache-server/api-impl-source.mustache
@@ -7,7 +7,7 @@
 namespace {{this}} {
 {{/apiNamespaceDeclarations}}
 
-using namespace {{modelNamespace}};
+//using namespace {{modelNamespace}};
 
 {{classname}}Impl::{{classname}}Impl(Pistache::Address addr)
     : {{classname}}(addr)

--- a/modules/swagger-codegen/src/main/resources/pistache-server/api-source.mustache
+++ b/modules/swagger-codegen/src/main/resources/pistache-server/api-source.mustache
@@ -7,7 +7,20 @@
 namespace {{this}} {
 {{/apiNamespaceDeclarations}}
 
-using namespace {{modelNamespace}};
+//using namespace {{modelNamespace}};
+
+template<typename T>
+Pistache::Optional<T> ConvertQueryParam(const Pistache::Optional<std::string>& str)
+{
+    if (str.isEmpty())
+        return Pistache::Optional<T>();
+    return Pistache::Optional<T>(Pistache::Some((T)std::stoi(str.get())));
+}
+
+Pistache::Optional<std::string> ConvertQueryParam(const Pistache::Optional<std::string>& str)
+{
+    return str;
+}
 
 {{classname}}::{{classname}}(Pistache::Address addr)
     : httpEndpoint(std::make_shared<Pistache::Http::Endpoint>(addr))
@@ -61,7 +74,7 @@ void {{classname}}::{{operationIdSnakeCase}}_handler(const Pistache::Rest::Reque
     {{/hasBodyParam}}{{#hasQueryParams}}
     // Getting the query params
     {{#queryParams}}
-    auto {{paramName}} = request.query().get("{{baseName}}");
+    auto {{paramName}} = ConvertQueryParam<{{dataType}}>(request.query().get("{{baseName}}"));
     {{/queryParams}}
     {{/hasQueryParams}}{{#hasHeaderParams}}
     // Getting the header params


### PR DESCRIPTION

### PR checklist

- [OK] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [OK] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [OK] Filed the PR against the correct branch: `3.0.0` branch for changes related to OpenAPI spec 3.0. Default: `master`.
- [OK] Copied the [technical committee](https://github.com/swagger-api/swagger-codegen/#swagger-codegen-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

The generated pistache code doesn't support an optional query parameter that is declared as being an integer. This code in the mustache templates fixes this issue.

