### PR TITLE
Fix #7866: Incorrect handling of --model-name-prefix/suffix (typescri…

### DIFF
--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/TypeScriptAngularClientCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/TypeScriptAngularClientCodegen.java
@@ -19,6 +19,8 @@ import io.swagger.codegen.utils.SemVer;
 import io.swagger.models.ModelImpl;
 import io.swagger.models.properties.*;
 
+import org.apache.commons.lang3.StringUtils;
+
 public class TypeScriptAngularClientCodegen extends AbstractTypeScriptClientCodegen {
     private static final SimpleDateFormat SNAPSHOT_SUFFIX_FORMAT = new SimpleDateFormat("yyyyMMddHHmm");
     private static final String X_DISCRIMINATOR_TYPE = "x-discriminator-value";
@@ -377,7 +379,22 @@ public class TypeScriptAngularClientCodegen extends AbstractTypeScriptClientCode
 
     @Override
     public String toModelImport(String name) {
-        return modelPackage() + "/" + toModelFilename(name);
+        // with modelNamePrefix/modelNameSuffix, name already includes
+        // the prefix/suffix.
+        // for example if modelNamePrefix is 'Swg' and the model name 'Pet',
+        // name is already SwgPet. toModelFilename(name) is SwgSwgPet instead
+        // of SwgPet.
+        String filename = toModelFilename(name);
+
+        if (!StringUtils.isEmpty(modelNamePrefix)) {
+            filename = StringUtils.removeStart(filename, modelNamePrefix);
+        }
+
+        if (!StringUtils.isEmpty(modelNameSuffix)) {
+            filename = StringUtils.removeEnd(filename, modelNameSuffix);
+        }
+
+        return modelPackage() + "/" + filename;
     }
 
     public String getNpmName() {


### PR DESCRIPTION
### Description of the PR

Fix import in *.service.ts when using --model-name-prefix or --model-name-suffix

java -jar swagger-codegen-cli.jar generate -l typescript-angular --model-name-prefix swg

Before:

import { SwgSwgError } from '../model/swgSwgError';

After:

import { SwgError} from '../model/swgError';
