### PR TITLE
[3.0.0] fix java.lang.NoSuchMethodError

### DIFF
--- a/modules/swagger-codegen/pom.xml
+++ b/modules/swagger-codegen/pom.xml
@@ -199,16 +199,6 @@
     </properties>
     <dependencies>
         <dependency>
-            <groupId>io.swagger</groupId>
-            <artifactId>swagger-models</artifactId>
-            <version>1.5.17</version>
-        </dependency>
-        <dependency>
-            <groupId>io.swagger</groupId>
-            <artifactId>swagger-core</artifactId>
-            <version>1.5.17</version>
-        </dependency>
-        <dependency>
             <groupId>io.swagger.core.v3</groupId>
             <artifactId>swagger-models</artifactId>
             <version>${swagger-core-version}</version>


### PR DESCRIPTION
I got this error when I have opened this spec: [api.yaml](https://gist.github.com/vidyas78/737441244829907cd961ce2a986ec94c)

```
Exception in thread "main" java.lang.NoSuchMethodError: io.swagger.models.Response.responseSchema(Lio/swagger/models/Model;)Lio/swagger/models/Response;
	at io.swagger.parser.util.SwaggerDeserializer.response(SwaggerDeserializer.java:1113)
	at io.swagger.parser.util.SwaggerDeserializer.responses(SwaggerDeserializer.java:1067)
	at io.swagger.parser.util.SwaggerDeserializer.operation(SwaggerDeserializer.java:341)
	at io.swagger.parser.util.SwaggerDeserializer.path(SwaggerDeserializer.java:223)
	at io.swagger.parser.util.SwaggerDeserializer.paths(SwaggerDeserializer.java:188)
	at io.swagger.parser.util.SwaggerDeserializer.parseRoot(SwaggerDeserializer.java:109)
	at io.swagger.parser.util.SwaggerDeserializer.deserialize(SwaggerDeserializer.java:39)
	at io.swagger.parser.Swagger20Parser.readWithInfo(Swagger20Parser.java:34)
	at io.swagger.parser.Swagger20Parser.readWithInfo(Swagger20Parser.java:66)
	at io.swagger.parser.SwaggerParser.readWithInfo(SwaggerParser.java:31)
	at io.swagger.v3.parser.converter.SwaggerConverter.readLocation(SwaggerConverter.java:88)
	at io.swagger.v3.parser.OpenAPIV3Parser.read(OpenAPIV3Parser.java:86)
```

---

I think the problem is that `io.swagger:swagger-codegen:3.0.0-SNAPSHOT` is defining following dependenies:

* `io.swagger:swagger-core:1.5.17`
* `io.swagger:swagger-models:1.5.17`

This a problem, because it overrides the versions defined in `io.swagger:swagger-parser:1.0.35-SNAPSHOT` and in `io.swagger:swagger-compat-spec-parser:1.0.35-SNAPSHOT`.

<img width="545" alt="conflict for 'io.swagger:swagger-core' dependency" src="https://user-images.githubusercontent.com/1222165/37556888-9f29c412-29fc-11e8-93d4-9e64dd88e6ac.png">

<img width="562" alt="conflict for 'io.swagger:swagger-models' dependency" src="https://user-images.githubusercontent.com/1222165/37556891-b43e19a2-29fc-11e8-8de5-3220d6d8d569.png">

I propose to remove the dependency declaration in `io.swagger:swagger-codegen:3.0.0-SNAPSHOT`, because it makes no sense to force to use a specific version of the dependencies.