### PR TITLE
doc: fix run-in-docker.sh example

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ Once built, `run-in-docker.sh` will act as an executable for swagger-codegen-cli
 ```sh
 ./run-in-docker.sh help # Executes 'help' command for swagger-codegen-cli
 ./run-in-docker.sh langs # Executes 'langs' command for swagger-codegen-cli
-./run-in-docker.sh /gen/bin/go-petstore.sh  # Builds the Go client
+./run-in-docker.sh bin/go-petstore.sh  # Builds the Go client
 ./run-in-docker.sh generate -i modules/swagger-codegen/src/test/resources/2_0/petstore.yaml \
     -l go -o /gen/out/go-petstore -DpackageName=petstore # generates go client, outputs locally to ./out/go-petstore
 ```


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [x] Filed the PR against the correct branch: `3.0.0` branch for changes related to OpenAPI spec 3.0. Default: `master`.
- [x] Copied the [technical committee](https://github.com/swagger-api/swagger-codegen/#swagger-codegen-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

An example from README.md doesn't work. Script `run-in-docker.sh` adds `/gen/` to command:

```
./run-in-docker.sh gen/bin/go-petstore.sh
/gen/docker-entrypoint.sh: line 23: /gen/gen/bin/go-petstore.sh: No such file or directory
```

corrected example:

```
./run-in-docker.sh bin/go-petstore.sh
```