### PR TITLE
[Dart] Fixes TypeError in Dart 2 mode

### DIFF
--- a/modules/swagger-codegen/src/main/resources/dart/api.mustache
+++ b/modules/swagger-codegen/src/main/resources/dart/api.mustache
@@ -89,7 +89,12 @@ class {{classname}} {
         {{#returnType}}(apiClient.deserialize(response.body, '{{{returnType}}}') as List).map((item) => item as {{returnBaseType}}).toList();{{/returnType}}
       {{/isListContainer}}
       {{^isListContainer}}
-        {{#returnType}}apiClient.deserialize(response.body, '{{{returnType}}}') as {{{returnType}}} {{/returnType}};
+        {{#isMapContainer}}
+          {{#returnType}}new {{{returnType}}}.from(apiClient.deserialize(response.body, '{{{returnType}}}')) {{/returnType}};
+        {{/isMapContainer}}
+        {{^isMapContainer}}
+          {{#returnType}}apiClient.deserialize(response.body, '{{{returnType}}}') as {{{returnType}}} {{/returnType}};
+        {{/isMapContainer}}
       {{/isListContainer}}
     } else {
       return {{#returnType}}null{{/returnType}};

--- a/modules/swagger-codegen/src/main/resources/dart/api.mustache
+++ b/modules/swagger-codegen/src/main/resources/dart/api.mustache
@@ -84,7 +84,13 @@ class {{classname}} {
     if(response.statusCode >= 400) {
       throw new ApiException(response.statusCode, response.body);
     } else if(response.body != null) {
-      return {{#returnType}}apiClient.deserialize(response.body, '{{{returnType}}}') as {{{returnType}}} {{/returnType}};
+      return 
+      {{#isListContainer}}
+        {{#returnType}}(apiClient.deserialize(response.body, '{{{returnType}}}') as List).map((item) => item as {{returnBaseType}}).toList();{{/returnType}}
+      {{/isListContainer}}
+      {{^isListContainer}}
+        {{#returnType}}apiClient.deserialize(response.body, '{{{returnType}}}') as {{{returnType}}} {{/returnType}};
+      {{/isListContainer}}
     } else {
       return {{#returnType}}null{{/returnType}};
     }

--- a/modules/swagger-codegen/src/main/resources/dart/class.mustache
+++ b/modules/swagger-codegen/src/main/resources/dart/class.mustache
@@ -44,7 +44,7 @@ class {{classname}} {
   }
 
   static List<{{classname}}> listFromJson(List<dynamic> json) {
-    return json.map((value) => new {{classname}}.fromJson(value)).toList();
+    return json == null ? new List<{{classname}}>() : json.map((value) => new {{classname}}.fromJson(value)).toList();
   }
 
   static Map<String, {{classname}}> mapFromJson(Map<String, Map<String, dynamic>> json) {

--- a/modules/swagger-codegen/src/main/resources/dart/class.mustache
+++ b/modules/swagger-codegen/src/main/resources/dart/class.mustache
@@ -19,11 +19,18 @@ class {{classname}} {
   {{^isDateTime}}
     {{name}} =
     {{#complexType}}
-        {{#isListContainer}}{{complexType}}.listFromJson(json['{{name}}']){{/isListContainer}}{{^isListContainer}}
-        {{#isMapContainer}}{{complexType}}.mapFromJson(json['{{name}}']){{/isMapContainer}}
-        {{^isMapContainer}}new {{complexType}}.fromJson(json['{{name}}']){{/isMapContainer}}{{/isListContainer}}
+      {{#isListContainer}}{{complexType}}.listFromJson(json['{{name}}']){{/isListContainer}}{{^isListContainer}}
+      {{#isMapContainer}}{{complexType}}.mapFromJson(json['{{name}}']){{/isMapContainer}}
+      {{^isMapContainer}}new {{complexType}}.fromJson(json['{{name}}']){{/isMapContainer}}{{/isListContainer}}
     {{/complexType}}
-    {{^complexType}}json['{{name}}']{{/complexType}};
+    {{^complexType}}
+      {{#isListContainer}}
+        (json['{{name}}'] as List).map((item) => item as {{items.datatype}}).toList()
+      {{/isListContainer}}
+      {{^isListContainer}}
+        json['{{name}}']
+      {{/isListContainer}}
+    {{/complexType}};
   {{/isDateTime}}
   {{/vars}}
   }
@@ -36,12 +43,8 @@ class {{classname}} {
      };
   }
 
-  static List<{{classname}}> listFromJson(List<Map<String, dynamic>> json) {
-    var list = new List<{{classname}}>();
-    if (json != null && json.length > 0) {
-      json.forEach((Map<String, dynamic> value) => list.add(new {{classname}}.fromJson(value)));
-    }
-    return list;
+  static List<{{classname}}> listFromJson(List<dynamic> json) {
+    return json.map((value) => new {{classname}}.fromJson(value)).toList();
   }
 
   static Map<String, {{classname}}> mapFromJson(Map<String, Map<String, dynamic>> json) {

--- a/samples/client/petstore/dart/flutter_petstore/swagger/README.md
+++ b/samples/client/petstore/dart/flutter_petstore/swagger/README.md
@@ -59,7 +59,7 @@ try {
 
 ## Documentation for API Endpoints
 
-All URIs are relative to *http://localhost/v2*
+All URIs are relative to *http://petstore.swagger.io/v2*
 
 Class | Method | HTTP request | Description
 ------------ | ------------- | ------------- | -------------

--- a/samples/client/petstore/dart/flutter_petstore/swagger/docs/PetApi.md
+++ b/samples/client/petstore/dart/flutter_petstore/swagger/docs/PetApi.md
@@ -5,7 +5,7 @@
 import 'package:swagger/api.dart';
 ```
 
-All URIs are relative to *http://localhost/v2*
+All URIs are relative to *http://petstore.swagger.io/v2*
 
 Method | HTTP request | Description
 ------------- | ------------- | -------------

--- a/samples/client/petstore/dart/flutter_petstore/swagger/docs/StoreApi.md
+++ b/samples/client/petstore/dart/flutter_petstore/swagger/docs/StoreApi.md
@@ -5,7 +5,7 @@
 import 'package:swagger/api.dart';
 ```
 
-All URIs are relative to *http://localhost/v2*
+All URIs are relative to *http://petstore.swagger.io/v2*
 
 Method | HTTP request | Description
 ------------- | ------------- | -------------

--- a/samples/client/petstore/dart/flutter_petstore/swagger/docs/UserApi.md
+++ b/samples/client/petstore/dart/flutter_petstore/swagger/docs/UserApi.md
@@ -5,7 +5,7 @@
 import 'package:swagger/api.dart';
 ```
 
-All URIs are relative to *http://localhost/v2*
+All URIs are relative to *http://petstore.swagger.io/v2*
 
 Method | HTTP request | Description
 ------------- | ------------- | -------------

--- a/samples/client/petstore/dart/flutter_petstore/swagger/lib/api/pet_api.dart
+++ b/samples/client/petstore/dart/flutter_petstore/swagger/lib/api/pet_api.dart
@@ -54,7 +54,7 @@ class PetApi {
       throw new ApiException(response.statusCode, response.body);
     } else if(response.body != null) {
       return 
-        ;
+          ;
     } else {
       return ;
     }
@@ -107,7 +107,7 @@ class PetApi {
       throw new ApiException(response.statusCode, response.body);
     } else if(response.body != null) {
       return 
-        ;
+          ;
     } else {
       return ;
     }
@@ -265,7 +265,7 @@ class PetApi {
       throw new ApiException(response.statusCode, response.body);
     } else if(response.body != null) {
       return 
-        apiClient.deserialize(response.body, 'Pet') as Pet ;
+          apiClient.deserialize(response.body, 'Pet') as Pet ;
     } else {
       return null;
     }
@@ -317,7 +317,7 @@ class PetApi {
       throw new ApiException(response.statusCode, response.body);
     } else if(response.body != null) {
       return 
-        ;
+          ;
     } else {
       return ;
     }
@@ -383,7 +383,7 @@ if (status != null)
       throw new ApiException(response.statusCode, response.body);
     } else if(response.body != null) {
       return 
-        ;
+          ;
     } else {
       return ;
     }
@@ -449,7 +449,7 @@ if (status != null)
       throw new ApiException(response.statusCode, response.body);
     } else if(response.body != null) {
       return 
-        apiClient.deserialize(response.body, 'ApiResponse') as ApiResponse ;
+          apiClient.deserialize(response.body, 'ApiResponse') as ApiResponse ;
     } else {
       return null;
     }

--- a/samples/client/petstore/dart/flutter_petstore/swagger/lib/api/pet_api.dart
+++ b/samples/client/petstore/dart/flutter_petstore/swagger/lib/api/pet_api.dart
@@ -53,7 +53,8 @@ class PetApi {
     if(response.statusCode >= 400) {
       throw new ApiException(response.statusCode, response.body);
     } else if(response.body != null) {
-      return ;
+      return 
+        ;
     } else {
       return ;
     }
@@ -105,7 +106,8 @@ class PetApi {
     if(response.statusCode >= 400) {
       throw new ApiException(response.statusCode, response.body);
     } else if(response.body != null) {
-      return ;
+      return 
+        ;
     } else {
       return ;
     }
@@ -157,7 +159,8 @@ class PetApi {
     if(response.statusCode >= 400) {
       throw new ApiException(response.statusCode, response.body);
     } else if(response.body != null) {
-      return apiClient.deserialize(response.body, 'List<Pet>') as List<Pet> ;
+      return 
+        (apiClient.deserialize(response.body, 'List<Pet>') as List).map((item) => item as Pet).toList();
     } else {
       return null;
     }
@@ -209,7 +212,8 @@ class PetApi {
     if(response.statusCode >= 400) {
       throw new ApiException(response.statusCode, response.body);
     } else if(response.body != null) {
-      return apiClient.deserialize(response.body, 'List<Pet>') as List<Pet> ;
+      return 
+        (apiClient.deserialize(response.body, 'List<Pet>') as List).map((item) => item as Pet).toList();
     } else {
       return null;
     }
@@ -260,7 +264,8 @@ class PetApi {
     if(response.statusCode >= 400) {
       throw new ApiException(response.statusCode, response.body);
     } else if(response.body != null) {
-      return apiClient.deserialize(response.body, 'Pet') as Pet ;
+      return 
+        apiClient.deserialize(response.body, 'Pet') as Pet ;
     } else {
       return null;
     }
@@ -311,7 +316,8 @@ class PetApi {
     if(response.statusCode >= 400) {
       throw new ApiException(response.statusCode, response.body);
     } else if(response.body != null) {
-      return ;
+      return 
+        ;
     } else {
       return ;
     }
@@ -376,7 +382,8 @@ if (status != null)
     if(response.statusCode >= 400) {
       throw new ApiException(response.statusCode, response.body);
     } else if(response.body != null) {
-      return ;
+      return 
+        ;
     } else {
       return ;
     }
@@ -441,7 +448,8 @@ if (status != null)
     if(response.statusCode >= 400) {
       throw new ApiException(response.statusCode, response.body);
     } else if(response.body != null) {
-      return apiClient.deserialize(response.body, 'ApiResponse') as ApiResponse ;
+      return 
+        apiClient.deserialize(response.body, 'ApiResponse') as ApiResponse ;
     } else {
       return null;
     }

--- a/samples/client/petstore/dart/flutter_petstore/swagger/lib/api/store_api.dart
+++ b/samples/client/petstore/dart/flutter_petstore/swagger/lib/api/store_api.dart
@@ -53,7 +53,8 @@ class StoreApi {
     if(response.statusCode >= 400) {
       throw new ApiException(response.statusCode, response.body);
     } else if(response.body != null) {
-      return ;
+      return 
+        ;
     } else {
       return ;
     }
@@ -101,7 +102,8 @@ class StoreApi {
     if(response.statusCode >= 400) {
       throw new ApiException(response.statusCode, response.body);
     } else if(response.body != null) {
-      return apiClient.deserialize(response.body, 'Map<String, int>') as Map<String, int> ;
+      return 
+        apiClient.deserialize(response.body, 'Map<String, int>') as Map<String, int> ;
     } else {
       return null;
     }
@@ -152,7 +154,8 @@ class StoreApi {
     if(response.statusCode >= 400) {
       throw new ApiException(response.statusCode, response.body);
     } else if(response.body != null) {
-      return apiClient.deserialize(response.body, 'Order') as Order ;
+      return 
+        apiClient.deserialize(response.body, 'Order') as Order ;
     } else {
       return null;
     }
@@ -203,7 +206,8 @@ class StoreApi {
     if(response.statusCode >= 400) {
       throw new ApiException(response.statusCode, response.body);
     } else if(response.body != null) {
-      return apiClient.deserialize(response.body, 'Order') as Order ;
+      return 
+        apiClient.deserialize(response.body, 'Order') as Order ;
     } else {
       return null;
     }

--- a/samples/client/petstore/dart/flutter_petstore/swagger/lib/api/store_api.dart
+++ b/samples/client/petstore/dart/flutter_petstore/swagger/lib/api/store_api.dart
@@ -54,7 +54,7 @@ class StoreApi {
       throw new ApiException(response.statusCode, response.body);
     } else if(response.body != null) {
       return 
-        ;
+          ;
     } else {
       return ;
     }
@@ -103,7 +103,7 @@ class StoreApi {
       throw new ApiException(response.statusCode, response.body);
     } else if(response.body != null) {
       return 
-        apiClient.deserialize(response.body, 'Map<String, int>') as Map<String, int> ;
+          new Map<String, int>.from(apiClient.deserialize(response.body, 'Map<String, int>')) ;
     } else {
       return null;
     }
@@ -155,7 +155,7 @@ class StoreApi {
       throw new ApiException(response.statusCode, response.body);
     } else if(response.body != null) {
       return 
-        apiClient.deserialize(response.body, 'Order') as Order ;
+          apiClient.deserialize(response.body, 'Order') as Order ;
     } else {
       return null;
     }
@@ -207,7 +207,7 @@ class StoreApi {
       throw new ApiException(response.statusCode, response.body);
     } else if(response.body != null) {
       return 
-        apiClient.deserialize(response.body, 'Order') as Order ;
+          apiClient.deserialize(response.body, 'Order') as Order ;
     } else {
       return null;
     }

--- a/samples/client/petstore/dart/flutter_petstore/swagger/lib/api/user_api.dart
+++ b/samples/client/petstore/dart/flutter_petstore/swagger/lib/api/user_api.dart
@@ -53,7 +53,8 @@ class UserApi {
     if(response.statusCode >= 400) {
       throw new ApiException(response.statusCode, response.body);
     } else if(response.body != null) {
-      return ;
+      return 
+        ;
     } else {
       return ;
     }
@@ -104,7 +105,8 @@ class UserApi {
     if(response.statusCode >= 400) {
       throw new ApiException(response.statusCode, response.body);
     } else if(response.body != null) {
-      return ;
+      return 
+        ;
     } else {
       return ;
     }
@@ -155,7 +157,8 @@ class UserApi {
     if(response.statusCode >= 400) {
       throw new ApiException(response.statusCode, response.body);
     } else if(response.body != null) {
-      return ;
+      return 
+        ;
     } else {
       return ;
     }
@@ -206,7 +209,8 @@ class UserApi {
     if(response.statusCode >= 400) {
       throw new ApiException(response.statusCode, response.body);
     } else if(response.body != null) {
-      return ;
+      return 
+        ;
     } else {
       return ;
     }
@@ -257,7 +261,8 @@ class UserApi {
     if(response.statusCode >= 400) {
       throw new ApiException(response.statusCode, response.body);
     } else if(response.body != null) {
-      return apiClient.deserialize(response.body, 'User') as User ;
+      return 
+        apiClient.deserialize(response.body, 'User') as User ;
     } else {
       return null;
     }
@@ -313,7 +318,8 @@ class UserApi {
     if(response.statusCode >= 400) {
       throw new ApiException(response.statusCode, response.body);
     } else if(response.body != null) {
-      return apiClient.deserialize(response.body, 'String') as String ;
+      return 
+        apiClient.deserialize(response.body, 'String') as String ;
     } else {
       return null;
     }
@@ -361,7 +367,8 @@ class UserApi {
     if(response.statusCode >= 400) {
       throw new ApiException(response.statusCode, response.body);
     } else if(response.body != null) {
-      return ;
+      return 
+        ;
     } else {
       return ;
     }
@@ -415,7 +422,8 @@ class UserApi {
     if(response.statusCode >= 400) {
       throw new ApiException(response.statusCode, response.body);
     } else if(response.body != null) {
-      return ;
+      return 
+        ;
     } else {
       return ;
     }

--- a/samples/client/petstore/dart/flutter_petstore/swagger/lib/api/user_api.dart
+++ b/samples/client/petstore/dart/flutter_petstore/swagger/lib/api/user_api.dart
@@ -54,7 +54,7 @@ class UserApi {
       throw new ApiException(response.statusCode, response.body);
     } else if(response.body != null) {
       return 
-        ;
+          ;
     } else {
       return ;
     }
@@ -106,7 +106,7 @@ class UserApi {
       throw new ApiException(response.statusCode, response.body);
     } else if(response.body != null) {
       return 
-        ;
+          ;
     } else {
       return ;
     }
@@ -158,7 +158,7 @@ class UserApi {
       throw new ApiException(response.statusCode, response.body);
     } else if(response.body != null) {
       return 
-        ;
+          ;
     } else {
       return ;
     }
@@ -210,7 +210,7 @@ class UserApi {
       throw new ApiException(response.statusCode, response.body);
     } else if(response.body != null) {
       return 
-        ;
+          ;
     } else {
       return ;
     }
@@ -262,7 +262,7 @@ class UserApi {
       throw new ApiException(response.statusCode, response.body);
     } else if(response.body != null) {
       return 
-        apiClient.deserialize(response.body, 'User') as User ;
+          apiClient.deserialize(response.body, 'User') as User ;
     } else {
       return null;
     }
@@ -319,7 +319,7 @@ class UserApi {
       throw new ApiException(response.statusCode, response.body);
     } else if(response.body != null) {
       return 
-        apiClient.deserialize(response.body, 'String') as String ;
+          apiClient.deserialize(response.body, 'String') as String ;
     } else {
       return null;
     }
@@ -368,7 +368,7 @@ class UserApi {
       throw new ApiException(response.statusCode, response.body);
     } else if(response.body != null) {
       return 
-        ;
+          ;
     } else {
       return ;
     }
@@ -423,7 +423,7 @@ class UserApi {
       throw new ApiException(response.statusCode, response.body);
     } else if(response.body != null) {
       return 
-        ;
+          ;
     } else {
       return ;
     }

--- a/samples/client/petstore/dart/flutter_petstore/swagger/lib/api_client.dart
+++ b/samples/client/petstore/dart/flutter_petstore/swagger/lib/api_client.dart
@@ -18,7 +18,7 @@ class ApiClient {
   final _RegList = new RegExp(r'^List<(.*)>$');
   final _RegMap = new RegExp(r'^Map<String,(.*)>$');
 
-  ApiClient({this.basePath: "http://localhost/v2"}) {
+  ApiClient({this.basePath: "http://petstore.swagger.io/v2"}) {
     // Setup authentications (key: authentication name, value: authentication).
     _authentications['api_key'] = new ApiKeyAuth("header", "api_key");
     _authentications['petstore_auth'] = new OAuth();

--- a/samples/client/petstore/dart/flutter_petstore/swagger/lib/model/api_response.dart
+++ b/samples/client/petstore/dart/flutter_petstore/swagger/lib/model/api_response.dart
@@ -20,11 +20,14 @@ class ApiResponse {
   ApiResponse.fromJson(Map<String, dynamic> json) {
     if (json == null) return;
     code =
-    json['code'];
+        json['code']
+    ;
     type =
-    json['type'];
+        json['type']
+    ;
     message =
-    json['message'];
+        json['message']
+    ;
   }
 
   Map<String, dynamic> toJson() {
@@ -35,12 +38,8 @@ class ApiResponse {
      };
   }
 
-  static List<ApiResponse> listFromJson(List<Map<String, dynamic>> json) {
-    var list = new List<ApiResponse>();
-    if (json != null && json.length > 0) {
-      json.forEach((Map<String, dynamic> value) => list.add(new ApiResponse.fromJson(value)));
-    }
-    return list;
+  static List<ApiResponse> listFromJson(List<dynamic> json) {
+    return json.map((value) => new ApiResponse.fromJson(value)).toList();
   }
 
   static Map<String, ApiResponse> mapFromJson(Map<String, Map<String, dynamic>> json) {

--- a/samples/client/petstore/dart/flutter_petstore/swagger/lib/model/api_response.dart
+++ b/samples/client/petstore/dart/flutter_petstore/swagger/lib/model/api_response.dart
@@ -39,7 +39,7 @@ class ApiResponse {
   }
 
   static List<ApiResponse> listFromJson(List<dynamic> json) {
-    return json.map((value) => new ApiResponse.fromJson(value)).toList();
+    return json == null ? new List<ApiResponse>() : json.map((value) => new ApiResponse.fromJson(value)).toList();
   }
 
   static Map<String, ApiResponse> mapFromJson(Map<String, Map<String, dynamic>> json) {

--- a/samples/client/petstore/dart/flutter_petstore/swagger/lib/model/category.dart
+++ b/samples/client/petstore/dart/flutter_petstore/swagger/lib/model/category.dart
@@ -17,9 +17,11 @@ class Category {
   Category.fromJson(Map<String, dynamic> json) {
     if (json == null) return;
     id =
-    json['id'];
+        json['id']
+    ;
     name =
-    json['name'];
+        json['name']
+    ;
   }
 
   Map<String, dynamic> toJson() {
@@ -29,12 +31,8 @@ class Category {
      };
   }
 
-  static List<Category> listFromJson(List<Map<String, dynamic>> json) {
-    var list = new List<Category>();
-    if (json != null && json.length > 0) {
-      json.forEach((Map<String, dynamic> value) => list.add(new Category.fromJson(value)));
-    }
-    return list;
+  static List<Category> listFromJson(List<dynamic> json) {
+    return json.map((value) => new Category.fromJson(value)).toList();
   }
 
   static Map<String, Category> mapFromJson(Map<String, Map<String, dynamic>> json) {

--- a/samples/client/petstore/dart/flutter_petstore/swagger/lib/model/category.dart
+++ b/samples/client/petstore/dart/flutter_petstore/swagger/lib/model/category.dart
@@ -32,7 +32,7 @@ class Category {
   }
 
   static List<Category> listFromJson(List<dynamic> json) {
-    return json.map((value) => new Category.fromJson(value)).toList();
+    return json == null ? new List<Category>() : json.map((value) => new Category.fromJson(value)).toList();
   }
 
   static Map<String, Category> mapFromJson(Map<String, Map<String, dynamic>> json) {

--- a/samples/client/petstore/dart/flutter_petstore/swagger/lib/model/order.dart
+++ b/samples/client/petstore/dart/flutter_petstore/swagger/lib/model/order.dart
@@ -29,16 +29,21 @@ class Order {
   Order.fromJson(Map<String, dynamic> json) {
     if (json == null) return;
     id =
-    json['id'];
+        json['id']
+    ;
     petId =
-    json['petId'];
+        json['petId']
+    ;
     quantity =
-    json['quantity'];
+        json['quantity']
+    ;
     shipDate = json['shipDate'] == null ? null : DateTime.parse(json['shipDate']);
     status =
-    json['status'];
+        json['status']
+    ;
     complete =
-    json['complete'];
+        json['complete']
+    ;
   }
 
   Map<String, dynamic> toJson() {
@@ -52,12 +57,8 @@ class Order {
      };
   }
 
-  static List<Order> listFromJson(List<Map<String, dynamic>> json) {
-    var list = new List<Order>();
-    if (json != null && json.length > 0) {
-      json.forEach((Map<String, dynamic> value) => list.add(new Order.fromJson(value)));
-    }
-    return list;
+  static List<Order> listFromJson(List<dynamic> json) {
+    return json.map((value) => new Order.fromJson(value)).toList();
   }
 
   static Map<String, Order> mapFromJson(Map<String, Map<String, dynamic>> json) {

--- a/samples/client/petstore/dart/flutter_petstore/swagger/lib/model/order.dart
+++ b/samples/client/petstore/dart/flutter_petstore/swagger/lib/model/order.dart
@@ -58,7 +58,7 @@ class Order {
   }
 
   static List<Order> listFromJson(List<dynamic> json) {
-    return json.map((value) => new Order.fromJson(value)).toList();
+    return json == null ? new List<Order>() : json.map((value) => new Order.fromJson(value)).toList();
   }
 
   static Map<String, Order> mapFromJson(Map<String, Map<String, dynamic>> json) {

--- a/samples/client/petstore/dart/flutter_petstore/swagger/lib/model/pet.dart
+++ b/samples/client/petstore/dart/flutter_petstore/swagger/lib/model/pet.dart
@@ -62,7 +62,7 @@ class Pet {
   }
 
   static List<Pet> listFromJson(List<dynamic> json) {
-    return json.map((value) => new Pet.fromJson(value)).toList();
+    return json == null ? new List<Pet>() : json.map((value) => new Pet.fromJson(value)).toList();
   }
 
   static Map<String, Pet> mapFromJson(Map<String, Map<String, dynamic>> json) {

--- a/samples/client/petstore/dart/flutter_petstore/swagger/lib/model/pet.dart
+++ b/samples/client/petstore/dart/flutter_petstore/swagger/lib/model/pet.dart
@@ -29,21 +29,25 @@ class Pet {
   Pet.fromJson(Map<String, dynamic> json) {
     if (json == null) return;
     id =
-    json['id'];
+        json['id']
+    ;
     category =
-        
-        
-        new Category.fromJson(json['category'])
-    ;
+      
+      
+      new Category.fromJson(json['category'])
+;
     name =
-    json['name'];
-    photoUrls =
-    json['photoUrls'];
-    tags =
-        Tag.listFromJson(json['tags'])
+        json['name']
     ;
+    photoUrls =
+        (json['photoUrls'] as List).map((item) => item as String).toList()
+    ;
+    tags =
+      Tag.listFromJson(json['tags'])
+;
     status =
-    json['status'];
+        json['status']
+    ;
   }
 
   Map<String, dynamic> toJson() {
@@ -57,12 +61,8 @@ class Pet {
      };
   }
 
-  static List<Pet> listFromJson(List<Map<String, dynamic>> json) {
-    var list = new List<Pet>();
-    if (json != null && json.length > 0) {
-      json.forEach((Map<String, dynamic> value) => list.add(new Pet.fromJson(value)));
-    }
-    return list;
+  static List<Pet> listFromJson(List<dynamic> json) {
+    return json.map((value) => new Pet.fromJson(value)).toList();
   }
 
   static Map<String, Pet> mapFromJson(Map<String, Map<String, dynamic>> json) {

--- a/samples/client/petstore/dart/flutter_petstore/swagger/lib/model/tag.dart
+++ b/samples/client/petstore/dart/flutter_petstore/swagger/lib/model/tag.dart
@@ -32,7 +32,7 @@ class Tag {
   }
 
   static List<Tag> listFromJson(List<dynamic> json) {
-    return json.map((value) => new Tag.fromJson(value)).toList();
+    return json == null ? new List<Tag>() : json.map((value) => new Tag.fromJson(value)).toList();
   }
 
   static Map<String, Tag> mapFromJson(Map<String, Map<String, dynamic>> json) {

--- a/samples/client/petstore/dart/flutter_petstore/swagger/lib/model/tag.dart
+++ b/samples/client/petstore/dart/flutter_petstore/swagger/lib/model/tag.dart
@@ -17,9 +17,11 @@ class Tag {
   Tag.fromJson(Map<String, dynamic> json) {
     if (json == null) return;
     id =
-    json['id'];
+        json['id']
+    ;
     name =
-    json['name'];
+        json['name']
+    ;
   }
 
   Map<String, dynamic> toJson() {
@@ -29,12 +31,8 @@ class Tag {
      };
   }
 
-  static List<Tag> listFromJson(List<Map<String, dynamic>> json) {
-    var list = new List<Tag>();
-    if (json != null && json.length > 0) {
-      json.forEach((Map<String, dynamic> value) => list.add(new Tag.fromJson(value)));
-    }
-    return list;
+  static List<Tag> listFromJson(List<dynamic> json) {
+    return json.map((value) => new Tag.fromJson(value)).toList();
   }
 
   static Map<String, Tag> mapFromJson(Map<String, Map<String, dynamic>> json) {

--- a/samples/client/petstore/dart/flutter_petstore/swagger/lib/model/user.dart
+++ b/samples/client/petstore/dart/flutter_petstore/swagger/lib/model/user.dart
@@ -35,21 +35,29 @@ class User {
   User.fromJson(Map<String, dynamic> json) {
     if (json == null) return;
     id =
-    json['id'];
+        json['id']
+    ;
     username =
-    json['username'];
+        json['username']
+    ;
     firstName =
-    json['firstName'];
+        json['firstName']
+    ;
     lastName =
-    json['lastName'];
+        json['lastName']
+    ;
     email =
-    json['email'];
+        json['email']
+    ;
     password =
-    json['password'];
+        json['password']
+    ;
     phone =
-    json['phone'];
+        json['phone']
+    ;
     userStatus =
-    json['userStatus'];
+        json['userStatus']
+    ;
   }
 
   Map<String, dynamic> toJson() {
@@ -65,12 +73,8 @@ class User {
      };
   }
 
-  static List<User> listFromJson(List<Map<String, dynamic>> json) {
-    var list = new List<User>();
-    if (json != null && json.length > 0) {
-      json.forEach((Map<String, dynamic> value) => list.add(new User.fromJson(value)));
-    }
-    return list;
+  static List<User> listFromJson(List<dynamic> json) {
+    return json.map((value) => new User.fromJson(value)).toList();
   }
 
   static Map<String, User> mapFromJson(Map<String, Map<String, dynamic>> json) {

--- a/samples/client/petstore/dart/flutter_petstore/swagger/lib/model/user.dart
+++ b/samples/client/petstore/dart/flutter_petstore/swagger/lib/model/user.dart
@@ -74,7 +74,7 @@ class User {
   }
 
   static List<User> listFromJson(List<dynamic> json) {
-    return json.map((value) => new User.fromJson(value)).toList();
+    return json == null ? new List<User>() : json.map((value) => new User.fromJson(value)).toList();
   }
 
   static Map<String, User> mapFromJson(Map<String, Map<String, dynamic>> json) {

--- a/samples/client/petstore/dart/swagger-browser-client/README.md
+++ b/samples/client/petstore/dart/swagger-browser-client/README.md
@@ -59,7 +59,7 @@ try {
 
 ## Documentation for API Endpoints
 
-All URIs are relative to *http://localhost/v2*
+All URIs are relative to *http://petstore.swagger.io/v2*
 
 Class | Method | HTTP request | Description
 ------------ | ------------- | ------------- | -------------

--- a/samples/client/petstore/dart/swagger-browser-client/docs/PetApi.md
+++ b/samples/client/petstore/dart/swagger-browser-client/docs/PetApi.md
@@ -5,7 +5,7 @@
 import 'package:swagger/api.dart';
 ```
 
-All URIs are relative to *http://localhost/v2*
+All URIs are relative to *http://petstore.swagger.io/v2*
 
 Method | HTTP request | Description
 ------------- | ------------- | -------------

--- a/samples/client/petstore/dart/swagger-browser-client/docs/StoreApi.md
+++ b/samples/client/petstore/dart/swagger-browser-client/docs/StoreApi.md
@@ -5,7 +5,7 @@
 import 'package:swagger/api.dart';
 ```
 
-All URIs are relative to *http://localhost/v2*
+All URIs are relative to *http://petstore.swagger.io/v2*
 
 Method | HTTP request | Description
 ------------- | ------------- | -------------

--- a/samples/client/petstore/dart/swagger-browser-client/docs/UserApi.md
+++ b/samples/client/petstore/dart/swagger-browser-client/docs/UserApi.md
@@ -5,7 +5,7 @@
 import 'package:swagger/api.dart';
 ```
 
-All URIs are relative to *http://localhost/v2*
+All URIs are relative to *http://petstore.swagger.io/v2*
 
 Method | HTTP request | Description
 ------------- | ------------- | -------------

--- a/samples/client/petstore/dart/swagger-browser-client/lib/api/pet_api.dart
+++ b/samples/client/petstore/dart/swagger-browser-client/lib/api/pet_api.dart
@@ -54,7 +54,7 @@ class PetApi {
       throw new ApiException(response.statusCode, response.body);
     } else if(response.body != null) {
       return 
-        ;
+          ;
     } else {
       return ;
     }
@@ -107,7 +107,7 @@ class PetApi {
       throw new ApiException(response.statusCode, response.body);
     } else if(response.body != null) {
       return 
-        ;
+          ;
     } else {
       return ;
     }
@@ -265,7 +265,7 @@ class PetApi {
       throw new ApiException(response.statusCode, response.body);
     } else if(response.body != null) {
       return 
-        apiClient.deserialize(response.body, 'Pet') as Pet ;
+          apiClient.deserialize(response.body, 'Pet') as Pet ;
     } else {
       return null;
     }
@@ -317,7 +317,7 @@ class PetApi {
       throw new ApiException(response.statusCode, response.body);
     } else if(response.body != null) {
       return 
-        ;
+          ;
     } else {
       return ;
     }
@@ -383,7 +383,7 @@ if (status != null)
       throw new ApiException(response.statusCode, response.body);
     } else if(response.body != null) {
       return 
-        ;
+          ;
     } else {
       return ;
     }
@@ -449,7 +449,7 @@ if (status != null)
       throw new ApiException(response.statusCode, response.body);
     } else if(response.body != null) {
       return 
-        apiClient.deserialize(response.body, 'ApiResponse') as ApiResponse ;
+          apiClient.deserialize(response.body, 'ApiResponse') as ApiResponse ;
     } else {
       return null;
     }

--- a/samples/client/petstore/dart/swagger-browser-client/lib/api/pet_api.dart
+++ b/samples/client/petstore/dart/swagger-browser-client/lib/api/pet_api.dart
@@ -53,7 +53,8 @@ class PetApi {
     if(response.statusCode >= 400) {
       throw new ApiException(response.statusCode, response.body);
     } else if(response.body != null) {
-      return ;
+      return 
+        ;
     } else {
       return ;
     }
@@ -105,7 +106,8 @@ class PetApi {
     if(response.statusCode >= 400) {
       throw new ApiException(response.statusCode, response.body);
     } else if(response.body != null) {
-      return ;
+      return 
+        ;
     } else {
       return ;
     }
@@ -157,7 +159,8 @@ class PetApi {
     if(response.statusCode >= 400) {
       throw new ApiException(response.statusCode, response.body);
     } else if(response.body != null) {
-      return apiClient.deserialize(response.body, 'List<Pet>') as List<Pet> ;
+      return 
+        (apiClient.deserialize(response.body, 'List<Pet>') as List).map((item) => item as Pet).toList();
     } else {
       return null;
     }
@@ -209,7 +212,8 @@ class PetApi {
     if(response.statusCode >= 400) {
       throw new ApiException(response.statusCode, response.body);
     } else if(response.body != null) {
-      return apiClient.deserialize(response.body, 'List<Pet>') as List<Pet> ;
+      return 
+        (apiClient.deserialize(response.body, 'List<Pet>') as List).map((item) => item as Pet).toList();
     } else {
       return null;
     }
@@ -260,7 +264,8 @@ class PetApi {
     if(response.statusCode >= 400) {
       throw new ApiException(response.statusCode, response.body);
     } else if(response.body != null) {
-      return apiClient.deserialize(response.body, 'Pet') as Pet ;
+      return 
+        apiClient.deserialize(response.body, 'Pet') as Pet ;
     } else {
       return null;
     }
@@ -311,7 +316,8 @@ class PetApi {
     if(response.statusCode >= 400) {
       throw new ApiException(response.statusCode, response.body);
     } else if(response.body != null) {
-      return ;
+      return 
+        ;
     } else {
       return ;
     }
@@ -376,7 +382,8 @@ if (status != null)
     if(response.statusCode >= 400) {
       throw new ApiException(response.statusCode, response.body);
     } else if(response.body != null) {
-      return ;
+      return 
+        ;
     } else {
       return ;
     }
@@ -441,7 +448,8 @@ if (status != null)
     if(response.statusCode >= 400) {
       throw new ApiException(response.statusCode, response.body);
     } else if(response.body != null) {
-      return apiClient.deserialize(response.body, 'ApiResponse') as ApiResponse ;
+      return 
+        apiClient.deserialize(response.body, 'ApiResponse') as ApiResponse ;
     } else {
       return null;
     }

--- a/samples/client/petstore/dart/swagger-browser-client/lib/api/store_api.dart
+++ b/samples/client/petstore/dart/swagger-browser-client/lib/api/store_api.dart
@@ -53,7 +53,8 @@ class StoreApi {
     if(response.statusCode >= 400) {
       throw new ApiException(response.statusCode, response.body);
     } else if(response.body != null) {
-      return ;
+      return 
+        ;
     } else {
       return ;
     }
@@ -101,7 +102,8 @@ class StoreApi {
     if(response.statusCode >= 400) {
       throw new ApiException(response.statusCode, response.body);
     } else if(response.body != null) {
-      return apiClient.deserialize(response.body, 'Map<String, int>') as Map<String, int> ;
+      return 
+        apiClient.deserialize(response.body, 'Map<String, int>') as Map<String, int> ;
     } else {
       return null;
     }
@@ -152,7 +154,8 @@ class StoreApi {
     if(response.statusCode >= 400) {
       throw new ApiException(response.statusCode, response.body);
     } else if(response.body != null) {
-      return apiClient.deserialize(response.body, 'Order') as Order ;
+      return 
+        apiClient.deserialize(response.body, 'Order') as Order ;
     } else {
       return null;
     }
@@ -203,7 +206,8 @@ class StoreApi {
     if(response.statusCode >= 400) {
       throw new ApiException(response.statusCode, response.body);
     } else if(response.body != null) {
-      return apiClient.deserialize(response.body, 'Order') as Order ;
+      return 
+        apiClient.deserialize(response.body, 'Order') as Order ;
     } else {
       return null;
     }

--- a/samples/client/petstore/dart/swagger-browser-client/lib/api/store_api.dart
+++ b/samples/client/petstore/dart/swagger-browser-client/lib/api/store_api.dart
@@ -54,7 +54,7 @@ class StoreApi {
       throw new ApiException(response.statusCode, response.body);
     } else if(response.body != null) {
       return 
-        ;
+          ;
     } else {
       return ;
     }
@@ -103,7 +103,7 @@ class StoreApi {
       throw new ApiException(response.statusCode, response.body);
     } else if(response.body != null) {
       return 
-        apiClient.deserialize(response.body, 'Map<String, int>') as Map<String, int> ;
+          new Map<String, int>.from(apiClient.deserialize(response.body, 'Map<String, int>')) ;
     } else {
       return null;
     }
@@ -155,7 +155,7 @@ class StoreApi {
       throw new ApiException(response.statusCode, response.body);
     } else if(response.body != null) {
       return 
-        apiClient.deserialize(response.body, 'Order') as Order ;
+          apiClient.deserialize(response.body, 'Order') as Order ;
     } else {
       return null;
     }
@@ -207,7 +207,7 @@ class StoreApi {
       throw new ApiException(response.statusCode, response.body);
     } else if(response.body != null) {
       return 
-        apiClient.deserialize(response.body, 'Order') as Order ;
+          apiClient.deserialize(response.body, 'Order') as Order ;
     } else {
       return null;
     }

--- a/samples/client/petstore/dart/swagger-browser-client/lib/api/user_api.dart
+++ b/samples/client/petstore/dart/swagger-browser-client/lib/api/user_api.dart
@@ -53,7 +53,8 @@ class UserApi {
     if(response.statusCode >= 400) {
       throw new ApiException(response.statusCode, response.body);
     } else if(response.body != null) {
-      return ;
+      return 
+        ;
     } else {
       return ;
     }
@@ -104,7 +105,8 @@ class UserApi {
     if(response.statusCode >= 400) {
       throw new ApiException(response.statusCode, response.body);
     } else if(response.body != null) {
-      return ;
+      return 
+        ;
     } else {
       return ;
     }
@@ -155,7 +157,8 @@ class UserApi {
     if(response.statusCode >= 400) {
       throw new ApiException(response.statusCode, response.body);
     } else if(response.body != null) {
-      return ;
+      return 
+        ;
     } else {
       return ;
     }
@@ -206,7 +209,8 @@ class UserApi {
     if(response.statusCode >= 400) {
       throw new ApiException(response.statusCode, response.body);
     } else if(response.body != null) {
-      return ;
+      return 
+        ;
     } else {
       return ;
     }
@@ -257,7 +261,8 @@ class UserApi {
     if(response.statusCode >= 400) {
       throw new ApiException(response.statusCode, response.body);
     } else if(response.body != null) {
-      return apiClient.deserialize(response.body, 'User') as User ;
+      return 
+        apiClient.deserialize(response.body, 'User') as User ;
     } else {
       return null;
     }
@@ -313,7 +318,8 @@ class UserApi {
     if(response.statusCode >= 400) {
       throw new ApiException(response.statusCode, response.body);
     } else if(response.body != null) {
-      return apiClient.deserialize(response.body, 'String') as String ;
+      return 
+        apiClient.deserialize(response.body, 'String') as String ;
     } else {
       return null;
     }
@@ -361,7 +367,8 @@ class UserApi {
     if(response.statusCode >= 400) {
       throw new ApiException(response.statusCode, response.body);
     } else if(response.body != null) {
-      return ;
+      return 
+        ;
     } else {
       return ;
     }
@@ -415,7 +422,8 @@ class UserApi {
     if(response.statusCode >= 400) {
       throw new ApiException(response.statusCode, response.body);
     } else if(response.body != null) {
-      return ;
+      return 
+        ;
     } else {
       return ;
     }

--- a/samples/client/petstore/dart/swagger-browser-client/lib/api/user_api.dart
+++ b/samples/client/petstore/dart/swagger-browser-client/lib/api/user_api.dart
@@ -54,7 +54,7 @@ class UserApi {
       throw new ApiException(response.statusCode, response.body);
     } else if(response.body != null) {
       return 
-        ;
+          ;
     } else {
       return ;
     }
@@ -106,7 +106,7 @@ class UserApi {
       throw new ApiException(response.statusCode, response.body);
     } else if(response.body != null) {
       return 
-        ;
+          ;
     } else {
       return ;
     }
@@ -158,7 +158,7 @@ class UserApi {
       throw new ApiException(response.statusCode, response.body);
     } else if(response.body != null) {
       return 
-        ;
+          ;
     } else {
       return ;
     }
@@ -210,7 +210,7 @@ class UserApi {
       throw new ApiException(response.statusCode, response.body);
     } else if(response.body != null) {
       return 
-        ;
+          ;
     } else {
       return ;
     }
@@ -262,7 +262,7 @@ class UserApi {
       throw new ApiException(response.statusCode, response.body);
     } else if(response.body != null) {
       return 
-        apiClient.deserialize(response.body, 'User') as User ;
+          apiClient.deserialize(response.body, 'User') as User ;
     } else {
       return null;
     }
@@ -319,7 +319,7 @@ class UserApi {
       throw new ApiException(response.statusCode, response.body);
     } else if(response.body != null) {
       return 
-        apiClient.deserialize(response.body, 'String') as String ;
+          apiClient.deserialize(response.body, 'String') as String ;
     } else {
       return null;
     }
@@ -368,7 +368,7 @@ class UserApi {
       throw new ApiException(response.statusCode, response.body);
     } else if(response.body != null) {
       return 
-        ;
+          ;
     } else {
       return ;
     }
@@ -423,7 +423,7 @@ class UserApi {
       throw new ApiException(response.statusCode, response.body);
     } else if(response.body != null) {
       return 
-        ;
+          ;
     } else {
       return ;
     }

--- a/samples/client/petstore/dart/swagger-browser-client/lib/api_client.dart
+++ b/samples/client/petstore/dart/swagger-browser-client/lib/api_client.dart
@@ -18,7 +18,7 @@ class ApiClient {
   final _RegList = new RegExp(r'^List<(.*)>$');
   final _RegMap = new RegExp(r'^Map<String,(.*)>$');
 
-  ApiClient({this.basePath: "http://localhost/v2"}) {
+  ApiClient({this.basePath: "http://petstore.swagger.io/v2"}) {
     // Setup authentications (key: authentication name, value: authentication).
     _authentications['api_key'] = new ApiKeyAuth("header", "api_key");
     _authentications['petstore_auth'] = new OAuth();

--- a/samples/client/petstore/dart/swagger-browser-client/lib/model/api_response.dart
+++ b/samples/client/petstore/dart/swagger-browser-client/lib/model/api_response.dart
@@ -20,11 +20,14 @@ class ApiResponse {
   ApiResponse.fromJson(Map<String, dynamic> json) {
     if (json == null) return;
     code =
-    json['code'];
+        json['code']
+    ;
     type =
-    json['type'];
+        json['type']
+    ;
     message =
-    json['message'];
+        json['message']
+    ;
   }
 
   Map<String, dynamic> toJson() {
@@ -35,12 +38,8 @@ class ApiResponse {
      };
   }
 
-  static List<ApiResponse> listFromJson(List<Map<String, dynamic>> json) {
-    var list = new List<ApiResponse>();
-    if (json != null && json.length > 0) {
-      json.forEach((Map<String, dynamic> value) => list.add(new ApiResponse.fromJson(value)));
-    }
-    return list;
+  static List<ApiResponse> listFromJson(List<dynamic> json) {
+    return json.map((value) => new ApiResponse.fromJson(value)).toList();
   }
 
   static Map<String, ApiResponse> mapFromJson(Map<String, Map<String, dynamic>> json) {

--- a/samples/client/petstore/dart/swagger-browser-client/lib/model/api_response.dart
+++ b/samples/client/petstore/dart/swagger-browser-client/lib/model/api_response.dart
@@ -39,7 +39,7 @@ class ApiResponse {
   }
 
   static List<ApiResponse> listFromJson(List<dynamic> json) {
-    return json.map((value) => new ApiResponse.fromJson(value)).toList();
+    return json == null ? new List<ApiResponse>() : json.map((value) => new ApiResponse.fromJson(value)).toList();
   }
 
   static Map<String, ApiResponse> mapFromJson(Map<String, Map<String, dynamic>> json) {

--- a/samples/client/petstore/dart/swagger-browser-client/lib/model/category.dart
+++ b/samples/client/petstore/dart/swagger-browser-client/lib/model/category.dart
@@ -17,9 +17,11 @@ class Category {
   Category.fromJson(Map<String, dynamic> json) {
     if (json == null) return;
     id =
-    json['id'];
+        json['id']
+    ;
     name =
-    json['name'];
+        json['name']
+    ;
   }
 
   Map<String, dynamic> toJson() {
@@ -29,12 +31,8 @@ class Category {
      };
   }
 
-  static List<Category> listFromJson(List<Map<String, dynamic>> json) {
-    var list = new List<Category>();
-    if (json != null && json.length > 0) {
-      json.forEach((Map<String, dynamic> value) => list.add(new Category.fromJson(value)));
-    }
-    return list;
+  static List<Category> listFromJson(List<dynamic> json) {
+    return json.map((value) => new Category.fromJson(value)).toList();
   }
 
   static Map<String, Category> mapFromJson(Map<String, Map<String, dynamic>> json) {

--- a/samples/client/petstore/dart/swagger-browser-client/lib/model/category.dart
+++ b/samples/client/petstore/dart/swagger-browser-client/lib/model/category.dart
@@ -32,7 +32,7 @@ class Category {
   }
 
   static List<Category> listFromJson(List<dynamic> json) {
-    return json.map((value) => new Category.fromJson(value)).toList();
+    return json == null ? new List<Category>() : json.map((value) => new Category.fromJson(value)).toList();
   }
 
   static Map<String, Category> mapFromJson(Map<String, Map<String, dynamic>> json) {

--- a/samples/client/petstore/dart/swagger-browser-client/lib/model/order.dart
+++ b/samples/client/petstore/dart/swagger-browser-client/lib/model/order.dart
@@ -29,16 +29,21 @@ class Order {
   Order.fromJson(Map<String, dynamic> json) {
     if (json == null) return;
     id =
-    json['id'];
+        json['id']
+    ;
     petId =
-    json['petId'];
+        json['petId']
+    ;
     quantity =
-    json['quantity'];
+        json['quantity']
+    ;
     shipDate = json['shipDate'] == null ? null : DateTime.parse(json['shipDate']);
     status =
-    json['status'];
+        json['status']
+    ;
     complete =
-    json['complete'];
+        json['complete']
+    ;
   }
 
   Map<String, dynamic> toJson() {
@@ -52,12 +57,8 @@ class Order {
      };
   }
 
-  static List<Order> listFromJson(List<Map<String, dynamic>> json) {
-    var list = new List<Order>();
-    if (json != null && json.length > 0) {
-      json.forEach((Map<String, dynamic> value) => list.add(new Order.fromJson(value)));
-    }
-    return list;
+  static List<Order> listFromJson(List<dynamic> json) {
+    return json.map((value) => new Order.fromJson(value)).toList();
   }
 
   static Map<String, Order> mapFromJson(Map<String, Map<String, dynamic>> json) {

--- a/samples/client/petstore/dart/swagger-browser-client/lib/model/order.dart
+++ b/samples/client/petstore/dart/swagger-browser-client/lib/model/order.dart
@@ -58,7 +58,7 @@ class Order {
   }
 
   static List<Order> listFromJson(List<dynamic> json) {
-    return json.map((value) => new Order.fromJson(value)).toList();
+    return json == null ? new List<Order>() : json.map((value) => new Order.fromJson(value)).toList();
   }
 
   static Map<String, Order> mapFromJson(Map<String, Map<String, dynamic>> json) {

--- a/samples/client/petstore/dart/swagger-browser-client/lib/model/pet.dart
+++ b/samples/client/petstore/dart/swagger-browser-client/lib/model/pet.dart
@@ -62,7 +62,7 @@ class Pet {
   }
 
   static List<Pet> listFromJson(List<dynamic> json) {
-    return json.map((value) => new Pet.fromJson(value)).toList();
+    return json == null ? new List<Pet>() : json.map((value) => new Pet.fromJson(value)).toList();
   }
 
   static Map<String, Pet> mapFromJson(Map<String, Map<String, dynamic>> json) {

--- a/samples/client/petstore/dart/swagger-browser-client/lib/model/pet.dart
+++ b/samples/client/petstore/dart/swagger-browser-client/lib/model/pet.dart
@@ -29,21 +29,25 @@ class Pet {
   Pet.fromJson(Map<String, dynamic> json) {
     if (json == null) return;
     id =
-    json['id'];
+        json['id']
+    ;
     category =
-        
-        
-        new Category.fromJson(json['category'])
-    ;
+      
+      
+      new Category.fromJson(json['category'])
+;
     name =
-    json['name'];
-    photoUrls =
-    json['photoUrls'];
-    tags =
-        Tag.listFromJson(json['tags'])
+        json['name']
     ;
+    photoUrls =
+        (json['photoUrls'] as List).map((item) => item as String).toList()
+    ;
+    tags =
+      Tag.listFromJson(json['tags'])
+;
     status =
-    json['status'];
+        json['status']
+    ;
   }
 
   Map<String, dynamic> toJson() {
@@ -57,12 +61,8 @@ class Pet {
      };
   }
 
-  static List<Pet> listFromJson(List<Map<String, dynamic>> json) {
-    var list = new List<Pet>();
-    if (json != null && json.length > 0) {
-      json.forEach((Map<String, dynamic> value) => list.add(new Pet.fromJson(value)));
-    }
-    return list;
+  static List<Pet> listFromJson(List<dynamic> json) {
+    return json.map((value) => new Pet.fromJson(value)).toList();
   }
 
   static Map<String, Pet> mapFromJson(Map<String, Map<String, dynamic>> json) {

--- a/samples/client/petstore/dart/swagger-browser-client/lib/model/tag.dart
+++ b/samples/client/petstore/dart/swagger-browser-client/lib/model/tag.dart
@@ -32,7 +32,7 @@ class Tag {
   }
 
   static List<Tag> listFromJson(List<dynamic> json) {
-    return json.map((value) => new Tag.fromJson(value)).toList();
+    return json == null ? new List<Tag>() : json.map((value) => new Tag.fromJson(value)).toList();
   }
 
   static Map<String, Tag> mapFromJson(Map<String, Map<String, dynamic>> json) {

--- a/samples/client/petstore/dart/swagger-browser-client/lib/model/tag.dart
+++ b/samples/client/petstore/dart/swagger-browser-client/lib/model/tag.dart
@@ -17,9 +17,11 @@ class Tag {
   Tag.fromJson(Map<String, dynamic> json) {
     if (json == null) return;
     id =
-    json['id'];
+        json['id']
+    ;
     name =
-    json['name'];
+        json['name']
+    ;
   }
 
   Map<String, dynamic> toJson() {
@@ -29,12 +31,8 @@ class Tag {
      };
   }
 
-  static List<Tag> listFromJson(List<Map<String, dynamic>> json) {
-    var list = new List<Tag>();
-    if (json != null && json.length > 0) {
-      json.forEach((Map<String, dynamic> value) => list.add(new Tag.fromJson(value)));
-    }
-    return list;
+  static List<Tag> listFromJson(List<dynamic> json) {
+    return json.map((value) => new Tag.fromJson(value)).toList();
   }
 
   static Map<String, Tag> mapFromJson(Map<String, Map<String, dynamic>> json) {

--- a/samples/client/petstore/dart/swagger-browser-client/lib/model/user.dart
+++ b/samples/client/petstore/dart/swagger-browser-client/lib/model/user.dart
@@ -35,21 +35,29 @@ class User {
   User.fromJson(Map<String, dynamic> json) {
     if (json == null) return;
     id =
-    json['id'];
+        json['id']
+    ;
     username =
-    json['username'];
+        json['username']
+    ;
     firstName =
-    json['firstName'];
+        json['firstName']
+    ;
     lastName =
-    json['lastName'];
+        json['lastName']
+    ;
     email =
-    json['email'];
+        json['email']
+    ;
     password =
-    json['password'];
+        json['password']
+    ;
     phone =
-    json['phone'];
+        json['phone']
+    ;
     userStatus =
-    json['userStatus'];
+        json['userStatus']
+    ;
   }
 
   Map<String, dynamic> toJson() {
@@ -65,12 +73,8 @@ class User {
      };
   }
 
-  static List<User> listFromJson(List<Map<String, dynamic>> json) {
-    var list = new List<User>();
-    if (json != null && json.length > 0) {
-      json.forEach((Map<String, dynamic> value) => list.add(new User.fromJson(value)));
-    }
-    return list;
+  static List<User> listFromJson(List<dynamic> json) {
+    return json.map((value) => new User.fromJson(value)).toList();
   }
 
   static Map<String, User> mapFromJson(Map<String, Map<String, dynamic>> json) {

--- a/samples/client/petstore/dart/swagger-browser-client/lib/model/user.dart
+++ b/samples/client/petstore/dart/swagger-browser-client/lib/model/user.dart
@@ -74,7 +74,7 @@ class User {
   }
 
   static List<User> listFromJson(List<dynamic> json) {
-    return json.map((value) => new User.fromJson(value)).toList();
+    return json == null ? new List<User>() : json.map((value) => new User.fromJson(value)).toList();
   }
 
   static Map<String, User> mapFromJson(Map<String, Map<String, dynamic>> json) {

--- a/samples/client/petstore/dart/swagger/README.md
+++ b/samples/client/petstore/dart/swagger/README.md
@@ -59,7 +59,7 @@ try {
 
 ## Documentation for API Endpoints
 
-All URIs are relative to *http://localhost/v2*
+All URIs are relative to *http://petstore.swagger.io/v2*
 
 Class | Method | HTTP request | Description
 ------------ | ------------- | ------------- | -------------

--- a/samples/client/petstore/dart/swagger/docs/PetApi.md
+++ b/samples/client/petstore/dart/swagger/docs/PetApi.md
@@ -5,7 +5,7 @@
 import 'package:swagger/api.dart';
 ```
 
-All URIs are relative to *http://localhost/v2*
+All URIs are relative to *http://petstore.swagger.io/v2*
 
 Method | HTTP request | Description
 ------------- | ------------- | -------------

--- a/samples/client/petstore/dart/swagger/docs/StoreApi.md
+++ b/samples/client/petstore/dart/swagger/docs/StoreApi.md
@@ -5,7 +5,7 @@
 import 'package:swagger/api.dart';
 ```
 
-All URIs are relative to *http://localhost/v2*
+All URIs are relative to *http://petstore.swagger.io/v2*
 
 Method | HTTP request | Description
 ------------- | ------------- | -------------

--- a/samples/client/petstore/dart/swagger/docs/UserApi.md
+++ b/samples/client/petstore/dart/swagger/docs/UserApi.md
@@ -5,7 +5,7 @@
 import 'package:swagger/api.dart';
 ```
 
-All URIs are relative to *http://localhost/v2*
+All URIs are relative to *http://petstore.swagger.io/v2*
 
 Method | HTTP request | Description
 ------------- | ------------- | -------------

--- a/samples/client/petstore/dart/swagger/lib/api/pet_api.dart
+++ b/samples/client/petstore/dart/swagger/lib/api/pet_api.dart
@@ -54,7 +54,7 @@ class PetApi {
       throw new ApiException(response.statusCode, response.body);
     } else if(response.body != null) {
       return 
-        ;
+          ;
     } else {
       return ;
     }
@@ -107,7 +107,7 @@ class PetApi {
       throw new ApiException(response.statusCode, response.body);
     } else if(response.body != null) {
       return 
-        ;
+          ;
     } else {
       return ;
     }
@@ -265,7 +265,7 @@ class PetApi {
       throw new ApiException(response.statusCode, response.body);
     } else if(response.body != null) {
       return 
-        apiClient.deserialize(response.body, 'Pet') as Pet ;
+          apiClient.deserialize(response.body, 'Pet') as Pet ;
     } else {
       return null;
     }
@@ -317,7 +317,7 @@ class PetApi {
       throw new ApiException(response.statusCode, response.body);
     } else if(response.body != null) {
       return 
-        ;
+          ;
     } else {
       return ;
     }
@@ -383,7 +383,7 @@ if (status != null)
       throw new ApiException(response.statusCode, response.body);
     } else if(response.body != null) {
       return 
-        ;
+          ;
     } else {
       return ;
     }
@@ -449,7 +449,7 @@ if (status != null)
       throw new ApiException(response.statusCode, response.body);
     } else if(response.body != null) {
       return 
-        apiClient.deserialize(response.body, 'ApiResponse') as ApiResponse ;
+          apiClient.deserialize(response.body, 'ApiResponse') as ApiResponse ;
     } else {
       return null;
     }

--- a/samples/client/petstore/dart/swagger/lib/api/pet_api.dart
+++ b/samples/client/petstore/dart/swagger/lib/api/pet_api.dart
@@ -53,7 +53,8 @@ class PetApi {
     if(response.statusCode >= 400) {
       throw new ApiException(response.statusCode, response.body);
     } else if(response.body != null) {
-      return ;
+      return 
+        ;
     } else {
       return ;
     }
@@ -105,7 +106,8 @@ class PetApi {
     if(response.statusCode >= 400) {
       throw new ApiException(response.statusCode, response.body);
     } else if(response.body != null) {
-      return ;
+      return 
+        ;
     } else {
       return ;
     }
@@ -157,7 +159,8 @@ class PetApi {
     if(response.statusCode >= 400) {
       throw new ApiException(response.statusCode, response.body);
     } else if(response.body != null) {
-      return apiClient.deserialize(response.body, 'List<Pet>') as List<Pet> ;
+      return 
+        (apiClient.deserialize(response.body, 'List<Pet>') as List).map((item) => item as Pet).toList();
     } else {
       return null;
     }
@@ -209,7 +212,8 @@ class PetApi {
     if(response.statusCode >= 400) {
       throw new ApiException(response.statusCode, response.body);
     } else if(response.body != null) {
-      return apiClient.deserialize(response.body, 'List<Pet>') as List<Pet> ;
+      return 
+        (apiClient.deserialize(response.body, 'List<Pet>') as List).map((item) => item as Pet).toList();
     } else {
       return null;
     }
@@ -260,7 +264,8 @@ class PetApi {
     if(response.statusCode >= 400) {
       throw new ApiException(response.statusCode, response.body);
     } else if(response.body != null) {
-      return apiClient.deserialize(response.body, 'Pet') as Pet ;
+      return 
+        apiClient.deserialize(response.body, 'Pet') as Pet ;
     } else {
       return null;
     }
@@ -311,7 +316,8 @@ class PetApi {
     if(response.statusCode >= 400) {
       throw new ApiException(response.statusCode, response.body);
     } else if(response.body != null) {
-      return ;
+      return 
+        ;
     } else {
       return ;
     }
@@ -376,7 +382,8 @@ if (status != null)
     if(response.statusCode >= 400) {
       throw new ApiException(response.statusCode, response.body);
     } else if(response.body != null) {
-      return ;
+      return 
+        ;
     } else {
       return ;
     }
@@ -441,7 +448,8 @@ if (status != null)
     if(response.statusCode >= 400) {
       throw new ApiException(response.statusCode, response.body);
     } else if(response.body != null) {
-      return apiClient.deserialize(response.body, 'ApiResponse') as ApiResponse ;
+      return 
+        apiClient.deserialize(response.body, 'ApiResponse') as ApiResponse ;
     } else {
       return null;
     }

--- a/samples/client/petstore/dart/swagger/lib/api/store_api.dart
+++ b/samples/client/petstore/dart/swagger/lib/api/store_api.dart
@@ -53,7 +53,8 @@ class StoreApi {
     if(response.statusCode >= 400) {
       throw new ApiException(response.statusCode, response.body);
     } else if(response.body != null) {
-      return ;
+      return 
+        ;
     } else {
       return ;
     }
@@ -101,7 +102,8 @@ class StoreApi {
     if(response.statusCode >= 400) {
       throw new ApiException(response.statusCode, response.body);
     } else if(response.body != null) {
-      return apiClient.deserialize(response.body, 'Map<String, int>') as Map<String, int> ;
+      return 
+        apiClient.deserialize(response.body, 'Map<String, int>') as Map<String, int> ;
     } else {
       return null;
     }
@@ -152,7 +154,8 @@ class StoreApi {
     if(response.statusCode >= 400) {
       throw new ApiException(response.statusCode, response.body);
     } else if(response.body != null) {
-      return apiClient.deserialize(response.body, 'Order') as Order ;
+      return 
+        apiClient.deserialize(response.body, 'Order') as Order ;
     } else {
       return null;
     }
@@ -203,7 +206,8 @@ class StoreApi {
     if(response.statusCode >= 400) {
       throw new ApiException(response.statusCode, response.body);
     } else if(response.body != null) {
-      return apiClient.deserialize(response.body, 'Order') as Order ;
+      return 
+        apiClient.deserialize(response.body, 'Order') as Order ;
     } else {
       return null;
     }

--- a/samples/client/petstore/dart/swagger/lib/api/store_api.dart
+++ b/samples/client/petstore/dart/swagger/lib/api/store_api.dart
@@ -54,7 +54,7 @@ class StoreApi {
       throw new ApiException(response.statusCode, response.body);
     } else if(response.body != null) {
       return 
-        ;
+          ;
     } else {
       return ;
     }
@@ -103,7 +103,7 @@ class StoreApi {
       throw new ApiException(response.statusCode, response.body);
     } else if(response.body != null) {
       return 
-        apiClient.deserialize(response.body, 'Map<String, int>') as Map<String, int> ;
+          new Map<String, int>.from(apiClient.deserialize(response.body, 'Map<String, int>')) ;
     } else {
       return null;
     }
@@ -155,7 +155,7 @@ class StoreApi {
       throw new ApiException(response.statusCode, response.body);
     } else if(response.body != null) {
       return 
-        apiClient.deserialize(response.body, 'Order') as Order ;
+          apiClient.deserialize(response.body, 'Order') as Order ;
     } else {
       return null;
     }
@@ -207,7 +207,7 @@ class StoreApi {
       throw new ApiException(response.statusCode, response.body);
     } else if(response.body != null) {
       return 
-        apiClient.deserialize(response.body, 'Order') as Order ;
+          apiClient.deserialize(response.body, 'Order') as Order ;
     } else {
       return null;
     }

--- a/samples/client/petstore/dart/swagger/lib/api/user_api.dart
+++ b/samples/client/petstore/dart/swagger/lib/api/user_api.dart
@@ -53,7 +53,8 @@ class UserApi {
     if(response.statusCode >= 400) {
       throw new ApiException(response.statusCode, response.body);
     } else if(response.body != null) {
-      return ;
+      return 
+        ;
     } else {
       return ;
     }
@@ -104,7 +105,8 @@ class UserApi {
     if(response.statusCode >= 400) {
       throw new ApiException(response.statusCode, response.body);
     } else if(response.body != null) {
-      return ;
+      return 
+        ;
     } else {
       return ;
     }
@@ -155,7 +157,8 @@ class UserApi {
     if(response.statusCode >= 400) {
       throw new ApiException(response.statusCode, response.body);
     } else if(response.body != null) {
-      return ;
+      return 
+        ;
     } else {
       return ;
     }
@@ -206,7 +209,8 @@ class UserApi {
     if(response.statusCode >= 400) {
       throw new ApiException(response.statusCode, response.body);
     } else if(response.body != null) {
-      return ;
+      return 
+        ;
     } else {
       return ;
     }
@@ -257,7 +261,8 @@ class UserApi {
     if(response.statusCode >= 400) {
       throw new ApiException(response.statusCode, response.body);
     } else if(response.body != null) {
-      return apiClient.deserialize(response.body, 'User') as User ;
+      return 
+        apiClient.deserialize(response.body, 'User') as User ;
     } else {
       return null;
     }
@@ -313,7 +318,8 @@ class UserApi {
     if(response.statusCode >= 400) {
       throw new ApiException(response.statusCode, response.body);
     } else if(response.body != null) {
-      return apiClient.deserialize(response.body, 'String') as String ;
+      return 
+        apiClient.deserialize(response.body, 'String') as String ;
     } else {
       return null;
     }
@@ -361,7 +367,8 @@ class UserApi {
     if(response.statusCode >= 400) {
       throw new ApiException(response.statusCode, response.body);
     } else if(response.body != null) {
-      return ;
+      return 
+        ;
     } else {
       return ;
     }
@@ -415,7 +422,8 @@ class UserApi {
     if(response.statusCode >= 400) {
       throw new ApiException(response.statusCode, response.body);
     } else if(response.body != null) {
-      return ;
+      return 
+        ;
     } else {
       return ;
     }

--- a/samples/client/petstore/dart/swagger/lib/api/user_api.dart
+++ b/samples/client/petstore/dart/swagger/lib/api/user_api.dart
@@ -54,7 +54,7 @@ class UserApi {
       throw new ApiException(response.statusCode, response.body);
     } else if(response.body != null) {
       return 
-        ;
+          ;
     } else {
       return ;
     }
@@ -106,7 +106,7 @@ class UserApi {
       throw new ApiException(response.statusCode, response.body);
     } else if(response.body != null) {
       return 
-        ;
+          ;
     } else {
       return ;
     }
@@ -158,7 +158,7 @@ class UserApi {
       throw new ApiException(response.statusCode, response.body);
     } else if(response.body != null) {
       return 
-        ;
+          ;
     } else {
       return ;
     }
@@ -210,7 +210,7 @@ class UserApi {
       throw new ApiException(response.statusCode, response.body);
     } else if(response.body != null) {
       return 
-        ;
+          ;
     } else {
       return ;
     }
@@ -262,7 +262,7 @@ class UserApi {
       throw new ApiException(response.statusCode, response.body);
     } else if(response.body != null) {
       return 
-        apiClient.deserialize(response.body, 'User') as User ;
+          apiClient.deserialize(response.body, 'User') as User ;
     } else {
       return null;
     }
@@ -319,7 +319,7 @@ class UserApi {
       throw new ApiException(response.statusCode, response.body);
     } else if(response.body != null) {
       return 
-        apiClient.deserialize(response.body, 'String') as String ;
+          apiClient.deserialize(response.body, 'String') as String ;
     } else {
       return null;
     }
@@ -368,7 +368,7 @@ class UserApi {
       throw new ApiException(response.statusCode, response.body);
     } else if(response.body != null) {
       return 
-        ;
+          ;
     } else {
       return ;
     }
@@ -423,7 +423,7 @@ class UserApi {
       throw new ApiException(response.statusCode, response.body);
     } else if(response.body != null) {
       return 
-        ;
+          ;
     } else {
       return ;
     }

--- a/samples/client/petstore/dart/swagger/lib/api_client.dart
+++ b/samples/client/petstore/dart/swagger/lib/api_client.dart
@@ -18,7 +18,7 @@ class ApiClient {
   final _RegList = new RegExp(r'^List<(.*)>$');
   final _RegMap = new RegExp(r'^Map<String,(.*)>$');
 
-  ApiClient({this.basePath: "http://localhost/v2"}) {
+  ApiClient({this.basePath: "http://petstore.swagger.io/v2"}) {
     // Setup authentications (key: authentication name, value: authentication).
     _authentications['api_key'] = new ApiKeyAuth("header", "api_key");
     _authentications['petstore_auth'] = new OAuth();

--- a/samples/client/petstore/dart/swagger/lib/model/api_response.dart
+++ b/samples/client/petstore/dart/swagger/lib/model/api_response.dart
@@ -20,11 +20,14 @@ class ApiResponse {
   ApiResponse.fromJson(Map<String, dynamic> json) {
     if (json == null) return;
     code =
-    json['code'];
+        json['code']
+    ;
     type =
-    json['type'];
+        json['type']
+    ;
     message =
-    json['message'];
+        json['message']
+    ;
   }
 
   Map<String, dynamic> toJson() {
@@ -35,12 +38,8 @@ class ApiResponse {
      };
   }
 
-  static List<ApiResponse> listFromJson(List<Map<String, dynamic>> json) {
-    var list = new List<ApiResponse>();
-    if (json != null && json.length > 0) {
-      json.forEach((Map<String, dynamic> value) => list.add(new ApiResponse.fromJson(value)));
-    }
-    return list;
+  static List<ApiResponse> listFromJson(List<dynamic> json) {
+    return json.map((value) => new ApiResponse.fromJson(value)).toList();
   }
 
   static Map<String, ApiResponse> mapFromJson(Map<String, Map<String, dynamic>> json) {

--- a/samples/client/petstore/dart/swagger/lib/model/api_response.dart
+++ b/samples/client/petstore/dart/swagger/lib/model/api_response.dart
@@ -39,7 +39,7 @@ class ApiResponse {
   }
 
   static List<ApiResponse> listFromJson(List<dynamic> json) {
-    return json.map((value) => new ApiResponse.fromJson(value)).toList();
+    return json == null ? new List<ApiResponse>() : json.map((value) => new ApiResponse.fromJson(value)).toList();
   }
 
   static Map<String, ApiResponse> mapFromJson(Map<String, Map<String, dynamic>> json) {

--- a/samples/client/petstore/dart/swagger/lib/model/category.dart
+++ b/samples/client/petstore/dart/swagger/lib/model/category.dart
@@ -17,9 +17,11 @@ class Category {
   Category.fromJson(Map<String, dynamic> json) {
     if (json == null) return;
     id =
-    json['id'];
+        json['id']
+    ;
     name =
-    json['name'];
+        json['name']
+    ;
   }
 
   Map<String, dynamic> toJson() {
@@ -29,12 +31,8 @@ class Category {
      };
   }
 
-  static List<Category> listFromJson(List<Map<String, dynamic>> json) {
-    var list = new List<Category>();
-    if (json != null && json.length > 0) {
-      json.forEach((Map<String, dynamic> value) => list.add(new Category.fromJson(value)));
-    }
-    return list;
+  static List<Category> listFromJson(List<dynamic> json) {
+    return json.map((value) => new Category.fromJson(value)).toList();
   }
 
   static Map<String, Category> mapFromJson(Map<String, Map<String, dynamic>> json) {

--- a/samples/client/petstore/dart/swagger/lib/model/category.dart
+++ b/samples/client/petstore/dart/swagger/lib/model/category.dart
@@ -32,7 +32,7 @@ class Category {
   }
 
   static List<Category> listFromJson(List<dynamic> json) {
-    return json.map((value) => new Category.fromJson(value)).toList();
+    return json == null ? new List<Category>() : json.map((value) => new Category.fromJson(value)).toList();
   }
 
   static Map<String, Category> mapFromJson(Map<String, Map<String, dynamic>> json) {

--- a/samples/client/petstore/dart/swagger/lib/model/order.dart
+++ b/samples/client/petstore/dart/swagger/lib/model/order.dart
@@ -29,16 +29,21 @@ class Order {
   Order.fromJson(Map<String, dynamic> json) {
     if (json == null) return;
     id =
-    json['id'];
+        json['id']
+    ;
     petId =
-    json['petId'];
+        json['petId']
+    ;
     quantity =
-    json['quantity'];
+        json['quantity']
+    ;
     shipDate = json['shipDate'] == null ? null : DateTime.parse(json['shipDate']);
     status =
-    json['status'];
+        json['status']
+    ;
     complete =
-    json['complete'];
+        json['complete']
+    ;
   }
 
   Map<String, dynamic> toJson() {
@@ -52,12 +57,8 @@ class Order {
      };
   }
 
-  static List<Order> listFromJson(List<Map<String, dynamic>> json) {
-    var list = new List<Order>();
-    if (json != null && json.length > 0) {
-      json.forEach((Map<String, dynamic> value) => list.add(new Order.fromJson(value)));
-    }
-    return list;
+  static List<Order> listFromJson(List<dynamic> json) {
+    return json.map((value) => new Order.fromJson(value)).toList();
   }
 
   static Map<String, Order> mapFromJson(Map<String, Map<String, dynamic>> json) {

--- a/samples/client/petstore/dart/swagger/lib/model/order.dart
+++ b/samples/client/petstore/dart/swagger/lib/model/order.dart
@@ -58,7 +58,7 @@ class Order {
   }
 
   static List<Order> listFromJson(List<dynamic> json) {
-    return json.map((value) => new Order.fromJson(value)).toList();
+    return json == null ? new List<Order>() : json.map((value) => new Order.fromJson(value)).toList();
   }
 
   static Map<String, Order> mapFromJson(Map<String, Map<String, dynamic>> json) {

--- a/samples/client/petstore/dart/swagger/lib/model/pet.dart
+++ b/samples/client/petstore/dart/swagger/lib/model/pet.dart
@@ -62,7 +62,7 @@ class Pet {
   }
 
   static List<Pet> listFromJson(List<dynamic> json) {
-    return json.map((value) => new Pet.fromJson(value)).toList();
+    return json == null ? new List<Pet>() : json.map((value) => new Pet.fromJson(value)).toList();
   }
 
   static Map<String, Pet> mapFromJson(Map<String, Map<String, dynamic>> json) {

--- a/samples/client/petstore/dart/swagger/lib/model/pet.dart
+++ b/samples/client/petstore/dart/swagger/lib/model/pet.dart
@@ -29,21 +29,25 @@ class Pet {
   Pet.fromJson(Map<String, dynamic> json) {
     if (json == null) return;
     id =
-    json['id'];
+        json['id']
+    ;
     category =
-        
-        
-        new Category.fromJson(json['category'])
-    ;
+      
+      
+      new Category.fromJson(json['category'])
+;
     name =
-    json['name'];
-    photoUrls =
-    json['photoUrls'];
-    tags =
-        Tag.listFromJson(json['tags'])
+        json['name']
     ;
+    photoUrls =
+        (json['photoUrls'] as List).map((item) => item as String).toList()
+    ;
+    tags =
+      Tag.listFromJson(json['tags'])
+;
     status =
-    json['status'];
+        json['status']
+    ;
   }
 
   Map<String, dynamic> toJson() {
@@ -57,12 +61,8 @@ class Pet {
      };
   }
 
-  static List<Pet> listFromJson(List<Map<String, dynamic>> json) {
-    var list = new List<Pet>();
-    if (json != null && json.length > 0) {
-      json.forEach((Map<String, dynamic> value) => list.add(new Pet.fromJson(value)));
-    }
-    return list;
+  static List<Pet> listFromJson(List<dynamic> json) {
+    return json.map((value) => new Pet.fromJson(value)).toList();
   }
 
   static Map<String, Pet> mapFromJson(Map<String, Map<String, dynamic>> json) {

--- a/samples/client/petstore/dart/swagger/lib/model/tag.dart
+++ b/samples/client/petstore/dart/swagger/lib/model/tag.dart
@@ -32,7 +32,7 @@ class Tag {
   }
 
   static List<Tag> listFromJson(List<dynamic> json) {
-    return json.map((value) => new Tag.fromJson(value)).toList();
+    return json == null ? new List<Tag>() : json.map((value) => new Tag.fromJson(value)).toList();
   }
 
   static Map<String, Tag> mapFromJson(Map<String, Map<String, dynamic>> json) {

--- a/samples/client/petstore/dart/swagger/lib/model/tag.dart
+++ b/samples/client/petstore/dart/swagger/lib/model/tag.dart
@@ -17,9 +17,11 @@ class Tag {
   Tag.fromJson(Map<String, dynamic> json) {
     if (json == null) return;
     id =
-    json['id'];
+        json['id']
+    ;
     name =
-    json['name'];
+        json['name']
+    ;
   }
 
   Map<String, dynamic> toJson() {
@@ -29,12 +31,8 @@ class Tag {
      };
   }
 
-  static List<Tag> listFromJson(List<Map<String, dynamic>> json) {
-    var list = new List<Tag>();
-    if (json != null && json.length > 0) {
-      json.forEach((Map<String, dynamic> value) => list.add(new Tag.fromJson(value)));
-    }
-    return list;
+  static List<Tag> listFromJson(List<dynamic> json) {
+    return json.map((value) => new Tag.fromJson(value)).toList();
   }
 
   static Map<String, Tag> mapFromJson(Map<String, Map<String, dynamic>> json) {

--- a/samples/client/petstore/dart/swagger/lib/model/user.dart
+++ b/samples/client/petstore/dart/swagger/lib/model/user.dart
@@ -35,21 +35,29 @@ class User {
   User.fromJson(Map<String, dynamic> json) {
     if (json == null) return;
     id =
-    json['id'];
+        json['id']
+    ;
     username =
-    json['username'];
+        json['username']
+    ;
     firstName =
-    json['firstName'];
+        json['firstName']
+    ;
     lastName =
-    json['lastName'];
+        json['lastName']
+    ;
     email =
-    json['email'];
+        json['email']
+    ;
     password =
-    json['password'];
+        json['password']
+    ;
     phone =
-    json['phone'];
+        json['phone']
+    ;
     userStatus =
-    json['userStatus'];
+        json['userStatus']
+    ;
   }
 
   Map<String, dynamic> toJson() {
@@ -65,12 +73,8 @@ class User {
      };
   }
 
-  static List<User> listFromJson(List<Map<String, dynamic>> json) {
-    var list = new List<User>();
-    if (json != null && json.length > 0) {
-      json.forEach((Map<String, dynamic> value) => list.add(new User.fromJson(value)));
-    }
-    return list;
+  static List<User> listFromJson(List<dynamic> json) {
+    return json.map((value) => new User.fromJson(value)).toList();
   }
 
   static Map<String, User> mapFromJson(Map<String, Map<String, dynamic>> json) {

--- a/samples/client/petstore/dart/swagger/lib/model/user.dart
+++ b/samples/client/petstore/dart/swagger/lib/model/user.dart
@@ -74,7 +74,7 @@ class User {
   }
 
   static List<User> listFromJson(List<dynamic> json) {
-    return json.map((value) => new User.fromJson(value)).toList();
+    return json == null ? new List<User>() : json.map((value) => new User.fromJson(value)).toList();
   }
 
   static Map<String, User> mapFromJson(Map<String, Map<String, dynamic>> json) {


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [x] Filed the PR against the correct branch: `3.0.0` branch for changes related to OpenAPI spec 3.0. Default: `master`.
- [x] Copied the [technical committee](https://github.com/swagger-api/swagger-codegen/#swagger-codegen-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

Fixes #7958 by introducing proper typecasts for lists of primitive types in the dart client templates

