### PR TITLE
Add option modelPropertyNaming to javascript generator

### DIFF
--- a/modules/swagger-codegen/src/test/java/io/swagger/codegen/javascript/JavaScriptClientOptionsTest.java
+++ b/modules/swagger-codegen/src/test/java/io/swagger/codegen/javascript/JavaScriptClientOptionsTest.java
@@ -5,7 +5,6 @@ import io.swagger.codegen.CodegenConfig;
 import io.swagger.codegen.options.JavaScriptOptionsProvider;
 import io.swagger.codegen.languages.JavascriptClientCodegen;
 import io.swagger.codegen.options.OptionsProvider;
-
 import mockit.Expectations;
 import mockit.Tested;
 
@@ -69,6 +68,8 @@ public class JavaScriptClientOptionsTest extends AbstractOptionsTest {
             clientCodegen.setEmitJSDoc(Boolean.valueOf(JavaScriptOptionsProvider.EMIT_JS_DOC_VALUE));
             times = 1;
             clientCodegen.setUseES6(Boolean.valueOf(JavaScriptOptionsProvider.USE_ES6_VALUE));
+            times = 1;
+            clientCodegen.setModelPropertyNaming(JavaScriptOptionsProvider.MODEL_PROPERTY_NAMING_VALUE);
             times = 1;
         }};
     }

--- a/modules/swagger-codegen/src/test/java/io/swagger/codegen/options/JavaScriptOptionsProvider.java
+++ b/modules/swagger-codegen/src/test/java/io/swagger/codegen/options/JavaScriptOptionsProvider.java
@@ -30,7 +30,7 @@ public class JavaScriptOptionsProvider implements OptionsProvider {
     public static final String EMIT_JS_DOC_VALUE = "false";
     public static final String ALLOW_UNICODE_IDENTIFIERS_VALUE = "false";
     public static final String USE_ES6_VALUE = "true";
-
+    public static final String MODEL_PROPERTY_NAMING_VALUE = "camelCase";
 
     private ImmutableMap<String, String> options;
 
@@ -63,6 +63,7 @@ public class JavaScriptOptionsProvider implements OptionsProvider {
                 .put(CodegenConstants.HIDE_GENERATION_TIMESTAMP, "true")
                 .put(CodegenConstants.ALLOW_UNICODE_IDENTIFIERS, ALLOW_UNICODE_IDENTIFIERS_VALUE)
                 .put(JavascriptClientCodegen.USE_ES6, USE_ES6_VALUE)
+                .put(CodegenConstants.MODEL_PROPERTY_NAMING, MODEL_PROPERTY_NAMING_VALUE)
                 .build();
     }
 


### PR DESCRIPTION
Fixes 6530.

### PR checklist

- [x] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`. **not relevant for this change — did not commit petstore sample**
- [x] Filed the PR against the correct branch: `3.0.0` branch for changes related to OpenAPI spec 3.0. Default: `master`.
- [x] Copied the [technical committee](https://github.com/swagger-api/swagger-codegen/#swagger-codegen-technical-committee) to review the pull request if your PR is targeting a particular programming language.  

### Description of the PR

Add option `modelPropertyNaming` to `JavascriptClientCodegen` to support different naming conventions for properties. See issue #6530

@CodeNinjai @frol @cliffano