### PR TITLE
Fix typescript-node generation of array type models

### DIFF
--- a/modules/swagger-codegen/src/main/resources/typescript-node/api.mustache
+++ b/modules/swagger-codegen/src/main/resources/typescript-node/api.mustache
@@ -151,6 +151,7 @@ export class {{classname}} {{#parent}}extends {{{parent}}} {{/parent}}{
     static discriminator = undefined;
     {{/discriminator}}
 
+    {{^isArrayModel}}
     static attributeTypeMap: Array<{name: string, baseName: string, type: string}> = [
         {{#vars}}
         {
@@ -170,6 +171,7 @@ export class {{classname}} {{#parent}}extends {{{parent}}} {{/parent}}{
         return {{classname}}.attributeTypeMap;
         {{/parent}}
     }
+    {{/isArrayModel}}    
 }
 
 {{#hasEnums}}


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [x] Filed the PR against the correct branch: `3.0.0` branch for changes related to OpenAPI spec 3.0. Default: `master`.
- [x] Copied the [technical committee](https://github.com/swagger-api/swagger-codegen/#swagger-codegen-technical-committee) to review the pull request if your PR is targeting a particular programming language.
@TiFu @taxpon @sebastianhaas @kenisteward @Vrolijkx @macjohnny

### Description of the PR

Fix for generating models of type array. If the model is of type array do not generate getAttributeTypeMap function and attributeTypeMap. Should address issue #7827.