### PR TITLE
[codegen][java]Issue 8055: create javadoc and source jar from gradle build

### DIFF
--- a/modules/swagger-codegen/src/main/resources/Java/build.gradle.mustache
+++ b/modules/swagger-codegen/src/main/resources/Java/build.gradle.mustache
@@ -18,8 +18,6 @@ repositories {
     jcenter()
 }
 
-
-
 if(hasProperty('target') && target == 'android') {
 
     apply plugin: 'com.android.library'

--- a/modules/swagger-codegen/src/main/resources/Java/build.gradle.mustache
+++ b/modules/swagger-codegen/src/main/resources/Java/build.gradle.mustache
@@ -18,20 +18,7 @@ repositories {
     jcenter()
 }
 
-task sourcesJar(type: Jar, dependsOn: classes) {
-    classifier = 'sources'
-    from sourceSets.main.allSource
-}
 
-task javadocJar(type: Jar, dependsOn: javadoc) {
-    classifier = 'javadoc'
-    from javadoc.destinationDir
-}
-
-artifacts {
-    archives sourcesJar
-    archives javadocJar
-}
 
 if(hasProperty('target') && target == 'android') {
 
@@ -116,6 +103,21 @@ if(hasProperty('target') && target == 'android') {
     task execute(type:JavaExec) {
        main = System.getProperty('mainClass')
        classpath = sourceSets.main.runtimeClasspath
+    }
+    
+    task sourcesJar(type: Jar, dependsOn: classes) {
+        classifier = 'sources'
+        from sourceSets.main.allSource
+    }
+
+    task javadocJar(type: Jar, dependsOn: javadoc) {
+        classifier = 'javadoc'
+        from javadoc.destinationDir
+    }
+
+    artifacts {
+        archives sourcesJar
+        archives javadocJar
     }
 }
 

--- a/modules/swagger-codegen/src/main/resources/Java/build.gradle.mustache
+++ b/modules/swagger-codegen/src/main/resources/Java/build.gradle.mustache
@@ -18,6 +18,20 @@ repositories {
     jcenter()
 }
 
+task sourcesJar(type: Jar, dependsOn: classes) {
+    classifier = 'sources'
+    from sourceSets.main.allSource
+}
+
+task javadocJar(type: Jar, dependsOn: javadoc) {
+    classifier = 'javadoc'
+    from javadoc.destinationDir
+}
+
+artifacts {
+    archives sourcesJar
+    archives javadocJar
+}
 
 if(hasProperty('target') && target == 'android') {
 
@@ -135,3 +149,4 @@ dependencies {
     {{/java8}}
     testCompile "junit:junit:$junit_version"
 }
+


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [x] Filed the PR against the correct branch: `3.0.0` branch for changes related to OpenAPI spec 3.0. Default: `master`.
- [x] Copied the [technical committee](https://github.com/swagger-api/swagger-codegen/#swagger-codegen-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

(details of the change, additional tests that have been done, reference to the issue for tracking, etc)
#8055 creates sources.jar and javadoc jar from gradlebuild for deploying to jfrog public snapshot repository
