### PR TITLE
[JAVA][Rest-assured] Version rest-assured has been updated to 3.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -532,7 +532,7 @@ CONFIG OPTIONS
 	    retrofit - HTTP client: OkHttp 2.4.0. JSON processing: Gson 2.3.1 (Retrofit 1.9.0)
         retrofit2 - HTTP client: OkHttp 2.5.0. JSON processing: Gson 2.4 (Retrofit 2.0.0-beta2)
         google-api-client - HTTP client: google-api-client 1.23.0. JSON processing: Jackson 2.8.9
-        rest-assured - HTTP client: rest-assured : 3.0.6. JSON processing: Gson 2.6.1. Only for Java8 
+        rest-assured - HTTP client: rest-assured : 3.1.0. JSON processing: Gson 2.6.1. Only for Java8 
 ```
 
 Your config file for Java can look like

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/JavaClientCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/JavaClientCodegen.java
@@ -84,7 +84,7 @@ public class JavaClientCodegen extends AbstractJavaCodegen
         supportedLibraries.put("resteasy", "HTTP client: Resteasy client 3.1.3.Final. JSON processing: Jackson 2.8.9");
         supportedLibraries.put("vertx", "HTTP client: VertX client 3.2.4. JSON processing: Jackson 2.8.9");
         supportedLibraries.put("google-api-client", "HTTP client: Google API client 1.23.0. JSON processing: Jackson 2.8.9");
-        supportedLibraries.put("rest-assured", "HTTP client: rest-assured : 3.0.6. JSON processing: Gson 2.6.1. Only for Java8");
+        supportedLibraries.put("rest-assured", "HTTP client: rest-assured : 3.1.0. JSON processing: Gson 2.6.1. Only for Java8");
 
         CliOption libraryOption = new CliOption(CodegenConstants.LIBRARY, "library template (sub-template) to use");
         libraryOption.setEnum(supportedLibraries);

--- a/modules/swagger-codegen/src/main/resources/Java/libraries/rest-assured/api.mustache
+++ b/modules/swagger-codegen/src/main/resources/Java/libraries/rest-assured/api.mustache
@@ -30,11 +30,8 @@ public class {{classname}} {
 
     private RequestSpecBuilder reqSpec;
 
-    private JSON json;
-
     private {{classname}}(RequestSpecBuilder reqSpec) {
         this.reqSpec = reqSpec;
-        this.json = new JSON();
     }
 
     public static {{classname}} {{classVarName}}(RequestSpecBuilder reqSpec) {
@@ -52,26 +49,6 @@ public class {{classname}} {
     }
 {{/operation}}
 {{/operations}}
-
-    /**
-     * Get JSON
-     *
-     * @return JSON object
-     */
-    public JSON getJSON() {
-        return json;
-    }
-
-    /**
-     * Set JSON
-     *
-     * @param json JSON object
-     * @return {{classname}}
-     */
-    public {{classname}} setJSON(JSON json) {
-        this.json = json;
-        return this;
-    }
 
     /**
     * Customise request specification
@@ -152,7 +129,7 @@ public class {{classname}} {
          */
         public {{{returnType}}} executeAs(Function<Response, Response> handler) {
             Type type = new TypeToken<{{{returnType}}}>(){}.getType();
-            return getJSON().deserialize(execute(handler).asString(), type);
+            return execute(handler).as(type);
         }
         {{/returnType}}
         {{#bodyParams}}
@@ -161,7 +138,7 @@ public class {{classname}} {
          * @param {{paramName}} ({{{dataType}}}) {{description}}{{#required}} (required){{/required}}{{^required}} (optional{{#defaultValue}}, default to {{{.}}}{{/defaultValue}}){{/required}}
          */
         public {{operationIdCamelCase}}Oper body({{{dataType}}} {{paramName}}) {
-            reqSpec.setBody(getJSON().serialize({{paramName}}));
+            reqSpec.setBody({{paramName}});
             return this;
         }
         {{/bodyParams}}

--- a/modules/swagger-codegen/src/main/resources/Java/libraries/rest-assured/build.gradle.mustache
+++ b/modules/swagger-codegen/src/main/resources/Java/libraries/rest-assured/build.gradle.mustache
@@ -95,7 +95,7 @@ if(hasProperty('target') && target == 'android') {
 
 ext {
     swagger_annotations_version = "1.5.15"
-    rest_assured_version = "3.0.6"
+    rest_assured_version = "3.1.0"
     junit_version = "4.12"
     gson_version = "2.6.1"
     gson_fire_version = "1.8.2"

--- a/modules/swagger-codegen/src/main/resources/Java/libraries/rest-assured/build.sbt.mustache
+++ b/modules/swagger-codegen/src/main/resources/Java/libraries/rest-assured/build.sbt.mustache
@@ -10,7 +10,7 @@ lazy val root = (project in file(".")).
     resolvers += Resolver.mavenLocal,
     libraryDependencies ++= Seq(
       "io.swagger" % "swagger-annotations" % "1.5.15",
-      "io.rest-assured" % "scala-support" % "3.0.6",
+      "io.rest-assured" % "scala-support" % "3.1.0",
       "com.google.code.gson" % "gson" % "2.6.1",
       "io.gsonfire" % "gson-fire" % "1.8.2" % "compile",
 {{#joda}}

--- a/modules/swagger-codegen/src/main/resources/Java/libraries/rest-assured/pom.mustache
+++ b/modules/swagger-codegen/src/main/resources/Java/libraries/rest-assured/pom.mustache
@@ -246,7 +246,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <swagger-core-version>1.5.15</swagger-core-version>
-        <rest-assured.version>3.0.6</rest-assured.version>
+        <rest-assured.version>3.1.0</rest-assured.version>
         <gson-version>2.6.1</gson-version>
         <gson-fire-version>1.8.2</gson-fire-version>
         <maven-plugin-version>1.0.0</maven-plugin-version>

--- a/samples/client/petstore/java/rest-assured/build.gradle
+++ b/samples/client/petstore/java/rest-assured/build.gradle
@@ -95,7 +95,7 @@ if(hasProperty('target') && target == 'android') {
 
 ext {
     swagger_annotations_version = "1.5.15"
-    rest_assured_version = "3.0.6"
+    rest_assured_version = "3.1.0"
     junit_version = "4.12"
     gson_version = "2.6.1"
     gson_fire_version = "1.8.2"

--- a/samples/client/petstore/java/rest-assured/build.sbt
+++ b/samples/client/petstore/java/rest-assured/build.sbt
@@ -10,7 +10,7 @@ lazy val root = (project in file(".")).
     resolvers += Resolver.mavenLocal,
     libraryDependencies ++= Seq(
       "io.swagger" % "swagger-annotations" % "1.5.15",
-      "io.rest-assured" % "scala-support" % "3.0.6",
+      "io.rest-assured" % "scala-support" % "3.1.0",
       "com.google.code.gson" % "gson" % "2.6.1",
       "io.gsonfire" % "gson-fire" % "1.8.2" % "compile",
       "org.threeten" % "threetenbp" % "1.3.5" % "compile",

--- a/samples/client/petstore/java/rest-assured/docs/EnumTest.md
+++ b/samples/client/petstore/java/rest-assured/docs/EnumTest.md
@@ -5,6 +5,7 @@
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **enumString** | [**EnumStringEnum**](#EnumStringEnum) |  |  [optional]
+**enumStringRequired** | [**EnumStringRequiredEnum**](#EnumStringRequiredEnum) |  | 
 **enumInteger** | [**EnumIntegerEnum**](#EnumIntegerEnum) |  |  [optional]
 **enumNumber** | [**EnumNumberEnum**](#EnumNumberEnum) |  |  [optional]
 **outerEnum** | [**OuterEnum**](OuterEnum.md) |  |  [optional]
@@ -12,6 +13,15 @@ Name | Type | Description | Notes
 
 <a name="EnumStringEnum"></a>
 ## Enum: EnumStringEnum
+Name | Value
+---- | -----
+UPPER | &quot;UPPER&quot;
+LOWER | &quot;lower&quot;
+EMPTY | &quot;&quot;
+
+
+<a name="EnumStringRequiredEnum"></a>
+## Enum: EnumStringRequiredEnum
 Name | Value
 ---- | -----
 UPPER | &quot;UPPER&quot;

--- a/samples/client/petstore/java/rest-assured/docs/FakeApi.md
+++ b/samples/client/petstore/java/rest-assured/docs/FakeApi.md
@@ -8,6 +8,7 @@ Method | HTTP request | Description
 [**fakeOuterCompositeSerialize**](FakeApi.md#fakeOuterCompositeSerialize) | **POST** /fake/outer/composite | 
 [**fakeOuterNumberSerialize**](FakeApi.md#fakeOuterNumberSerialize) | **POST** /fake/outer/number | 
 [**fakeOuterStringSerialize**](FakeApi.md#fakeOuterStringSerialize) | **POST** /fake/outer/string | 
+[**testBodyWithQueryParams**](FakeApi.md#testBodyWithQueryParams) | **PUT** /fake/body-with-query-params | 
 [**testClientModel**](FakeApi.md#testClientModel) | **PATCH** /fake | To test \&quot;client\&quot; model
 [**testEndpointParameters**](FakeApi.md#testEndpointParameters) | **POST** /fake | Fake endpoint for testing various parameters 假端點 偽のエンドポイント 가짜 엔드 포인트 
 [**testEnumParameters**](FakeApi.md#testEnumParameters) | **GET** /fake | To test enum parameters
@@ -177,6 +178,48 @@ No authorization required
 ### HTTP request headers
 
  - **Content-Type**: Not defined
+ - **Accept**: Not defined
+
+<a name="testBodyWithQueryParams"></a>
+# **testBodyWithQueryParams**
+> testBodyWithQueryParams(body, query)
+
+
+
+### Example
+```java
+// Import classes:
+//import io.swagger.client.ApiClient;
+//import io.restassured.builder.RequestSpecBuilder;
+//import io.restassured.filter.log.ErrorLoggingFilter;
+
+FakeApi api = ApiClient.api(ApiClient.Config.apiConfig().withReqSpecSupplier(
+                () -> new RequestSpecBuilder()
+                        .setBaseUri("http://petstore.swagger.io:80/v2"))).fake();
+
+api.testBodyWithQueryParams()
+    .body(body)
+    .queryQuery(query).execute(r -> r.prettyPeek());
+```
+
+### Parameters
+
+Name | Type | Description  | Notes
+------------- | ------------- | ------------- | -------------
+ **body** | [**User**](User.md)|  |
+ **query** | **String**|  |
+
+### Return type
+
+null (empty response body)
+
+### Authorization
+
+No authorization required
+
+### HTTP request headers
+
+ - **Content-Type**: application/json
  - **Accept**: Not defined
 
 <a name="testClientModel"></a>

--- a/samples/client/petstore/java/rest-assured/pom.xml
+++ b/samples/client/petstore/java/rest-assured/pom.xml
@@ -237,7 +237,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <swagger-core-version>1.5.15</swagger-core-version>
-        <rest-assured.version>3.0.6</rest-assured.version>
+        <rest-assured.version>3.1.0</rest-assured.version>
         <gson-version>2.6.1</gson-version>
         <gson-fire-version>1.8.2</gson-fire-version>
         <maven-plugin-version>1.0.0</maven-plugin-version>

--- a/samples/client/petstore/java/rest-assured/src/main/java/io/swagger/client/api/AnotherFakeApi.java
+++ b/samples/client/petstore/java/rest-assured/src/main/java/io/swagger/client/api/AnotherFakeApi.java
@@ -14,35 +14,24 @@
 package io.swagger.client.api;
 
 import com.google.gson.reflect.TypeToken;
-import io.swagger.client.model.Client;
-
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
 import io.restassured.RestAssured;
 import io.restassured.builder.RequestSpecBuilder;
 import io.restassured.builder.ResponseSpecBuilder;
 import io.restassured.response.Response;
+import io.swagger.client.model.Client;
 
 import java.lang.reflect.Type;
 import java.util.function.Consumer;
 import java.util.function.Function;
-import java.util.function.Supplier;
-import io.swagger.client.JSON;
 
-import static io.restassured.http.Method.*;
+import static io.restassured.http.Method.PATCH;
 
 public class AnotherFakeApi {
 
     private RequestSpecBuilder reqSpec;
 
-    private JSON json;
-
     private AnotherFakeApi(RequestSpecBuilder reqSpec) {
         this.reqSpec = reqSpec;
-        this.json = new JSON();
     }
 
     public static AnotherFakeApi anotherFake(RequestSpecBuilder reqSpec) {
@@ -52,26 +41,6 @@ public class AnotherFakeApi {
 
     public TestSpecialTagsOper testSpecialTags() {
         return new TestSpecialTagsOper(reqSpec);
-    }
-
-    /**
-     * Get JSON
-     *
-     * @return JSON object
-     */
-    public JSON getJSON() {
-        return json;
-    }
-
-    /**
-     * Set JSON
-     *
-     * @param json JSON object
-     * @return AnotherFakeApi
-     */
-    public AnotherFakeApi setJSON(JSON json) {
-        this.json = json;
-        return this;
     }
 
     /**
@@ -124,14 +93,14 @@ public class AnotherFakeApi {
          */
         public Client executeAs(Function<Response, Response> handler) {
             Type type = new TypeToken<Client>(){}.getType();
-            return getJSON().deserialize(execute(handler).asString(), type);
+            return execute(handler).as(type);
         }
 
          /**
          * @param body (Client) client model (required)
          */
         public TestSpecialTagsOper body(Client body) {
-            reqSpec.setBody(getJSON().serialize(body));
+            reqSpec.setBody(body);
             return this;
         }
 

--- a/samples/client/petstore/java/rest-assured/src/main/java/io/swagger/client/api/FakeApi.java
+++ b/samples/client/petstore/java/rest-assured/src/main/java/io/swagger/client/api/FakeApi.java
@@ -19,6 +19,7 @@ import io.swagger.client.model.Client;
 import org.threeten.bp.LocalDate;
 import org.threeten.bp.OffsetDateTime;
 import io.swagger.client.model.OuterComposite;
+import io.swagger.client.model.User;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -42,11 +43,8 @@ public class FakeApi {
 
     private RequestSpecBuilder reqSpec;
 
-    private JSON json;
-
     private FakeApi(RequestSpecBuilder reqSpec) {
         this.reqSpec = reqSpec;
-        this.json = new JSON();
     }
 
     public static FakeApi fake(RequestSpecBuilder reqSpec) {
@@ -70,6 +68,10 @@ public class FakeApi {
         return new FakeOuterStringSerializeOper(reqSpec);
     }
 
+    public TestBodyWithQueryParamsOper testBodyWithQueryParams() {
+        return new TestBodyWithQueryParamsOper(reqSpec);
+    }
+
     public TestClientModelOper testClientModel() {
         return new TestClientModelOper(reqSpec);
     }
@@ -88,26 +90,6 @@ public class FakeApi {
 
     public TestJsonFormDataOper testJsonFormData() {
         return new TestJsonFormDataOper(reqSpec);
-    }
-
-    /**
-     * Get JSON
-     *
-     * @return JSON object
-     */
-    public JSON getJSON() {
-        return json;
-    }
-
-    /**
-     * Set JSON
-     *
-     * @param json JSON object
-     * @return FakeApi
-     */
-    public FakeApi setJSON(JSON json) {
-        this.json = json;
-        return this;
     }
 
     /**
@@ -160,14 +142,14 @@ public class FakeApi {
          */
         public Boolean executeAs(Function<Response, Response> handler) {
             Type type = new TypeToken<Boolean>(){}.getType();
-            return getJSON().deserialize(execute(handler).asString(), type);
+            return execute(handler).as(type);
         }
 
          /**
          * @param body (Boolean) Input boolean as post body (optional)
          */
         public FakeOuterBooleanSerializeOper body(Boolean body) {
-            reqSpec.setBody(getJSON().serialize(body));
+            reqSpec.setBody(body);
             return this;
         }
 
@@ -229,14 +211,14 @@ public class FakeApi {
          */
         public OuterComposite executeAs(Function<Response, Response> handler) {
             Type type = new TypeToken<OuterComposite>(){}.getType();
-            return getJSON().deserialize(execute(handler).asString(), type);
+            return execute(handler).as(type);
         }
 
          /**
          * @param body (OuterComposite) Input composite as post body (optional)
          */
         public FakeOuterCompositeSerializeOper body(OuterComposite body) {
-            reqSpec.setBody(getJSON().serialize(body));
+            reqSpec.setBody(body);
             return this;
         }
 
@@ -298,14 +280,14 @@ public class FakeApi {
          */
         public BigDecimal executeAs(Function<Response, Response> handler) {
             Type type = new TypeToken<BigDecimal>(){}.getType();
-            return getJSON().deserialize(execute(handler).asString(), type);
+            return execute(handler).as(type);
         }
 
          /**
          * @param body (BigDecimal) Input number as post body (optional)
          */
         public FakeOuterNumberSerializeOper body(BigDecimal body) {
-            reqSpec.setBody(getJSON().serialize(body));
+            reqSpec.setBody(body);
             return this;
         }
 
@@ -367,14 +349,14 @@ public class FakeApi {
          */
         public String executeAs(Function<Response, Response> handler) {
             Type type = new TypeToken<String>(){}.getType();
-            return getJSON().deserialize(execute(handler).asString(), type);
+            return execute(handler).as(type);
         }
 
          /**
          * @param body (String) Input string as post body (optional)
          */
         public FakeOuterStringSerializeOper body(String body) {
-            reqSpec.setBody(getJSON().serialize(body));
+            reqSpec.setBody(body);
             return this;
         }
 
@@ -390,6 +372,74 @@ public class FakeApi {
          * Customise response specification
          */
         public FakeOuterStringSerializeOper respSpec(Consumer<ResponseSpecBuilder> consumer) {
+            consumer.accept(respSpec);
+            return this;
+        }
+    }
+    /**
+     * 
+     * 
+     *
+     * @see #body  (required)
+     * @see #queryQuery  (required)
+     */
+    public class TestBodyWithQueryParamsOper {
+
+        public static final String REQ_URI = "/fake/body-with-query-params";
+
+        private RequestSpecBuilder reqSpec;
+
+        private ResponseSpecBuilder respSpec;
+
+        public TestBodyWithQueryParamsOper() {
+            this.reqSpec = new RequestSpecBuilder();
+            reqSpec.setContentType("application/json");
+            reqSpec.setAccept("application/json");
+            this.respSpec = new ResponseSpecBuilder();
+        }
+
+        public TestBodyWithQueryParamsOper(RequestSpecBuilder reqSpec) {
+            this.reqSpec = reqSpec;
+            reqSpec.setContentType("application/json");
+            reqSpec.setAccept("application/json");
+            this.respSpec = new ResponseSpecBuilder();
+        }
+
+        /**
+         * PUT /fake/body-with-query-params
+         */
+        public <T> T execute(Function<Response, T> handler) {
+            return handler.apply(RestAssured.given().spec(reqSpec.build()).expect().spec(respSpec.build()).when().request(PUT, REQ_URI));
+        }
+
+         /**
+         * @param body (User)  (required)
+         */
+        public TestBodyWithQueryParamsOper body(User body) {
+            reqSpec.setBody(body);
+            return this;
+        }
+
+        /**
+         * @param query (String)  (required)
+         */
+        public TestBodyWithQueryParamsOper queryQuery(Object... query) {
+            reqSpec.addQueryParam("query", query);
+            return this;
+        }
+
+        /**
+         * Customise request specification
+         */
+        public TestBodyWithQueryParamsOper reqSpec(Consumer<RequestSpecBuilder> consumer) {
+            consumer.accept(reqSpec);
+            return this;
+        }
+
+        /**
+         * Customise response specification
+         */
+        public TestBodyWithQueryParamsOper respSpec(Consumer<ResponseSpecBuilder> consumer) {
             consumer.accept(respSpec);
             return this;
         }
@@ -436,14 +486,14 @@ public class FakeApi {
          */
         public Client executeAs(Function<Response, Response> handler) {
             Type type = new TypeToken<Client>(){}.getType();
-            return getJSON().deserialize(execute(handler).asString(), type);
+            return execute(handler).as(type);
         }
 
          /**
          * @param body (Client) client model (required)
          */
         public TestClientModelOper body(Client body) {
-            reqSpec.setBody(getJSON().serialize(body));
+            reqSpec.setBody(body);
             return this;
         }
 
@@ -800,7 +850,7 @@ public class FakeApi {
          * @param param (Object) request body (required)
          */
         public TestInlineAdditionalPropertiesOper body(Object param) {
-            reqSpec.setBody(getJSON().serialize(param));
+            reqSpec.setBody(param);
             return this;
         }
 

--- a/samples/client/petstore/java/rest-assured/src/main/java/io/swagger/client/api/FakeClassnameTags123Api.java
+++ b/samples/client/petstore/java/rest-assured/src/main/java/io/swagger/client/api/FakeClassnameTags123Api.java
@@ -14,35 +14,24 @@
 package io.swagger.client.api;
 
 import com.google.gson.reflect.TypeToken;
-import io.swagger.client.model.Client;
-
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
 import io.restassured.RestAssured;
 import io.restassured.builder.RequestSpecBuilder;
 import io.restassured.builder.ResponseSpecBuilder;
 import io.restassured.response.Response;
+import io.swagger.client.model.Client;
 
 import java.lang.reflect.Type;
 import java.util.function.Consumer;
 import java.util.function.Function;
-import java.util.function.Supplier;
-import io.swagger.client.JSON;
 
-import static io.restassured.http.Method.*;
+import static io.restassured.http.Method.PATCH;
 
 public class FakeClassnameTags123Api {
 
     private RequestSpecBuilder reqSpec;
 
-    private JSON json;
-
     private FakeClassnameTags123Api(RequestSpecBuilder reqSpec) {
         this.reqSpec = reqSpec;
-        this.json = new JSON();
     }
 
     public static FakeClassnameTags123Api fakeClassnameTags123(RequestSpecBuilder reqSpec) {
@@ -52,26 +41,6 @@ public class FakeClassnameTags123Api {
 
     public TestClassnameOper testClassname() {
         return new TestClassnameOper(reqSpec);
-    }
-
-    /**
-     * Get JSON
-     *
-     * @return JSON object
-     */
-    public JSON getJSON() {
-        return json;
-    }
-
-    /**
-     * Set JSON
-     *
-     * @param json JSON object
-     * @return FakeClassnameTags123Api
-     */
-    public FakeClassnameTags123Api setJSON(JSON json) {
-        this.json = json;
-        return this;
     }
 
     /**
@@ -124,14 +93,14 @@ public class FakeClassnameTags123Api {
          */
         public Client executeAs(Function<Response, Response> handler) {
             Type type = new TypeToken<Client>(){}.getType();
-            return getJSON().deserialize(execute(handler).asString(), type);
+            return execute(handler).as(type);
         }
 
          /**
          * @param body (Client) client model (required)
          */
         public TestClassnameOper body(Client body) {
-            reqSpec.setBody(getJSON().serialize(body));
+            reqSpec.setBody(body);
             return this;
         }
 

--- a/samples/client/petstore/java/rest-assured/src/main/java/io/swagger/client/api/PetApi.java
+++ b/samples/client/petstore/java/rest-assured/src/main/java/io/swagger/client/api/PetApi.java
@@ -14,37 +14,30 @@
 package io.swagger.client.api;
 
 import com.google.gson.reflect.TypeToken;
-import java.io.File;
-import io.swagger.client.model.ModelApiResponse;
-import io.swagger.client.model.Pet;
-
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
 import io.restassured.RestAssured;
 import io.restassured.builder.RequestSpecBuilder;
 import io.restassured.builder.ResponseSpecBuilder;
 import io.restassured.response.Response;
+import io.swagger.client.model.ModelApiResponse;
+import io.swagger.client.model.Pet;
 
+import java.io.File;
 import java.lang.reflect.Type;
+import java.util.List;
 import java.util.function.Consumer;
 import java.util.function.Function;
-import java.util.function.Supplier;
-import io.swagger.client.JSON;
 
-import static io.restassured.http.Method.*;
+import static io.restassured.http.Method.DELETE;
+import static io.restassured.http.Method.GET;
+import static io.restassured.http.Method.POST;
+import static io.restassured.http.Method.PUT;
 
 public class PetApi {
 
     private RequestSpecBuilder reqSpec;
 
-    private JSON json;
-
     private PetApi(RequestSpecBuilder reqSpec) {
         this.reqSpec = reqSpec;
-        this.json = new JSON();
     }
 
     public static PetApi pet(RequestSpecBuilder reqSpec) {
@@ -83,26 +76,6 @@ public class PetApi {
 
     public UploadFileOper uploadFile() {
         return new UploadFileOper(reqSpec);
-    }
-
-    /**
-     * Get JSON
-     *
-     * @return JSON object
-     */
-    public JSON getJSON() {
-        return json;
-    }
-
-    /**
-     * Set JSON
-     *
-     * @param json JSON object
-     * @return PetApi
-     */
-    public PetApi setJSON(JSON json) {
-        this.json = json;
-        return this;
     }
 
     /**
@@ -152,7 +125,7 @@ public class PetApi {
          * @param body (Pet) Pet object that needs to be added to the store (required)
          */
         public AddPetOper body(Pet body) {
-            reqSpec.setBody(getJSON().serialize(body));
+            reqSpec.setBody(body);
             return this;
         }
 
@@ -278,7 +251,7 @@ public class PetApi {
          */
         public List<Pet> executeAs(Function<Response, Response> handler) {
             Type type = new TypeToken<List<Pet>>(){}.getType();
-            return getJSON().deserialize(execute(handler).asString(), type);
+            return execute(handler).as(type);
         }
 
         /**
@@ -347,7 +320,7 @@ public class PetApi {
          */
         public List<Pet> executeAs(Function<Response, Response> handler) {
             Type type = new TypeToken<List<Pet>>(){}.getType();
-            return getJSON().deserialize(execute(handler).asString(), type);
+            return execute(handler).as(type);
         }
 
         /**
@@ -414,7 +387,7 @@ public class PetApi {
          */
         public Pet executeAs(Function<Response, Response> handler) {
             Type type = new TypeToken<Pet>(){}.getType();
-            return getJSON().deserialize(execute(handler).asString(), type);
+            return execute(handler).as(type);
         }
 
         /**
@@ -480,7 +453,7 @@ public class PetApi {
          * @param body (Pet) Pet object that needs to be added to the store (required)
          */
         public UpdatePetOper body(Pet body) {
-            reqSpec.setBody(getJSON().serialize(body));
+            reqSpec.setBody(body);
             return this;
         }
 
@@ -621,7 +594,7 @@ public class PetApi {
          */
         public ModelApiResponse executeAs(Function<Response, Response> handler) {
             Type type = new TypeToken<ModelApiResponse>(){}.getType();
-            return getJSON().deserialize(execute(handler).asString(), type);
+            return execute(handler).as(type);
         }
 
         /**

--- a/samples/client/petstore/java/rest-assured/src/main/java/io/swagger/client/api/StoreApi.java
+++ b/samples/client/petstore/java/rest-assured/src/main/java/io/swagger/client/api/StoreApi.java
@@ -14,35 +14,27 @@
 package io.swagger.client.api;
 
 import com.google.gson.reflect.TypeToken;
-import io.swagger.client.model.Order;
-
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
 import io.restassured.RestAssured;
 import io.restassured.builder.RequestSpecBuilder;
 import io.restassured.builder.ResponseSpecBuilder;
 import io.restassured.response.Response;
+import io.swagger.client.model.Order;
 
 import java.lang.reflect.Type;
+import java.util.Map;
 import java.util.function.Consumer;
 import java.util.function.Function;
-import java.util.function.Supplier;
-import io.swagger.client.JSON;
 
-import static io.restassured.http.Method.*;
+import static io.restassured.http.Method.DELETE;
+import static io.restassured.http.Method.GET;
+import static io.restassured.http.Method.POST;
 
 public class StoreApi {
 
     private RequestSpecBuilder reqSpec;
 
-    private JSON json;
-
     private StoreApi(RequestSpecBuilder reqSpec) {
         this.reqSpec = reqSpec;
-        this.json = new JSON();
     }
 
     public static StoreApi store(RequestSpecBuilder reqSpec) {
@@ -64,26 +56,6 @@ public class StoreApi {
 
     public PlaceOrderOper placeOrder() {
         return new PlaceOrderOper(reqSpec);
-    }
-
-    /**
-     * Get JSON
-     *
-     * @return JSON object
-     */
-    public JSON getJSON() {
-        return json;
-    }
-
-    /**
-     * Set JSON
-     *
-     * @param json JSON object
-     * @return StoreApi
-     */
-    public StoreApi setJSON(JSON json) {
-        this.json = json;
-        return this;
     }
 
     /**
@@ -190,7 +162,7 @@ public class StoreApi {
          */
         public Map<String, Integer> executeAs(Function<Response, Response> handler) {
             Type type = new TypeToken<Map<String, Integer>>(){}.getType();
-            return getJSON().deserialize(execute(handler).asString(), type);
+            return execute(handler).as(type);
         }
 
         /**
@@ -249,7 +221,7 @@ public class StoreApi {
          */
         public Order executeAs(Function<Response, Response> handler) {
             Type type = new TypeToken<Order>(){}.getType();
-            return getJSON().deserialize(execute(handler).asString(), type);
+            return execute(handler).as(type);
         }
 
         /**
@@ -318,14 +290,14 @@ public class StoreApi {
          */
         public Order executeAs(Function<Response, Response> handler) {
             Type type = new TypeToken<Order>(){}.getType();
-            return getJSON().deserialize(execute(handler).asString(), type);
+            return execute(handler).as(type);
         }
 
          /**
          * @param body (Order) order placed for purchasing the pet (required)
          */
         public PlaceOrderOper body(Order body) {
-            reqSpec.setBody(getJSON().serialize(body));
+            reqSpec.setBody(body);
             return this;
         }
 

--- a/samples/client/petstore/java/rest-assured/src/main/java/io/swagger/client/api/UserApi.java
+++ b/samples/client/petstore/java/rest-assured/src/main/java/io/swagger/client/api/UserApi.java
@@ -14,35 +14,28 @@
 package io.swagger.client.api;
 
 import com.google.gson.reflect.TypeToken;
-import io.swagger.client.model.User;
-
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
 import io.restassured.RestAssured;
 import io.restassured.builder.RequestSpecBuilder;
 import io.restassured.builder.ResponseSpecBuilder;
 import io.restassured.response.Response;
+import io.swagger.client.model.User;
 
 import java.lang.reflect.Type;
+import java.util.List;
 import java.util.function.Consumer;
 import java.util.function.Function;
-import java.util.function.Supplier;
-import io.swagger.client.JSON;
 
-import static io.restassured.http.Method.*;
+import static io.restassured.http.Method.DELETE;
+import static io.restassured.http.Method.GET;
+import static io.restassured.http.Method.POST;
+import static io.restassured.http.Method.PUT;
 
 public class UserApi {
 
     private RequestSpecBuilder reqSpec;
 
-    private JSON json;
-
     private UserApi(RequestSpecBuilder reqSpec) {
         this.reqSpec = reqSpec;
-        this.json = new JSON();
     }
 
     public static UserApi user(RequestSpecBuilder reqSpec) {
@@ -80,26 +73,6 @@ public class UserApi {
 
     public UpdateUserOper updateUser() {
         return new UpdateUserOper(reqSpec);
-    }
-
-    /**
-     * Get JSON
-     *
-     * @return JSON object
-     */
-    public JSON getJSON() {
-        return json;
-    }
-
-    /**
-     * Set JSON
-     *
-     * @param json JSON object
-     * @return UserApi
-     */
-    public UserApi setJSON(JSON json) {
-        this.json = json;
-        return this;
     }
 
     /**
@@ -149,7 +122,7 @@ public class UserApi {
          * @param body (User) Created user object (required)
          */
         public CreateUserOper body(User body) {
-            reqSpec.setBody(getJSON().serialize(body));
+            reqSpec.setBody(body);
             return this;
         }
 
@@ -208,7 +181,7 @@ public class UserApi {
          * @param body (List<User>) List of user object (required)
          */
         public CreateUsersWithArrayInputOper body(List<User> body) {
-            reqSpec.setBody(getJSON().serialize(body));
+            reqSpec.setBody(body);
             return this;
         }
 
@@ -267,7 +240,7 @@ public class UserApi {
          * @param body (List<User>) List of user object (required)
          */
         public CreateUsersWithListInputOper body(List<User> body) {
-            reqSpec.setBody(getJSON().serialize(body));
+            reqSpec.setBody(body);
             return this;
         }
 
@@ -384,7 +357,7 @@ public class UserApi {
          */
         public User executeAs(Function<Response, Response> handler) {
             Type type = new TypeToken<User>(){}.getType();
-            return getJSON().deserialize(execute(handler).asString(), type);
+            return execute(handler).as(type);
         }
 
         /**
@@ -452,7 +425,7 @@ public class UserApi {
          */
         public String executeAs(Function<Response, Response> handler) {
             Type type = new TypeToken<String>(){}.getType();
-            return getJSON().deserialize(execute(handler).asString(), type);
+            return execute(handler).as(type);
         }
 
         /**
@@ -575,7 +548,7 @@ public class UserApi {
          * @param body (User) Updated user object (required)
          */
         public UpdateUserOper body(User body) {
-            reqSpec.setBody(getJSON().serialize(body));
+            reqSpec.setBody(body);
             return this;
         }
 

--- a/samples/client/petstore/java/rest-assured/src/main/java/io/swagger/client/model/EnumTest.java
+++ b/samples/client/petstore/java/rest-assured/src/main/java/io/swagger/client/model/EnumTest.java
@@ -13,17 +13,15 @@
 
 package io.swagger.client.model;
 
-import java.util.Objects;
-import java.util.Arrays;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;
 import com.google.gson.stream.JsonReader;
 import com.google.gson.stream.JsonWriter;
-import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
-import io.swagger.client.model.OuterEnum;
+
 import java.io.IOException;
+import java.util.Objects;
 
 /**
  * EnumTest
@@ -81,6 +79,58 @@ public class EnumTest {
 
   @SerializedName("enum_string")
   private EnumStringEnum enumString = null;
+
+  /**
+   * Gets or Sets enumStringRequired
+   */
+  @JsonAdapter(EnumStringRequiredEnum.Adapter.class)
+  public enum EnumStringRequiredEnum {
+    UPPER("UPPER"),
+    
+    LOWER("lower"),
+    
+    EMPTY("");
+
+    private String value;
+
+    EnumStringRequiredEnum(String value) {
+      this.value = value;
+    }
+
+    public String getValue() {
+      return value;
+    }
+
+    @Override
+    public String toString() {
+      return String.valueOf(value);
+    }
+
+    public static EnumStringRequiredEnum fromValue(String text) {
+      for (EnumStringRequiredEnum b : EnumStringRequiredEnum.values()) {
+        if (String.valueOf(b.value).equals(text)) {
+          return b;
+        }
+      }
+      return null;
+    }
+
+    public static class Adapter extends TypeAdapter<EnumStringRequiredEnum> {
+      @Override
+      public void write(final JsonWriter jsonWriter, final EnumStringRequiredEnum enumeration) throws IOException {
+        jsonWriter.value(enumeration.getValue());
+      }
+
+      @Override
+      public EnumStringRequiredEnum read(final JsonReader jsonReader) throws IOException {
+        String value = jsonReader.nextString();
+        return EnumStringRequiredEnum.fromValue(String.valueOf(value));
+      }
+    }
+  }
+
+  @SerializedName("enum_string_required")
+  private EnumStringRequiredEnum enumStringRequired = null;
 
   /**
    * Gets or Sets enumInteger
@@ -203,6 +253,24 @@ public class EnumTest {
     this.enumString = enumString;
   }
 
+  public EnumTest enumStringRequired(EnumStringRequiredEnum enumStringRequired) {
+    this.enumStringRequired = enumStringRequired;
+    return this;
+  }
+
+   /**
+   * Get enumStringRequired
+   * @return enumStringRequired
+  **/
+  @ApiModelProperty(required = true, value = "")
+  public EnumStringRequiredEnum getEnumStringRequired() {
+    return enumStringRequired;
+  }
+
+  public void setEnumStringRequired(EnumStringRequiredEnum enumStringRequired) {
+    this.enumStringRequired = enumStringRequired;
+  }
+
   public EnumTest enumInteger(EnumIntegerEnum enumInteger) {
     this.enumInteger = enumInteger;
     return this;
@@ -268,6 +336,7 @@ public class EnumTest {
     }
     EnumTest enumTest = (EnumTest) o;
     return Objects.equals(this.enumString, enumTest.enumString) &&
+        Objects.equals(this.enumStringRequired, enumTest.enumStringRequired) &&
         Objects.equals(this.enumInteger, enumTest.enumInteger) &&
         Objects.equals(this.enumNumber, enumTest.enumNumber) &&
         Objects.equals(this.outerEnum, enumTest.outerEnum);
@@ -275,7 +344,7 @@ public class EnumTest {
 
   @Override
   public int hashCode() {
-    return Objects.hash(enumString, enumInteger, enumNumber, outerEnum);
+    return Objects.hash(enumString, enumStringRequired, enumInteger, enumNumber, outerEnum);
   }
 
 
@@ -285,6 +354,7 @@ public class EnumTest {
     sb.append("class EnumTest {\n");
     
     sb.append("    enumString: ").append(toIndentedString(enumString)).append("\n");
+    sb.append("    enumStringRequired: ").append(toIndentedString(enumStringRequired)).append("\n");
     sb.append("    enumInteger: ").append(toIndentedString(enumInteger)).append("\n");
     sb.append("    enumNumber: ").append(toIndentedString(enumNumber)).append("\n");
     sb.append("    outerEnum: ").append(toIndentedString(outerEnum)).append("\n");


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [ ] Filed the PR against the correct branch: `3.0.0` branch for changes related to OpenAPI spec 3.0. Default: `master`.
- [ ] Copied the [technical committee](https://github.com/swagger-api/swagger-codegen/#swagger-codegen-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR
Hello, guys
As you know new rest-assured just has been released. New feature "Type instead of Class for mapping" was added in version 3.1.0. Here is the link: https://github.com/rest-assured/rest-assured/pull/980.  My aim is to use the feature in Rest-assured client. 
So, the PR: updated  rest-assured from 3.0.6  up to 3.1.0. Additional mapper was deleted for ApiClient& Now you are able to customise mapper via Rest-assured config easier than it was before.

Just want to notice that your test server (Petstore) is now returning 500 for some requests. For instance: curl -X GET "http://petstore.swagger.io/v2/store/inventory" -H  "accept: application/json"



