### PR TITLE
Camelize Kotlin model names and filenames

### DIFF
--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/AbstractKotlinCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/AbstractKotlinCodegen.java
@@ -453,11 +453,20 @@ public abstract class AbstractKotlinCodegen extends DefaultCodegen implements Co
         String modifiedName = name.replaceAll("\\.", "");
         modifiedName = sanitizeKotlinSpecificNames(modifiedName);
 
+        // Camelize name of nested properties
+        modifiedName = camelize(modifiedName);
+
         if (reservedWords.contains(modifiedName)) {
             modifiedName = escapeReservedWord(modifiedName);
         }
 
         return titleCase(modifiedName);
+    }
+
+    @Override
+    public String toModelFilename(String name) {
+        // Should be the same as the model name
+        return toModelName(name);
     }
 
     /**

--- a/modules/swagger-codegen/src/test/java/io/swagger/codegen/kotlin/KotlinClientCodegenModelTest.java
+++ b/modules/swagger-codegen/src/test/java/io/swagger/codegen/kotlin/KotlinClientCodegenModelTest.java
@@ -221,9 +221,9 @@ public class KotlinClientCodegenModelTest {
         return new Object[][]{
                 {"TestNs.TestClass", new ModelNameTest("TestNs.TestClass", "TestNsTestClass")},
                 {"$", new ModelNameTest("$", "Dollar")},
-                {"for", new ModelNameTest("`for`", "`for`")},
-                {"One<Two", new ModelNameTest("One<Two", "OneLess_ThanTwo")},
-                {"this is a test", new ModelNameTest("this is a test", "This_is_a_test")}
+                {"for", new ModelNameTest("`for`", "For")},
+                {"One<Two", new ModelNameTest("One<Two", "OneLessThanTwo")},
+                {"this is a test", new ModelNameTest("this is a test", "ThisIsATest")}
         };
     }
 


### PR DESCRIPTION
Previously the case of the names could be inconsistent if there were nested object properties. Eg. 'MyNewPet_barking_type' now becomes 'MyNewPetBarkingType'.
Ideally, we should use nested classes to take advantage of the namespace of the parent class, but this is much more work.

### PR checklist

- [X] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [X] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [X] Filed the PR against the correct branch: `3.0.0` branch for changes related to OpenAPI spec 3.0. Default: `master`.
- [X] Copied the [technical committee](https://github.com/swagger-api/swagger-codegen/#swagger-codegen-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

Previously the case of the names could be inconsistent if there were nested object properties. Eg. 'MyNewPet_barking_type' now becomes 'MyNewPetBarkingType'.

Ideally, we should use nested classes to take advantage of the namespace of the parent class, but this is much more work.

Technical committee member: @jimschubert 