### PR TITLE
[qt5cpp] Fix crash when API return a map container

### DIFF
--- a/modules/swagger-codegen/src/main/resources/qt5cpp/api-body.mustache
+++ b/modules/swagger-codegen/src/main/resources/qt5cpp/api-body.mustache
@@ -185,7 +185,7 @@ void
     QJsonObject obj = doc.object();
 
     foreach(QString key, obj.keys()) {
-        qint32 val;
+        {{returnBaseType}} val;
         setValue(&val, obj[key], "{{returnBaseType}}", QString());
         output->insert(key, val);
     }

--- a/modules/swagger-codegen/src/main/resources/qt5cpp/api-body.mustache
+++ b/modules/swagger-codegen/src/main/resources/qt5cpp/api-body.mustache
@@ -185,9 +185,9 @@ void
     QJsonObject obj = doc.object();
 
     foreach(QString key, obj.keys()) {
-        qint32* val;
+        qint32 val;
         setValue(&val, obj[key], "{{returnBaseType}}", QString());
-        output->insert(key, *val);
+        output->insert(key, val);
     }
     {{/isMapContainer}}
     {{^isMapContainer}}

--- a/samples/client/petstore/qt5cpp/client/SWGStoreApi.cpp
+++ b/samples/client/petstore/qt5cpp/client/SWGStoreApi.cpp
@@ -126,9 +126,9 @@ SWGStoreApi::getInventoryCallback(SWGHttpRequestWorker * worker) {
     QJsonObject obj = doc.object();
 
     foreach(QString key, obj.keys()) {
-        qint32* val;
+        qint32 val;
         setValue(&val, obj[key], "qint32", QString());
-        output->insert(key, *val);
+        output->insert(key, val);
     }
     worker->deleteLater();
 


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [x] Filed the PR against the correct branch: `3.0.0` branch for changes related to OpenAPI spec 3.0. Default: `master`.
- [x] Copied the [technical committee](https://github.com/swagger-api/swagger-codegen/#swagger-codegen-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

The client was crashing during the callback with a map container. This was due to an initialized pointer passed to the *setValue* method.

@ravinikam @stkrwork @fvarose @etherealjoy