### PR TITLE
Create default_config instance and use it as default for ApiClient (#…

### DIFF
--- a/modules/swagger-codegen/src/main/resources/python/README.mustache
+++ b/modules/swagger-codegen/src/main/resources/python/README.mustache
@@ -57,17 +57,18 @@ from __future__ import print_function
 import time
 import {{{packageName}}}
 from {{{packageName}}}.rest import ApiException
+from {{{packageName}}}.configuration import default_config
 from pprint import pprint
 {{#apiInfo}}{{#apis}}{{#-first}}{{#operations}}{{#operation}}{{#-first}}{{#hasAuthMethods}}{{#authMethods}}{{#isBasic}}
 # Configure HTTP basic authorization: {{{name}}}
-{{{packageName}}}.configuration.username = 'YOUR_USERNAME'
-{{{packageName}}}.configuration.password = 'YOUR_PASSWORD'{{/isBasic}}{{#isApiKey}}
+default_config.username = 'YOUR_USERNAME'
+default_config.password = 'YOUR_PASSWORD'{{/isBasic}}{{#isApiKey}}
 # Configure API key authorization: {{{name}}}
-{{{packageName}}}.configuration.api_key['{{{keyParamName}}}'] = 'YOUR_API_KEY'
+default_config.api_key['{{{keyParamName}}}'] = 'YOUR_API_KEY'
 # Uncomment below to setup prefix (e.g. Bearer) for API key, if needed
-# {{{packageName}}}.configuration.api_key_prefix['{{{keyParamName}}}'] = 'Bearer'{{/isApiKey}}{{#isOAuth}}
+# default_config.api_key_prefix['{{{keyParamName}}}'] = 'Bearer'{{/isApiKey}}{{#isOAuth}}
 # Configure OAuth2 access token for authorization: {{{name}}}
-{{{packageName}}}.configuration.access_token = 'YOUR_ACCESS_TOKEN'{{/isOAuth}}{{/authMethods}}
+default_config.access_token = 'YOUR_ACCESS_TOKEN'{{/isOAuth}}{{/authMethods}}
 {{/hasAuthMethods}}
 # create an instance of the API class
 api_instance = {{{packageName}}}.{{{classname}}}()

--- a/modules/swagger-codegen/src/main/resources/python/api_client.mustache
+++ b/modules/swagger-codegen/src/main/resources/python/api_client.mustache
@@ -17,7 +17,7 @@ from six.moves.urllib.parse import quote
 import tornado.gen
 {{/tornado}}
 
-from {{packageName}}.configuration import Configuration
+from {{packageName}}.configuration import default_config
 import {{modelPackage}}
 from {{packageName}} import rest
 
@@ -57,7 +57,7 @@ class ApiClient(object):
     def __init__(self, configuration=None, header_name=None, header_value=None,
                  cookie=None):
         if configuration is None:
-            configuration = Configuration()
+            configuration = default_config
         self.configuration = configuration
 
         self.pool = ThreadPool()

--- a/modules/swagger-codegen/src/main/resources/python/configuration.mustache
+++ b/modules/swagger-codegen/src/main/resources/python/configuration.mustache
@@ -258,3 +258,6 @@ class Configuration(six.with_metaclass(TypeWithDefault, object)):
                "Version of the API: {{version}}\n"\
                "SDK Package Version: {{packageVersion}}".\
                format(env=sys.platform, pyversion=sys.version)
+
+
+default_config = Configuration()


### PR DESCRIPTION
…7269)

### PR checklist

- [ ] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [ ] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [ ] Filed the PR against the correct branch: `3.0.0` branch for changes related to OpenAPI spec 3.0. Default: `master`.
- [ ] Copied the [technical committee](https://github.com/swagger-api/swagger-codegen/#swagger-codegen-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

(details of the change, additional tests that have been done, reference to the issue for tracking, etc)

