### PR TITLE
[Docker] Fixing build failure (#7870)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,10 +14,10 @@ COPY ./LICENSE ${GEN_DIR}
 COPY ./google_checkstyle.xml ${GEN_DIR}
 
 # Modules are copied individually here to allow for caching of docker layers between major.minor versions
-# NOTE: swagger-generator is not included here, it is available as swaggerapi/swagger-generator
 COPY ./modules/swagger-codegen-maven-plugin ${GEN_DIR}/modules/swagger-codegen-maven-plugin
 COPY ./modules/swagger-codegen-cli ${GEN_DIR}/modules/swagger-codegen-cli
 COPY ./modules/swagger-codegen ${GEN_DIR}/modules/swagger-codegen
+COPY ./modules/swagger-generator ${GEN_DIR}/modules/swagger-generator
 COPY ./pom.xml ${GEN_DIR}
 
 # Pre-compile swagger-codegen-cli


### PR DESCRIPTION
 * Copying swagger-generator in Dockerfile to fix docker build failures (#7870)

### PR checklist

- [ ] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [ ] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [ ] Filed the PR against the correct branch: `3.0.0` branch for changes related to OpenAPI spec 3.0. Default: `master`.
- [ ] Copied the [technical committee](https://github.com/swagger-api/swagger-codegen/#swagger-codegen-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

Docker builds without any errors now

