### PR TITLE
Added operationID as default name for models

### DIFF
--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/InlineModelResolver.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/InlineModelResolver.java
@@ -50,7 +50,7 @@ public class InlineModelResolver {
                                         if (obj.getType() == null || "object".equals(obj.getType())) {
                                             if (obj.getProperties() != null && obj.getProperties().size() > 0) {
                                                 flattenProperties(obj.getProperties(), pathname);
-                                                String modelName = resolveModelName(obj.getTitle(), bp.getName());
+                                                String modelName = resolveModelName(obj.getTitle(), bp.getName(), operation.getOperationId());
                                                 bp.setSchema(new RefModel(modelName));
                                                 addGenerated(modelName, model);
                                                 swagger.addDefinition(modelName, model);
@@ -64,7 +64,7 @@ public class InlineModelResolver {
                                             ObjectProperty op = (ObjectProperty) inner;
                                             if (op.getProperties() != null && op.getProperties().size() > 0) {
                                                 flattenProperties(op.getProperties(), pathname);
-                                                String modelName = resolveModelName(op.getTitle(), bp.getName());
+                                                String modelName = resolveModelName(op.getTitle(), bp.getName(), operation.getOperationId());
                                                 Model innerModel = modelFromProperty(op, modelName);
                                                 String existing = matchGenerated(innerModel);
                                                 if (existing != null) {
@@ -90,7 +90,7 @@ public class InlineModelResolver {
                                 if (property instanceof ObjectProperty) {
                                     ObjectProperty op = (ObjectProperty) property;
                                     if (op.getProperties() != null && op.getProperties().size() > 0) {
-                                        String modelName = resolveModelName(op.getTitle(), "inline_response_" + key);
+                                        String modelName = resolveModelName(op.getTitle(), "inline_response_" + key, operation.getOperationId());
                                         Model model = modelFromProperty(op, modelName);
                                         String existing = matchGenerated(model);
                                         if (existing != null) {
@@ -109,8 +109,7 @@ public class InlineModelResolver {
                                         ObjectProperty op = (ObjectProperty) inner;
                                         if (op.getProperties() != null && op.getProperties().size() > 0) {
                                             flattenProperties(op.getProperties(), pathname);
-                                            String modelName = resolveModelName(op.getTitle(),
-                                                    "inline_response_" + key);
+                                            String modelName = resolveModelName(op.getTitle(),"inline_response_" + key, operation.getOperationId());
                                             Model innerModel = modelFromProperty(op, modelName);
                                             String existing = matchGenerated(innerModel);
                                             if (existing != null) {
@@ -130,8 +129,7 @@ public class InlineModelResolver {
                                         ObjectProperty op = (ObjectProperty) innerProperty;
                                         if (op.getProperties() != null && op.getProperties().size() > 0) {
                                             flattenProperties(op.getProperties(), pathname);
-                                            String modelName = resolveModelName(op.getTitle(),
-                                                    "inline_response_" + key);
+                                            String modelName = resolveModelName(op.getTitle(), "inline_response_" + key, operation.getOperationId());
                                             Model innerModel = modelFromProperty(op, modelName);
                                             String existing = matchGenerated(innerModel);
                                             if (existing != null) {
@@ -168,7 +166,7 @@ public class InlineModelResolver {
                     if (inner instanceof ObjectProperty) {
                         ObjectProperty op = (ObjectProperty) inner;
                         if (op.getProperties() != null && op.getProperties().size() > 0) {
-                            String innerModelName = resolveModelName(op.getTitle(), modelName + "_inner");
+                            String innerModelName = resolveModelName(op.getTitle(), modelName + "_inner", null);
                             Model innerModel = modelFromProperty(op, innerModelName);
                             String existing = matchGenerated(innerModel);
                             if (existing == null) {
@@ -206,12 +204,16 @@ public class InlineModelResolver {
         }
     }
 
-    private String resolveModelName(String title, String key) {
-        if (title == null) {
+    private String resolveModelName(String title, String key,  String operationID) {
+        if (title == null && operationID ==null) {
             return uniqueName(key);
-        } else {
+        } else if (title != null){
             return uniqueName(title);
         }
+		else
+		{
+			return uniqueName(operationID);
+		}
     }
 
     public String matchGenerated(Model model) {
@@ -265,7 +267,7 @@ public class InlineModelResolver {
 
                 ObjectProperty op = (ObjectProperty) property;
 
-                String modelName = resolveModelName(op.getTitle(), path + "_" + key);
+                String modelName = resolveModelName(op.getTitle(), path + "_" + key, null);
                 Model model = modelFromProperty(op, modelName);
 
                 String existing = matchGenerated(model);
@@ -286,7 +288,7 @@ public class InlineModelResolver {
                     ObjectProperty op = (ObjectProperty) inner;
                     if (op.getProperties() != null && op.getProperties().size() > 0) {
                         flattenProperties(op.getProperties(), path);
-                        String modelName = resolveModelName(op.getTitle(), path + "_" + key);
+                        String modelName = resolveModelName(op.getTitle(), path + "_" + key, null);
                         Model innerModel = modelFromProperty(op, modelName);
                         String existing = matchGenerated(innerModel);
                         if (existing != null) {
@@ -306,7 +308,7 @@ public class InlineModelResolver {
                     ObjectProperty op = (ObjectProperty) inner;
                     if (op.getProperties() != null && op.getProperties().size() > 0) {
                         flattenProperties(op.getProperties(), path);
-                        String modelName = resolveModelName(op.getTitle(), path + "_" + key);
+                        String modelName = resolveModelName(op.getTitle(), path + "_" + key, null);
                         Model innerModel = modelFromProperty(op, modelName);
                         String existing = matchGenerated(innerModel);
                         if (existing != null) {

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/InlineModelResolver.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/InlineModelResolver.java
@@ -208,12 +208,11 @@ public class InlineModelResolver {
         if (title == null && operationID ==null) {
             return uniqueName(key);
         } else if (title != null){
-			return uniqueName(title);
+            return uniqueName(title);
         }
-		else
-		{
-			return uniqueName(operationID);
-		}
+        else{
+            return uniqueName(operationID);
+        }
     }
 
     public String matchGenerated(Model model) {

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/InlineModelResolver.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/InlineModelResolver.java
@@ -208,7 +208,7 @@ public class InlineModelResolver {
         if (title == null && operationID ==null) {
             return uniqueName(key);
         } else if (title != null){
-            return uniqueName(title);
+			return uniqueName(title);
         }
 		else
 		{


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [x] Filed the PR against the correct branch: `3.0.0` branch for changes related to OpenAPI spec 3.0. Default: `master`.
- [x] Copied the [technical committee](https://github.com/swagger-api/swagger-codegen/#swagger-codegen-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

(details of the change, additional tests that have been done, reference to the issue for tracking, etc)

