### PR TITLE
[WIP] Fix string length validation

### DIFF
--- a/modules/swagger-codegen/src/main/resources/php/model_generic.mustache
+++ b/modules/swagger-codegen/src/main/resources/php/model_generic.mustache
@@ -205,13 +205,13 @@ class {{classname}} {{#parentSchema}}extends {{{parent}}} {{/parentSchema}}{{^pa
         {{/isEnum}}
         {{#hasValidation}}
         {{#maxLength}}
-        if ({{^required}}!is_null($this->container['{{name}}']) && {{/required}}(strlen($this->container['{{name}}']) > {{maxLength}})) {
+        if ({{^required}}!is_null($this->container['{{name}}']) && {{/required}}(mb_strlen($this->container['{{name}}']) > {{maxLength}})) {
             $invalidProperties[] = "invalid value for '{{name}}', the character length must be smaller than or equal to {{{maxLength}}}.";
         }
 
         {{/maxLength}}
         {{#minLength}}
-        if ({{^required}}!is_null($this->container['{{name}}']) && {{/required}}(strlen($this->container['{{name}}']) < {{minLength}})) {
+        if ({{^required}}!is_null($this->container['{{name}}']) && {{/required}}(mb_strlen($this->container['{{name}}']) < {{minLength}})) {
             $invalidProperties[] = "invalid value for '{{name}}', the character length must be bigger than or equal to {{{minLength}}}.";
         }
 
@@ -281,12 +281,12 @@ class {{classname}} {{#parentSchema}}extends {{{parent}}} {{/parentSchema}}{{^pa
         {{/isEnum}}
         {{#hasValidation}}
         {{#maxLength}}
-        if (strlen($this->container['{{name}}']) > {{maxLength}}) {
+        if (mb_strlen($this->container['{{name}}']) > {{maxLength}}) {
             return false;
         }
         {{/maxLength}}
         {{#minLength}}
-        if (strlen($this->container['{{name}}']) < {{minLength}}) {
+        if (mb_strlen($this->container['{{name}}']) < {{minLength}}) {
             return false;
         }
         {{/minLength}}
@@ -366,11 +366,11 @@ class {{classname}} {{#parentSchema}}extends {{{parent}}} {{/parentSchema}}{{^pa
         {{/isEnum}}
         {{#hasValidation}}
         {{#maxLength}}
-        if ({{^required}}!is_null(${{name}}) && {{/required}}(strlen(${{name}}) > {{maxLength}})) {
+        if ({{^required}}!is_null(${{name}}) && {{/required}}(mb_strlen(${{name}}) > {{maxLength}})) {
             throw new \InvalidArgumentException('invalid length for ${{name}} when calling {{classname}}.{{operationId}}, must be smaller than or equal to {{maxLength}}.');
         }{{/maxLength}}
         {{#minLength}}
-        if ({{^required}}!is_null(${{name}}) && {{/required}}(strlen(${{name}}) < {{minLength}})) {
+        if ({{^required}}!is_null(${{name}}) && {{/required}}(mb_strlen(${{name}}) < {{minLength}})) {
             throw new \InvalidArgumentException('invalid length for ${{name}} when calling {{classname}}.{{operationId}}, must be bigger than or equal to {{minLength}}.');
         }
         {{/minLength}}

--- a/samples/client/petstore/php/SwaggerClient-php/tests/FormatTestTest.php
+++ b/samples/client/petstore/php/SwaggerClient-php/tests/FormatTestTest.php
@@ -1,0 +1,26 @@
+<?php
+
+use Swagger\Client\Model\FormatTest;
+
+class FormatTestTest extends \PHPUnit_Framework_TestCase
+{
+    public function testCountTheLengthOfMultiByteStringsCorrectly()
+    {
+        $the64MultiByteStrings = '１２３４５６７８９０１２３４５６７８９０１２３４５６７８９０１２３４５６７８９０１２３４５６７８９０１２３４５６７８９０１２３';
+
+        // Pass the string via constructor.
+        $formatTest = new FormatTest([
+            'password' => $the64MultiByteStrings,
+            // mandatory parameters
+            'number' => 500,
+            'byte' => base64_encode('test'),
+            'date' => new DateTime(),
+        ]);
+
+        $this->assertEmpty($formatTest->listInvalidProperties());
+
+        // Pass the strings via setter.
+        // Throws InvalidArgumentException if it doesn't count the length correctly.
+        $formatTest->setPassword($the64MultiByteStrings);
+    }
+}


### PR DESCRIPTION
### PR checklist

- [ ] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [ ] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [ ] Filed the PR against the correct branch: `3.0.0` branch for changes related to OpenAPI spec 3.0. Default: `master`.
- [ ] Copied the [technical committee](https://github.com/swagger-api/swagger-codegen/#swagger-codegen-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

refs: [[PHP] String length validation in models · Issue #7846 · swagger-api/swagger-codegen](https://github.com/swagger-api/swagger-codegen/issues/7846)

This PR fixes the issue that multibyte string can't be count correctly.

