### PR TITLE
Fix inputSpec for multi module builds

### DIFF
--- a/modules/swagger-codegen-maven-plugin/README.md
+++ b/modules/swagger-codegen-maven-plugin/README.md
@@ -18,7 +18,7 @@ Add to your `build->plugins` section (default phase is `generate-sources` phase)
                 <goal>generate</goal>
             </goals>
             <configuration>
-                <inputSpec>src/main/resources/api.yaml</inputSpec>
+                <inputSpec>${project.basedir}/src/main/resources/api.yaml</inputSpec>
                 <language>java</language>
                 <configOptions>
                    <sourceFolder>src/gen/java/main</sourceFolder>
@@ -76,7 +76,7 @@ Specifying a custom generator is a bit different. It doesn't support the classpa
                 <goal>generate</goal>
             </goals>
             <configuration>
-                <inputSpec>src/main/resources/yaml/yamlfilename.yaml</inputSpec>
+                <inputSpec>${project.basedir}/src/main/resources/yaml/yamlfilename.yaml</inputSpec>
                 <!-- language file, like e.g. JavaJaxRSCodegen shipped with swagger -->
                 <language>com.my.package.for.GeneratorLanguage</language>
                 <templateDirectory>myTemplateDir</templateDirectory>


### PR DESCRIPTION
Prefix path to `inputSpec` with maven's `${project.basedir}`. The codegen-maven-plugin will look inside the current working directory so whether a relative path works or not is depending on where the maven build is invoked from. Using `${project.basedir}` makes the path absolute.

### PR checklist

- [ ] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [ ] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [ ] Filed the PR against the correct branch: `3.0.0` branch for changes related to OpenAPI spec 3.0. Default: `master`.
- [ ] Copied the [technical committee](https://github.com/swagger-api/swagger-codegen/#swagger-codegen-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

(details of the change, additional tests that have been done, reference to the issue for tracking, etc)

