### PR TITLE
fix #7906 [cpprest] add parameterToString for number type with unspecified format

### DIFF
--- a/modules/swagger-codegen/src/main/resources/cpprest/apiclient-header.mustache
+++ b/modules/swagger-codegen/src/main/resources/cpprest/apiclient-header.mustache
@@ -39,6 +39,7 @@ public:
     static utility::string_t parameterToString(int32_t value);
     static utility::string_t parameterToString(int64_t value);
     static utility::string_t parameterToString(float value);
+    static utility::string_t parameterToString(double value);
     static utility::string_t parameterToString(const utility::datetime &value);
     template<class T>
     static utility::string_t parameterToString(const std::vector<T>& value);

--- a/modules/swagger-codegen/src/main/resources/cpprest/apiclient-source.mustache
+++ b/modules/swagger-codegen/src/main/resources/cpprest/apiclient-source.mustache
@@ -49,6 +49,11 @@ utility::string_t ApiClient::parameterToString(float value)
     return utility::conversions::to_string_t(std::to_string(value));
 }
 
+utility::string_t ApiClient::parameterToString(double value)
+{
+    return utility::conversions::to_string_t(std::to_string(value));
+}
+
 utility::string_t ApiClient::parameterToString(const utility::datetime &value)
 {
     return utility::conversions::to_string_t(value.to_string(utility::datetime::ISO_8601));

--- a/samples/client/petstore/cpprest/ApiClient.cpp
+++ b/samples/client/petstore/cpprest/ApiClient.cpp
@@ -61,6 +61,11 @@ utility::string_t ApiClient::parameterToString(float value)
     return utility::conversions::to_string_t(std::to_string(value));
 }
 
+utility::string_t ApiClient::parameterToString(double value)
+{
+    return utility::conversions::to_string_t(std::to_string(value));
+}
+
 utility::string_t ApiClient::parameterToString(const utility::datetime &value)
 {
     return utility::conversions::to_string_t(value.to_string(utility::datetime::ISO_8601));

--- a/samples/client/petstore/cpprest/ApiClient.h
+++ b/samples/client/petstore/cpprest/ApiClient.h
@@ -51,6 +51,7 @@ public:
     static utility::string_t parameterToString(int32_t value);
     static utility::string_t parameterToString(int64_t value);
     static utility::string_t parameterToString(float value);
+    static utility::string_t parameterToString(double value);
     static utility::string_t parameterToString(const utility::datetime &value);
     template<class T>
     static utility::string_t parameterToString(const std::vector<T>& value);


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [x] Filed the PR against the correct branch: `3.0.0` branch for changes related to OpenAPI spec 3.0. Default: `master`.
- [x] Copied the [technical committee](https://github.com/swagger-api/swagger-codegen/#swagger-codegen-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR
Type `number` with unspecified format is generated to type `double` in C++ code. 
```
 - name: some_number
          in: query
          type: number
          required: true
```
It doesnt have corresponding ApiClient::parameterToString method.
no test were updated

@ravinikam, @stkrwork, @fvarose, @etherealjoy, @martindelille could you please review my PR?

### Comment
cpprest related scripts under `./bin/` were failed by some unknown reason before i have modified source code, sorry have no enougt time to fix them