### PR TITLE
Issue 5542, generate pom.xml with separate parameter. InterfaceOnly=t…

### DIFF
--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/SpringCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/SpringCodegen.java
@@ -23,6 +23,7 @@ public class SpringCodegen extends AbstractJavaCodegen
     public static final String CONFIG_PACKAGE = "configPackage";
     public static final String BASE_PACKAGE = "basePackage";
     public static final String INTERFACE_ONLY = "interfaceOnly";
+    public static final String GENERATE_META = "generateMeta";
     public static final String DELEGATE_PATTERN = "delegatePattern";
     public static final String SINGLE_CONTENT_TYPES = "singleContentTypes";
     public static final String JAVA_8 = "java8";
@@ -38,6 +39,7 @@ public class SpringCodegen extends AbstractJavaCodegen
     protected String configPackage = "io.swagger.configuration";
     protected String basePackage = "io.swagger";
     protected boolean interfaceOnly = false;
+    protected boolean generateMeta = false;
     protected boolean delegatePattern = false;
     protected boolean delegateMethod = false;
     protected boolean singleContentTypes = false;
@@ -70,6 +72,7 @@ public class SpringCodegen extends AbstractJavaCodegen
         cliOptions.add(new CliOption(CONFIG_PACKAGE, "configuration package for generated code"));
         cliOptions.add(new CliOption(BASE_PACKAGE, "base package (invokerPackage) for generated code"));
         cliOptions.add(CliOption.newBoolean(INTERFACE_ONLY, "Whether to generate only API interface stubs without the server files."));
+        cliOptions.add(CliOption.newBoolean(GENERATE_META,"Use for generating pom.xml and README.md"));
         cliOptions.add(CliOption.newBoolean(DELEGATE_PATTERN, "Whether to generate the server files using the delegate pattern"));
         cliOptions.add(CliOption.newBoolean(SINGLE_CONTENT_TYPES, "Whether to select only one produces/consumes content-type by operation."));
         cliOptions.add(CliOption.newBoolean(JAVA_8, "use java8 default interface"));
@@ -155,6 +158,10 @@ public class SpringCodegen extends AbstractJavaCodegen
             this.setInterfaceOnly(Boolean.valueOf(additionalProperties.get(INTERFACE_ONLY).toString()));
         }
 
+        if (additionalProperties.containsKey(GENERATE_META)) {
+            this.setGenerateMeta(Boolean.valueOf(additionalProperties.get(GENERATE_META).toString()));
+        }
+
         if (additionalProperties.containsKey(DELEGATE_PATTERN)) {
             this.setDelegatePattern(Boolean.valueOf(additionalProperties.get(DELEGATE_PATTERN).toString()));
         }
@@ -216,10 +223,14 @@ public class SpringCodegen extends AbstractJavaCodegen
                                 DELEGATE_PATTERN, INTERFACE_ONLY, JAVA_8));
             }
         }
-
-        if (!this.interfaceOnly) {
+        if(this.generateMeta)
+        {
             supportingFiles.add(new SupportingFile("pom.mustache", "", "pom.xml"));
             supportingFiles.add(new SupportingFile("README.mustache", "", "README.md"));
+
+        }
+
+        if (!this.interfaceOnly) {
 
             if (library.equals(DEFAULT_LIBRARY)) {
                 supportingFiles.add(new SupportingFile("homeController.mustache",
@@ -595,6 +606,8 @@ public class SpringCodegen extends AbstractJavaCodegen
     }
 
     public void setInterfaceOnly(boolean interfaceOnly) { this.interfaceOnly = interfaceOnly; }
+
+    public void setGenerateMeta(boolean generateMeta) { this.generateMeta = generateMeta; }
 
     public void setDelegatePattern(boolean delegatePattern) { this.delegatePattern = delegatePattern; }
 


### PR DESCRIPTION
…rue for not generating pom.xml not works in every situation.

### PR checklist

- [ ] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [ ] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [ ] Filed the PR against the correct branch: `3.0.0` branch for changes related to OpenAPI spec 3.0. Default: `master`.
- [ ] Copied the [technical committee](https://github.com/swagger-api/swagger-codegen/#swagger-codegen-technical-committee) to review the pull request if your PR is targeting a particular programming language.
@jeff9finger
### Description of the PR

(details of the change, additional tests that have been done, reference to the issue for tracking, etc)
Issue 5542, i added the additionalParameter "generateMeta=[true|false]" for controling generation of pom.xml and README.md. The generation of pom.xml depending on parameter interfaceOnly did not work for our situation. I generated with -DgenerateMeta=true and false

false
[main] INFO io.swagger.codegen.AbstractGenerator - writing file ...XXXResponse.java
[main] INFO io.swagger.codegen.AbstractGenerator - writing file ...XXXApi.java
[main] INFO io.swagger.codegen.AbstractGenerator - writing file ...swagger/.swagger-codegen/VERSION


and true
[main] INFO io.swagger.codegen.AbstractGenerator - writing file ...XXXResponse.java
[main] INFO io.swagger.codegen.AbstractGenerator - writing file ...XXXApi.java
[main] INFO io.swagger.codegen.AbstractGenerator - writing file ...swagger/pom.xml
[main] INFO io.swagger.codegen.AbstractGenerator - writing file ...swagger/README.md
[main] INFO io.swagger.codegen.AbstractGenerator - writing file ...swagger/.swagger-codegen/VERSION
