### PR TITLE
Allow to set values with setApiPackage(..) and setModelPackage(..)

### DIFF
--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/AbstractJavaCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/AbstractJavaCodegen.java
@@ -207,6 +207,14 @@ public abstract class AbstractJavaCodegen extends DefaultCodegen implements Code
             additionalProperties.put(CodegenConstants.INVOKER_PACKAGE, invokerPackage);
         }
 
+        if (!additionalProperties.containsKey(CodegenConstants.MODEL_PACKAGE)) {
+            additionalProperties.put(CodegenConstants.MODEL_PACKAGE, modelPackage);
+        }
+
+        if (!additionalProperties.containsKey(CodegenConstants.API_PACKAGE)) {
+            additionalProperties.put(CodegenConstants.API_PACKAGE, apiPackage);
+        }
+
         if (additionalProperties.containsKey(CodegenConstants.GROUP_ID)) {
             this.setGroupId((String) additionalProperties.get(CodegenConstants.GROUP_ID));
         } else {

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/AbstractJavaCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/AbstractJavaCodegen.java
@@ -1125,6 +1125,10 @@ public abstract class AbstractJavaCodegen extends DefaultCodegen implements Code
         return packageName;
     }
 
+    public String getInvokerPackage() {
+        return invokerPackage;
+    }
+
     public void setInvokerPackage(String invokerPackage) {
         this.invokerPackage = invokerPackage;
     }

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/AbstractPhpCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/AbstractPhpCodegen.java
@@ -345,6 +345,10 @@ public abstract class AbstractPhpCodegen extends DefaultCodegen implements Codeg
         return toModelName(type);
     }
 
+    public String getInvokerPackage() {
+        return invokerPackage;
+    }
+
     public void setInvokerPackage(String invokerPackage) {
         this.invokerPackage = invokerPackage;
     }

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/AndroidClientCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/AndroidClientCodegen.java
@@ -364,6 +364,14 @@ public class AndroidClientCodegen extends DefaultCodegen implements CodegenConfi
             additionalProperties.put("authPackage", authPackage);
         }
 
+        if (!additionalProperties.containsKey(CodegenConstants.MODEL_PACKAGE)) {
+            additionalProperties.put(CodegenConstants.MODEL_PACKAGE, modelPackage);
+        }
+
+        if (!additionalProperties.containsKey(CodegenConstants.API_PACKAGE)) {
+            additionalProperties.put(CodegenConstants.API_PACKAGE, apiPackage);
+        }
+
         if (additionalProperties.containsKey(CodegenConstants.GROUP_ID)) {
             this.setGroupId((String) additionalProperties.get(CodegenConstants.GROUP_ID));
         } else {

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/AndroidClientCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/AndroidClientCodegen.java
@@ -549,6 +549,10 @@ public class AndroidClientCodegen extends DefaultCodegen implements CodegenConfi
         this.androidBuildToolsVersion = androidBuildToolsVersion;
     }
 
+    public String getInvokerPackage() {
+        return invokerPackage;
+    }
+
     public void setInvokerPackage(String invokerPackage) {
         this.invokerPackage = invokerPackage;
     }

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/JavascriptClientCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/JavascriptClientCodegen.java
@@ -10,8 +10,8 @@ import io.swagger.codegen.CodegenOperation;
 import io.swagger.codegen.CodegenParameter;
 import io.swagger.codegen.CodegenProperty;
 import io.swagger.codegen.CodegenType;
-import io.swagger.codegen.SupportingFile;
 import io.swagger.codegen.DefaultCodegen;
+import io.swagger.codegen.SupportingFile;
 import io.swagger.models.ArrayModel;
 import io.swagger.models.Info;
 import io.swagger.models.License;
@@ -389,6 +389,10 @@ public class JavascriptClientCodegen extends DefaultCodegen implements CodegenCo
     @Override
     public String modelFileFolder() {
         return createPath(outputFolder, sourceFolder, invokerPackage, modelPackage());
+    }
+
+    public String getInvokerPackage() {
+        return invokerPackage;
     }
 
     public void setInvokerPackage(String invokerPackage) {

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/PhpClientCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/PhpClientCodegen.java
@@ -403,6 +403,10 @@ public class PhpClientCodegen extends DefaultCodegen implements CodegenConfig {
         return toModelName(type);
     }
 
+    public String getInvokerPackage() {
+        return invokerPackage;
+    }
+
     public void setInvokerPackage(String invokerPackage) {
         this.invokerPackage = invokerPackage;
     }

--- a/modules/swagger-codegen/src/test/java/io/swagger/codegen/android/AndroidClientCodegenTest.java
+++ b/modules/swagger-codegen/src/test/java/io/swagger/codegen/android/AndroidClientCodegenTest.java
@@ -16,6 +16,9 @@ public class AndroidClientCodegenTest {
         Assert.assertEquals(codegen.additionalProperties().get(CodegenConstants.HIDE_GENERATION_TIMESTAMP), Boolean.TRUE);
         Assert.assertEquals(codegen.isHideGenerationTimestamp(), true);
         Assert.assertEquals(codegen.modelPackage(), "io.swagger.client.model");
+        Assert.assertEquals(codegen.additionalProperties().get(CodegenConstants.MODEL_PACKAGE), "io.swagger.client.model");
+        Assert.assertEquals(codegen.apiPackage(), "io.swagger.client.api");
+        Assert.assertEquals(codegen.additionalProperties().get(CodegenConstants.API_PACKAGE), "io.swagger.client.api");
         Assert.assertEquals(codegen.getInvokerPackage(), "io.swagger.client");
         Assert.assertEquals(codegen.additionalProperties().get(CodegenConstants.INVOKER_PACKAGE), "io.swagger.client");
     }
@@ -29,7 +32,9 @@ public class AndroidClientCodegenTest {
         codegen.processOpts();
 
         Assert.assertEquals(codegen.modelPackage(), "xx.yyyyyyyy.model");
+        Assert.assertEquals(codegen.additionalProperties().get(CodegenConstants.MODEL_PACKAGE), "xx.yyyyyyyy.model");
         Assert.assertEquals(codegen.apiPackage(), "xx.yyyyyyyy.api");
+        Assert.assertEquals(codegen.additionalProperties().get(CodegenConstants.API_PACKAGE), "xx.yyyyyyyy.api");
         Assert.assertEquals(codegen.getInvokerPackage(), "xx.yyyyyyyy.invoker");
         Assert.assertEquals(codegen.additionalProperties().get(CodegenConstants.INVOKER_PACKAGE), "xx.yyyyyyyy.invoker");
     }

--- a/modules/swagger-codegen/src/test/java/io/swagger/codegen/android/AndroidClientCodegenTest.java
+++ b/modules/swagger-codegen/src/test/java/io/swagger/codegen/android/AndroidClientCodegenTest.java
@@ -1,0 +1,52 @@
+package io.swagger.codegen.android;
+
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import io.swagger.codegen.CodegenConstants;
+import io.swagger.codegen.languages.AndroidClientCodegen;
+
+public class AndroidClientCodegenTest {
+
+    @Test
+    public void testInitialConfigValues() throws Exception {
+        final AndroidClientCodegen codegen = new AndroidClientCodegen();
+        codegen.processOpts();
+
+        Assert.assertEquals(codegen.additionalProperties().get(CodegenConstants.HIDE_GENERATION_TIMESTAMP), Boolean.TRUE);
+        Assert.assertEquals(codegen.isHideGenerationTimestamp(), true);
+        Assert.assertEquals(codegen.modelPackage(), "io.swagger.client.model");
+        Assert.assertEquals(codegen.getInvokerPackage(), "io.swagger.client");
+        Assert.assertEquals(codegen.additionalProperties().get(CodegenConstants.INVOKER_PACKAGE), "io.swagger.client");
+    }
+
+    @Test
+    public void testSettersForConfigValues() throws Exception {
+        final AndroidClientCodegen codegen = new AndroidClientCodegen();
+        codegen.setModelPackage("xx.yyyyyyyy.model");
+        codegen.setApiPackage("xx.yyyyyyyy.api");
+        codegen.setInvokerPackage("xx.yyyyyyyy.invoker");
+        codegen.processOpts();
+
+        Assert.assertEquals(codegen.modelPackage(), "xx.yyyyyyyy.model");
+        Assert.assertEquals(codegen.apiPackage(), "xx.yyyyyyyy.api");
+        Assert.assertEquals(codegen.getInvokerPackage(), "xx.yyyyyyyy.invoker");
+        Assert.assertEquals(codegen.additionalProperties().get(CodegenConstants.INVOKER_PACKAGE), "xx.yyyyyyyy.invoker");
+    }
+
+    @Test
+    public void testAdditionalPropertiesPutForConfigValues() throws Exception {
+        final AndroidClientCodegen codegen = new AndroidClientCodegen();
+        codegen.additionalProperties().put(CodegenConstants.MODEL_PACKAGE, "xyz.yyyyy.mmmmm.model");
+        codegen.additionalProperties().put(CodegenConstants.API_PACKAGE, "xyz.yyyyy.aaaaa.api");
+        codegen.additionalProperties().put(CodegenConstants.INVOKER_PACKAGE,"xyz.yyyyy.iiii.invoker");
+        codegen.processOpts();
+
+        Assert.assertEquals(codegen.modelPackage(), "xyz.yyyyy.mmmmm.model");
+        Assert.assertEquals(codegen.additionalProperties().get(CodegenConstants.MODEL_PACKAGE), "xyz.yyyyy.mmmmm.model");
+        Assert.assertEquals(codegen.apiPackage(), "xyz.yyyyy.aaaaa.api");
+        Assert.assertEquals(codegen.additionalProperties().get(CodegenConstants.API_PACKAGE), "xyz.yyyyy.aaaaa.api");
+        Assert.assertEquals(codegen.getInvokerPackage(), "xyz.yyyyy.iiii.invoker");
+        Assert.assertEquals(codegen.additionalProperties().get(CodegenConstants.INVOKER_PACKAGE), "xyz.yyyyy.iiii.invoker");
+    }
+}

--- a/modules/swagger-codegen/src/test/java/io/swagger/codegen/java/AbstractJavaCodegenTest.java
+++ b/modules/swagger-codegen/src/test/java/io/swagger/codegen/java/AbstractJavaCodegenTest.java
@@ -94,9 +94,9 @@ public class AbstractJavaCodegenTest {
         Assert.assertEquals(codegen.additionalProperties().get(CodegenConstants.HIDE_GENERATION_TIMESTAMP), Boolean.FALSE);
         Assert.assertEquals(codegen.isHideGenerationTimestamp(), false);
         Assert.assertEquals(codegen.modelPackage(), "invalidPackageName");
-        Assert.assertEquals(codegen.additionalProperties().get(CodegenConstants.MODEL_PACKAGE), null);
+        Assert.assertEquals(codegen.additionalProperties().get(CodegenConstants.MODEL_PACKAGE), "invalidPackageName");
         Assert.assertEquals(codegen.apiPackage(), "invalidPackageName");
-        Assert.assertEquals(codegen.additionalProperties().get(CodegenConstants.API_PACKAGE), null);
+        Assert.assertEquals(codegen.additionalProperties().get(CodegenConstants.API_PACKAGE), "invalidPackageName");
         Assert.assertEquals(codegen.getInvokerPackage(), "io.swagger");
         Assert.assertEquals(codegen.additionalProperties().get(CodegenConstants.INVOKER_PACKAGE), "io.swagger");
     }
@@ -113,7 +113,9 @@ public class AbstractJavaCodegenTest {
         Assert.assertEquals(codegen.additionalProperties().get(CodegenConstants.HIDE_GENERATION_TIMESTAMP), Boolean.TRUE);
         Assert.assertEquals(codegen.isHideGenerationTimestamp(), true);
         Assert.assertEquals(codegen.modelPackage(), "xyz.yyyyy.zzzzzzz.model");
+        Assert.assertEquals(codegen.additionalProperties().get(CodegenConstants.MODEL_PACKAGE), "xyz.yyyyy.zzzzzzz.model");
         Assert.assertEquals(codegen.apiPackage(), "xyz.yyyyy.zzzzzzz.api");
+        Assert.assertEquals(codegen.additionalProperties().get(CodegenConstants.API_PACKAGE), "xyz.yyyyy.zzzzzzz.api");
         Assert.assertEquals(codegen.getInvokerPackage(), "xyz.yyyyy.zzzzzzz.invoker");
         Assert.assertEquals(codegen.additionalProperties().get(CodegenConstants.INVOKER_PACKAGE), "xyz.yyyyy.zzzzzzz.invoker");
     }

--- a/modules/swagger-codegen/src/test/java/io/swagger/codegen/java/AbstractJavaCodegenTest.java
+++ b/modules/swagger-codegen/src/test/java/io/swagger/codegen/java/AbstractJavaCodegenTest.java
@@ -93,26 +93,48 @@ public class AbstractJavaCodegenTest {
 
         Assert.assertEquals(codegen.additionalProperties().get(CodegenConstants.HIDE_GENERATION_TIMESTAMP), Boolean.FALSE);
         Assert.assertEquals(codegen.isHideGenerationTimestamp(), false);
+        Assert.assertEquals(codegen.modelPackage(), "invalidPackageName");
+        Assert.assertEquals(codegen.additionalProperties().get(CodegenConstants.MODEL_PACKAGE), null);
+        Assert.assertEquals(codegen.apiPackage(), "invalidPackageName");
+        Assert.assertEquals(codegen.additionalProperties().get(CodegenConstants.API_PACKAGE), null);
+        Assert.assertEquals(codegen.getInvokerPackage(), "io.swagger");
+        Assert.assertEquals(codegen.additionalProperties().get(CodegenConstants.INVOKER_PACKAGE), "io.swagger");
     }
 
     @Test
     public void testSettersForConfigValues() throws Exception {
         final AbstractJavaCodegen codegen = new P_AbstractJavaCodegen();
         codegen.setHideGenerationTimestamp(true);
+        codegen.setModelPackage("xyz.yyyyy.zzzzzzz.model");
+        codegen.setApiPackage("xyz.yyyyy.zzzzzzz.api");
+        codegen.setInvokerPackage("xyz.yyyyy.zzzzzzz.invoker");
         codegen.processOpts();
 
         Assert.assertEquals(codegen.additionalProperties().get(CodegenConstants.HIDE_GENERATION_TIMESTAMP), Boolean.TRUE);
         Assert.assertEquals(codegen.isHideGenerationTimestamp(), true);
+        Assert.assertEquals(codegen.modelPackage(), "xyz.yyyyy.zzzzzzz.model");
+        Assert.assertEquals(codegen.apiPackage(), "xyz.yyyyy.zzzzzzz.api");
+        Assert.assertEquals(codegen.getInvokerPackage(), "xyz.yyyyy.zzzzzzz.invoker");
+        Assert.assertEquals(codegen.additionalProperties().get(CodegenConstants.INVOKER_PACKAGE), "xyz.yyyyy.zzzzzzz.invoker");
     }
 
     @Test
     public void testAdditionalPropertiesPutForConfigValues() throws Exception {
         final AbstractJavaCodegen codegen = new P_AbstractJavaCodegen();
         codegen.additionalProperties().put(CodegenConstants.HIDE_GENERATION_TIMESTAMP, false);
+        codegen.additionalProperties().put(CodegenConstants.MODEL_PACKAGE, "xyz.yyyyy.model.oooooo");
+        codegen.additionalProperties().put(CodegenConstants.API_PACKAGE, "xyz.yyyyy.api.oooooo");
+        codegen.additionalProperties().put(CodegenConstants.INVOKER_PACKAGE, "xyz.yyyyy.invoker.oooooo");
         codegen.processOpts();
 
         Assert.assertEquals(codegen.additionalProperties().get(CodegenConstants.HIDE_GENERATION_TIMESTAMP), Boolean.FALSE);
         Assert.assertEquals(codegen.isHideGenerationTimestamp(), false);
+        Assert.assertEquals(codegen.modelPackage(), "xyz.yyyyy.model.oooooo");
+        Assert.assertEquals(codegen.additionalProperties().get(CodegenConstants.MODEL_PACKAGE), "xyz.yyyyy.model.oooooo");
+        Assert.assertEquals(codegen.apiPackage(), "xyz.yyyyy.api.oooooo");
+        Assert.assertEquals(codegen.additionalProperties().get(CodegenConstants.API_PACKAGE), "xyz.yyyyy.api.oooooo");
+        Assert.assertEquals(codegen.getInvokerPackage(), "xyz.yyyyy.invoker.oooooo");
+        Assert.assertEquals(codegen.additionalProperties().get(CodegenConstants.INVOKER_PACKAGE), "xyz.yyyyy.invoker.oooooo");
     }
 
     private static class P_AbstractJavaCodegen extends AbstractJavaCodegen {

--- a/modules/swagger-codegen/src/test/java/io/swagger/codegen/java/jaxrs/AbstractJavaJAXRSServerCodegenTest.java
+++ b/modules/swagger-codegen/src/test/java/io/swagger/codegen/java/jaxrs/AbstractJavaJAXRSServerCodegenTest.java
@@ -28,6 +28,9 @@ public class AbstractJavaJAXRSServerCodegenTest {
         Assert.assertEquals(codegen.additionalProperties().get(CodegenConstants.HIDE_GENERATION_TIMESTAMP), Boolean.FALSE);
         Assert.assertEquals(codegen.isHideGenerationTimestamp(), false);
         Assert.assertEquals(codegen.modelPackage(), "io.swagger.model");
+        Assert.assertEquals(codegen.additionalProperties().get(CodegenConstants.MODEL_PACKAGE), "io.swagger.model");
+        Assert.assertEquals(codegen.apiPackage(), "io.swagger.api");
+        Assert.assertEquals(codegen.additionalProperties().get(CodegenConstants.API_PACKAGE), "io.swagger.api");
         Assert.assertEquals(codegen.getInvokerPackage(), "io.swagger.api");
         Assert.assertEquals(codegen.additionalProperties().get(CodegenConstants.INVOKER_PACKAGE), "io.swagger.api");
     }
@@ -44,7 +47,9 @@ public class AbstractJavaJAXRSServerCodegenTest {
         Assert.assertEquals(codegen.additionalProperties().get(CodegenConstants.HIDE_GENERATION_TIMESTAMP), Boolean.TRUE);
         Assert.assertEquals(codegen.isHideGenerationTimestamp(), true);
         Assert.assertEquals(codegen.modelPackage(), "xx.yyyyyyyy.model");
+        Assert.assertEquals(codegen.additionalProperties().get(CodegenConstants.MODEL_PACKAGE), "xx.yyyyyyyy.model");
         Assert.assertEquals(codegen.apiPackage(), "xx.yyyyyyyy.api");
+        Assert.assertEquals(codegen.additionalProperties().get(CodegenConstants.API_PACKAGE), "xx.yyyyyyyy.api");
         Assert.assertEquals(codegen.getInvokerPackage(), "xx.yyyyyyyy.invoker");
         Assert.assertEquals(codegen.additionalProperties().get(CodegenConstants.INVOKER_PACKAGE), "xx.yyyyyyyy.invoker");
     }

--- a/modules/swagger-codegen/src/test/java/io/swagger/codegen/java/jaxrs/AbstractJavaJAXRSServerCodegenTest.java
+++ b/modules/swagger-codegen/src/test/java/io/swagger/codegen/java/jaxrs/AbstractJavaJAXRSServerCodegenTest.java
@@ -1,0 +1,88 @@
+package io.swagger.codegen.java.jaxrs;
+
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import io.swagger.codegen.CodegenConstants;
+import io.swagger.codegen.CodegenType;
+import io.swagger.codegen.languages.AbstractJavaJAXRSServerCodegen;
+
+public class AbstractJavaJAXRSServerCodegenTest {
+
+    private final AbstractJavaJAXRSServerCodegen fakeJavaJAXRSCodegen = new P_AbstractJavaJAXRSServerCodegen();
+
+    @Test
+    public void convertApiName() throws Exception {
+        Assert.assertEquals(fakeJavaJAXRSCodegen.toApiName("name"), "NameApi");
+        Assert.assertEquals(fakeJavaJAXRSCodegen.toApiName("$name"), "NameApi");
+        Assert.assertEquals(fakeJavaJAXRSCodegen.toApiName("nam#e"), "NameApi");
+        Assert.assertEquals(fakeJavaJAXRSCodegen.toApiName("$another-fake?"), "AnotherFakeApi");
+        Assert.assertEquals(fakeJavaJAXRSCodegen.toApiName("fake_classname_tags 123#$%^"), "FakeClassnameTags123Api");
+    }
+
+    @Test
+    public void testInitialConfigValues() throws Exception {
+        final AbstractJavaJAXRSServerCodegen codegen = new P_AbstractJavaJAXRSServerCodegen();
+        codegen.processOpts();
+
+        Assert.assertEquals(codegen.additionalProperties().get(CodegenConstants.HIDE_GENERATION_TIMESTAMP), Boolean.FALSE);
+        Assert.assertEquals(codegen.isHideGenerationTimestamp(), false);
+        Assert.assertEquals(codegen.modelPackage(), "io.swagger.model");
+        Assert.assertEquals(codegen.getInvokerPackage(), "io.swagger.api");
+        Assert.assertEquals(codegen.additionalProperties().get(CodegenConstants.INVOKER_PACKAGE), "io.swagger.api");
+    }
+
+    @Test
+    public void testSettersForConfigValues() throws Exception {
+        final AbstractJavaJAXRSServerCodegen codegen = new P_AbstractJavaJAXRSServerCodegen();
+        codegen.setHideGenerationTimestamp(true);
+        codegen.setModelPackage("xx.yyyyyyyy.model");
+        codegen.setApiPackage("xx.yyyyyyyy.api");
+        codegen.setInvokerPackage("xx.yyyyyyyy.invoker");
+        codegen.processOpts();
+
+        Assert.assertEquals(codegen.additionalProperties().get(CodegenConstants.HIDE_GENERATION_TIMESTAMP), Boolean.TRUE);
+        Assert.assertEquals(codegen.isHideGenerationTimestamp(), true);
+        Assert.assertEquals(codegen.modelPackage(), "xx.yyyyyyyy.model");
+        Assert.assertEquals(codegen.apiPackage(), "xx.yyyyyyyy.api");
+        Assert.assertEquals(codegen.getInvokerPackage(), "xx.yyyyyyyy.invoker");
+        Assert.assertEquals(codegen.additionalProperties().get(CodegenConstants.INVOKER_PACKAGE), "xx.yyyyyyyy.invoker");
+    }
+
+    @Test
+    public void testAdditionalPropertiesPutForConfigValues() throws Exception {
+        final AbstractJavaJAXRSServerCodegen codegen = new P_AbstractJavaJAXRSServerCodegen();
+        codegen.additionalProperties().put(CodegenConstants.HIDE_GENERATION_TIMESTAMP, "true");
+        codegen.additionalProperties().put(CodegenConstants.MODEL_PACKAGE, "xyz.yyyyy.mmmmm.model");
+        codegen.additionalProperties().put(CodegenConstants.API_PACKAGE, "xyz.yyyyy.aaaaa.api");
+        codegen.additionalProperties().put(CodegenConstants.INVOKER_PACKAGE,"xyz.yyyyy.iiii.invoker");
+        codegen.processOpts();
+
+        Assert.assertEquals(codegen.additionalProperties().get(CodegenConstants.HIDE_GENERATION_TIMESTAMP), Boolean.TRUE);
+        Assert.assertEquals(codegen.isHideGenerationTimestamp(), true);
+        Assert.assertEquals(codegen.modelPackage(), "xyz.yyyyy.mmmmm.model");
+        Assert.assertEquals(codegen.additionalProperties().get(CodegenConstants.MODEL_PACKAGE), "xyz.yyyyy.mmmmm.model");
+        Assert.assertEquals(codegen.apiPackage(), "xyz.yyyyy.aaaaa.api");
+        Assert.assertEquals(codegen.additionalProperties().get(CodegenConstants.API_PACKAGE), "xyz.yyyyy.aaaaa.api");
+        Assert.assertEquals(codegen.getInvokerPackage(), "xyz.yyyyy.iiii.invoker");
+        Assert.assertEquals(codegen.additionalProperties().get(CodegenConstants.INVOKER_PACKAGE), "xyz.yyyyy.iiii.invoker");
+    }
+
+    private static class P_AbstractJavaJAXRSServerCodegen extends AbstractJavaJAXRSServerCodegen {
+
+        @Override
+        public CodegenType getTag() {
+            return null;
+        }
+
+        @Override
+        public String getName() {
+            return null;
+        }
+
+        @Override
+        public String getHelp() {
+            return null;
+        }
+    }
+}

--- a/modules/swagger-codegen/src/test/java/io/swagger/codegen/javascript/JavascriptClientCodegenTest.java
+++ b/modules/swagger-codegen/src/test/java/io/swagger/codegen/javascript/JavascriptClientCodegenTest.java
@@ -15,6 +15,12 @@ public class JavascriptClientCodegenTest {
 
         Assert.assertEquals(codegen.additionalProperties().get(CodegenConstants.HIDE_GENERATION_TIMESTAMP), Boolean.TRUE);
         Assert.assertEquals(codegen.isHideGenerationTimestamp(), true);
+        Assert.assertEquals(codegen.modelPackage(), "model");
+        Assert.assertEquals(codegen.additionalProperties().get(CodegenConstants.MODEL_PACKAGE), null);
+        Assert.assertEquals(codegen.apiPackage(), "api");
+        Assert.assertEquals(codegen.additionalProperties().get(CodegenConstants.API_PACKAGE), null);
+        Assert.assertEquals(codegen.getInvokerPackage(), null);
+        Assert.assertEquals(codegen.additionalProperties().get(CodegenConstants.INVOKER_PACKAGE), null);
     }
 
     @Test

--- a/modules/swagger-codegen/src/test/java/io/swagger/codegen/languages/JavaClientCodegenTest.java
+++ b/modules/swagger-codegen/src/test/java/io/swagger/codegen/languages/JavaClientCodegenTest.java
@@ -14,6 +14,7 @@ import org.testng.annotations.Test;
 
 import com.google.common.collect.ImmutableMap;
 
+import io.swagger.codegen.CodegenConstants;
 import io.swagger.codegen.CodegenOperation;
 import io.swagger.codegen.CodegenParameter;
 
@@ -108,6 +109,80 @@ public class JavaClientCodegenTest {
         Assert.assertFalse(queryParamOptional.hasMore);
 
     }
+    
+    @Test
+    public void testInitialConfigValues() throws Exception {
+        final JavaClientCodegen codegen = new JavaClientCodegen();
+        codegen.processOpts();
+
+        Assert.assertEquals(codegen.additionalProperties().get(CodegenConstants.HIDE_GENERATION_TIMESTAMP), Boolean.FALSE);
+        Assert.assertEquals(codegen.isHideGenerationTimestamp(), false);
+
+        Assert.assertEquals(codegen.modelPackage(), "io.swagger.client.model");
+        Assert.assertEquals(codegen.apiPackage(), "io.swagger.client.api");
+        Assert.assertEquals(codegen.invokerPackage, "io.swagger.client");
+        Assert.assertEquals(codegen.additionalProperties().get(CodegenConstants.INVOKER_PACKAGE), "io.swagger.client");
+    }
+
+    @Test
+    public void testSettersForConfigValues() throws Exception {
+        final JavaClientCodegen codegen = new JavaClientCodegen();
+        codegen.setHideGenerationTimestamp(true);
+        codegen.setInvokerPackage("xyz.yyyyy.zzzzzzz.invoker");
+        codegen.processOpts();
+
+        Assert.assertEquals(codegen.additionalProperties().get(CodegenConstants.HIDE_GENERATION_TIMESTAMP), Boolean.TRUE);
+        Assert.assertEquals(codegen.isHideGenerationTimestamp(), true);
+        Assert.assertEquals(codegen.invokerPackage, "xyz.yyyyy.zzzzzzz.invoker");
+        Assert.assertEquals(codegen.additionalProperties().get(CodegenConstants.INVOKER_PACKAGE), "xyz.yyyyy.zzzzzzz.invoker");
+    }
+
+    @Test
+    public void testAdditionalPropertiesPutForConfigValues() throws Exception {
+        final JavaClientCodegen codegen = new JavaClientCodegen();
+        codegen.additionalProperties().put(CodegenConstants.HIDE_GENERATION_TIMESTAMP, "true");
+        codegen.additionalProperties().put(CodegenConstants.MODEL_PACKAGE, "xyz.yyyyy.zzzzzzz.mmmmm.model");
+        codegen.additionalProperties().put(CodegenConstants.API_PACKAGE, "xyz.yyyyy.zzzzzzz.aaaaa.api");
+        codegen.additionalProperties().put(CodegenConstants.INVOKER_PACKAGE,"xyz.yyyyy.zzzzzzz.iiii.invoker");
+        codegen.processOpts();
+
+        Assert.assertEquals(codegen.additionalProperties().get(CodegenConstants.HIDE_GENERATION_TIMESTAMP), Boolean.TRUE);
+        Assert.assertEquals(codegen.isHideGenerationTimestamp(), true);
+        Assert.assertEquals(codegen.modelPackage(), "xyz.yyyyy.zzzzzzz.mmmmm.model");
+        Assert.assertEquals(codegen.additionalProperties().get(CodegenConstants.MODEL_PACKAGE), "xyz.yyyyy.zzzzzzz.mmmmm.model");
+        Assert.assertEquals(codegen.apiPackage(), "xyz.yyyyy.zzzzzzz.aaaaa.api");
+        Assert.assertEquals(codegen.additionalProperties().get(CodegenConstants.API_PACKAGE), "xyz.yyyyy.zzzzzzz.aaaaa.api");
+        Assert.assertEquals(codegen.invokerPackage, "xyz.yyyyy.zzzzzzz.iiii.invoker");
+        Assert.assertEquals(codegen.additionalProperties().get(CodegenConstants.INVOKER_PACKAGE), "xyz.yyyyy.zzzzzzz.iiii.invoker");
+    }
+
+    @Test
+    public void testPackageNamesSetInvokerDerivedFromApi() throws Exception {
+        final JavaClientCodegen codegen = new JavaClientCodegen();
+        codegen.additionalProperties().put(CodegenConstants.MODEL_PACKAGE, "xyz.yyyyy.zzzzzzz.mmmmm.model");
+        codegen.additionalProperties().put(CodegenConstants.API_PACKAGE, "xyz.yyyyy.zzzzzzz.aaaaa.api");
+        codegen.processOpts();
+
+        Assert.assertEquals(codegen.modelPackage(), "xyz.yyyyy.zzzzzzz.mmmmm.model");
+        Assert.assertEquals(codegen.additionalProperties().get(CodegenConstants.MODEL_PACKAGE), "xyz.yyyyy.zzzzzzz.mmmmm.model");
+        Assert.assertEquals(codegen.apiPackage(), "xyz.yyyyy.zzzzzzz.aaaaa.api");
+        Assert.assertEquals(codegen.additionalProperties().get(CodegenConstants.API_PACKAGE), "xyz.yyyyy.zzzzzzz.aaaaa.api");
+        Assert.assertEquals(codegen.invokerPackage, "xyz.yyyyy.zzzzzzz.aaaaa");
+        Assert.assertEquals(codegen.additionalProperties().get(CodegenConstants.INVOKER_PACKAGE), "xyz.yyyyy.zzzzzzz.aaaaa");
+    }
+
+    @Test
+    public void testPackageNamesSetInvokerDerivedFromModel() throws Exception {
+        final JavaClientCodegen codegen = new JavaClientCodegen();
+        codegen.additionalProperties().put(CodegenConstants.MODEL_PACKAGE, "xyz.yyyyy.zzzzzzz.mmmmm.model");
+        codegen.processOpts();
+
+        Assert.assertEquals(codegen.modelPackage(), "xyz.yyyyy.zzzzzzz.mmmmm.model");
+        Assert.assertEquals(codegen.additionalProperties().get(CodegenConstants.MODEL_PACKAGE), "xyz.yyyyy.zzzzzzz.mmmmm.model");
+        Assert.assertEquals(codegen.apiPackage(), "io.swagger.client.api");
+        Assert.assertEquals(codegen.invokerPackage, "xyz.yyyyy.zzzzzzz.mmmmm");
+        Assert.assertEquals(codegen.additionalProperties().get(CodegenConstants.INVOKER_PACKAGE), "xyz.yyyyy.zzzzzzz.mmmmm");
+    }
 
     private CodegenParameter createPathParam(String name) {
         CodegenParameter codegenParameter = createStringParam(name);
@@ -129,6 +204,4 @@ public class JavaClientCodegenTest {
         codegenParameter.dataType = "String";
         return codegenParameter;
     }
-
-
 }

--- a/modules/swagger-codegen/src/test/java/io/swagger/codegen/languages/JavaClientCodegenTest.java
+++ b/modules/swagger-codegen/src/test/java/io/swagger/codegen/languages/JavaClientCodegenTest.java
@@ -119,7 +119,9 @@ public class JavaClientCodegenTest {
         Assert.assertEquals(codegen.isHideGenerationTimestamp(), false);
 
         Assert.assertEquals(codegen.modelPackage(), "io.swagger.client.model");
+        Assert.assertEquals(codegen.additionalProperties().get(CodegenConstants.MODEL_PACKAGE), "io.swagger.client.model");
         Assert.assertEquals(codegen.apiPackage(), "io.swagger.client.api");
+        Assert.assertEquals(codegen.additionalProperties().get(CodegenConstants.API_PACKAGE), "io.swagger.client.api");
         Assert.assertEquals(codegen.invokerPackage, "io.swagger.client");
         Assert.assertEquals(codegen.additionalProperties().get(CodegenConstants.INVOKER_PACKAGE), "io.swagger.client");
     }
@@ -128,11 +130,17 @@ public class JavaClientCodegenTest {
     public void testSettersForConfigValues() throws Exception {
         final JavaClientCodegen codegen = new JavaClientCodegen();
         codegen.setHideGenerationTimestamp(true);
+        codegen.setModelPackage("xyz.yyyyy.zzzzzzz.model");
+        codegen.setApiPackage("xyz.yyyyy.zzzzzzz.api");
         codegen.setInvokerPackage("xyz.yyyyy.zzzzzzz.invoker");
         codegen.processOpts();
 
         Assert.assertEquals(codegen.additionalProperties().get(CodegenConstants.HIDE_GENERATION_TIMESTAMP), Boolean.TRUE);
         Assert.assertEquals(codegen.isHideGenerationTimestamp(), true);
+        Assert.assertEquals(codegen.modelPackage(), "xyz.yyyyy.zzzzzzz.model");
+        Assert.assertEquals(codegen.additionalProperties().get(CodegenConstants.MODEL_PACKAGE), "xyz.yyyyy.zzzzzzz.model");
+        Assert.assertEquals(codegen.apiPackage(), "xyz.yyyyy.zzzzzzz.api");
+        Assert.assertEquals(codegen.additionalProperties().get(CodegenConstants.API_PACKAGE), "xyz.yyyyy.zzzzzzz.api");
         Assert.assertEquals(codegen.invokerPackage, "xyz.yyyyy.zzzzzzz.invoker");
         Assert.assertEquals(codegen.additionalProperties().get(CodegenConstants.INVOKER_PACKAGE), "xyz.yyyyy.zzzzzzz.invoker");
     }
@@ -180,6 +188,7 @@ public class JavaClientCodegenTest {
         Assert.assertEquals(codegen.modelPackage(), "xyz.yyyyy.zzzzzzz.mmmmm.model");
         Assert.assertEquals(codegen.additionalProperties().get(CodegenConstants.MODEL_PACKAGE), "xyz.yyyyy.zzzzzzz.mmmmm.model");
         Assert.assertEquals(codegen.apiPackage(), "io.swagger.client.api");
+        Assert.assertEquals(codegen.additionalProperties().get(CodegenConstants.API_PACKAGE), "io.swagger.client.api");
         Assert.assertEquals(codegen.invokerPackage, "xyz.yyyyy.zzzzzzz.mmmmm");
         Assert.assertEquals(codegen.additionalProperties().get(CodegenConstants.INVOKER_PACKAGE), "xyz.yyyyy.zzzzzzz.mmmmm");
     }

--- a/modules/swagger-codegen/src/test/java/io/swagger/codegen/php/AbstractPhpCodegenTest.java
+++ b/modules/swagger-codegen/src/test/java/io/swagger/codegen/php/AbstractPhpCodegenTest.java
@@ -1,0 +1,81 @@
+package io.swagger.codegen.php;
+
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import io.swagger.codegen.CodegenConstants;
+import io.swagger.codegen.CodegenType;
+import io.swagger.codegen.languages.AbstractPhpCodegen;
+
+public class AbstractPhpCodegenTest {
+
+    @Test
+    public void testInitialConfigValues() throws Exception {
+        final AbstractPhpCodegen codegen = new P_AbstractPhpCodegen();
+        codegen.processOpts();
+
+        Assert.assertEquals(codegen.additionalProperties().get(CodegenConstants.HIDE_GENERATION_TIMESTAMP), Boolean.TRUE);
+        Assert.assertEquals(codegen.isHideGenerationTimestamp(), true);
+        Assert.assertEquals(codegen.modelPackage(), "php\\Model");
+        Assert.assertEquals(codegen.additionalProperties().get(CodegenConstants.MODEL_PACKAGE), "php\\Model");
+        Assert.assertEquals(codegen.apiPackage(), "php\\Api");
+        Assert.assertEquals(codegen.additionalProperties().get(CodegenConstants.API_PACKAGE), "php\\Api");
+        Assert.assertEquals(codegen.getInvokerPackage(), "php");
+        Assert.assertEquals(codegen.additionalProperties().get(CodegenConstants.INVOKER_PACKAGE), "php");
+    }
+
+    @Test
+    public void testSettersForConfigValues() throws Exception {
+        final AbstractPhpCodegen codegen = new P_AbstractPhpCodegen();
+        codegen.setHideGenerationTimestamp(false);
+        codegen.setModelPackage("My\\Client\\Model");
+        codegen.setApiPackage("My\\Client\\Api");
+        codegen.setInvokerPackage("My\\Client\\Invoker");
+        codegen.processOpts();
+
+        Assert.assertEquals(codegen.additionalProperties().get(CodegenConstants.HIDE_GENERATION_TIMESTAMP), Boolean.FALSE);
+        Assert.assertEquals(codegen.isHideGenerationTimestamp(), false);
+        Assert.assertEquals(codegen.modelPackage(), "My\\Client\\Model");
+        Assert.assertEquals(codegen.additionalProperties().get(CodegenConstants.MODEL_PACKAGE), "My\\Client\\Model");
+        Assert.assertEquals(codegen.apiPackage(), "My\\Client\\Api");
+        Assert.assertEquals(codegen.additionalProperties().get(CodegenConstants.API_PACKAGE),"My\\Client\\Api");
+        Assert.assertEquals(codegen.getInvokerPackage(), "My\\Client\\Invoker");
+        Assert.assertEquals(codegen.additionalProperties().get(CodegenConstants.INVOKER_PACKAGE), "My\\Client\\Invoker");
+    }
+
+    @Test
+    public void testAdditionalPropertiesPutForConfigValues() throws Exception {
+        final AbstractPhpCodegen codegen = new P_AbstractPhpCodegen();
+        codegen.additionalProperties().put(CodegenConstants.HIDE_GENERATION_TIMESTAMP, false);
+        codegen.additionalProperties().put(CodegenConstants.MODEL_PACKAGE, "PHPmodel");
+        codegen.additionalProperties().put(CodegenConstants.API_PACKAGE, "PHPapi");
+        codegen.additionalProperties().put(CodegenConstants.INVOKER_PACKAGE, "PHPinvoker");
+        codegen.processOpts();
+
+        Assert.assertEquals(codegen.additionalProperties().get(CodegenConstants.HIDE_GENERATION_TIMESTAMP), Boolean.FALSE);
+        Assert.assertEquals(codegen.isHideGenerationTimestamp(), false);
+        Assert.assertEquals(codegen.modelPackage(), "PHPmodel");
+        Assert.assertEquals(codegen.additionalProperties().get(CodegenConstants.MODEL_PACKAGE), "PHPmodel");
+        Assert.assertEquals(codegen.apiPackage(), "PHPapi");
+        Assert.assertEquals(codegen.additionalProperties().get(CodegenConstants.API_PACKAGE), "PHPapi");
+        Assert.assertEquals(codegen.getInvokerPackage(), "PHPinvoker");
+        Assert.assertEquals(codegen.additionalProperties().get(CodegenConstants.INVOKER_PACKAGE), "PHPinvoker");
+    }
+
+    private static class P_AbstractPhpCodegen extends AbstractPhpCodegen {
+        @Override
+        public CodegenType getTag() {
+            return null;
+        }
+
+        @Override
+        public String getName() {
+            return null;
+        }
+
+        @Override
+        public String getHelp() {
+            return null;
+        }
+    }
+}

--- a/modules/swagger-codegen/src/test/java/io/swagger/codegen/php/PhpClientCodegenTest.java
+++ b/modules/swagger-codegen/src/test/java/io/swagger/codegen/php/PhpClientCodegenTest.java
@@ -15,26 +15,49 @@ public class PhpClientCodegenTest {
 
         Assert.assertEquals(codegen.additionalProperties().get(CodegenConstants.HIDE_GENERATION_TIMESTAMP), Boolean.TRUE);
         Assert.assertEquals(codegen.isHideGenerationTimestamp(), true);
+        Assert.assertEquals(codegen.modelPackage(), "Swagger\\Client\\Model");
+        Assert.assertEquals(codegen.additionalProperties().get(CodegenConstants.MODEL_PACKAGE), "Swagger\\Client\\Model");
+        Assert.assertEquals(codegen.apiPackage(), "Swagger\\Client\\Api");
+        Assert.assertEquals(codegen.additionalProperties().get(CodegenConstants.API_PACKAGE), "Swagger\\Client\\Api");
+        Assert.assertEquals(codegen.getInvokerPackage(), "Swagger\\Client");
     }
 
     @Test
     public void testSettersForConfigValues() throws Exception {
         final PhpClientCodegen codegen = new PhpClientCodegen();
         codegen.setHideGenerationTimestamp(false);
+        codegen.setModelPackage("My\\Client\\Model");
+        codegen.setApiPackage("My\\Client\\Api");
+        codegen.setInvokerPackage("My\\Client\\Invoker");
         codegen.processOpts();
 
         Assert.assertEquals(codegen.additionalProperties().get(CodegenConstants.HIDE_GENERATION_TIMESTAMP), Boolean.FALSE);
         Assert.assertEquals(codegen.isHideGenerationTimestamp(), false);
+        Assert.assertEquals(codegen.modelPackage(), "My\\Client\\Model");
+        Assert.assertEquals(codegen.additionalProperties().get(CodegenConstants.MODEL_PACKAGE), "My\\Client\\Model");
+        Assert.assertEquals(codegen.apiPackage(), "My\\Client\\Api");
+        Assert.assertEquals(codegen.additionalProperties().get(CodegenConstants.API_PACKAGE),"My\\Client\\Api");
+        Assert.assertEquals(codegen.getInvokerPackage(), "My\\Client\\Invoker");
+        Assert.assertEquals(codegen.additionalProperties().get(CodegenConstants.INVOKER_PACKAGE), "My\\Client\\Invoker");
     }
 
     @Test
     public void testAdditionalPropertiesPutForConfigValues() throws Exception {
         final PhpClientCodegen codegen = new PhpClientCodegen();
         codegen.additionalProperties().put(CodegenConstants.HIDE_GENERATION_TIMESTAMP, false);
+        codegen.additionalProperties().put(CodegenConstants.MODEL_PACKAGE, "Xmodel");
+        codegen.additionalProperties().put(CodegenConstants.API_PACKAGE, "Xapi");
+        codegen.additionalProperties().put(CodegenConstants.INVOKER_PACKAGE, "Xinvoker");
         codegen.processOpts();
 
         Assert.assertEquals(codegen.additionalProperties().get(CodegenConstants.HIDE_GENERATION_TIMESTAMP), Boolean.FALSE);
         Assert.assertEquals(codegen.isHideGenerationTimestamp(), false);
+        Assert.assertEquals(codegen.modelPackage(), "Xinvoker\\Xmodel");
+        Assert.assertEquals(codegen.additionalProperties().get(CodegenConstants.MODEL_PACKAGE), "Xinvoker\\Xmodel");
+        Assert.assertEquals(codegen.apiPackage(), "Xinvoker\\Xapi");
+        Assert.assertEquals(codegen.additionalProperties().get(CodegenConstants.API_PACKAGE), "Xinvoker\\Xapi");
+        Assert.assertEquals(codegen.getInvokerPackage(), "Xinvoker");
+        Assert.assertEquals(codegen.additionalProperties().get(CodegenConstants.INVOKER_PACKAGE), "Xinvoker");
     }
 
 }

--- a/modules/swagger-codegen/src/test/java/io/swagger/codegen/ruby/RubyClientCodegenTest.java
+++ b/modules/swagger-codegen/src/test/java/io/swagger/codegen/ruby/RubyClientCodegenTest.java
@@ -71,6 +71,10 @@ public class RubyClientCodegenTest {
 
       Assert.assertEquals(codegen.additionalProperties().get(CodegenConstants.HIDE_GENERATION_TIMESTAMP), Boolean.TRUE);
       Assert.assertEquals(codegen.isHideGenerationTimestamp(), true);
+      Assert.assertEquals(codegen.modelPackage(), "models");
+      Assert.assertEquals(codegen.additionalProperties().get(CodegenConstants.MODEL_PACKAGE), null);
+      Assert.assertEquals(codegen.apiPackage(), "api");
+      Assert.assertEquals(codegen.additionalProperties().get(CodegenConstants.API_PACKAGE), null);
   }
 
   @Test
@@ -87,9 +91,13 @@ public class RubyClientCodegenTest {
   public void testAdditionalPropertiesPutForConfigValues() throws Exception {
       final RubyClientCodegen codegen = new RubyClientCodegen();
       codegen.additionalProperties().put(CodegenConstants.HIDE_GENERATION_TIMESTAMP, false);
+      codegen.additionalProperties().put(CodegenConstants.MODEL_PACKAGE, "ruby-models");
+      codegen.additionalProperties().put(CodegenConstants.API_PACKAGE, "ruby-api");
       codegen.processOpts();
 
       Assert.assertEquals(codegen.additionalProperties().get(CodegenConstants.HIDE_GENERATION_TIMESTAMP), Boolean.FALSE);
       Assert.assertEquals(codegen.isHideGenerationTimestamp(), false);
+      Assert.assertEquals(codegen.additionalProperties().get(CodegenConstants.MODEL_PACKAGE), "ruby-models");
+      Assert.assertEquals(codegen.additionalProperties().get(CodegenConstants.API_PACKAGE), "ruby-api");
   }
 }


### PR DESCRIPTION
See issue description in #8004.

* New getter `getInvokerPackage()` added (to be consistent with other genertors already having this method with c10099536e9e5dc9b9f49c4dbcd750f0841c4c8c
* Test cases added for any logic change with 68cc55cd5676310958f4bce72e1a8ce4289d2d27 => This demonstrates that there is no regression introduced with the main change.
* **Main change:** aff61bad8fdaeea4e54a8ec468ea14b5d346326b: values set with `setApiPackage(..)` and `setModelPackage(..)` are now taken in account [1]

[1] As I wrote it in #8004, my change is limited to all `java` generators (including `android-client`). I now have there the same behavior as for the PHP generators. See [AbstractPhpCodegenTest.java](https://github.com/swagger-api/swagger-codegen/blob/68cc55cd5676310958f4bce72e1a8ce4289d2d27/modules/swagger-codegen/src/test/java/io/swagger/codegen/php/AbstractPhpCodegenTest.java) for a reference: no matter if you set the values with the setters or with the map, they will be available (when you read them in the map or with the getters)

After this change you have a similar behavior for the java generators (see the corresponding test cases)
