### PR TITLE
Fix #7865: Incorrect handling of --model-name-prefix/suffix (python-f…

### DIFF
--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/FlaskConnexionCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/FlaskConnexionCodegen.java
@@ -446,6 +446,15 @@ public class FlaskConnexionCodegen extends DefaultCodegen implements CodegenConf
         // remove dollar sign
         name = name.replaceAll("$", "");
 
+        // Add prefix/suffix before testing for reserved words/starts with number.
+        if (!StringUtils.isEmpty(modelNamePrefix)) {
+            name = modelNamePrefix + "_" + name;
+        }
+
+        if (!StringUtils.isEmpty(modelNameSuffix)) {
+            name = name + "_" + modelNameSuffix;
+        }
+
         // model name cannot use reserved keyword, e.g. return
         if (isReservedWord(name)) {
             LOGGER.warn(name + " (reserved word) cannot be used as model name. Renamed to " + camelize("model_" + name));
@@ -456,14 +465,6 @@ public class FlaskConnexionCodegen extends DefaultCodegen implements CodegenConf
         if (name.matches("^\\d.*")) {
             LOGGER.warn(name + " (model name starts with number) cannot be used as model name. Renamed to " + camelize("model_" + name));
             name = "model_" + name; // e.g. 200Response => Model200Response (after camelize)
-        }
-
-        if (!StringUtils.isEmpty(modelNamePrefix)) {
-            name = modelNamePrefix + "_" + name;
-        }
-
-        if (!StringUtils.isEmpty(modelNameSuffix)) {
-            name = name + "_" + modelNameSuffix;
         }
 
         // camelize the model name
@@ -654,7 +655,23 @@ public class FlaskConnexionCodegen extends DefaultCodegen implements CodegenConf
             if (!"".equals(modelPackage())) {
                 modelImport += modelPackage() + ".";
             }
-            modelImport += toModelFilename(name)+ " import " + name;
+
+            // with modelNamePrefix/modelNameSuffix, name already includes
+            // the prefix/suffix.
+            // for example if modelNamePrefix is 'swg' and the model name 'pet',
+            // name is already SwgPet. toModelFilename(name) is swg_swg_pet instead
+            // of swg_pet.
+            String filename = toModelFilename(name);
+
+            if (!StringUtils.isEmpty(modelNamePrefix)) {
+                filename = StringUtils.removeStartIgnoreCase(filename, modelNamePrefix + "_");
+            }
+
+            if (!StringUtils.isEmpty(modelNameSuffix)) {
+                filename = StringUtils.removeEndIgnoreCase(filename, "_" + modelNameSuffix);
+            }
+
+            modelImport += filename + " import " + name;
         }
         return modelImport;
     }

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/PythonClientCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/PythonClientCodegen.java
@@ -239,7 +239,23 @@ public class PythonClientCodegen extends DefaultCodegen implements CodegenConfig
             if (!"".equals(modelPackage())) {
                 modelImport += modelPackage() + ".";
             }
-            modelImport += toModelFilename(name)+ " import " + name;
+
+            // with modelNamePrefix/modelNameSuffix, name already includes
+            // the prefix/suffix.
+            // for example if modelNamePrefix is 'swg' and the model name 'pet',
+            // name is already SwgPet. toModelFilename(name) is swg_swg_pet instead
+            // of swg_pet.
+            String filename = toModelFilename(name);
+
+            if (!StringUtils.isEmpty(modelNamePrefix)) {
+                filename = StringUtils.removeStartIgnoreCase(filename, modelNamePrefix + "_");
+            }
+
+            if (!StringUtils.isEmpty(modelNameSuffix)) {
+                filename = StringUtils.removeEndIgnoreCase(filename, "_" + modelNameSuffix);
+            }
+
+            modelImport += filename + " import " + name;
         }
         return modelImport;
     }
@@ -429,6 +445,15 @@ public class PythonClientCodegen extends DefaultCodegen implements CodegenConfig
         // remove dollar sign
         name = name.replaceAll("$", "");
 
+        // Add prefix/suffix before testing for reserved words/starts with number.
+        if (!StringUtils.isEmpty(modelNamePrefix)) {
+            name = modelNamePrefix + "_" + name;
+        }
+
+        if (!StringUtils.isEmpty(modelNameSuffix)) {
+            name = name + "_" + modelNameSuffix;
+        }
+
         // model name cannot use reserved keyword, e.g. return
         if (isReservedWord(name)) {
             LOGGER.warn(name + " (reserved word) cannot be used as model name. Renamed to " + camelize("model_" + name));
@@ -439,14 +464,6 @@ public class PythonClientCodegen extends DefaultCodegen implements CodegenConfig
         if (name.matches("^\\d.*")) {
             LOGGER.warn(name + " (model name starts with number) cannot be used as model name. Renamed to " + camelize("model_" + name));
             name = "model_" + name; // e.g. 200Response => Model200Response (after camelize)
-        }
-
-        if (!StringUtils.isEmpty(modelNamePrefix)) {
-            name = modelNamePrefix + "_" + name;
-        }
-
-        if (!StringUtils.isEmpty(modelNameSuffix)) {
-            name = name + "_" + modelNameSuffix;
         }
 
         // camelize the model name


### PR DESCRIPTION
### Description of the PR

Fix import in *_controller.py when using --model-name-prefix or --model-name-suffix

java -jar swagger-codegen-cli.jar generate -l python-flask --model-name-prefix swg 

Before:

from swagger_server.models.swg_swg_error import SwgError

After:

from swagger_server.api_models.swg_error import SwgError  
