### PR TITLE
Fix context import order

### DIFF
--- a/modules/swagger-codegen/src/main/resources/go/api.mustache
+++ b/modules/swagger-codegen/src/main/resources/go/api.mustache
@@ -3,11 +3,11 @@ package {{packageName}}
 
 {{#operations}}
 import (
+	"context"
 	"io/ioutil"
 	"net/http"
 	"net/url"
 	"strings"
-	"context"
 {{#imports}}	"{{import}}"
 {{/imports}}
 )

--- a/modules/swagger-codegen/src/main/resources/go/client.mustache
+++ b/modules/swagger-codegen/src/main/resources/go/client.mustache
@@ -3,6 +3,7 @@ package {{packageName}}
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"encoding/xml"
 	"errors"
@@ -20,7 +21,6 @@ import (
 	"time"
 	"unicode/utf8"
 
-	"context"
 	"golang.org/x/oauth2"
 )
 

--- a/samples/client/petstore/go/go-petstore-withXml/README.md
+++ b/samples/client/petstore/go/go-petstore-withXml/README.md
@@ -22,11 +22,11 @@ All URIs are relative to *http://petstore.swagger.io:80/v2*
 Class | Method | HTTP request | Description
 ------------ | ------------- | ------------- | -------------
 *AnotherFakeApi* | [**TestSpecialTags**](docs/AnotherFakeApi.md#testspecialtags) | **Patch** /another-fake/dummy | To test special tags
-*DefaultApi* | [**TestBodyWithQueryParams**](docs/DefaultApi.md#testbodywithqueryparams) | **Put** /fake/body-with-query-params | 
 *FakeApi* | [**FakeOuterBooleanSerialize**](docs/FakeApi.md#fakeouterbooleanserialize) | **Post** /fake/outer/boolean | 
 *FakeApi* | [**FakeOuterCompositeSerialize**](docs/FakeApi.md#fakeoutercompositeserialize) | **Post** /fake/outer/composite | 
 *FakeApi* | [**FakeOuterNumberSerialize**](docs/FakeApi.md#fakeouternumberserialize) | **Post** /fake/outer/number | 
 *FakeApi* | [**FakeOuterStringSerialize**](docs/FakeApi.md#fakeouterstringserialize) | **Post** /fake/outer/string | 
+*FakeApi* | [**TestBodyWithQueryParams**](docs/FakeApi.md#testbodywithqueryparams) | **Put** /fake/body-with-query-params | 
 *FakeApi* | [**TestClientModel**](docs/FakeApi.md#testclientmodel) | **Patch** /fake | To test \&quot;client\&quot; model
 *FakeApi* | [**TestEndpointParameters**](docs/FakeApi.md#testendpointparameters) | **Post** /fake | Fake endpoint for testing various parameters 假端點 偽のエンドポイント 가짜 엔드 포인트 
 *FakeApi* | [**TestEnumParameters**](docs/FakeApi.md#testenumparameters) | **Get** /fake | To test enum parameters

--- a/samples/client/petstore/go/go-petstore-withXml/api/swagger.yaml
+++ b/samples/client/petstore/go/go-petstore-withXml/api/swagger.yaml
@@ -107,11 +107,11 @@ paths:
         type: "array"
         items:
           type: "string"
+          default: "available"
           enum:
           - "available"
           - "pending"
           - "sold"
-          default: "available"
         collectionFormat: "csv"
         x-exportParamName: "Status"
       responses:
@@ -216,12 +216,14 @@ paths:
         required: false
         type: "string"
         x-exportParamName: "Name"
+        x-optionalDataType: "String"
       - name: "status"
         in: "formData"
         description: "Updated status of the pet"
         required: false
         type: "string"
         x-exportParamName: "Status"
+        x-optionalDataType: "String"
       responses:
         405:
           description: "Invalid input"
@@ -244,6 +246,7 @@ paths:
         required: false
         type: "string"
         x-exportParamName: "ApiKey"
+        x-optionalDataType: "String"
       - name: "petId"
         in: "path"
         description: "Pet id to delete"
@@ -283,6 +286,7 @@ paths:
         required: false
         type: "string"
         x-exportParamName: "AdditionalMetadata"
+        x-optionalDataType: "String"
       - name: "file"
         in: "formData"
         description: "file to upload"
@@ -635,10 +639,10 @@ paths:
         type: "array"
         items:
           type: "string"
+          default: "$"
           enum:
           - ">"
           - "$"
-          default: "$"
         x-exportParamName: "EnumFormStringArray"
       - name: "enum_form_string"
         in: "formData"
@@ -651,6 +655,7 @@ paths:
         - "-efg"
         - "(xyz)"
         x-exportParamName: "EnumFormString"
+        x-optionalDataType: "String"
       - name: "enum_header_string_array"
         in: "header"
         description: "Header parameter enum test (string array)"
@@ -658,10 +663,10 @@ paths:
         type: "array"
         items:
           type: "string"
+          default: "$"
           enum:
           - ">"
           - "$"
-          default: "$"
         x-exportParamName: "EnumHeaderStringArray"
       - name: "enum_header_string"
         in: "header"
@@ -674,6 +679,7 @@ paths:
         - "-efg"
         - "(xyz)"
         x-exportParamName: "EnumHeaderString"
+        x-optionalDataType: "String"
       - name: "enum_query_string_array"
         in: "query"
         description: "Query parameter enum test (string array)"
@@ -681,10 +687,10 @@ paths:
         type: "array"
         items:
           type: "string"
+          default: "$"
           enum:
           - ">"
           - "$"
-          default: "$"
         x-exportParamName: "EnumQueryStringArray"
       - name: "enum_query_string"
         in: "query"
@@ -697,6 +703,7 @@ paths:
         - "-efg"
         - "(xyz)"
         x-exportParamName: "EnumQueryString"
+        x-optionalDataType: "String"
       - name: "enum_query_integer"
         in: "query"
         description: "Query parameter enum test (double)"
@@ -707,6 +714,7 @@ paths:
         - 1
         - -2
         x-exportParamName: "EnumQueryInteger"
+        x-optionalDataType: "Int32"
       - name: "enum_query_double"
         in: "formData"
         description: "Query parameter enum test (double)"
@@ -717,6 +725,7 @@ paths:
         - 1.1
         - -1.2
         x-exportParamName: "EnumQueryDouble"
+        x-optionalDataType: "Float64"
       responses:
         400:
           description: "Invalid request"
@@ -745,6 +754,7 @@ paths:
         maximum: 100
         minimum: 10
         x-exportParamName: "Integer"
+        x-optionalDataType: "Int32"
       - name: "int32"
         in: "formData"
         description: "None"
@@ -754,6 +764,7 @@ paths:
         minimum: 20
         format: "int32"
         x-exportParamName: "Int32_"
+        x-optionalDataType: "Int32"
       - name: "int64"
         in: "formData"
         description: "None"
@@ -761,6 +772,7 @@ paths:
         type: "integer"
         format: "int64"
         x-exportParamName: "Int64_"
+        x-optionalDataType: "Int64"
       - name: "number"
         in: "formData"
         description: "None"
@@ -777,6 +789,7 @@ paths:
         maximum: 987.6
         format: "float"
         x-exportParamName: "Float"
+        x-optionalDataType: "Float32"
       - name: "double"
         in: "formData"
         description: "None"
@@ -793,6 +806,7 @@ paths:
         type: "string"
         pattern: "/[a-z]/i"
         x-exportParamName: "String_"
+        x-optionalDataType: "String"
       - name: "pattern_without_delimiter"
         in: "formData"
         description: "None"
@@ -814,6 +828,7 @@ paths:
         type: "string"
         format: "binary"
         x-exportParamName: "Binary"
+        x-optionalDataType: "String"
       - name: "date"
         in: "formData"
         description: "None"
@@ -821,6 +836,7 @@ paths:
         type: "string"
         format: "date"
         x-exportParamName: "Date"
+        x-optionalDataType: "String"
       - name: "dateTime"
         in: "formData"
         description: "None"
@@ -828,6 +844,7 @@ paths:
         type: "string"
         format: "date-time"
         x-exportParamName: "DateTime"
+        x-optionalDataType: "Time"
       - name: "password"
         in: "formData"
         description: "None"
@@ -837,12 +854,14 @@ paths:
         minLength: 10
         format: "password"
         x-exportParamName: "Password"
+        x-optionalDataType: "String"
       - name: "callback"
         in: "formData"
         description: "None"
         required: false
         type: "string"
         x-exportParamName: "Callback"
+        x-optionalDataType: "String"
       responses:
         400:
           description: "Invalid username supplied"
@@ -998,6 +1017,8 @@ paths:
           description: "successful operation"
   /fake/body-with-query-params:
     put:
+      tags:
+      - "fake"
       operationId: "testBodyWithQueryParams"
       consumes:
       - "application/json"

--- a/samples/client/petstore/go/go-petstore-withXml/api_another_fake.go
+++ b/samples/client/petstore/go/go-petstore-withXml/api_another_fake.go
@@ -11,11 +11,11 @@
 package petstore
 
 import (
+	"context"
 	"io/ioutil"
 	"net/http"
 	"net/url"
 	"strings"
-	"golang.org/x/net/context"
 )
 
 // Linger please
@@ -25,11 +25,14 @@ var (
 
 type AnotherFakeApiService service
 
-/* AnotherFakeApiService To test special tags
+/* 
+AnotherFakeApiService To test special tags
 To test special tags
- * @param ctx context.Context for authentication, logging, tracing, etc.
-@param body client model
-@return Client*/
+ * @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+ * @param body client model
+
+@return Client
+*/
 func (a *AnotherFakeApiService) TestSpecialTags(ctx context.Context, body Client) (Client, *http.Response, error) {
 	var (
 		localVarHttpMethod = strings.ToUpper("Patch")
@@ -76,6 +79,7 @@ func (a *AnotherFakeApiService) TestSpecialTags(ctx context.Context, body Client
 	}
 
 	localVarBody, err := ioutil.ReadAll(localVarHttpResponse.Body)
+	localVarHttpResponse.Body.Close()
 	if err != nil {
 		return localVarReturnValue, localVarHttpResponse, err
 	}

--- a/samples/client/petstore/go/go-petstore-withXml/api_fake.go
+++ b/samples/client/petstore/go/go-petstore-withXml/api_fake.go
@@ -11,13 +11,12 @@
 package petstore
 
 import (
+	"context"
 	"io/ioutil"
 	"net/http"
 	"net/url"
 	"strings"
-	"time"
-
-	"golang.org/x/net/context"
+	"github.com/antihax/optional"
 )
 
 // Linger please
@@ -27,18 +26,26 @@ var (
 
 type FakeApiService service
 
-/* FakeApiService
+/* 
+FakeApiService
 Test serialization of outer boolean types
- * @param ctx context.Context for authentication, logging, tracing, etc.
-@param optional (nil or map[string]interface{}) with one or more of:
-    @param "body" (OuterBoolean) Input boolean as post body
-@return OuterBoolean*/
-func (a *FakeApiService) FakeOuterBooleanSerialize(ctx context.Context, localVarOptionals map[string]interface{}) (OuterBoolean, *http.Response, error) {
+ * @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+ * @param optional nil or *FakeOuterBooleanSerializeOpts - Optional Parameters:
+     * @param "Body" (optional.Interface of OuterBoolean) -  Input boolean as post body
+
+@return OuterBoolean
+*/
+
+type FakeOuterBooleanSerializeOpts struct { 
+	Body optional.Interface
+}
+
+func (a *FakeApiService) FakeOuterBooleanSerialize(ctx context.Context, localVarOptionals *FakeOuterBooleanSerializeOpts) (OuterBoolean, *http.Response, error) {
 	var (
-		localVarHttpMethod  = strings.ToUpper("Post")
-		localVarPostBody    interface{}
-		localVarFileName    string
-		localVarFileBytes   []byte
+		localVarHttpMethod = strings.ToUpper("Post")
+		localVarPostBody   interface{}
+		localVarFileName   string
+		localVarFileBytes  []byte
 		localVarReturnValue OuterBoolean
 	)
 
@@ -67,8 +74,13 @@ func (a *FakeApiService) FakeOuterBooleanSerialize(ctx context.Context, localVar
 		localVarHeaderParams["Accept"] = localVarHttpHeaderAccept
 	}
 	// body params
-	if localVarTempParam, localVarOk := localVarOptionals["body"].(OuterBoolean); localVarOk {
-		localVarPostBody = &localVarTempParam
+	if localVarOptionals != nil && localVarOptionals.Body.IsSet() {
+		
+		localVarOptionalBody, localVarOptionalBodyok := localVarOptionals.Body.Value().(OuterBoolean)
+		if !localVarOptionalBodyok {
+				return localVarReturnValue, nil, reportError("body should be OuterBoolean")
+		}
+		localVarPostBody = &localVarOptionalBody
 	}
 	r, err := a.client.prepareRequest(ctx, localVarPath, localVarHttpMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFileName, localVarFileBytes)
 	if err != nil {
@@ -81,24 +93,25 @@ func (a *FakeApiService) FakeOuterBooleanSerialize(ctx context.Context, localVar
 	}
 
 	localVarBody, err := ioutil.ReadAll(localVarHttpResponse.Body)
+	localVarHttpResponse.Body.Close()
 	if err != nil {
 		return localVarReturnValue, localVarHttpResponse, err
 	}
 
 	if localVarHttpResponse.StatusCode < 300 {
 		// If we succeed, return the data, otherwise pass on to decode error.
-		err = a.client.decode(&localVarReturnValue, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
-		if err == nil {
+		err = a.client.decode(&localVarReturnValue, localVarBody, localVarHttpResponse.Header.Get("Content-Type"));
+		if err == nil { 
 			return localVarReturnValue, localVarHttpResponse, err
 		}
 	}
 
 	if localVarHttpResponse.StatusCode >= 300 {
 		newErr := GenericSwaggerError{
-			body:  localVarBody,
+			body: localVarBody,
 			error: localVarHttpResponse.Status,
 		}
-
+		
 		if localVarHttpResponse.StatusCode == 200 {
 			localVarBody, err := ioutil.ReadAll(localVarHttpResponse.Body)
 			if err != nil {
@@ -106,33 +119,41 @@ func (a *FakeApiService) FakeOuterBooleanSerialize(ctx context.Context, localVar
 			}
 
 			var v OuterBoolean
-			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
-			if err != nil {
-				newErr.error = err.Error()
+			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"));
+				if err != nil {
+					newErr.error = err.Error()
+					return localVarReturnValue, localVarHttpResponse, newErr
+				}
+				newErr.model = v
 				return localVarReturnValue, localVarHttpResponse, newErr
-			}
-			newErr.model = v
-			return localVarReturnValue, localVarHttpResponse, newErr
 		}
-
+		
 		return localVarReturnValue, localVarHttpResponse, newErr
 	}
 
 	return localVarReturnValue, localVarHttpResponse, nil
 }
 
-/* FakeApiService
+/* 
+FakeApiService
 Test serialization of object with outer number type
- * @param ctx context.Context for authentication, logging, tracing, etc.
-@param optional (nil or map[string]interface{}) with one or more of:
-    @param "body" (OuterComposite) Input composite as post body
-@return OuterComposite*/
-func (a *FakeApiService) FakeOuterCompositeSerialize(ctx context.Context, localVarOptionals map[string]interface{}) (OuterComposite, *http.Response, error) {
+ * @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+ * @param optional nil or *FakeOuterCompositeSerializeOpts - Optional Parameters:
+     * @param "Body" (optional.Interface of OuterComposite) -  Input composite as post body
+
+@return OuterComposite
+*/
+
+type FakeOuterCompositeSerializeOpts struct { 
+	Body optional.Interface
+}
+
+func (a *FakeApiService) FakeOuterCompositeSerialize(ctx context.Context, localVarOptionals *FakeOuterCompositeSerializeOpts) (OuterComposite, *http.Response, error) {
 	var (
-		localVarHttpMethod  = strings.ToUpper("Post")
-		localVarPostBody    interface{}
-		localVarFileName    string
-		localVarFileBytes   []byte
+		localVarHttpMethod = strings.ToUpper("Post")
+		localVarPostBody   interface{}
+		localVarFileName   string
+		localVarFileBytes  []byte
 		localVarReturnValue OuterComposite
 	)
 
@@ -161,8 +182,13 @@ func (a *FakeApiService) FakeOuterCompositeSerialize(ctx context.Context, localV
 		localVarHeaderParams["Accept"] = localVarHttpHeaderAccept
 	}
 	// body params
-	if localVarTempParam, localVarOk := localVarOptionals["body"].(OuterComposite); localVarOk {
-		localVarPostBody = &localVarTempParam
+	if localVarOptionals != nil && localVarOptionals.Body.IsSet() {
+		
+		localVarOptionalBody, localVarOptionalBodyok := localVarOptionals.Body.Value().(OuterComposite)
+		if !localVarOptionalBodyok {
+				return localVarReturnValue, nil, reportError("body should be OuterComposite")
+		}
+		localVarPostBody = &localVarOptionalBody
 	}
 	r, err := a.client.prepareRequest(ctx, localVarPath, localVarHttpMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFileName, localVarFileBytes)
 	if err != nil {
@@ -175,24 +201,25 @@ func (a *FakeApiService) FakeOuterCompositeSerialize(ctx context.Context, localV
 	}
 
 	localVarBody, err := ioutil.ReadAll(localVarHttpResponse.Body)
+	localVarHttpResponse.Body.Close()
 	if err != nil {
 		return localVarReturnValue, localVarHttpResponse, err
 	}
 
 	if localVarHttpResponse.StatusCode < 300 {
 		// If we succeed, return the data, otherwise pass on to decode error.
-		err = a.client.decode(&localVarReturnValue, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
-		if err == nil {
+		err = a.client.decode(&localVarReturnValue, localVarBody, localVarHttpResponse.Header.Get("Content-Type"));
+		if err == nil { 
 			return localVarReturnValue, localVarHttpResponse, err
 		}
 	}
 
 	if localVarHttpResponse.StatusCode >= 300 {
 		newErr := GenericSwaggerError{
-			body:  localVarBody,
+			body: localVarBody,
 			error: localVarHttpResponse.Status,
 		}
-
+		
 		if localVarHttpResponse.StatusCode == 200 {
 			localVarBody, err := ioutil.ReadAll(localVarHttpResponse.Body)
 			if err != nil {
@@ -200,33 +227,41 @@ func (a *FakeApiService) FakeOuterCompositeSerialize(ctx context.Context, localV
 			}
 
 			var v OuterComposite
-			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
-			if err != nil {
-				newErr.error = err.Error()
+			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"));
+				if err != nil {
+					newErr.error = err.Error()
+					return localVarReturnValue, localVarHttpResponse, newErr
+				}
+				newErr.model = v
 				return localVarReturnValue, localVarHttpResponse, newErr
-			}
-			newErr.model = v
-			return localVarReturnValue, localVarHttpResponse, newErr
 		}
-
+		
 		return localVarReturnValue, localVarHttpResponse, newErr
 	}
 
 	return localVarReturnValue, localVarHttpResponse, nil
 }
 
-/* FakeApiService
+/* 
+FakeApiService
 Test serialization of outer number types
- * @param ctx context.Context for authentication, logging, tracing, etc.
-@param optional (nil or map[string]interface{}) with one or more of:
-    @param "body" (OuterNumber) Input number as post body
-@return OuterNumber*/
-func (a *FakeApiService) FakeOuterNumberSerialize(ctx context.Context, localVarOptionals map[string]interface{}) (OuterNumber, *http.Response, error) {
+ * @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+ * @param optional nil or *FakeOuterNumberSerializeOpts - Optional Parameters:
+     * @param "Body" (optional.Interface of OuterNumber) -  Input number as post body
+
+@return OuterNumber
+*/
+
+type FakeOuterNumberSerializeOpts struct { 
+	Body optional.Interface
+}
+
+func (a *FakeApiService) FakeOuterNumberSerialize(ctx context.Context, localVarOptionals *FakeOuterNumberSerializeOpts) (OuterNumber, *http.Response, error) {
 	var (
-		localVarHttpMethod  = strings.ToUpper("Post")
-		localVarPostBody    interface{}
-		localVarFileName    string
-		localVarFileBytes   []byte
+		localVarHttpMethod = strings.ToUpper("Post")
+		localVarPostBody   interface{}
+		localVarFileName   string
+		localVarFileBytes  []byte
 		localVarReturnValue OuterNumber
 	)
 
@@ -255,8 +290,13 @@ func (a *FakeApiService) FakeOuterNumberSerialize(ctx context.Context, localVarO
 		localVarHeaderParams["Accept"] = localVarHttpHeaderAccept
 	}
 	// body params
-	if localVarTempParam, localVarOk := localVarOptionals["body"].(OuterNumber); localVarOk {
-		localVarPostBody = &localVarTempParam
+	if localVarOptionals != nil && localVarOptionals.Body.IsSet() {
+		
+		localVarOptionalBody, localVarOptionalBodyok := localVarOptionals.Body.Value().(OuterNumber)
+		if !localVarOptionalBodyok {
+				return localVarReturnValue, nil, reportError("body should be OuterNumber")
+		}
+		localVarPostBody = &localVarOptionalBody
 	}
 	r, err := a.client.prepareRequest(ctx, localVarPath, localVarHttpMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFileName, localVarFileBytes)
 	if err != nil {
@@ -269,24 +309,25 @@ func (a *FakeApiService) FakeOuterNumberSerialize(ctx context.Context, localVarO
 	}
 
 	localVarBody, err := ioutil.ReadAll(localVarHttpResponse.Body)
+	localVarHttpResponse.Body.Close()
 	if err != nil {
 		return localVarReturnValue, localVarHttpResponse, err
 	}
 
 	if localVarHttpResponse.StatusCode < 300 {
 		// If we succeed, return the data, otherwise pass on to decode error.
-		err = a.client.decode(&localVarReturnValue, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
-		if err == nil {
+		err = a.client.decode(&localVarReturnValue, localVarBody, localVarHttpResponse.Header.Get("Content-Type"));
+		if err == nil { 
 			return localVarReturnValue, localVarHttpResponse, err
 		}
 	}
 
 	if localVarHttpResponse.StatusCode >= 300 {
 		newErr := GenericSwaggerError{
-			body:  localVarBody,
+			body: localVarBody,
 			error: localVarHttpResponse.Status,
 		}
-
+		
 		if localVarHttpResponse.StatusCode == 200 {
 			localVarBody, err := ioutil.ReadAll(localVarHttpResponse.Body)
 			if err != nil {
@@ -294,33 +335,41 @@ func (a *FakeApiService) FakeOuterNumberSerialize(ctx context.Context, localVarO
 			}
 
 			var v OuterNumber
-			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
-			if err != nil {
-				newErr.error = err.Error()
+			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"));
+				if err != nil {
+					newErr.error = err.Error()
+					return localVarReturnValue, localVarHttpResponse, newErr
+				}
+				newErr.model = v
 				return localVarReturnValue, localVarHttpResponse, newErr
-			}
-			newErr.model = v
-			return localVarReturnValue, localVarHttpResponse, newErr
 		}
-
+		
 		return localVarReturnValue, localVarHttpResponse, newErr
 	}
 
 	return localVarReturnValue, localVarHttpResponse, nil
 }
 
-/* FakeApiService
+/* 
+FakeApiService
 Test serialization of outer string types
- * @param ctx context.Context for authentication, logging, tracing, etc.
-@param optional (nil or map[string]interface{}) with one or more of:
-    @param "body" (OuterString) Input string as post body
-@return OuterString*/
-func (a *FakeApiService) FakeOuterStringSerialize(ctx context.Context, localVarOptionals map[string]interface{}) (OuterString, *http.Response, error) {
+ * @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+ * @param optional nil or *FakeOuterStringSerializeOpts - Optional Parameters:
+     * @param "Body" (optional.Interface of OuterString) -  Input string as post body
+
+@return OuterString
+*/
+
+type FakeOuterStringSerializeOpts struct { 
+	Body optional.Interface
+}
+
+func (a *FakeApiService) FakeOuterStringSerialize(ctx context.Context, localVarOptionals *FakeOuterStringSerializeOpts) (OuterString, *http.Response, error) {
 	var (
-		localVarHttpMethod  = strings.ToUpper("Post")
-		localVarPostBody    interface{}
-		localVarFileName    string
-		localVarFileBytes   []byte
+		localVarHttpMethod = strings.ToUpper("Post")
+		localVarPostBody   interface{}
+		localVarFileName   string
+		localVarFileBytes  []byte
 		localVarReturnValue OuterString
 	)
 
@@ -349,8 +398,13 @@ func (a *FakeApiService) FakeOuterStringSerialize(ctx context.Context, localVarO
 		localVarHeaderParams["Accept"] = localVarHttpHeaderAccept
 	}
 	// body params
-	if localVarTempParam, localVarOk := localVarOptionals["body"].(OuterString); localVarOk {
-		localVarPostBody = &localVarTempParam
+	if localVarOptionals != nil && localVarOptionals.Body.IsSet() {
+		
+		localVarOptionalBody, localVarOptionalBodyok := localVarOptionals.Body.Value().(OuterString)
+		if !localVarOptionalBodyok {
+				return localVarReturnValue, nil, reportError("body should be OuterString")
+		}
+		localVarPostBody = &localVarOptionalBody
 	}
 	r, err := a.client.prepareRequest(ctx, localVarPath, localVarHttpMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFileName, localVarFileBytes)
 	if err != nil {
@@ -363,24 +417,25 @@ func (a *FakeApiService) FakeOuterStringSerialize(ctx context.Context, localVarO
 	}
 
 	localVarBody, err := ioutil.ReadAll(localVarHttpResponse.Body)
+	localVarHttpResponse.Body.Close()
 	if err != nil {
 		return localVarReturnValue, localVarHttpResponse, err
 	}
 
 	if localVarHttpResponse.StatusCode < 300 {
 		// If we succeed, return the data, otherwise pass on to decode error.
-		err = a.client.decode(&localVarReturnValue, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
-		if err == nil {
+		err = a.client.decode(&localVarReturnValue, localVarBody, localVarHttpResponse.Header.Get("Content-Type"));
+		if err == nil { 
 			return localVarReturnValue, localVarHttpResponse, err
 		}
 	}
 
 	if localVarHttpResponse.StatusCode >= 300 {
 		newErr := GenericSwaggerError{
-			body:  localVarBody,
+			body: localVarBody,
 			error: localVarHttpResponse.Status,
 		}
-
+		
 		if localVarHttpResponse.StatusCode == 200 {
 			localVarBody, err := ioutil.ReadAll(localVarHttpResponse.Body)
 			if err != nil {
@@ -388,32 +443,108 @@ func (a *FakeApiService) FakeOuterStringSerialize(ctx context.Context, localVarO
 			}
 
 			var v OuterString
-			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
-			if err != nil {
-				newErr.error = err.Error()
+			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"));
+				if err != nil {
+					newErr.error = err.Error()
+					return localVarReturnValue, localVarHttpResponse, newErr
+				}
+				newErr.model = v
 				return localVarReturnValue, localVarHttpResponse, newErr
-			}
-			newErr.model = v
-			return localVarReturnValue, localVarHttpResponse, newErr
 		}
-
+		
 		return localVarReturnValue, localVarHttpResponse, newErr
 	}
 
 	return localVarReturnValue, localVarHttpResponse, nil
 }
 
-/* FakeApiService To test \&quot;client\&quot; model
+/* 
+FakeApiService
+ * @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+ * @param body
+ * @param query
+
+
+*/
+func (a *FakeApiService) TestBodyWithQueryParams(ctx context.Context, body User, query string) (*http.Response, error) {
+	var (
+		localVarHttpMethod = strings.ToUpper("Put")
+		localVarPostBody   interface{}
+		localVarFileName   string
+		localVarFileBytes  []byte
+		
+	)
+
+	// create path and map variables
+	localVarPath := a.client.cfg.BasePath + "/fake/body-with-query-params"
+
+	localVarHeaderParams := make(map[string]string)
+	localVarQueryParams := url.Values{}
+	localVarFormParams := url.Values{}
+
+	localVarQueryParams.Add("query", parameterToString(query, ""))
+	// to determine the Content-Type header
+	localVarHttpContentTypes := []string{"application/json"}
+
+	// set Content-Type header
+	localVarHttpContentType := selectHeaderContentType(localVarHttpContentTypes)
+	if localVarHttpContentType != "" {
+		localVarHeaderParams["Content-Type"] = localVarHttpContentType
+	}
+
+	// to determine the Accept header
+	localVarHttpHeaderAccepts := []string{}
+
+	// set Accept header
+	localVarHttpHeaderAccept := selectHeaderAccept(localVarHttpHeaderAccepts)
+	if localVarHttpHeaderAccept != "" {
+		localVarHeaderParams["Accept"] = localVarHttpHeaderAccept
+	}
+	// body params
+	localVarPostBody = &body
+	r, err := a.client.prepareRequest(ctx, localVarPath, localVarHttpMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFileName, localVarFileBytes)
+	if err != nil {
+		return nil, err
+	}
+
+	localVarHttpResponse, err := a.client.callAPI(r)
+	if err != nil || localVarHttpResponse == nil {
+		return localVarHttpResponse, err
+	}
+
+	localVarBody, err := ioutil.ReadAll(localVarHttpResponse.Body)
+	localVarHttpResponse.Body.Close()
+	if err != nil {
+		return localVarHttpResponse, err
+	}
+
+
+	if localVarHttpResponse.StatusCode >= 300 {
+		newErr := GenericSwaggerError{
+			body: localVarBody,
+			error: localVarHttpResponse.Status,
+		}
+		
+		return localVarHttpResponse, newErr
+	}
+
+	return localVarHttpResponse, nil
+}
+
+/* 
+FakeApiService To test \&quot;client\&quot; model
 To test \&quot;client\&quot; model
- * @param ctx context.Context for authentication, logging, tracing, etc.
-@param body client model
-@return Client*/
+ * @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+ * @param body client model
+
+@return Client
+*/
 func (a *FakeApiService) TestClientModel(ctx context.Context, body Client) (Client, *http.Response, error) {
 	var (
-		localVarHttpMethod  = strings.ToUpper("Patch")
-		localVarPostBody    interface{}
-		localVarFileName    string
-		localVarFileBytes   []byte
+		localVarHttpMethod = strings.ToUpper("Patch")
+		localVarPostBody   interface{}
+		localVarFileName   string
+		localVarFileBytes  []byte
 		localVarReturnValue Client
 	)
 
@@ -454,24 +585,25 @@ func (a *FakeApiService) TestClientModel(ctx context.Context, body Client) (Clie
 	}
 
 	localVarBody, err := ioutil.ReadAll(localVarHttpResponse.Body)
+	localVarHttpResponse.Body.Close()
 	if err != nil {
 		return localVarReturnValue, localVarHttpResponse, err
 	}
 
 	if localVarHttpResponse.StatusCode < 300 {
 		// If we succeed, return the data, otherwise pass on to decode error.
-		err = a.client.decode(&localVarReturnValue, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
-		if err == nil {
+		err = a.client.decode(&localVarReturnValue, localVarBody, localVarHttpResponse.Header.Get("Content-Type"));
+		if err == nil { 
 			return localVarReturnValue, localVarHttpResponse, err
 		}
 	}
 
 	if localVarHttpResponse.StatusCode >= 300 {
 		newErr := GenericSwaggerError{
-			body:  localVarBody,
+			body: localVarBody,
 			error: localVarHttpResponse.Status,
 		}
-
+		
 		if localVarHttpResponse.StatusCode == 200 {
 			localVarBody, err := ioutil.ReadAll(localVarHttpResponse.Body)
 			if err != nil {
@@ -479,46 +611,64 @@ func (a *FakeApiService) TestClientModel(ctx context.Context, body Client) (Clie
 			}
 
 			var v Client
-			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
-			if err != nil {
-				newErr.error = err.Error()
+			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"));
+				if err != nil {
+					newErr.error = err.Error()
+					return localVarReturnValue, localVarHttpResponse, newErr
+				}
+				newErr.model = v
 				return localVarReturnValue, localVarHttpResponse, newErr
-			}
-			newErr.model = v
-			return localVarReturnValue, localVarHttpResponse, newErr
 		}
-
+		
 		return localVarReturnValue, localVarHttpResponse, newErr
 	}
 
 	return localVarReturnValue, localVarHttpResponse, nil
 }
 
-/* FakeApiService Fake endpoint for testing various parameters 假端點 偽のエンドポイント 가짜 엔드 포인트
-Fake endpoint for testing various parameters 假端點 偽のエンドポイント 가짜 엔드 포인트
- * @param ctx context.Context for authentication, logging, tracing, etc.
-@param number None
-@param double None
-@param patternWithoutDelimiter None
-@param byte_ None
-@param optional (nil or map[string]interface{}) with one or more of:
-    @param "integer" (int32) None
-    @param "int32_" (int32) None
-    @param "int64_" (int64) None
-    @param "float" (float32) None
-    @param "string_" (string) None
-    @param "binary" (string) None
-    @param "date" (string) None
-    @param "dateTime" (time.Time) None
-    @param "password" (string) None
-    @param "callback" (string) None
-@return */
-func (a *FakeApiService) TestEndpointParameters(ctx context.Context, number float32, double float64, patternWithoutDelimiter string, byte_ string, localVarOptionals map[string]interface{}) (*http.Response, error) {
+/* 
+FakeApiService Fake endpoint for testing various parameters 假端點 偽のエンドポイント 가짜 엔드 포인트 
+Fake endpoint for testing various parameters 假端點 偽のエンドポイント 가짜 엔드 포인트 
+ * @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+ * @param number None
+ * @param double None
+ * @param patternWithoutDelimiter None
+ * @param byte_ None
+ * @param optional nil or *TestEndpointParametersOpts - Optional Parameters:
+     * @param "Integer" (optional.Int32) -  None
+     * @param "Int32_" (optional.Int32) -  None
+     * @param "Int64_" (optional.Int64) -  None
+     * @param "Float" (optional.Float32) -  None
+     * @param "String_" (optional.String) -  None
+     * @param "Binary" (optional.String) -  None
+     * @param "Date" (optional.String) -  None
+     * @param "DateTime" (optional.Time) -  None
+     * @param "Password" (optional.String) -  None
+     * @param "Callback" (optional.String) -  None
+
+
+*/
+
+type TestEndpointParametersOpts struct { 
+	Integer optional.Int32
+	Int32_ optional.Int32
+	Int64_ optional.Int64
+	Float optional.Float32
+	String_ optional.String
+	Binary optional.String
+	Date optional.String
+	DateTime optional.Time
+	Password optional.String
+	Callback optional.String
+}
+
+func (a *FakeApiService) TestEndpointParameters(ctx context.Context, number float32, double float64, patternWithoutDelimiter string, byte_ string, localVarOptionals *TestEndpointParametersOpts) (*http.Response, error) {
 	var (
 		localVarHttpMethod = strings.ToUpper("Post")
 		localVarPostBody   interface{}
 		localVarFileName   string
 		localVarFileBytes  []byte
+		
 	)
 
 	// create path and map variables
@@ -539,36 +689,6 @@ func (a *FakeApiService) TestEndpointParameters(ctx context.Context, number floa
 	if double > 123.4 {
 		return nil, reportError("double must be less than 123.4")
 	}
-	if err := typeCheckParameter(localVarOptionals["integer"], "int32", "integer"); err != nil {
-		return nil, err
-	}
-	if err := typeCheckParameter(localVarOptionals["int32_"], "int32", "int32_"); err != nil {
-		return nil, err
-	}
-	if err := typeCheckParameter(localVarOptionals["int64_"], "int64", "int64_"); err != nil {
-		return nil, err
-	}
-	if err := typeCheckParameter(localVarOptionals["float"], "float32", "float"); err != nil {
-		return nil, err
-	}
-	if err := typeCheckParameter(localVarOptionals["string_"], "string", "string_"); err != nil {
-		return nil, err
-	}
-	if err := typeCheckParameter(localVarOptionals["binary"], "string", "binary"); err != nil {
-		return nil, err
-	}
-	if err := typeCheckParameter(localVarOptionals["date"], "string", "date"); err != nil {
-		return nil, err
-	}
-	if err := typeCheckParameter(localVarOptionals["dateTime"], "time.Time", "dateTime"); err != nil {
-		return nil, err
-	}
-	if err := typeCheckParameter(localVarOptionals["password"], "string", "password"); err != nil {
-		return nil, err
-	}
-	if err := typeCheckParameter(localVarOptionals["callback"], "string", "callback"); err != nil {
-		return nil, err
-	}
 
 	// to determine the Content-Type header
 	localVarHttpContentTypes := []string{"application/xml; charset=utf-8", "application/json; charset=utf-8"}
@@ -587,39 +707,39 @@ func (a *FakeApiService) TestEndpointParameters(ctx context.Context, number floa
 	if localVarHttpHeaderAccept != "" {
 		localVarHeaderParams["Accept"] = localVarHttpHeaderAccept
 	}
-	if localVarTempParam, localVarOk := localVarOptionals["integer"].(int32); localVarOk {
-		localVarFormParams.Add("integer", parameterToString(localVarTempParam, ""))
+	if localVarOptionals != nil && localVarOptionals.Integer.IsSet() {
+		localVarFormParams.Add("integer", parameterToString(localVarOptionals.Integer.Value(), ""))
 	}
-	if localVarTempParam, localVarOk := localVarOptionals["int32_"].(int32); localVarOk {
-		localVarFormParams.Add("int32", parameterToString(localVarTempParam, ""))
+	if localVarOptionals != nil && localVarOptionals.Int32_.IsSet() {
+		localVarFormParams.Add("int32", parameterToString(localVarOptionals.Int32_.Value(), ""))
 	}
-	if localVarTempParam, localVarOk := localVarOptionals["int64_"].(int64); localVarOk {
-		localVarFormParams.Add("int64", parameterToString(localVarTempParam, ""))
+	if localVarOptionals != nil && localVarOptionals.Int64_.IsSet() {
+		localVarFormParams.Add("int64", parameterToString(localVarOptionals.Int64_.Value(), ""))
 	}
 	localVarFormParams.Add("number", parameterToString(number, ""))
-	if localVarTempParam, localVarOk := localVarOptionals["float"].(float32); localVarOk {
-		localVarFormParams.Add("float", parameterToString(localVarTempParam, ""))
+	if localVarOptionals != nil && localVarOptionals.Float.IsSet() {
+		localVarFormParams.Add("float", parameterToString(localVarOptionals.Float.Value(), ""))
 	}
 	localVarFormParams.Add("double", parameterToString(double, ""))
-	if localVarTempParam, localVarOk := localVarOptionals["string_"].(string); localVarOk {
-		localVarFormParams.Add("string", parameterToString(localVarTempParam, ""))
+	if localVarOptionals != nil && localVarOptionals.String_.IsSet() {
+		localVarFormParams.Add("string", parameterToString(localVarOptionals.String_.Value(), ""))
 	}
 	localVarFormParams.Add("pattern_without_delimiter", parameterToString(patternWithoutDelimiter, ""))
 	localVarFormParams.Add("byte", parameterToString(byte_, ""))
-	if localVarTempParam, localVarOk := localVarOptionals["binary"].(string); localVarOk {
-		localVarFormParams.Add("binary", parameterToString(localVarTempParam, ""))
+	if localVarOptionals != nil && localVarOptionals.Binary.IsSet() {
+		localVarFormParams.Add("binary", parameterToString(localVarOptionals.Binary.Value(), ""))
 	}
-	if localVarTempParam, localVarOk := localVarOptionals["date"].(string); localVarOk {
-		localVarFormParams.Add("date", parameterToString(localVarTempParam, ""))
+	if localVarOptionals != nil && localVarOptionals.Date.IsSet() {
+		localVarFormParams.Add("date", parameterToString(localVarOptionals.Date.Value(), ""))
 	}
-	if localVarTempParam, localVarOk := localVarOptionals["dateTime"].(time.Time); localVarOk {
-		localVarFormParams.Add("dateTime", parameterToString(localVarTempParam, ""))
+	if localVarOptionals != nil && localVarOptionals.DateTime.IsSet() {
+		localVarFormParams.Add("dateTime", parameterToString(localVarOptionals.DateTime.Value(), ""))
 	}
-	if localVarTempParam, localVarOk := localVarOptionals["password"].(string); localVarOk {
-		localVarFormParams.Add("password", parameterToString(localVarTempParam, ""))
+	if localVarOptionals != nil && localVarOptionals.Password.IsSet() {
+		localVarFormParams.Add("password", parameterToString(localVarOptionals.Password.Value(), ""))
 	}
-	if localVarTempParam, localVarOk := localVarOptionals["callback"].(string); localVarOk {
-		localVarFormParams.Add("callback", parameterToString(localVarTempParam, ""))
+	if localVarOptionals != nil && localVarOptionals.Callback.IsSet() {
+		localVarFormParams.Add("callback", parameterToString(localVarOptionals.Callback.Value(), ""))
 	}
 	r, err := a.client.prepareRequest(ctx, localVarPath, localVarHttpMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFileName, localVarFileBytes)
 	if err != nil {
@@ -632,41 +752,59 @@ func (a *FakeApiService) TestEndpointParameters(ctx context.Context, number floa
 	}
 
 	localVarBody, err := ioutil.ReadAll(localVarHttpResponse.Body)
+	localVarHttpResponse.Body.Close()
 	if err != nil {
 		return localVarHttpResponse, err
 	}
 
+
 	if localVarHttpResponse.StatusCode >= 300 {
 		newErr := GenericSwaggerError{
-			body:  localVarBody,
+			body: localVarBody,
 			error: localVarHttpResponse.Status,
 		}
-
+		
 		return localVarHttpResponse, newErr
 	}
 
 	return localVarHttpResponse, nil
 }
 
-/* FakeApiService To test enum parameters
+/* 
+FakeApiService To test enum parameters
 To test enum parameters
- * @param ctx context.Context for authentication, logging, tracing, etc.
-@param optional (nil or map[string]interface{}) with one or more of:
-    @param "enumFormStringArray" ([]string) Form parameter enum test (string array)
-    @param "enumFormString" (string) Form parameter enum test (string)
-    @param "enumHeaderStringArray" ([]string) Header parameter enum test (string array)
-    @param "enumHeaderString" (string) Header parameter enum test (string)
-    @param "enumQueryStringArray" ([]string) Query parameter enum test (string array)
-    @param "enumQueryString" (string) Query parameter enum test (string)
-    @param "enumQueryInteger" (int32) Query parameter enum test (double)
-    @param "enumQueryDouble" (float64) Query parameter enum test (double)
-@return */
-func (a *FakeApiService) TestEnumParameters(ctx context.Context, localVarOptionals map[string]interface{}) (*http.Response, error) {
+ * @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+ * @param optional nil or *TestEnumParametersOpts - Optional Parameters:
+     * @param "EnumFormStringArray" (optional.Interface of []string) -  Form parameter enum test (string array)
+     * @param "EnumFormString" (optional.String) -  Form parameter enum test (string)
+     * @param "EnumHeaderStringArray" (optional.Interface of []string) -  Header parameter enum test (string array)
+     * @param "EnumHeaderString" (optional.String) -  Header parameter enum test (string)
+     * @param "EnumQueryStringArray" (optional.Interface of []string) -  Query parameter enum test (string array)
+     * @param "EnumQueryString" (optional.String) -  Query parameter enum test (string)
+     * @param "EnumQueryInteger" (optional.Int32) -  Query parameter enum test (double)
+     * @param "EnumQueryDouble" (optional.Float64) -  Query parameter enum test (double)
+
+
+*/
+
+type TestEnumParametersOpts struct { 
+	EnumFormStringArray optional.Interface
+	EnumFormString optional.String
+	EnumHeaderStringArray optional.Interface
+	EnumHeaderString optional.String
+	EnumQueryStringArray optional.Interface
+	EnumQueryString optional.String
+	EnumQueryInteger optional.Int32
+	EnumQueryDouble optional.Float64
+}
+
+func (a *FakeApiService) TestEnumParameters(ctx context.Context, localVarOptionals *TestEnumParametersOpts) (*http.Response, error) {
 	var (
 		localVarHttpMethod = strings.ToUpper("Get")
 		localVarPostBody   interface{}
 		localVarFileName   string
 		localVarFileBytes  []byte
+		
 	)
 
 	// create path and map variables
@@ -675,30 +813,15 @@ func (a *FakeApiService) TestEnumParameters(ctx context.Context, localVarOptiona
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := url.Values{}
 	localVarFormParams := url.Values{}
-	if err := typeCheckParameter(localVarOptionals["enumFormString"], "string", "enumFormString"); err != nil {
-		return nil, err
-	}
-	if err := typeCheckParameter(localVarOptionals["enumHeaderString"], "string", "enumHeaderString"); err != nil {
-		return nil, err
-	}
-	if err := typeCheckParameter(localVarOptionals["enumQueryString"], "string", "enumQueryString"); err != nil {
-		return nil, err
-	}
-	if err := typeCheckParameter(localVarOptionals["enumQueryInteger"], "int32", "enumQueryInteger"); err != nil {
-		return nil, err
-	}
-	if err := typeCheckParameter(localVarOptionals["enumQueryDouble"], "float64", "enumQueryDouble"); err != nil {
-		return nil, err
-	}
 
-	if localVarTempParam, localVarOk := localVarOptionals["enumQueryStringArray"].([]string); localVarOk {
-		localVarQueryParams.Add("enum_query_string_array", parameterToString(localVarTempParam, "csv"))
+	if localVarOptionals != nil && localVarOptionals.EnumQueryStringArray.IsSet() {
+		localVarQueryParams.Add("enum_query_string_array", parameterToString(localVarOptionals.EnumQueryStringArray.Value(), "csv"))
 	}
-	if localVarTempParam, localVarOk := localVarOptionals["enumQueryString"].(string); localVarOk {
-		localVarQueryParams.Add("enum_query_string", parameterToString(localVarTempParam, ""))
+	if localVarOptionals != nil && localVarOptionals.EnumQueryString.IsSet() {
+		localVarQueryParams.Add("enum_query_string", parameterToString(localVarOptionals.EnumQueryString.Value(), ""))
 	}
-	if localVarTempParam, localVarOk := localVarOptionals["enumQueryInteger"].(int32); localVarOk {
-		localVarQueryParams.Add("enum_query_integer", parameterToString(localVarTempParam, ""))
+	if localVarOptionals != nil && localVarOptionals.EnumQueryInteger.IsSet() {
+		localVarQueryParams.Add("enum_query_integer", parameterToString(localVarOptionals.EnumQueryInteger.Value(), ""))
 	}
 	// to determine the Content-Type header
 	localVarHttpContentTypes := []string{"*/*"}
@@ -717,20 +840,20 @@ func (a *FakeApiService) TestEnumParameters(ctx context.Context, localVarOptiona
 	if localVarHttpHeaderAccept != "" {
 		localVarHeaderParams["Accept"] = localVarHttpHeaderAccept
 	}
-	if localVarTempParam, localVarOk := localVarOptionals["enumHeaderStringArray"].([]string); localVarOk {
-		localVarHeaderParams["enum_header_string_array"] = parameterToString(localVarTempParam, "csv")
+	if localVarOptionals != nil && localVarOptionals.EnumHeaderStringArray.IsSet() {
+		localVarHeaderParams["enum_header_string_array"] = parameterToString(localVarOptionals.EnumHeaderStringArray.Value(), "csv")
 	}
-	if localVarTempParam, localVarOk := localVarOptionals["enumHeaderString"].(string); localVarOk {
-		localVarHeaderParams["enum_header_string"] = parameterToString(localVarTempParam, "")
+	if localVarOptionals != nil && localVarOptionals.EnumHeaderString.IsSet() {
+		localVarHeaderParams["enum_header_string"] = parameterToString(localVarOptionals.EnumHeaderString.Value(), "")
 	}
-	if localVarTempParam, localVarOk := localVarOptionals["enumFormStringArray"].([]string); localVarOk {
-		localVarFormParams.Add("enum_form_string_array", parameterToString(localVarTempParam, "csv"))
+	if localVarOptionals != nil && localVarOptionals.EnumFormStringArray.IsSet() {
+		localVarFormParams.Add("enum_form_string_array", parameterToString(localVarOptionals.EnumFormStringArray.Value(), "csv"))
 	}
-	if localVarTempParam, localVarOk := localVarOptionals["enumFormString"].(string); localVarOk {
-		localVarFormParams.Add("enum_form_string", parameterToString(localVarTempParam, ""))
+	if localVarOptionals != nil && localVarOptionals.EnumFormString.IsSet() {
+		localVarFormParams.Add("enum_form_string", parameterToString(localVarOptionals.EnumFormString.Value(), ""))
 	}
-	if localVarTempParam, localVarOk := localVarOptionals["enumQueryDouble"].(float64); localVarOk {
-		localVarFormParams.Add("enum_query_double", parameterToString(localVarTempParam, ""))
+	if localVarOptionals != nil && localVarOptionals.EnumQueryDouble.IsSet() {
+		localVarFormParams.Add("enum_query_double", parameterToString(localVarOptionals.EnumQueryDouble.Value(), ""))
 	}
 	r, err := a.client.prepareRequest(ctx, localVarPath, localVarHttpMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFileName, localVarFileBytes)
 	if err != nil {
@@ -743,33 +866,39 @@ func (a *FakeApiService) TestEnumParameters(ctx context.Context, localVarOptiona
 	}
 
 	localVarBody, err := ioutil.ReadAll(localVarHttpResponse.Body)
+	localVarHttpResponse.Body.Close()
 	if err != nil {
 		return localVarHttpResponse, err
 	}
 
+
 	if localVarHttpResponse.StatusCode >= 300 {
 		newErr := GenericSwaggerError{
-			body:  localVarBody,
+			body: localVarBody,
 			error: localVarHttpResponse.Status,
 		}
-
+		
 		return localVarHttpResponse, newErr
 	}
 
 	return localVarHttpResponse, nil
 }
 
-/* FakeApiService test inline additionalProperties
+/* 
+FakeApiService test inline additionalProperties
 
- * @param ctx context.Context for authentication, logging, tracing, etc.
-@param param request body
-@return */
+ * @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+ * @param param request body
+
+
+*/
 func (a *FakeApiService) TestInlineAdditionalProperties(ctx context.Context, param interface{}) (*http.Response, error) {
 	var (
 		localVarHttpMethod = strings.ToUpper("Post")
 		localVarPostBody   interface{}
 		localVarFileName   string
 		localVarFileBytes  []byte
+		
 	)
 
 	// create path and map variables
@@ -809,34 +938,40 @@ func (a *FakeApiService) TestInlineAdditionalProperties(ctx context.Context, par
 	}
 
 	localVarBody, err := ioutil.ReadAll(localVarHttpResponse.Body)
+	localVarHttpResponse.Body.Close()
 	if err != nil {
 		return localVarHttpResponse, err
 	}
 
+
 	if localVarHttpResponse.StatusCode >= 300 {
 		newErr := GenericSwaggerError{
-			body:  localVarBody,
+			body: localVarBody,
 			error: localVarHttpResponse.Status,
 		}
-
+		
 		return localVarHttpResponse, newErr
 	}
 
 	return localVarHttpResponse, nil
 }
 
-/* FakeApiService test json serialization of form data
+/* 
+FakeApiService test json serialization of form data
 
- * @param ctx context.Context for authentication, logging, tracing, etc.
-@param param field1
-@param param2 field2
-@return */
+ * @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+ * @param param field1
+ * @param param2 field2
+
+
+*/
 func (a *FakeApiService) TestJsonFormData(ctx context.Context, param string, param2 string) (*http.Response, error) {
 	var (
 		localVarHttpMethod = strings.ToUpper("Get")
 		localVarPostBody   interface{}
 		localVarFileName   string
 		localVarFileBytes  []byte
+		
 	)
 
 	// create path and map variables
@@ -876,16 +1011,18 @@ func (a *FakeApiService) TestJsonFormData(ctx context.Context, param string, par
 	}
 
 	localVarBody, err := ioutil.ReadAll(localVarHttpResponse.Body)
+	localVarHttpResponse.Body.Close()
 	if err != nil {
 		return localVarHttpResponse, err
 	}
 
+
 	if localVarHttpResponse.StatusCode >= 300 {
 		newErr := GenericSwaggerError{
-			body:  localVarBody,
+			body: localVarBody,
 			error: localVarHttpResponse.Status,
 		}
-
+		
 		return localVarHttpResponse, newErr
 	}
 

--- a/samples/client/petstore/go/go-petstore-withXml/api_fake_classname_tags123.go
+++ b/samples/client/petstore/go/go-petstore-withXml/api_fake_classname_tags123.go
@@ -11,11 +11,11 @@
 package petstore
 
 import (
+	"context"
 	"io/ioutil"
 	"net/http"
 	"net/url"
 	"strings"
-	"golang.org/x/net/context"
 )
 
 // Linger please
@@ -25,11 +25,14 @@ var (
 
 type FakeClassnameTags123ApiService service
 
-/* FakeClassnameTags123ApiService To test class name in snake case
+/* 
+FakeClassnameTags123ApiService To test class name in snake case
 To test class name in snake case
- * @param ctx context.Context for authentication, logging, tracing, etc.
-@param body client model
-@return Client*/
+ * @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+ * @param body client model
+
+@return Client
+*/
 func (a *FakeClassnameTags123ApiService) TestClassname(ctx context.Context, body Client) (Client, *http.Response, error) {
 	var (
 		localVarHttpMethod = strings.ToUpper("Patch")
@@ -74,6 +77,7 @@ func (a *FakeClassnameTags123ApiService) TestClassname(ctx context.Context, body
 			} else {
 				key = auth.Key
 			}
+			
 			localVarQueryParams.Add("api_key_query", key)
 		}
 	}
@@ -88,6 +92,7 @@ func (a *FakeClassnameTags123ApiService) TestClassname(ctx context.Context, body
 	}
 
 	localVarBody, err := ioutil.ReadAll(localVarHttpResponse.Body)
+	localVarHttpResponse.Body.Close()
 	if err != nil {
 		return localVarReturnValue, localVarHttpResponse, err
 	}

--- a/samples/client/petstore/go/go-petstore-withXml/api_pet.go
+++ b/samples/client/petstore/go/go-petstore-withXml/api_pet.go
@@ -11,13 +11,14 @@
 package petstore
 
 import (
+	"context"
 	"io/ioutil"
 	"net/http"
 	"net/url"
 	"strings"
-	"golang.org/x/net/context"
-	"os"
 	"fmt"
+	"github.com/antihax/optional"
+	"os"
 )
 
 // Linger please
@@ -27,11 +28,14 @@ var (
 
 type PetApiService service
 
-/* PetApiService Add a new pet to the store
+/* 
+PetApiService Add a new pet to the store
 
- * @param ctx context.Context for authentication, logging, tracing, etc.
-@param body Pet object that needs to be added to the store
-@return */
+ * @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+ * @param body Pet object that needs to be added to the store
+
+
+*/
 func (a *PetApiService) AddPet(ctx context.Context, body Pet) (*http.Response, error) {
 	var (
 		localVarHttpMethod = strings.ToUpper("Post")
@@ -78,6 +82,7 @@ func (a *PetApiService) AddPet(ctx context.Context, body Pet) (*http.Response, e
 	}
 
 	localVarBody, err := ioutil.ReadAll(localVarHttpResponse.Body)
+	localVarHttpResponse.Body.Close()
 	if err != nil {
 		return localVarHttpResponse, err
 	}
@@ -95,14 +100,22 @@ func (a *PetApiService) AddPet(ctx context.Context, body Pet) (*http.Response, e
 	return localVarHttpResponse, nil
 }
 
-/* PetApiService Deletes a pet
+/* 
+PetApiService Deletes a pet
 
- * @param ctx context.Context for authentication, logging, tracing, etc.
-@param petId Pet id to delete
-@param optional (nil or map[string]interface{}) with one or more of:
-    @param "apiKey" (string)
-@return */
-func (a *PetApiService) DeletePet(ctx context.Context, petId int64, localVarOptionals map[string]interface{}) (*http.Response, error) {
+ * @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+ * @param petId Pet id to delete
+ * @param optional nil or *DeletePetOpts - Optional Parameters:
+     * @param "ApiKey" (optional.String) - 
+
+
+*/
+
+type DeletePetOpts struct { 
+	ApiKey optional.String
+}
+
+func (a *PetApiService) DeletePet(ctx context.Context, petId int64, localVarOptionals *DeletePetOpts) (*http.Response, error) {
 	var (
 		localVarHttpMethod = strings.ToUpper("Delete")
 		localVarPostBody   interface{}
@@ -118,9 +131,6 @@ func (a *PetApiService) DeletePet(ctx context.Context, petId int64, localVarOpti
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := url.Values{}
 	localVarFormParams := url.Values{}
-	if err := typeCheckParameter(localVarOptionals["apiKey"], "string", "apiKey"); err != nil {
-		return nil, err
-	}
 
 	// to determine the Content-Type header
 	localVarHttpContentTypes := []string{}
@@ -139,8 +149,8 @@ func (a *PetApiService) DeletePet(ctx context.Context, petId int64, localVarOpti
 	if localVarHttpHeaderAccept != "" {
 		localVarHeaderParams["Accept"] = localVarHttpHeaderAccept
 	}
-	if localVarTempParam, localVarOk := localVarOptionals["apiKey"].(string); localVarOk {
-		localVarHeaderParams["api_key"] = parameterToString(localVarTempParam, "")
+	if localVarOptionals != nil && localVarOptionals.ApiKey.IsSet() {
+		localVarHeaderParams["api_key"] = parameterToString(localVarOptionals.ApiKey.Value(), "")
 	}
 	r, err := a.client.prepareRequest(ctx, localVarPath, localVarHttpMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFileName, localVarFileBytes)
 	if err != nil {
@@ -153,6 +163,7 @@ func (a *PetApiService) DeletePet(ctx context.Context, petId int64, localVarOpti
 	}
 
 	localVarBody, err := ioutil.ReadAll(localVarHttpResponse.Body)
+	localVarHttpResponse.Body.Close()
 	if err != nil {
 		return localVarHttpResponse, err
 	}
@@ -170,11 +181,14 @@ func (a *PetApiService) DeletePet(ctx context.Context, petId int64, localVarOpti
 	return localVarHttpResponse, nil
 }
 
-/* PetApiService Finds Pets by status
+/* 
+PetApiService Finds Pets by status
 Multiple status values can be provided with comma separated strings
- * @param ctx context.Context for authentication, logging, tracing, etc.
-@param status Status values that need to be considered for filter
-@return []Pet*/
+ * @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+ * @param status Status values that need to be considered for filter
+
+@return []Pet
+*/
 func (a *PetApiService) FindPetsByStatus(ctx context.Context, status []string) ([]Pet, *http.Response, error) {
 	var (
 		localVarHttpMethod = strings.ToUpper("Get")
@@ -220,6 +234,7 @@ func (a *PetApiService) FindPetsByStatus(ctx context.Context, status []string) (
 	}
 
 	localVarBody, err := ioutil.ReadAll(localVarHttpResponse.Body)
+	localVarHttpResponse.Body.Close()
 	if err != nil {
 		return localVarReturnValue, localVarHttpResponse, err
 	}
@@ -260,11 +275,14 @@ func (a *PetApiService) FindPetsByStatus(ctx context.Context, status []string) (
 	return localVarReturnValue, localVarHttpResponse, nil
 }
 
-/* PetApiService Finds Pets by tags
+/* 
+PetApiService Finds Pets by tags
 Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
- * @param ctx context.Context for authentication, logging, tracing, etc.
-@param tags Tags to filter by
-@return []Pet*/
+ * @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+ * @param tags Tags to filter by
+
+@return []Pet
+*/
 func (a *PetApiService) FindPetsByTags(ctx context.Context, tags []string) ([]Pet, *http.Response, error) {
 	var (
 		localVarHttpMethod = strings.ToUpper("Get")
@@ -310,6 +328,7 @@ func (a *PetApiService) FindPetsByTags(ctx context.Context, tags []string) ([]Pe
 	}
 
 	localVarBody, err := ioutil.ReadAll(localVarHttpResponse.Body)
+	localVarHttpResponse.Body.Close()
 	if err != nil {
 		return localVarReturnValue, localVarHttpResponse, err
 	}
@@ -350,11 +369,14 @@ func (a *PetApiService) FindPetsByTags(ctx context.Context, tags []string) ([]Pe
 	return localVarReturnValue, localVarHttpResponse, nil
 }
 
-/* PetApiService Find pet by ID
+/* 
+PetApiService Find pet by ID
 Returns a single pet
- * @param ctx context.Context for authentication, logging, tracing, etc.
-@param petId ID of pet to return
-@return Pet*/
+ * @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+ * @param petId ID of pet to return
+
+@return Pet
+*/
 func (a *PetApiService) GetPetById(ctx context.Context, petId int64) (Pet, *http.Response, error) {
 	var (
 		localVarHttpMethod = strings.ToUpper("Get")
@@ -399,6 +421,7 @@ func (a *PetApiService) GetPetById(ctx context.Context, petId int64) (Pet, *http
 				key = auth.Key
 			}
 			localVarHeaderParams["api_key"] = key
+			
 		}
 	}
 	r, err := a.client.prepareRequest(ctx, localVarPath, localVarHttpMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFileName, localVarFileBytes)
@@ -412,6 +435,7 @@ func (a *PetApiService) GetPetById(ctx context.Context, petId int64) (Pet, *http
 	}
 
 	localVarBody, err := ioutil.ReadAll(localVarHttpResponse.Body)
+	localVarHttpResponse.Body.Close()
 	if err != nil {
 		return localVarReturnValue, localVarHttpResponse, err
 	}
@@ -452,11 +476,14 @@ func (a *PetApiService) GetPetById(ctx context.Context, petId int64) (Pet, *http
 	return localVarReturnValue, localVarHttpResponse, nil
 }
 
-/* PetApiService Update an existing pet
+/* 
+PetApiService Update an existing pet
 
- * @param ctx context.Context for authentication, logging, tracing, etc.
-@param body Pet object that needs to be added to the store
-@return */
+ * @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+ * @param body Pet object that needs to be added to the store
+
+
+*/
 func (a *PetApiService) UpdatePet(ctx context.Context, body Pet) (*http.Response, error) {
 	var (
 		localVarHttpMethod = strings.ToUpper("Put")
@@ -503,6 +530,7 @@ func (a *PetApiService) UpdatePet(ctx context.Context, body Pet) (*http.Response
 	}
 
 	localVarBody, err := ioutil.ReadAll(localVarHttpResponse.Body)
+	localVarHttpResponse.Body.Close()
 	if err != nil {
 		return localVarHttpResponse, err
 	}
@@ -520,15 +548,24 @@ func (a *PetApiService) UpdatePet(ctx context.Context, body Pet) (*http.Response
 	return localVarHttpResponse, nil
 }
 
-/* PetApiService Updates a pet in the store with form data
+/* 
+PetApiService Updates a pet in the store with form data
 
- * @param ctx context.Context for authentication, logging, tracing, etc.
-@param petId ID of pet that needs to be updated
-@param optional (nil or map[string]interface{}) with one or more of:
-    @param "name" (string) Updated name of the pet
-    @param "status" (string) Updated status of the pet
-@return */
-func (a *PetApiService) UpdatePetWithForm(ctx context.Context, petId int64, localVarOptionals map[string]interface{}) (*http.Response, error) {
+ * @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+ * @param petId ID of pet that needs to be updated
+ * @param optional nil or *UpdatePetWithFormOpts - Optional Parameters:
+     * @param "Name" (optional.String) -  Updated name of the pet
+     * @param "Status" (optional.String) -  Updated status of the pet
+
+
+*/
+
+type UpdatePetWithFormOpts struct { 
+	Name optional.String
+	Status optional.String
+}
+
+func (a *PetApiService) UpdatePetWithForm(ctx context.Context, petId int64, localVarOptionals *UpdatePetWithFormOpts) (*http.Response, error) {
 	var (
 		localVarHttpMethod = strings.ToUpper("Post")
 		localVarPostBody   interface{}
@@ -544,12 +581,6 @@ func (a *PetApiService) UpdatePetWithForm(ctx context.Context, petId int64, loca
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := url.Values{}
 	localVarFormParams := url.Values{}
-	if err := typeCheckParameter(localVarOptionals["name"], "string", "name"); err != nil {
-		return nil, err
-	}
-	if err := typeCheckParameter(localVarOptionals["status"], "string", "status"); err != nil {
-		return nil, err
-	}
 
 	// to determine the Content-Type header
 	localVarHttpContentTypes := []string{"application/x-www-form-urlencoded"}
@@ -568,11 +599,11 @@ func (a *PetApiService) UpdatePetWithForm(ctx context.Context, petId int64, loca
 	if localVarHttpHeaderAccept != "" {
 		localVarHeaderParams["Accept"] = localVarHttpHeaderAccept
 	}
-	if localVarTempParam, localVarOk := localVarOptionals["name"].(string); localVarOk {
-		localVarFormParams.Add("name", parameterToString(localVarTempParam, ""))
+	if localVarOptionals != nil && localVarOptionals.Name.IsSet() {
+		localVarFormParams.Add("name", parameterToString(localVarOptionals.Name.Value(), ""))
 	}
-	if localVarTempParam, localVarOk := localVarOptionals["status"].(string); localVarOk {
-		localVarFormParams.Add("status", parameterToString(localVarTempParam, ""))
+	if localVarOptionals != nil && localVarOptionals.Status.IsSet() {
+		localVarFormParams.Add("status", parameterToString(localVarOptionals.Status.Value(), ""))
 	}
 	r, err := a.client.prepareRequest(ctx, localVarPath, localVarHttpMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFileName, localVarFileBytes)
 	if err != nil {
@@ -585,6 +616,7 @@ func (a *PetApiService) UpdatePetWithForm(ctx context.Context, petId int64, loca
 	}
 
 	localVarBody, err := ioutil.ReadAll(localVarHttpResponse.Body)
+	localVarHttpResponse.Body.Close()
 	if err != nil {
 		return localVarHttpResponse, err
 	}
@@ -602,15 +634,24 @@ func (a *PetApiService) UpdatePetWithForm(ctx context.Context, petId int64, loca
 	return localVarHttpResponse, nil
 }
 
-/* PetApiService uploads an image
+/* 
+PetApiService uploads an image
 
- * @param ctx context.Context for authentication, logging, tracing, etc.
-@param petId ID of pet to update
-@param optional (nil or map[string]interface{}) with one or more of:
-    @param "additionalMetadata" (string) Additional data to pass to server
-    @param "file" (*os.File) file to upload
-@return ModelApiResponse*/
-func (a *PetApiService) UploadFile(ctx context.Context, petId int64, localVarOptionals map[string]interface{}) (ModelApiResponse, *http.Response, error) {
+ * @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+ * @param petId ID of pet to update
+ * @param optional nil or *UploadFileOpts - Optional Parameters:
+     * @param "AdditionalMetadata" (optional.String) -  Additional data to pass to server
+     * @param "File" (optional.Interface of *os.File) -  file to upload
+
+@return ModelApiResponse
+*/
+
+type UploadFileOpts struct { 
+	AdditionalMetadata optional.String
+	File optional.Interface
+}
+
+func (a *PetApiService) UploadFile(ctx context.Context, petId int64, localVarOptionals *UploadFileOpts) (ModelApiResponse, *http.Response, error) {
 	var (
 		localVarHttpMethod = strings.ToUpper("Post")
 		localVarPostBody   interface{}
@@ -626,9 +667,6 @@ func (a *PetApiService) UploadFile(ctx context.Context, petId int64, localVarOpt
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := url.Values{}
 	localVarFormParams := url.Values{}
-	if err := typeCheckParameter(localVarOptionals["additionalMetadata"], "string", "additionalMetadata"); err != nil {
-		return localVarReturnValue, nil, err
-	}
 
 	// to determine the Content-Type header
 	localVarHttpContentTypes := []string{"multipart/form-data"}
@@ -647,12 +685,16 @@ func (a *PetApiService) UploadFile(ctx context.Context, petId int64, localVarOpt
 	if localVarHttpHeaderAccept != "" {
 		localVarHeaderParams["Accept"] = localVarHttpHeaderAccept
 	}
-	if localVarTempParam, localVarOk := localVarOptionals["additionalMetadata"].(string); localVarOk {
-		localVarFormParams.Add("additionalMetadata", parameterToString(localVarTempParam, ""))
+	if localVarOptionals != nil && localVarOptionals.AdditionalMetadata.IsSet() {
+		localVarFormParams.Add("additionalMetadata", parameterToString(localVarOptionals.AdditionalMetadata.Value(), ""))
 	}
-	var localVarFile (*os.File)
-	if localVarTempParam, localVarOk := localVarOptionals["file"].(*os.File); localVarOk {
-		localVarFile = localVarTempParam
+	var localVarFile *os.File
+	if localVarOptionals != nil && localVarOptionals.File.IsSet() {
+		localVarFileOk := false
+		localVarFile, localVarFileOk = localVarOptionals.File.Value().(*os.File)
+		if !localVarFileOk {
+				return localVarReturnValue, nil, reportError("file should be *os.File")
+		}
 	}
 	if localVarFile != nil {
 		fbs, _ := ioutil.ReadAll(localVarFile)
@@ -671,6 +713,7 @@ func (a *PetApiService) UploadFile(ctx context.Context, petId int64, localVarOpt
 	}
 
 	localVarBody, err := ioutil.ReadAll(localVarHttpResponse.Body)
+	localVarHttpResponse.Body.Close()
 	if err != nil {
 		return localVarReturnValue, localVarHttpResponse, err
 	}

--- a/samples/client/petstore/go/go-petstore-withXml/api_store.go
+++ b/samples/client/petstore/go/go-petstore-withXml/api_store.go
@@ -11,11 +11,11 @@
 package petstore
 
 import (
+	"context"
 	"io/ioutil"
 	"net/http"
 	"net/url"
 	"strings"
-	"golang.org/x/net/context"
 	"fmt"
 )
 
@@ -26,11 +26,14 @@ var (
 
 type StoreApiService service
 
-/* StoreApiService Delete purchase order by ID
+/* 
+StoreApiService Delete purchase order by ID
 For valid response try integer IDs with value &lt; 1000. Anything above 1000 or nonintegers will generate API errors
- * @param ctx context.Context for authentication, logging, tracing, etc.
-@param orderId ID of the order that needs to be deleted
-@return */
+ * @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+ * @param orderId ID of the order that needs to be deleted
+
+
+*/
 func (a *StoreApiService) DeleteOrder(ctx context.Context, orderId string) (*http.Response, error) {
 	var (
 		localVarHttpMethod = strings.ToUpper("Delete")
@@ -76,6 +79,7 @@ func (a *StoreApiService) DeleteOrder(ctx context.Context, orderId string) (*htt
 	}
 
 	localVarBody, err := ioutil.ReadAll(localVarHttpResponse.Body)
+	localVarHttpResponse.Body.Close()
 	if err != nil {
 		return localVarHttpResponse, err
 	}
@@ -93,10 +97,13 @@ func (a *StoreApiService) DeleteOrder(ctx context.Context, orderId string) (*htt
 	return localVarHttpResponse, nil
 }
 
-/* StoreApiService Returns pet inventories by status
+/* 
+StoreApiService Returns pet inventories by status
 Returns a map of status codes to quantities
- * @param ctx context.Context for authentication, logging, tracing, etc.
-@return map[string]int32*/
+ * @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+
+@return map[string]int32
+*/
 func (a *StoreApiService) GetInventory(ctx context.Context) (map[string]int32, *http.Response, error) {
 	var (
 		localVarHttpMethod = strings.ToUpper("Get")
@@ -140,6 +147,7 @@ func (a *StoreApiService) GetInventory(ctx context.Context) (map[string]int32, *
 				key = auth.Key
 			}
 			localVarHeaderParams["api_key"] = key
+			
 		}
 	}
 	r, err := a.client.prepareRequest(ctx, localVarPath, localVarHttpMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFileName, localVarFileBytes)
@@ -153,6 +161,7 @@ func (a *StoreApiService) GetInventory(ctx context.Context) (map[string]int32, *
 	}
 
 	localVarBody, err := ioutil.ReadAll(localVarHttpResponse.Body)
+	localVarHttpResponse.Body.Close()
 	if err != nil {
 		return localVarReturnValue, localVarHttpResponse, err
 	}
@@ -193,11 +202,14 @@ func (a *StoreApiService) GetInventory(ctx context.Context) (map[string]int32, *
 	return localVarReturnValue, localVarHttpResponse, nil
 }
 
-/* StoreApiService Find purchase order by ID
+/* 
+StoreApiService Find purchase order by ID
 For valid response try integer IDs with value &lt;&#x3D; 5 or &gt; 10. Other values will generated exceptions
- * @param ctx context.Context for authentication, logging, tracing, etc.
-@param orderId ID of pet that needs to be fetched
-@return Order*/
+ * @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+ * @param orderId ID of pet that needs to be fetched
+
+@return Order
+*/
 func (a *StoreApiService) GetOrderById(ctx context.Context, orderId int64) (Order, *http.Response, error) {
 	var (
 		localVarHttpMethod = strings.ToUpper("Get")
@@ -249,6 +261,7 @@ func (a *StoreApiService) GetOrderById(ctx context.Context, orderId int64) (Orde
 	}
 
 	localVarBody, err := ioutil.ReadAll(localVarHttpResponse.Body)
+	localVarHttpResponse.Body.Close()
 	if err != nil {
 		return localVarReturnValue, localVarHttpResponse, err
 	}
@@ -289,11 +302,14 @@ func (a *StoreApiService) GetOrderById(ctx context.Context, orderId int64) (Orde
 	return localVarReturnValue, localVarHttpResponse, nil
 }
 
-/* StoreApiService Place an order for a pet
+/* 
+StoreApiService Place an order for a pet
 
- * @param ctx context.Context for authentication, logging, tracing, etc.
-@param body order placed for purchasing the pet
-@return Order*/
+ * @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+ * @param body order placed for purchasing the pet
+
+@return Order
+*/
 func (a *StoreApiService) PlaceOrder(ctx context.Context, body Order) (Order, *http.Response, error) {
 	var (
 		localVarHttpMethod = strings.ToUpper("Post")
@@ -340,6 +356,7 @@ func (a *StoreApiService) PlaceOrder(ctx context.Context, body Order) (Order, *h
 	}
 
 	localVarBody, err := ioutil.ReadAll(localVarHttpResponse.Body)
+	localVarHttpResponse.Body.Close()
 	if err != nil {
 		return localVarReturnValue, localVarHttpResponse, err
 	}

--- a/samples/client/petstore/go/go-petstore-withXml/api_user.go
+++ b/samples/client/petstore/go/go-petstore-withXml/api_user.go
@@ -11,11 +11,11 @@
 package petstore
 
 import (
+	"context"
 	"io/ioutil"
 	"net/http"
 	"net/url"
 	"strings"
-	"golang.org/x/net/context"
 	"fmt"
 )
 
@@ -26,11 +26,14 @@ var (
 
 type UserApiService service
 
-/* UserApiService Create user
+/* 
+UserApiService Create user
 This can only be done by the logged in user.
- * @param ctx context.Context for authentication, logging, tracing, etc.
-@param body Created user object
-@return */
+ * @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+ * @param body Created user object
+
+
+*/
 func (a *UserApiService) CreateUser(ctx context.Context, body User) (*http.Response, error) {
 	var (
 		localVarHttpMethod = strings.ToUpper("Post")
@@ -77,6 +80,7 @@ func (a *UserApiService) CreateUser(ctx context.Context, body User) (*http.Respo
 	}
 
 	localVarBody, err := ioutil.ReadAll(localVarHttpResponse.Body)
+	localVarHttpResponse.Body.Close()
 	if err != nil {
 		return localVarHttpResponse, err
 	}
@@ -94,11 +98,14 @@ func (a *UserApiService) CreateUser(ctx context.Context, body User) (*http.Respo
 	return localVarHttpResponse, nil
 }
 
-/* UserApiService Creates list of users with given input array
+/* 
+UserApiService Creates list of users with given input array
 
- * @param ctx context.Context for authentication, logging, tracing, etc.
-@param body List of user object
-@return */
+ * @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+ * @param body List of user object
+
+
+*/
 func (a *UserApiService) CreateUsersWithArrayInput(ctx context.Context, body []User) (*http.Response, error) {
 	var (
 		localVarHttpMethod = strings.ToUpper("Post")
@@ -145,6 +152,7 @@ func (a *UserApiService) CreateUsersWithArrayInput(ctx context.Context, body []U
 	}
 
 	localVarBody, err := ioutil.ReadAll(localVarHttpResponse.Body)
+	localVarHttpResponse.Body.Close()
 	if err != nil {
 		return localVarHttpResponse, err
 	}
@@ -162,11 +170,14 @@ func (a *UserApiService) CreateUsersWithArrayInput(ctx context.Context, body []U
 	return localVarHttpResponse, nil
 }
 
-/* UserApiService Creates list of users with given input array
+/* 
+UserApiService Creates list of users with given input array
 
- * @param ctx context.Context for authentication, logging, tracing, etc.
-@param body List of user object
-@return */
+ * @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+ * @param body List of user object
+
+
+*/
 func (a *UserApiService) CreateUsersWithListInput(ctx context.Context, body []User) (*http.Response, error) {
 	var (
 		localVarHttpMethod = strings.ToUpper("Post")
@@ -213,6 +224,7 @@ func (a *UserApiService) CreateUsersWithListInput(ctx context.Context, body []Us
 	}
 
 	localVarBody, err := ioutil.ReadAll(localVarHttpResponse.Body)
+	localVarHttpResponse.Body.Close()
 	if err != nil {
 		return localVarHttpResponse, err
 	}
@@ -230,11 +242,14 @@ func (a *UserApiService) CreateUsersWithListInput(ctx context.Context, body []Us
 	return localVarHttpResponse, nil
 }
 
-/* UserApiService Delete user
+/* 
+UserApiService Delete user
 This can only be done by the logged in user.
- * @param ctx context.Context for authentication, logging, tracing, etc.
-@param username The name that needs to be deleted
-@return */
+ * @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+ * @param username The name that needs to be deleted
+
+
+*/
 func (a *UserApiService) DeleteUser(ctx context.Context, username string) (*http.Response, error) {
 	var (
 		localVarHttpMethod = strings.ToUpper("Delete")
@@ -280,6 +295,7 @@ func (a *UserApiService) DeleteUser(ctx context.Context, username string) (*http
 	}
 
 	localVarBody, err := ioutil.ReadAll(localVarHttpResponse.Body)
+	localVarHttpResponse.Body.Close()
 	if err != nil {
 		return localVarHttpResponse, err
 	}
@@ -297,11 +313,14 @@ func (a *UserApiService) DeleteUser(ctx context.Context, username string) (*http
 	return localVarHttpResponse, nil
 }
 
-/* UserApiService Get user by user name
+/* 
+UserApiService Get user by user name
 
- * @param ctx context.Context for authentication, logging, tracing, etc.
-@param username The name that needs to be fetched. Use user1 for testing.
-@return User*/
+ * @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+ * @param username The name that needs to be fetched. Use user1 for testing.
+
+@return User
+*/
 func (a *UserApiService) GetUserByName(ctx context.Context, username string) (User, *http.Response, error) {
 	var (
 		localVarHttpMethod = strings.ToUpper("Get")
@@ -347,6 +366,7 @@ func (a *UserApiService) GetUserByName(ctx context.Context, username string) (Us
 	}
 
 	localVarBody, err := ioutil.ReadAll(localVarHttpResponse.Body)
+	localVarHttpResponse.Body.Close()
 	if err != nil {
 		return localVarReturnValue, localVarHttpResponse, err
 	}
@@ -387,12 +407,15 @@ func (a *UserApiService) GetUserByName(ctx context.Context, username string) (Us
 	return localVarReturnValue, localVarHttpResponse, nil
 }
 
-/* UserApiService Logs user into the system
+/* 
+UserApiService Logs user into the system
 
- * @param ctx context.Context for authentication, logging, tracing, etc.
-@param username The user name for login
-@param password The password for login in clear text
-@return string*/
+ * @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+ * @param username The user name for login
+ * @param password The password for login in clear text
+
+@return string
+*/
 func (a *UserApiService) LoginUser(ctx context.Context, username string, password string) (string, *http.Response, error) {
 	var (
 		localVarHttpMethod = strings.ToUpper("Get")
@@ -439,6 +462,7 @@ func (a *UserApiService) LoginUser(ctx context.Context, username string, passwor
 	}
 
 	localVarBody, err := ioutil.ReadAll(localVarHttpResponse.Body)
+	localVarHttpResponse.Body.Close()
 	if err != nil {
 		return localVarReturnValue, localVarHttpResponse, err
 	}
@@ -479,10 +503,13 @@ func (a *UserApiService) LoginUser(ctx context.Context, username string, passwor
 	return localVarReturnValue, localVarHttpResponse, nil
 }
 
-/* UserApiService Logs out current logged in user session
+/* 
+UserApiService Logs out current logged in user session
 
- * @param ctx context.Context for authentication, logging, tracing, etc.
-@return */
+ * @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+
+
+*/
 func (a *UserApiService) LogoutUser(ctx context.Context) (*http.Response, error) {
 	var (
 		localVarHttpMethod = strings.ToUpper("Get")
@@ -527,6 +554,7 @@ func (a *UserApiService) LogoutUser(ctx context.Context) (*http.Response, error)
 	}
 
 	localVarBody, err := ioutil.ReadAll(localVarHttpResponse.Body)
+	localVarHttpResponse.Body.Close()
 	if err != nil {
 		return localVarHttpResponse, err
 	}
@@ -544,12 +572,15 @@ func (a *UserApiService) LogoutUser(ctx context.Context) (*http.Response, error)
 	return localVarHttpResponse, nil
 }
 
-/* UserApiService Updated user
+/* 
+UserApiService Updated user
 This can only be done by the logged in user.
- * @param ctx context.Context for authentication, logging, tracing, etc.
-@param username name that need to be deleted
-@param body Updated user object
-@return */
+ * @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+ * @param username name that need to be deleted
+ * @param body Updated user object
+
+
+*/
 func (a *UserApiService) UpdateUser(ctx context.Context, username string, body User) (*http.Response, error) {
 	var (
 		localVarHttpMethod = strings.ToUpper("Put")
@@ -597,6 +628,7 @@ func (a *UserApiService) UpdateUser(ctx context.Context, username string, body U
 	}
 
 	localVarBody, err := ioutil.ReadAll(localVarHttpResponse.Body)
+	localVarHttpResponse.Body.Close()
 	if err != nil {
 		return localVarHttpResponse, err
 	}

--- a/samples/client/petstore/go/go-petstore-withXml/docs/AnotherFakeApi.md
+++ b/samples/client/petstore/go/go-petstore-withXml/docs/AnotherFakeApi.md
@@ -17,7 +17,7 @@ To test special tags
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
- **ctx** | **context.Context** | context for logging, tracing, authentication, etc.
+ **ctx** | **context.Context** | context for authentication, logging, cancellation, deadlines, tracing, etc.
   **body** | [**Client**](Client.md)| client model | 
 
 ### Return type

--- a/samples/client/petstore/go/go-petstore-withXml/docs/FakeApi.md
+++ b/samples/client/petstore/go/go-petstore-withXml/docs/FakeApi.md
@@ -8,6 +8,7 @@ Method | HTTP request | Description
 [**FakeOuterCompositeSerialize**](FakeApi.md#FakeOuterCompositeSerialize) | **Post** /fake/outer/composite | 
 [**FakeOuterNumberSerialize**](FakeApi.md#FakeOuterNumberSerialize) | **Post** /fake/outer/number | 
 [**FakeOuterStringSerialize**](FakeApi.md#FakeOuterStringSerialize) | **Post** /fake/outer/string | 
+[**TestBodyWithQueryParams**](FakeApi.md#TestBodyWithQueryParams) | **Put** /fake/body-with-query-params | 
 [**TestClientModel**](FakeApi.md#TestClientModel) | **Patch** /fake | To test \&quot;client\&quot; model
 [**TestEndpointParameters**](FakeApi.md#TestEndpointParameters) | **Post** /fake | Fake endpoint for testing various parameters 假端點 偽のエンドポイント 가짜 엔드 포인트 
 [**TestEnumParameters**](FakeApi.md#TestEnumParameters) | **Get** /fake | To test enum parameters
@@ -25,15 +26,15 @@ Test serialization of outer boolean types
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
- **ctx** | **context.Context** | context for logging, tracing, authentication, etc.
- **optional** | **map[string]interface{}** | optional parameters | nil if no parameters
+ **ctx** | **context.Context** | context for authentication, logging, cancellation, deadlines, tracing, etc.
+ **optional** | ***FakeOuterBooleanSerializeOpts** | optional parameters | nil if no parameters
 
 ### Optional Parameters
-Optional parameters are passed through a map[string]interface{}.
+Optional parameters are passed through a pointer to a FakeOuterBooleanSerializeOpts struct
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
- **body** | [**OuterBoolean**](OuterBoolean.md)| Input boolean as post body | 
+ **body** | [**optional.Interface of OuterBoolean**](OuterBoolean.md)| Input boolean as post body | 
 
 ### Return type
 
@@ -60,15 +61,15 @@ Test serialization of object with outer number type
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
- **ctx** | **context.Context** | context for logging, tracing, authentication, etc.
- **optional** | **map[string]interface{}** | optional parameters | nil if no parameters
+ **ctx** | **context.Context** | context for authentication, logging, cancellation, deadlines, tracing, etc.
+ **optional** | ***FakeOuterCompositeSerializeOpts** | optional parameters | nil if no parameters
 
 ### Optional Parameters
-Optional parameters are passed through a map[string]interface{}.
+Optional parameters are passed through a pointer to a FakeOuterCompositeSerializeOpts struct
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
- **body** | [**OuterComposite**](OuterComposite.md)| Input composite as post body | 
+ **body** | [**optional.Interface of OuterComposite**](OuterComposite.md)| Input composite as post body | 
 
 ### Return type
 
@@ -95,15 +96,15 @@ Test serialization of outer number types
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
- **ctx** | **context.Context** | context for logging, tracing, authentication, etc.
- **optional** | **map[string]interface{}** | optional parameters | nil if no parameters
+ **ctx** | **context.Context** | context for authentication, logging, cancellation, deadlines, tracing, etc.
+ **optional** | ***FakeOuterNumberSerializeOpts** | optional parameters | nil if no parameters
 
 ### Optional Parameters
-Optional parameters are passed through a map[string]interface{}.
+Optional parameters are passed through a pointer to a FakeOuterNumberSerializeOpts struct
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
- **body** | [**OuterNumber**](OuterNumber.md)| Input number as post body | 
+ **body** | [**optional.Interface of OuterNumber**](OuterNumber.md)| Input number as post body | 
 
 ### Return type
 
@@ -130,15 +131,15 @@ Test serialization of outer string types
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
- **ctx** | **context.Context** | context for logging, tracing, authentication, etc.
- **optional** | **map[string]interface{}** | optional parameters | nil if no parameters
+ **ctx** | **context.Context** | context for authentication, logging, cancellation, deadlines, tracing, etc.
+ **optional** | ***FakeOuterStringSerializeOpts** | optional parameters | nil if no parameters
 
 ### Optional Parameters
-Optional parameters are passed through a map[string]interface{}.
+Optional parameters are passed through a pointer to a FakeOuterStringSerializeOpts struct
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
- **body** | [**OuterString**](OuterString.md)| Input string as post body | 
+ **body** | [**optional.Interface of OuterString**](OuterString.md)| Input string as post body | 
 
 ### Return type
 
@@ -155,6 +156,33 @@ No authorization required
 
 [[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
 
+# **TestBodyWithQueryParams**
+> TestBodyWithQueryParams(ctx, body, query)
+
+
+### Required Parameters
+
+Name | Type | Description  | Notes
+------------- | ------------- | ------------- | -------------
+ **ctx** | **context.Context** | context for authentication, logging, cancellation, deadlines, tracing, etc.
+  **body** | [**User**](User.md)|  | 
+  **query** | **string**|  | 
+
+### Return type
+
+ (empty response body)
+
+### Authorization
+
+No authorization required
+
+### HTTP request headers
+
+ - **Content-Type**: application/json
+ - **Accept**: Not defined
+
+[[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
+
 # **TestClientModel**
 > Client TestClientModel(ctx, body)
 To test \"client\" model
@@ -165,7 +193,7 @@ To test \"client\" model
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
- **ctx** | **context.Context** | context for logging, tracing, authentication, etc.
+ **ctx** | **context.Context** | context for authentication, logging, cancellation, deadlines, tracing, etc.
   **body** | [**Client**](Client.md)| client model | 
 
 ### Return type
@@ -193,32 +221,32 @@ Fake endpoint for testing various parameters 假端點 偽のエンドポイン�
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
- **ctx** | **context.Context** | context for logging, tracing, authentication, etc.
+ **ctx** | **context.Context** | context for authentication, logging, cancellation, deadlines, tracing, etc.
   **number** | **float32**| None | 
   **double** | **float64**| None | 
   **patternWithoutDelimiter** | **string**| None | 
   **byte_** | **string**| None | 
- **optional** | **map[string]interface{}** | optional parameters | nil if no parameters
+ **optional** | ***TestEndpointParametersOpts** | optional parameters | nil if no parameters
 
 ### Optional Parameters
-Optional parameters are passed through a map[string]interface{}.
+Optional parameters are passed through a pointer to a TestEndpointParametersOpts struct
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
- **number** | **float32**| None | 
- **double** | **float64**| None | 
- **patternWithoutDelimiter** | **string**| None | 
- **byte_** | **string**| None | 
- **integer** | **int32**| None | 
- **int32_** | **int32**| None | 
- **int64_** | **int64**| None | 
- **float** | **float32**| None | 
- **string_** | **string**| None | 
- **binary** | **string**| None | 
- **date** | **string**| None | 
- **dateTime** | **time.Time**| None | 
- **password** | **string**| None | 
- **callback** | **string**| None | 
+
+
+
+
+ **integer** | **optional.Int32**| None | 
+ **int32_** | **optional.Int32**| None | 
+ **int64_** | **optional.Int64**| None | 
+ **float** | **optional.Float32**| None | 
+ **string_** | **optional.String**| None | 
+ **binary** | **optional.String**| None | 
+ **date** | **optional.String**| None | 
+ **dateTime** | **optional.Time**| None | 
+ **password** | **optional.String**| None | 
+ **callback** | **optional.String**| None | 
 
 ### Return type
 
@@ -245,22 +273,22 @@ To test enum parameters
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
- **ctx** | **context.Context** | context for logging, tracing, authentication, etc.
- **optional** | **map[string]interface{}** | optional parameters | nil if no parameters
+ **ctx** | **context.Context** | context for authentication, logging, cancellation, deadlines, tracing, etc.
+ **optional** | ***TestEnumParametersOpts** | optional parameters | nil if no parameters
 
 ### Optional Parameters
-Optional parameters are passed through a map[string]interface{}.
+Optional parameters are passed through a pointer to a TestEnumParametersOpts struct
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
- **enumFormStringArray** | [**[]string**](string.md)| Form parameter enum test (string array) | 
- **enumFormString** | **string**| Form parameter enum test (string) | [default to -efg]
- **enumHeaderStringArray** | [**[]string**](string.md)| Header parameter enum test (string array) | 
- **enumHeaderString** | **string**| Header parameter enum test (string) | [default to -efg]
- **enumQueryStringArray** | [**[]string**](string.md)| Query parameter enum test (string array) | 
- **enumQueryString** | **string**| Query parameter enum test (string) | [default to -efg]
- **enumQueryInteger** | **int32**| Query parameter enum test (double) | 
- **enumQueryDouble** | **float64**| Query parameter enum test (double) | 
+ **enumFormStringArray** | [**optional.Interface of []string**](string.md)| Form parameter enum test (string array) | 
+ **enumFormString** | **optional.String**| Form parameter enum test (string) | [default to -efg]
+ **enumHeaderStringArray** | [**optional.Interface of []string**](string.md)| Header parameter enum test (string array) | 
+ **enumHeaderString** | **optional.String**| Header parameter enum test (string) | [default to -efg]
+ **enumQueryStringArray** | [**optional.Interface of []string**](string.md)| Query parameter enum test (string array) | 
+ **enumQueryString** | **optional.String**| Query parameter enum test (string) | [default to -efg]
+ **enumQueryInteger** | **optional.Int32**| Query parameter enum test (double) | 
+ **enumQueryDouble** | **optional.Float64**| Query parameter enum test (double) | 
 
 ### Return type
 
@@ -287,7 +315,7 @@ test inline additionalProperties
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
- **ctx** | **context.Context** | context for logging, tracing, authentication, etc.
+ **ctx** | **context.Context** | context for authentication, logging, cancellation, deadlines, tracing, etc.
   **param** | [**interface{}**](interface{}.md)| request body | 
 
 ### Return type
@@ -315,7 +343,7 @@ test json serialization of form data
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
- **ctx** | **context.Context** | context for logging, tracing, authentication, etc.
+ **ctx** | **context.Context** | context for authentication, logging, cancellation, deadlines, tracing, etc.
   **param** | **string**| field1 | 
   **param2** | **string**| field2 | 
 

--- a/samples/client/petstore/go/go-petstore-withXml/docs/FakeClassnameTags123Api.md
+++ b/samples/client/petstore/go/go-petstore-withXml/docs/FakeClassnameTags123Api.md
@@ -17,7 +17,7 @@ To test class name in snake case
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
- **ctx** | **context.Context** | context for logging, tracing, authentication, etc.
+ **ctx** | **context.Context** | context for authentication, logging, cancellation, deadlines, tracing, etc.
   **body** | [**Client**](Client.md)| client model | 
 
 ### Return type

--- a/samples/client/petstore/go/go-petstore-withXml/docs/PetApi.md
+++ b/samples/client/petstore/go/go-petstore-withXml/docs/PetApi.md
@@ -24,7 +24,7 @@ Add a new pet to the store
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
- **ctx** | **context.Context** | context for logging, tracing, authentication, etc.
+ **ctx** | **context.Context** | context for authentication, logging, cancellation, deadlines, tracing, etc.
   **body** | [**Pet**](Pet.md)| Pet object that needs to be added to the store | 
 
 ### Return type
@@ -52,17 +52,17 @@ Deletes a pet
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
- **ctx** | **context.Context** | context for logging, tracing, authentication, etc.
+ **ctx** | **context.Context** | context for authentication, logging, cancellation, deadlines, tracing, etc.
   **petId** | **int64**| Pet id to delete | 
- **optional** | **map[string]interface{}** | optional parameters | nil if no parameters
+ **optional** | ***DeletePetOpts** | optional parameters | nil if no parameters
 
 ### Optional Parameters
-Optional parameters are passed through a map[string]interface{}.
+Optional parameters are passed through a pointer to a DeletePetOpts struct
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
- **petId** | **int64**| Pet id to delete | 
- **apiKey** | **string**|  | 
+
+ **apiKey** | **optional.String**|  | 
 
 ### Return type
 
@@ -89,7 +89,7 @@ Multiple status values can be provided with comma separated strings
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
- **ctx** | **context.Context** | context for logging, tracing, authentication, etc.
+ **ctx** | **context.Context** | context for authentication, logging, cancellation, deadlines, tracing, etc.
   **status** | [**[]string**](string.md)| Status values that need to be considered for filter | 
 
 ### Return type
@@ -117,7 +117,7 @@ Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
- **ctx** | **context.Context** | context for logging, tracing, authentication, etc.
+ **ctx** | **context.Context** | context for authentication, logging, cancellation, deadlines, tracing, etc.
   **tags** | [**[]string**](string.md)| Tags to filter by | 
 
 ### Return type
@@ -145,7 +145,7 @@ Returns a single pet
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
- **ctx** | **context.Context** | context for logging, tracing, authentication, etc.
+ **ctx** | **context.Context** | context for authentication, logging, cancellation, deadlines, tracing, etc.
   **petId** | **int64**| ID of pet to return | 
 
 ### Return type
@@ -173,7 +173,7 @@ Update an existing pet
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
- **ctx** | **context.Context** | context for logging, tracing, authentication, etc.
+ **ctx** | **context.Context** | context for authentication, logging, cancellation, deadlines, tracing, etc.
   **body** | [**Pet**](Pet.md)| Pet object that needs to be added to the store | 
 
 ### Return type
@@ -201,18 +201,18 @@ Updates a pet in the store with form data
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
- **ctx** | **context.Context** | context for logging, tracing, authentication, etc.
+ **ctx** | **context.Context** | context for authentication, logging, cancellation, deadlines, tracing, etc.
   **petId** | **int64**| ID of pet that needs to be updated | 
- **optional** | **map[string]interface{}** | optional parameters | nil if no parameters
+ **optional** | ***UpdatePetWithFormOpts** | optional parameters | nil if no parameters
 
 ### Optional Parameters
-Optional parameters are passed through a map[string]interface{}.
+Optional parameters are passed through a pointer to a UpdatePetWithFormOpts struct
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
- **petId** | **int64**| ID of pet that needs to be updated | 
- **name** | **string**| Updated name of the pet | 
- **status** | **string**| Updated status of the pet | 
+
+ **name** | **optional.String**| Updated name of the pet | 
+ **status** | **optional.String**| Updated status of the pet | 
 
 ### Return type
 
@@ -239,18 +239,18 @@ uploads an image
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
- **ctx** | **context.Context** | context for logging, tracing, authentication, etc.
+ **ctx** | **context.Context** | context for authentication, logging, cancellation, deadlines, tracing, etc.
   **petId** | **int64**| ID of pet to update | 
- **optional** | **map[string]interface{}** | optional parameters | nil if no parameters
+ **optional** | ***UploadFileOpts** | optional parameters | nil if no parameters
 
 ### Optional Parameters
-Optional parameters are passed through a map[string]interface{}.
+Optional parameters are passed through a pointer to a UploadFileOpts struct
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
- **petId** | **int64**| ID of pet to update | 
- **additionalMetadata** | **string**| Additional data to pass to server | 
- **file** | ***os.File**| file to upload | 
+
+ **additionalMetadata** | **optional.String**| Additional data to pass to server | 
+ **file** | **optional.Interface of *os.File**| file to upload | 
 
 ### Return type
 

--- a/samples/client/petstore/go/go-petstore-withXml/docs/StoreApi.md
+++ b/samples/client/petstore/go/go-petstore-withXml/docs/StoreApi.md
@@ -20,7 +20,7 @@ For valid response try integer IDs with value < 1000. Anything above 1000 or non
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
- **ctx** | **context.Context** | context for logging, tracing, authentication, etc.
+ **ctx** | **context.Context** | context for authentication, logging, cancellation, deadlines, tracing, etc.
   **orderId** | **string**| ID of the order that needs to be deleted | 
 
 ### Return type
@@ -72,7 +72,7 @@ For valid response try integer IDs with value <= 5 or > 10. Other values will ge
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
- **ctx** | **context.Context** | context for logging, tracing, authentication, etc.
+ **ctx** | **context.Context** | context for authentication, logging, cancellation, deadlines, tracing, etc.
   **orderId** | **int64**| ID of pet that needs to be fetched | 
 
 ### Return type
@@ -100,7 +100,7 @@ Place an order for a pet
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
- **ctx** | **context.Context** | context for logging, tracing, authentication, etc.
+ **ctx** | **context.Context** | context for authentication, logging, cancellation, deadlines, tracing, etc.
   **body** | [**Order**](Order.md)| order placed for purchasing the pet | 
 
 ### Return type

--- a/samples/client/petstore/go/go-petstore-withXml/docs/UserApi.md
+++ b/samples/client/petstore/go/go-petstore-withXml/docs/UserApi.md
@@ -24,7 +24,7 @@ This can only be done by the logged in user.
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
- **ctx** | **context.Context** | context for logging, tracing, authentication, etc.
+ **ctx** | **context.Context** | context for authentication, logging, cancellation, deadlines, tracing, etc.
   **body** | [**User**](User.md)| Created user object | 
 
 ### Return type
@@ -52,7 +52,7 @@ Creates list of users with given input array
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
- **ctx** | **context.Context** | context for logging, tracing, authentication, etc.
+ **ctx** | **context.Context** | context for authentication, logging, cancellation, deadlines, tracing, etc.
   **body** | [**[]User**](User.md)| List of user object | 
 
 ### Return type
@@ -80,7 +80,7 @@ Creates list of users with given input array
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
- **ctx** | **context.Context** | context for logging, tracing, authentication, etc.
+ **ctx** | **context.Context** | context for authentication, logging, cancellation, deadlines, tracing, etc.
   **body** | [**[]User**](User.md)| List of user object | 
 
 ### Return type
@@ -108,7 +108,7 @@ This can only be done by the logged in user.
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
- **ctx** | **context.Context** | context for logging, tracing, authentication, etc.
+ **ctx** | **context.Context** | context for authentication, logging, cancellation, deadlines, tracing, etc.
   **username** | **string**| The name that needs to be deleted | 
 
 ### Return type
@@ -136,7 +136,7 @@ Get user by user name
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
- **ctx** | **context.Context** | context for logging, tracing, authentication, etc.
+ **ctx** | **context.Context** | context for authentication, logging, cancellation, deadlines, tracing, etc.
   **username** | **string**| The name that needs to be fetched. Use user1 for testing. | 
 
 ### Return type
@@ -164,7 +164,7 @@ Logs user into the system
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
- **ctx** | **context.Context** | context for logging, tracing, authentication, etc.
+ **ctx** | **context.Context** | context for authentication, logging, cancellation, deadlines, tracing, etc.
   **username** | **string**| The user name for login | 
   **password** | **string**| The password for login in clear text | 
 
@@ -217,7 +217,7 @@ This can only be done by the logged in user.
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
- **ctx** | **context.Context** | context for logging, tracing, authentication, etc.
+ **ctx** | **context.Context** | context for authentication, logging, cancellation, deadlines, tracing, etc.
   **username** | **string**| name that need to be deleted | 
   **body** | [**User**](User.md)| Updated user object | 
 

--- a/samples/client/petstore/go/go-petstore/README.md
+++ b/samples/client/petstore/go/go-petstore/README.md
@@ -22,11 +22,11 @@ All URIs are relative to *http://petstore.swagger.io:80/v2*
 Class | Method | HTTP request | Description
 ------------ | ------------- | ------------- | -------------
 *AnotherFakeApi* | [**TestSpecialTags**](docs/AnotherFakeApi.md#testspecialtags) | **Patch** /another-fake/dummy | To test special tags
-*DefaultApi* | [**TestBodyWithQueryParams**](docs/DefaultApi.md#testbodywithqueryparams) | **Put** /fake/body-with-query-params | 
 *FakeApi* | [**FakeOuterBooleanSerialize**](docs/FakeApi.md#fakeouterbooleanserialize) | **Post** /fake/outer/boolean | 
 *FakeApi* | [**FakeOuterCompositeSerialize**](docs/FakeApi.md#fakeoutercompositeserialize) | **Post** /fake/outer/composite | 
 *FakeApi* | [**FakeOuterNumberSerialize**](docs/FakeApi.md#fakeouternumberserialize) | **Post** /fake/outer/number | 
 *FakeApi* | [**FakeOuterStringSerialize**](docs/FakeApi.md#fakeouterstringserialize) | **Post** /fake/outer/string | 
+*FakeApi* | [**TestBodyWithQueryParams**](docs/FakeApi.md#testbodywithqueryparams) | **Put** /fake/body-with-query-params | 
 *FakeApi* | [**TestClientModel**](docs/FakeApi.md#testclientmodel) | **Patch** /fake | To test \&quot;client\&quot; model
 *FakeApi* | [**TestEndpointParameters**](docs/FakeApi.md#testendpointparameters) | **Post** /fake | Fake endpoint for testing various parameters 假端點 偽のエンドポイント 가짜 엔드 포인트 
 *FakeApi* | [**TestEnumParameters**](docs/FakeApi.md#testenumparameters) | **Get** /fake | To test enum parameters

--- a/samples/client/petstore/go/go-petstore/api/swagger.yaml
+++ b/samples/client/petstore/go/go-petstore/api/swagger.yaml
@@ -1017,6 +1017,8 @@ paths:
           description: "successful operation"
   /fake/body-with-query-params:
     put:
+      tags:
+      - "fake"
       operationId: "testBodyWithQueryParams"
       consumes:
       - "application/json"

--- a/samples/client/petstore/go/go-petstore/api_another_fake.go
+++ b/samples/client/petstore/go/go-petstore/api_another_fake.go
@@ -11,11 +11,11 @@
 package petstore
 
 import (
+	"context"
 	"io/ioutil"
 	"net/http"
 	"net/url"
 	"strings"
-	"context"
 )
 
 // Linger please

--- a/samples/client/petstore/go/go-petstore/api_fake.go
+++ b/samples/client/petstore/go/go-petstore/api_fake.go
@@ -11,11 +11,11 @@
 package petstore
 
 import (
+	"context"
 	"io/ioutil"
 	"net/http"
 	"net/url"
 	"strings"
-	"context"
 	"github.com/antihax/optional"
 )
 
@@ -456,6 +456,79 @@ func (a *FakeApiService) FakeOuterStringSerialize(ctx context.Context, localVarO
 	}
 
 	return localVarReturnValue, localVarHttpResponse, nil
+}
+
+/* 
+FakeApiService
+ * @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+ * @param body
+ * @param query
+
+
+*/
+func (a *FakeApiService) TestBodyWithQueryParams(ctx context.Context, body User, query string) (*http.Response, error) {
+	var (
+		localVarHttpMethod = strings.ToUpper("Put")
+		localVarPostBody   interface{}
+		localVarFileName   string
+		localVarFileBytes  []byte
+		
+	)
+
+	// create path and map variables
+	localVarPath := a.client.cfg.BasePath + "/fake/body-with-query-params"
+
+	localVarHeaderParams := make(map[string]string)
+	localVarQueryParams := url.Values{}
+	localVarFormParams := url.Values{}
+
+	localVarQueryParams.Add("query", parameterToString(query, ""))
+	// to determine the Content-Type header
+	localVarHttpContentTypes := []string{"application/json"}
+
+	// set Content-Type header
+	localVarHttpContentType := selectHeaderContentType(localVarHttpContentTypes)
+	if localVarHttpContentType != "" {
+		localVarHeaderParams["Content-Type"] = localVarHttpContentType
+	}
+
+	// to determine the Accept header
+	localVarHttpHeaderAccepts := []string{}
+
+	// set Accept header
+	localVarHttpHeaderAccept := selectHeaderAccept(localVarHttpHeaderAccepts)
+	if localVarHttpHeaderAccept != "" {
+		localVarHeaderParams["Accept"] = localVarHttpHeaderAccept
+	}
+	// body params
+	localVarPostBody = &body
+	r, err := a.client.prepareRequest(ctx, localVarPath, localVarHttpMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFileName, localVarFileBytes)
+	if err != nil {
+		return nil, err
+	}
+
+	localVarHttpResponse, err := a.client.callAPI(r)
+	if err != nil || localVarHttpResponse == nil {
+		return localVarHttpResponse, err
+	}
+
+	localVarBody, err := ioutil.ReadAll(localVarHttpResponse.Body)
+	localVarHttpResponse.Body.Close()
+	if err != nil {
+		return localVarHttpResponse, err
+	}
+
+
+	if localVarHttpResponse.StatusCode >= 300 {
+		newErr := GenericSwaggerError{
+			body: localVarBody,
+			error: localVarHttpResponse.Status,
+		}
+		
+		return localVarHttpResponse, newErr
+	}
+
+	return localVarHttpResponse, nil
 }
 
 /* 

--- a/samples/client/petstore/go/go-petstore/api_fake_classname_tags123.go
+++ b/samples/client/petstore/go/go-petstore/api_fake_classname_tags123.go
@@ -11,11 +11,11 @@
 package petstore
 
 import (
+	"context"
 	"io/ioutil"
 	"net/http"
 	"net/url"
 	"strings"
-	"context"
 )
 
 // Linger please

--- a/samples/client/petstore/go/go-petstore/api_pet.go
+++ b/samples/client/petstore/go/go-petstore/api_pet.go
@@ -11,11 +11,11 @@
 package petstore
 
 import (
+	"context"
 	"io/ioutil"
 	"net/http"
 	"net/url"
 	"strings"
-	"context"
 	"fmt"
 	"github.com/antihax/optional"
 	"os"

--- a/samples/client/petstore/go/go-petstore/api_store.go
+++ b/samples/client/petstore/go/go-petstore/api_store.go
@@ -11,11 +11,11 @@
 package petstore
 
 import (
+	"context"
 	"io/ioutil"
 	"net/http"
 	"net/url"
 	"strings"
-	"context"
 	"fmt"
 )
 

--- a/samples/client/petstore/go/go-petstore/api_user.go
+++ b/samples/client/petstore/go/go-petstore/api_user.go
@@ -11,11 +11,11 @@
 package petstore
 
 import (
+	"context"
 	"io/ioutil"
 	"net/http"
 	"net/url"
 	"strings"
-	"context"
 	"fmt"
 )
 

--- a/samples/client/petstore/go/go-petstore/client.go
+++ b/samples/client/petstore/go/go-petstore/client.go
@@ -12,6 +12,7 @@ package petstore
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"encoding/xml"
 	"errors"
@@ -29,7 +30,6 @@ import (
 	"time"
 	"unicode/utf8"
 
-	"context"
 	"golang.org/x/oauth2"
 )
 
@@ -47,8 +47,6 @@ type APIClient struct {
 	// API Services
 
 	AnotherFakeApi *AnotherFakeApiService
-
-	DefaultApi *DefaultApiService
 
 	FakeApi *FakeApiService
 
@@ -78,7 +76,6 @@ func NewAPIClient(cfg *Configuration) *APIClient {
 
 	// API Services
 	c.AnotherFakeApi = (*AnotherFakeApiService)(&c.common)
-	c.DefaultApi = (*DefaultApiService)(&c.common)
 	c.FakeApi = (*FakeApiService)(&c.common)
 	c.FakeClassnameTags123Api = (*FakeClassnameTags123ApiService)(&c.common)
 	c.PetApi = (*PetApiService)(&c.common)

--- a/samples/client/petstore/go/go-petstore/docs/FakeApi.md
+++ b/samples/client/petstore/go/go-petstore/docs/FakeApi.md
@@ -8,6 +8,7 @@ Method | HTTP request | Description
 [**FakeOuterCompositeSerialize**](FakeApi.md#FakeOuterCompositeSerialize) | **Post** /fake/outer/composite | 
 [**FakeOuterNumberSerialize**](FakeApi.md#FakeOuterNumberSerialize) | **Post** /fake/outer/number | 
 [**FakeOuterStringSerialize**](FakeApi.md#FakeOuterStringSerialize) | **Post** /fake/outer/string | 
+[**TestBodyWithQueryParams**](FakeApi.md#TestBodyWithQueryParams) | **Put** /fake/body-with-query-params | 
 [**TestClientModel**](FakeApi.md#TestClientModel) | **Patch** /fake | To test \&quot;client\&quot; model
 [**TestEndpointParameters**](FakeApi.md#TestEndpointParameters) | **Post** /fake | Fake endpoint for testing various parameters 假端點 偽のエンドポイント 가짜 엔드 포인트 
 [**TestEnumParameters**](FakeApi.md#TestEnumParameters) | **Get** /fake | To test enum parameters
@@ -151,6 +152,33 @@ No authorization required
 ### HTTP request headers
 
  - **Content-Type**: Not defined
+ - **Accept**: Not defined
+
+[[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
+
+# **TestBodyWithQueryParams**
+> TestBodyWithQueryParams(ctx, body, query)
+
+
+### Required Parameters
+
+Name | Type | Description  | Notes
+------------- | ------------- | ------------- | -------------
+ **ctx** | **context.Context** | context for authentication, logging, cancellation, deadlines, tracing, etc.
+  **body** | [**User**](User.md)|  | 
+  **query** | **string**|  | 
+
+### Return type
+
+ (empty response body)
+
+### Authorization
+
+No authorization required
+
+### HTTP request headers
+
+ - **Content-Type**: application/json
  - **Accept**: Not defined
 
 [[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [x] Filed the PR against the correct branch: `3.0.0` branch for changes related to OpenAPI spec 3.0. Default: `master`.
- [x] Copied the [technical committee](https://github.com/swagger-api/swagger-codegen/#swagger-codegen-technical-committee) to review the pull request if your PR is targeting a particular programming language.
@antihax 
### Description of the PR

Fix ordering of package context in imports after change to use "context" package rather than "golang.org/x/net/context".