### PR TITLE
Added vendorExtensions.x-isPrimitive.

### DIFF
--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/JavascriptClientCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/JavascriptClientCodegen.java
@@ -797,7 +797,7 @@ public class JavascriptClientCodegen extends DefaultCodegen implements CodegenCo
                 codegenModel.vendorExtensions.put("x-itemType", getSwaggerType(mm.getAdditionalProperties()));
             } else {
                 String type = mm.getType();
-                if (type != null && (type.equals("number") || type.equals("integer") || type.equals("string") || type.equals("boolean") || type.equals("null"))) {
+                if (isPrimitiveType(type)){
                     codegenModel.vendorExtensions.put("x-isPrimitive", true);
                 }
             }
@@ -882,6 +882,11 @@ public class JavascriptClientCodegen extends DefaultCodegen implements CodegenCo
     private boolean isModelledType(CodegenOperation co) {
         // This seems to be the only way to tell whether an operation return type is modelled.
         return !Boolean.TRUE.equals(co.returnTypeIsPrimitive);
+    }
+
+    private boolean isPrimitiveType(String type) {
+        final String[] primitives = {"number", "integer", "string", "boolean", "null"};
+        return Arrays.asList(primitives).contains(type);
     }
 
     @SuppressWarnings("unchecked")

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/JavascriptClientCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/JavascriptClientCodegen.java
@@ -795,6 +795,11 @@ public class JavascriptClientCodegen extends DefaultCodegen implements CodegenCo
             if (mm.getAdditionalProperties() != null) {
                 codegenModel.vendorExtensions.put("x-isMap", true);
                 codegenModel.vendorExtensions.put("x-itemType", getSwaggerType(mm.getAdditionalProperties()));
+            } else {
+                String type = mm.getType();
+                if (type != null && (type.equals("number") || type.equals("integer") || type.equals("string") || type.equals("boolean") || type.equals("null"))) {
+                    codegenModel.vendorExtensions.put("x-isPrimitive", true);
+                }
             }
         }
 

--- a/modules/swagger-codegen/src/main/resources/Javascript/partial_model_generic.mustache
+++ b/modules/swagger-codegen/src/main/resources/Javascript/partial_model_generic.mustache
@@ -36,6 +36,12 @@
    * @return {{=< >=}}{module:<#invokerPackage><invokerPackage>/</invokerPackage><#modelPackage><modelPackage>/</modelPackage><classname>}<={{ }}=> The populated <code>{{classname}}</code> instance.
    */
 {{/emitJSDoc}}
+{{#vendorExtensions.x-isPrimitive}}
+  exports.constructFromObject = function(data, obj) {
+    return data;
+  }
+{{/vendorExtensions.x-isPrimitive}}
+{{^vendorExtensions.x-isPrimitive}}
   exports.constructFromObject = function(data, obj) {
     if (data){{! TODO: support polymorphism: discriminator property on data determines class to instantiate.}} {
       obj = obj || new exports();
@@ -48,6 +54,7 @@
 {{/vars}}    }
     return obj;
   }
+{{/vendorExtensions.x-isPrimitive}}
 {{#useInheritance}}{{#parentModel}}
   exports.prototype = Object.create({{classname}}.prototype);
   exports.prototype.constructor = exports;


### PR DESCRIPTION
Switch template for constructFromObject.

### PR checklist

- [x] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [ ] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [x] Filed the PR against the correct branch: `3.0.0` branch for changes related to OpenAPI spec 3.0. Default: `master`.
- [x] Copied the [technical committee](https://github.com/swagger-api/swagger-codegen/#swagger-codegen-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

(details of the change, additional tests that have been done, reference to the issue for tracking, etc)

When `$ref` is used to reference primitive types, The value is always empty object.
This forces users to modify the Swagger file even if the API definition is valid.

Reported in #4973
