### PR TITLE
[kotlin] Add OkHttpClient.Builder to ApiClient.

### DIFF
--- a/modules/swagger-codegen/src/main/resources/kotlin-client/infrastructure/ApiClient.kt.mustache
+++ b/modules/swagger-codegen/src/main/resources/kotlin-client/infrastructure/ApiClient.kt.mustache
@@ -12,7 +12,12 @@ open class ApiClient(val baseUrl: String) {
         protected val XmlMediaType = "application/xml"
 
         @JvmStatic
-        val client : OkHttpClient = OkHttpClient()
+        val client by lazy {
+            builder.build()
+        }
+
+        @JvmStatic
+        val builder: OkHttpClient.Builder = OkHttpClient.Builder()
 
         @JvmStatic
         var defaultHeaders: Map<String, String> by ApplicationDelegates.setOnce(mapOf(ContentType to JsonMediaType, Accept to JsonMediaType))

--- a/samples/client/petstore/kotlin-string/docs/UserApi.md
+++ b/samples/client/petstore/kotlin-string/docs/UserApi.md
@@ -213,7 +213,7 @@ Get user by user name
 //import io.swagger.client.models.*
 
 val apiInstance = UserApi()
-val username : kotlin.String = username_example // kotlin.String | The name that needs to be fetched. Use user1 for testing. 
+val username : kotlin.String = username_example // kotlin.String | The name that needs to be fetched. Use user1 for testing.
 try {
     val result : User = apiInstance.getUserByName(username)
     println(result)
@@ -230,7 +230,7 @@ try {
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
- **username** | **kotlin.String**| The name that needs to be fetched. Use user1 for testing.  |
+ **username** | **kotlin.String**| The name that needs to be fetched. Use user1 for testing. |
 
 ### Return type
 

--- a/samples/client/petstore/kotlin-string/src/main/kotlin/io/swagger/client/apis/UserApi.kt
+++ b/samples/client/petstore/kotlin-string/src/main/kotlin/io/swagger/client/apis/UserApi.kt
@@ -144,7 +144,7 @@ class UserApi(basePath: kotlin.String = "http://petstore.swagger.io/v2") : ApiCl
     /**
     * Get user by user name
     * 
-    * @param username The name that needs to be fetched. Use user1 for testing.  
+    * @param username The name that needs to be fetched. Use user1 for testing. 
     * @return User
     */
     @Suppress("UNCHECKED_CAST")

--- a/samples/client/petstore/kotlin-string/src/main/kotlin/io/swagger/client/infrastructure/ApiClient.kt
+++ b/samples/client/petstore/kotlin-string/src/main/kotlin/io/swagger/client/infrastructure/ApiClient.kt
@@ -12,7 +12,12 @@ open class ApiClient(val baseUrl: String) {
         protected val XmlMediaType = "application/xml"
 
         @JvmStatic
-        val client : OkHttpClient = OkHttpClient()
+        val client by lazy {
+            builder.build()
+        }
+
+        @JvmStatic
+        val builder: OkHttpClient.Builder = OkHttpClient.Builder()
 
         @JvmStatic
         var defaultHeaders: Map<String, String> by ApplicationDelegates.setOnce(mapOf(ContentType to JsonMediaType, Accept to JsonMediaType))
@@ -85,9 +90,9 @@ open class ApiClient(val baseUrl: String) {
             RequestMethod.DELETE -> Request.Builder().url(url).delete()
             RequestMethod.GET -> Request.Builder().url(url)
             RequestMethod.HEAD -> Request.Builder().url(url).head()
-            RequestMethod.PATCH -> Request.Builder().url(url).patch(requestBody(body!!, contentType))
-            RequestMethod.PUT -> Request.Builder().url(url).put(requestBody(body!!, contentType))
-            RequestMethod.POST -> Request.Builder().url(url).post(requestBody(body!!, contentType))
+            RequestMethod.PATCH -> Request.Builder().url(url).patch(requestBody(body, contentType))
+            RequestMethod.PUT -> Request.Builder().url(url).put(requestBody(body, contentType))
+            RequestMethod.POST -> Request.Builder().url(url).post(requestBody(body, contentType))
             RequestMethod.OPTIONS -> Request.Builder().url(url).method("OPTIONS", null)
         }
 

--- a/samples/client/petstore/kotlin-string/src/main/kotlin/io/swagger/client/models/Order.kt
+++ b/samples/client/petstore/kotlin-string/src/main/kotlin/io/swagger/client/models/Order.kt
@@ -35,7 +35,7 @@ data class Order (
     * Order Status
     * Values: placed,approved,delivered
     */
-    enum class Status(val value: kotlin.Any){
+    enum class Status(val value: kotlin.String){
     
         placed("placed"),
     

--- a/samples/client/petstore/kotlin-string/src/main/kotlin/io/swagger/client/models/Pet.kt
+++ b/samples/client/petstore/kotlin-string/src/main/kotlin/io/swagger/client/models/Pet.kt
@@ -37,7 +37,7 @@ data class Pet (
     * pet status in the store
     * Values: available,pending,sold
     */
-    enum class Status(val value: kotlin.Any){
+    enum class Status(val value: kotlin.String){
     
         available("available"),
     

--- a/samples/client/petstore/kotlin-threetenbp/docs/UserApi.md
+++ b/samples/client/petstore/kotlin-threetenbp/docs/UserApi.md
@@ -213,7 +213,7 @@ Get user by user name
 //import io.swagger.client.models.*
 
 val apiInstance = UserApi()
-val username : kotlin.String = username_example // kotlin.String | The name that needs to be fetched. Use user1 for testing. 
+val username : kotlin.String = username_example // kotlin.String | The name that needs to be fetched. Use user1 for testing.
 try {
     val result : User = apiInstance.getUserByName(username)
     println(result)
@@ -230,7 +230,7 @@ try {
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
- **username** | **kotlin.String**| The name that needs to be fetched. Use user1 for testing.  |
+ **username** | **kotlin.String**| The name that needs to be fetched. Use user1 for testing. |
 
 ### Return type
 

--- a/samples/client/petstore/kotlin-threetenbp/src/main/kotlin/io/swagger/client/apis/UserApi.kt
+++ b/samples/client/petstore/kotlin-threetenbp/src/main/kotlin/io/swagger/client/apis/UserApi.kt
@@ -145,7 +145,7 @@ class UserApi(basePath: kotlin.String = "http://petstore.swagger.io/v2") : ApiCl
     /**
     * Get user by user name
     * 
-    * @param username The name that needs to be fetched. Use user1 for testing.  
+    * @param username The name that needs to be fetched. Use user1 for testing. 
     * @return User
     */
     @Suppress("UNCHECKED_CAST")

--- a/samples/client/petstore/kotlin-threetenbp/src/main/kotlin/io/swagger/client/infrastructure/ApiClient.kt
+++ b/samples/client/petstore/kotlin-threetenbp/src/main/kotlin/io/swagger/client/infrastructure/ApiClient.kt
@@ -12,7 +12,12 @@ open class ApiClient(val baseUrl: String) {
         protected val XmlMediaType = "application/xml"
 
         @JvmStatic
-        val client : OkHttpClient = OkHttpClient()
+        val client by lazy {
+            builder.build()
+        }
+
+        @JvmStatic
+        val builder: OkHttpClient.Builder = OkHttpClient.Builder()
 
         @JvmStatic
         var defaultHeaders: Map<String, String> by ApplicationDelegates.setOnce(mapOf(ContentType to JsonMediaType, Accept to JsonMediaType))
@@ -85,9 +90,9 @@ open class ApiClient(val baseUrl: String) {
             RequestMethod.DELETE -> Request.Builder().url(url).delete()
             RequestMethod.GET -> Request.Builder().url(url)
             RequestMethod.HEAD -> Request.Builder().url(url).head()
-            RequestMethod.PATCH -> Request.Builder().url(url).patch(requestBody(body!!, contentType))
-            RequestMethod.PUT -> Request.Builder().url(url).put(requestBody(body!!, contentType))
-            RequestMethod.POST -> Request.Builder().url(url).post(requestBody(body!!, contentType))
+            RequestMethod.PATCH -> Request.Builder().url(url).patch(requestBody(body, contentType))
+            RequestMethod.PUT -> Request.Builder().url(url).put(requestBody(body, contentType))
+            RequestMethod.POST -> Request.Builder().url(url).post(requestBody(body, contentType))
             RequestMethod.OPTIONS -> Request.Builder().url(url).method("OPTIONS", null)
         }
 

--- a/samples/client/petstore/kotlin-threetenbp/src/main/kotlin/io/swagger/client/models/Order.kt
+++ b/samples/client/petstore/kotlin-threetenbp/src/main/kotlin/io/swagger/client/models/Order.kt
@@ -36,7 +36,7 @@ data class Order (
     * Order Status
     * Values: placed,approved,delivered
     */
-    enum class Status(val value: kotlin.Any){
+    enum class Status(val value: kotlin.String){
     
         placed("placed"),
     

--- a/samples/client/petstore/kotlin-threetenbp/src/main/kotlin/io/swagger/client/models/Pet.kt
+++ b/samples/client/petstore/kotlin-threetenbp/src/main/kotlin/io/swagger/client/models/Pet.kt
@@ -38,7 +38,7 @@ data class Pet (
     * pet status in the store
     * Values: available,pending,sold
     */
-    enum class Status(val value: kotlin.Any){
+    enum class Status(val value: kotlin.String){
     
         available("available"),
     

--- a/samples/client/petstore/kotlin/docs/UserApi.md
+++ b/samples/client/petstore/kotlin/docs/UserApi.md
@@ -213,7 +213,7 @@ Get user by user name
 //import io.swagger.client.models.*
 
 val apiInstance = UserApi()
-val username : kotlin.String = username_example // kotlin.String | The name that needs to be fetched. Use user1 for testing. 
+val username : kotlin.String = username_example // kotlin.String | The name that needs to be fetched. Use user1 for testing.
 try {
     val result : User = apiInstance.getUserByName(username)
     println(result)
@@ -230,7 +230,7 @@ try {
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
- **username** | **kotlin.String**| The name that needs to be fetched. Use user1 for testing.  |
+ **username** | **kotlin.String**| The name that needs to be fetched. Use user1 for testing. |
 
 ### Return type
 

--- a/samples/client/petstore/kotlin/src/main/kotlin/io/swagger/client/apis/UserApi.kt
+++ b/samples/client/petstore/kotlin/src/main/kotlin/io/swagger/client/apis/UserApi.kt
@@ -144,7 +144,7 @@ class UserApi(basePath: kotlin.String = "http://petstore.swagger.io/v2") : ApiCl
     /**
     * Get user by user name
     * 
-    * @param username The name that needs to be fetched. Use user1 for testing.  
+    * @param username The name that needs to be fetched. Use user1 for testing. 
     * @return User
     */
     @Suppress("UNCHECKED_CAST")

--- a/samples/client/petstore/kotlin/src/main/kotlin/io/swagger/client/infrastructure/ApiClient.kt
+++ b/samples/client/petstore/kotlin/src/main/kotlin/io/swagger/client/infrastructure/ApiClient.kt
@@ -12,7 +12,12 @@ open class ApiClient(val baseUrl: String) {
         protected val XmlMediaType = "application/xml"
 
         @JvmStatic
-        val client : OkHttpClient = OkHttpClient()
+        val client by lazy {
+            builder.build()
+        }
+
+        @JvmStatic
+        val builder: OkHttpClient.Builder = OkHttpClient.Builder()
 
         @JvmStatic
         var defaultHeaders: Map<String, String> by ApplicationDelegates.setOnce(mapOf(ContentType to JsonMediaType, Accept to JsonMediaType))


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [x] Filed the PR against the correct branch: `3.0.0` branch for changes related to OpenAPI spec 3.0. Default: `master`.
- [x] Copied the [technical committee](https://github.com/swagger-api/swagger-codegen/#swagger-codegen-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

https://github.com/swagger-api/swagger-codegen/issues/7872

Default constructor of OkHttpClient generates a Builder instance implicitly, but I need to customize it. For instance, set some interceptors by calling addInterceptor()

So I add an explicit Builder to ApiClient.
