### PR TITLE
Add HideGenerationTimestamp getter and setter in CodegenConfig

### DIFF
--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/CodegenConfig.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/CodegenConfig.java
@@ -177,6 +177,10 @@ public interface CodegenConfig {
 
     void setRemoveOperationIdPrefix(boolean removeOperationIdPrefix);
 
+    public boolean isHideGenerationTimestamp();
+
+    public void setHideGenerationTimestamp(boolean hideGenerationTimestamp);
+
     Map<String, String> supportedLibraries();
 
     void setLibrary(String library);

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/DefaultCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/DefaultCodegen.java
@@ -3378,7 +3378,7 @@ public class DefaultCodegen {
     public void setRemoveOperationIdPrefix(boolean removeOperationIdPrefix) {
         this.removeOperationIdPrefix = removeOperationIdPrefix;
     }
-    
+
     public boolean isHideGenerationTimestamp() {
         return hideGenerationTimestamp;
     }


### PR DESCRIPTION
In #7998 I forgot to add the new getter (`isHideGenerationTimestamp()`) and setter (`setHideGenerationTimestamp(boolean)`) method in the `CodegenConfig` interface.

Original Issue: #7997