### PR TITLE
Fix Issue 7924 - Allow host and base path to be changed independently

### DIFF
--- a/modules/swagger-codegen/src/main/resources/Java/libraries/okhttp-gson/ApiClient.mustache
+++ b/modules/swagger-codegen/src/main/resources/Java/libraries/okhttp-gson/ApiClient.mustache
@@ -53,7 +53,8 @@ import {{invokerPackage}}.auth.OAuth;
 
 public class ApiClient {
 
-    private String basePath = "{{{basePath}}}";
+    private String host = "{{host}}";
+    private String basePath = "{{{basePathWithoutHost}}}";
     private boolean debugging = false;
     private Map<String, String> defaultHeaderMap = new HashMap<String, String>();
     private String tempFolderPath = null;
@@ -102,9 +103,29 @@ public class ApiClient {
     }
 
     /**
+     * Get host
+     *
+     * @return host
+     */
+     public String getHost() {
+        return host;
+      }
+
+    /**
+     * Set host
+     *
+     * @param host (e.g {{{host}}})
+     * @return An instance of OkHttpClient
+     */
+    public ApiClient setHost(String host) {
+        this.host = host;
+        return this;
+      }
+
+    /**
      * Get base path
      *
-     * @return Baes path
+     * @return Base path
      */
     public String getBasePath() {
         return basePath;
@@ -113,7 +134,7 @@ public class ApiClient {
     /**
      * Set base path
      *
-     * @param basePath Base path of the URL (e.g {{{basePath}}}
+     * @param basePath Base path of the URL (e.g {{{basePathWithoutHost}}})
      * @return An instance of OkHttpClient
      */
     public ApiClient setBasePath(String basePath) {
@@ -981,7 +1002,7 @@ public class ApiClient {
      * @param formParams The form parameters
      * @param authNames The authentications to apply
      * @param progressRequestListener Progress request listener
-     * @return The HTTP request 
+     * @return The HTTP request
      * @throws ApiException If fail to serialize the request body object
      */
     public Request buildRequest(String path, String method, List<Pair> queryParams, List<Pair> collectionQueryParams, Object body, Map<String, String> headerParams, Map<String, Object> formParams, String[] authNames, ProgressRequestBody.ProgressRequestListener progressRequestListener) throws ApiException {
@@ -1038,7 +1059,7 @@ public class ApiClient {
      */
     public String buildUrl(String path, List<Pair> queryParams, List<Pair> collectionQueryParams) {
         final StringBuilder url = new StringBuilder();
-        url.append(basePath).append(path);
+        url.append("{{scheme}}://").append(host).append(basePath).append(path);
 
         if (queryParams != null && !queryParams.isEmpty()) {
             // support (constant) query string in `path`, e.g. "/posts?draft=1"

--- a/modules/swagger-codegen/src/main/resources/Java/libraries/okhttp-gson/ApiClient.mustache
+++ b/modules/swagger-codegen/src/main/resources/Java/libraries/okhttp-gson/ApiClient.mustache
@@ -53,7 +53,7 @@ import {{invokerPackage}}.auth.OAuth;
 
 public class ApiClient {
 
-    private String host = "{{host}}{{^host}}localhost{{/host}}";
+    private String host = "{{scheme}}://{{host}}{{^host}}localhost{{/host}}";
     private String basePath = "{{{basePathWithoutHost}}}";
     private boolean debugging = false;
     private Map<String, String> defaultHeaderMap = new HashMap<String, String>();
@@ -114,7 +114,7 @@ public class ApiClient {
     /**
      * Set host
      *
-     * @param host (e.g {{{host}}})
+     * @param host (e.g "{{scheme}}://{{host}}{{^host}}localhost{{/host}}";)
      * @return An instance of OkHttpClient
      */
     public ApiClient setHost(String host) {
@@ -134,7 +134,7 @@ public class ApiClient {
     /**
      * Set base path
      *
-     * @param basePath Base path of the URL (e.g {{{basePathWithoutHost}}})
+     * @param basePath Base path of the URL (e.g "{{basePathWithoutHost}}")
      * @return An instance of OkHttpClient
      */
     public ApiClient setBasePath(String basePath) {
@@ -1059,7 +1059,7 @@ public class ApiClient {
      */
     public String buildUrl(String path, List<Pair> queryParams, List<Pair> collectionQueryParams) {
         final StringBuilder url = new StringBuilder();
-        url.append("{{scheme}}://").append(host).append(basePath).append(path);
+        url.append(host).append(basePath).append(path);
 
         if (queryParams != null && !queryParams.isEmpty()) {
             // support (constant) query string in `path`, e.g. "/posts?draft=1"

--- a/modules/swagger-codegen/src/main/resources/Java/libraries/okhttp-gson/ApiClient.mustache
+++ b/modules/swagger-codegen/src/main/resources/Java/libraries/okhttp-gson/ApiClient.mustache
@@ -53,7 +53,7 @@ import {{invokerPackage}}.auth.OAuth;
 
 public class ApiClient {
 
-    private String host = "{{host}}";
+    private String host = "{{host}}{{^host}}localhost{{/host}}";
     private String basePath = "{{{basePathWithoutHost}}}";
     private boolean debugging = false;
     private Map<String, String> defaultHeaderMap = new HashMap<String, String>();

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/io/swagger/client/ApiClient.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/io/swagger/client/ApiClient.java
@@ -52,7 +52,8 @@ import io.swagger.client.auth.OAuth;
 
 public class ApiClient {
 
-    private String basePath = "http://petstore.swagger.io:80/v2";
+    private String host = "petstore.swagger.io:80";
+    private String basePath = "/v2";
     private boolean debugging = false;
     private Map<String, String> defaultHeaderMap = new HashMap<String, String>();
     private String tempFolderPath = null;
@@ -98,9 +99,29 @@ public class ApiClient {
     }
 
     /**
+     * Get host
+     *
+     * @return host
+     */
+     public String getHost() {
+        return host;
+      }
+
+    /**
+     * Set host
+     *
+     * @param host (e.g petstore.swagger.io:80)
+     * @return An instance of OkHttpClient
+     */
+    public ApiClient setHost(String host) {
+        this.host = host;
+        return this;
+      }
+
+    /**
      * Get base path
      *
-     * @return Baes path
+     * @return Base path
      */
     public String getBasePath() {
         return basePath;
@@ -109,7 +130,7 @@ public class ApiClient {
     /**
      * Set base path
      *
-     * @param basePath Base path of the URL (e.g http://petstore.swagger.io:80/v2
+     * @param basePath Base path of the URL (e.g /v2)
      * @return An instance of OkHttpClient
      */
     public ApiClient setBasePath(String basePath) {
@@ -963,7 +984,7 @@ public class ApiClient {
      * @param formParams The form parameters
      * @param authNames The authentications to apply
      * @param progressRequestListener Progress request listener
-     * @return The HTTP request 
+     * @return The HTTP request
      * @throws ApiException If fail to serialize the request body object
      */
     public Request buildRequest(String path, String method, List<Pair> queryParams, List<Pair> collectionQueryParams, Object body, Map<String, String> headerParams, Map<String, Object> formParams, String[] authNames, ProgressRequestBody.ProgressRequestListener progressRequestListener) throws ApiException {
@@ -1020,7 +1041,7 @@ public class ApiClient {
      */
     public String buildUrl(String path, List<Pair> queryParams, List<Pair> collectionQueryParams) {
         final StringBuilder url = new StringBuilder();
-        url.append(basePath).append(path);
+        url.append("http://").append(host).append(basePath).append(path);
 
         if (queryParams != null && !queryParams.isEmpty()) {
             // support (constant) query string in `path`, e.g. "/posts?draft=1"

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/io/swagger/client/ApiClient.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/io/swagger/client/ApiClient.java
@@ -52,7 +52,7 @@ import io.swagger.client.auth.OAuth;
 
 public class ApiClient {
 
-    private String host = "petstore.swagger.io:80";
+    private String host = "http://petstore.swagger.io:80";
     private String basePath = "/v2";
     private boolean debugging = false;
     private Map<String, String> defaultHeaderMap = new HashMap<String, String>();
@@ -110,7 +110,7 @@ public class ApiClient {
     /**
      * Set host
      *
-     * @param host (e.g petstore.swagger.io:80)
+     * @param host (e.g "http://petstore.swagger.io:80";)
      * @return An instance of OkHttpClient
      */
     public ApiClient setHost(String host) {
@@ -130,7 +130,7 @@ public class ApiClient {
     /**
      * Set base path
      *
-     * @param basePath Base path of the URL (e.g /v2)
+     * @param basePath Base path of the URL (e.g "/v2")
      * @return An instance of OkHttpClient
      */
     public ApiClient setBasePath(String basePath) {
@@ -1041,7 +1041,7 @@ public class ApiClient {
      */
     public String buildUrl(String path, List<Pair> queryParams, List<Pair> collectionQueryParams) {
         final StringBuilder url = new StringBuilder();
-        url.append("http://").append(host).append(basePath).append(path);
+        url.append(host).append(basePath).append(path);
 
         if (queryParams != null && !queryParams.isEmpty()) {
             // support (constant) query string in `path`, e.g. "/posts?draft=1"


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [x] Filed the PR against the correct branch: `3.0.0` branch for changes related to OpenAPI spec 3.0. Default: `master`.
- [x] Copied the [technical committee](https://github.com/swagger-api/swagger-codegen/#swagger-codegen-technical-committee) to review the pull request if your PR is targeting a particular programming language.

@bbdouglas  @JFCote  @sreeshas @jfiala  @lukoyanov @cbornet @jeff9finger

### Description of the PR

Fixes #7924 
Separate the hostname and the base path so that they can be changed independently of one another
