### PR TITLE
[8062][Go][Client] Fix body format for `application/x-www-form-urlencoded` resquests

### DIFF
--- a/modules/swagger-codegen/src/main/resources/go/client.mustache
+++ b/modules/swagger-codegen/src/main/resources/go/client.mustache
@@ -215,10 +215,10 @@ func (c *APIClient) prepareRequest(
 			if err != nil {
 				return nil, err
 			}
-			// Set the Boundary in the Content-Type
-			headerParams["Content-Type"] = w.FormDataContentType()
 		}
 
+        // Set the Boundary in the Content-Type
+		headerParams["Content-Type"] = w.FormDataContentType()
 		// Set Content-Length
 		headerParams["Content-Length"] = fmt.Sprintf("%d", body.Len())
 		w.Close()

--- a/modules/swagger-codegen/src/main/resources/go/client.mustache
+++ b/modules/swagger-codegen/src/main/resources/go/client.mustache
@@ -190,38 +190,42 @@ func (c *APIClient) prepareRequest(
 			return nil, errors.New("Cannot specify postBody and multipart form at the same time.")
 		}
 		body = &bytes.Buffer{}
-		w := multipart.NewWriter(body)
+        if headerParams["Content-Type"] == "application/x-www-form-urlencoded" {
+            body.Write([]byte(formParams.Encode()))
+        } else {
+            w := multipart.NewWriter(body)
 
-		for k, v := range formParams {
-			for _, iv := range v {
-				if strings.HasPrefix(k, "@") { // file
-					err = addFile(w, k[1:], iv)
-					if err != nil {
-						return nil, err
-					}
-				} else { // form value
-					w.WriteField(k, iv)
-				}
-			}
-		}
-		if len(fileBytes) > 0 && fileName != "" {
-			w.Boundary()
-			//_, fileNm := filepath.Split(fileName)
-			part, err := w.CreateFormFile("file", filepath.Base(fileName))
-			if err != nil {
-				return nil, err
-			}
-			_, err = part.Write(fileBytes)
-			if err != nil {
-				return nil, err
-			}
-		}
+            for k, v := range formParams {
+                for _, iv := range v {
+                    if strings.HasPrefix(k, "@") { // file
+                        err = addFile(w, k[1:], iv)
+                        if err != nil {
+                            return nil, err
+                        }
+                    } else { // form value
+                        w.WriteField(k, iv)
+                    }
+                }
+            }
+            if len(fileBytes) > 0 && fileName != "" {
+                w.Boundary()
+                //_, fileNm := filepath.Split(fileName)
+                part, err := w.CreateFormFile("file", filepath.Base(fileName))
+                if err != nil {
+                    return nil, err
+                }
+                _, err = part.Write(fileBytes)
+                if err != nil {
+                    return nil, err
+                }
+            }
 
-        // Set the Boundary in the Content-Type
-		headerParams["Content-Type"] = w.FormDataContentType()
-		// Set Content-Length
-		headerParams["Content-Length"] = fmt.Sprintf("%d", body.Len())
-		w.Close()
+            // Set the Boundary in the Content-Type
+            headerParams["Content-Type"] = w.FormDataContentType()
+            w.Close()
+        }
+        // Set Content-Length
+        headerParams["Content-Length"] = fmt.Sprintf("%d", body.Len())
 	}
 
 	// Setup path and query parameters


### PR DESCRIPTION
### PR checklist

- [x ] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [ ] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [x ] Filed the PR against the correct branch: `3.0.0` branch for changes related to OpenAPI spec 3.0. Default: `master`.
- [X] Copied the [technical committee](https://github.com/swagger-api/swagger-codegen/#swagger-codegen-technical-committee) to review the pull request if your PR is targeting a particular programming language.
@antihax @bvwells 

### Description of the PR
0. Moving the `headerParams["Content-Type"] = w.FormDataContentType()` statement in the api-client mustache to outside of the upload "if" block, then it will be called always when the request content-type is not `application/x-www-form-urlencoded`
0. Creating a if condition to determine if the body content must be writen by `multipart.NewWriter` or `formParams.Encode()` (URL encoded)

Fixs #8062