### PR TITLE
Issue 7949 - Added in injected basePath observable to api service to allow it to respond to external updates to this setting post construction.

### DIFF
--- a/modules/swagger-codegen/src/main/resources/typescript-angular/api.service.mustache
+++ b/modules/swagger-codegen/src/main/resources/typescript-angular/api.service.mustache
@@ -23,7 +23,7 @@ import '../rxjs-operators';
 import { {{classname}} } from '../{{filename}}';
 {{/imports}}
 
-import { BASE_PATH, COLLECTION_FORMATS }                     from '../variables';
+import { BASE_PATH, COLLECTION_FORMATS, BASE_PATH_OBSERVABLE }                     from '../variables';
 import { Configuration }                                     from '../configuration';
 {{#withInterfaces}}
 import { {{classname}}Interface }                            from './{{classname}}Interface';
@@ -48,13 +48,19 @@ export class {{classname}} {
     public defaultHeaders = new {{#useHttpClient}}Http{{/useHttpClient}}Headers();
     public configuration = new Configuration();
 
-    constructor(protected {{#useHttpClient}}httpClient: HttpClient{{/useHttpClient}}{{^useHttpClient}}http: Http{{/useHttpClient}}, @Optional()@Inject(BASE_PATH) basePath: string, @Optional() configuration: Configuration) {
+    constructor(protected {{#useHttpClient}}httpClient: HttpClient{{/useHttpClient}}{{^useHttpClient}}http: Http{{/useHttpClient}},
+                @Optional() @Inject(BASE_PATH) basePath: string,
+                @Optional() configuration: Configuration,
+                @Optional() @Inject(BASE_PATH_OBSERVABLE) basePath$: Observable<string>) {
         if (basePath) {
             this.basePath = basePath;
         }
         if (configuration) {
             this.configuration = configuration;
             this.basePath = basePath || configuration.basePath || this.basePath;
+        }
+        if (basePath$) {
+            basePath$.subscribe(nextBasePath => this.basePath = nextBasePath);
         }
     }
 

--- a/modules/swagger-codegen/src/main/resources/typescript-angular/variables.mustache
+++ b/modules/swagger-codegen/src/main/resources/typescript-angular/variables.mustache
@@ -1,6 +1,8 @@
 import { {{injectionToken}} } from '@angular/core';
+import {Observable} from 'rxjs/Observable';
 
 export const BASE_PATH = new {{injectionToken}}{{#injectionTokenTyped}}<string>{{/injectionTokenTyped}}('basePath');
+export const BASE_PATH_OBSERVABLE = new {{injectionToken}}{{#injectionTokenTyped}}<Observable<string>>{{/injectionTokenTyped}}('basePathObservable');
 export const COLLECTION_FORMATS = {
     'csv': ',',
     'tsv': '   ',


### PR DESCRIPTION
Extended api service to allow optional injection of an observable basePath. This facilities configuration of basePath post service construction which is required in circumstances where runtime setting of basePath cannot be achieved using APP_INITIALIZER tokens in angular. One such use case is when using libraries such as ngrx effects that do not respect such angular APP_INITIALIZER tokens.