### PR TITLE
add binary type

### DIFF
--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/PythonClientCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/PythonClientCodegen.java
@@ -79,6 +79,7 @@ public class PythonClientCodegen extends DefaultCodegen implements CodegenConfig
         languageSpecificPrimitives.add("datetime");
         languageSpecificPrimitives.add("date");
         languageSpecificPrimitives.add("object");
+        languageSpecificPrimitives.add("binary_type");
 
         typeMapping.clear();
         typeMapping.put("integer", "int");
@@ -96,8 +97,8 @@ public class PythonClientCodegen extends DefaultCodegen implements CodegenConfig
         typeMapping.put("file", "file");
         // TODO binary should be mapped to byte array
         // mapped to String as a workaround
-        typeMapping.put("binary", "str");
-        typeMapping.put("ByteArray", "str");
+        typeMapping.put("binary", "binary_type");
+        typeMapping.put("ByteArray", "binary_type");
         // map uuid to string for the time being
         typeMapping.put("UUID", "str");
 


### PR DESCRIPTION
Hello,   
this is my humble try to implement a portable python binary stream typemapping. As far as I can teel, this should be non-breaking because six, and could maybe fix #2305 and other py3 encoding-related issues.

For me, this is a sideproduct developed for unlocking kubernetes-client/python#494 as per #7900, altough specific patch for kubeclient will live in 676da33d2089fffb332140a35b48865d93d031e7 because local python generator choices.

Tests went ok, but maybe you could help me point out if more are required.

Thank you, regards

/cc @taxpon @frol @mbohlool @cbornet @kenjones-cisco 