### PR TITLE
Fix the missing tag on FakeApi

### DIFF
--- a/modules/swagger-codegen/src/test/resources/2_0/petstore-with-fake-endpoints-models-for-testing.yaml
+++ b/modules/swagger-codegen/src/test/resources/2_0/petstore-with-fake-endpoints-models-for-testing.yaml
@@ -921,6 +921,8 @@ paths:
           description: successful operation
   /fake/body-with-query-params:
     put:
+      tags:
+        - fake
       operationId: testBodyWithQueryParams
       parameters:
         - name: body


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [x] Filed the PR against the correct branch: `3.0.0` branch for changes related to OpenAPI spec 3.0. Default: `master`.
- [x] Copied the [technical committee](https://github.com/swagger-api/swagger-codegen/#swagger-codegen-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

The definition of `/fake/body-with-query-params` added in  https://github.com/swagger-api/swagger-codegen/pull/7896/commits/afb095bf5e6088a12b8a6b456975017a076d564c , should have a `fake` tag.
With this fix, operation `testBodyWithQueryParams` will be added to the FakeApi.

