### PR TITLE
[Clojure] Default */* MIME to application/json

### DIFF
--- a/modules/swagger-codegen/src/main/resources/clojure/core.mustache
+++ b/modules/swagger-codegen/src/main/resources/clojure/core.mustache
@@ -169,6 +169,13 @@
        (map (fn [[k v]] [k (normalize-param v)]))
        (into {})))
 
+(defn default-to-json-mime
+  "Default to JSON MIME if given */* MIME"
+  [mime]
+  (if (= mime "*/*")
+    "application/json"
+    mime))
+
 (defn json-mime?
   "Check if the given MIME is a standard JSON MIME or :json."
   [mime]
@@ -182,7 +189,7 @@
   [mimes]
   (-> (filter json-mime? mimes)
       first
-      (or (first mimes))))
+      (or (default-to-json-mime (first mimes)))))
 
 (defn serialize
   "Serialize the given data according to content-type.

--- a/samples/client/petstore/clojure/git_push.sh
+++ b/samples/client/petstore/clojure/git_push.sh
@@ -36,7 +36,7 @@ git_remote=`git remote`
 if [ "$git_remote" = "" ]; then # git remote not defined
 
     if [ "$GIT_TOKEN" = "" ]; then
-        echo "[INFO] \$GIT_TOKEN (environment variable) is not set. Using the git crediential in your environment."
+        echo "[INFO] \$GIT_TOKEN (environment variable) is not set. Using the git credential in your environment."
         git remote add origin https://github.com/${git_user_id}/${git_repo_id}.git
     else
         git remote add origin https://${git_user_id}:${GIT_TOKEN}@github.com/${git_user_id}/${git_repo_id}.git

--- a/samples/client/petstore/clojure/project.clj
+++ b/samples/client/petstore/clojure/project.clj
@@ -1,6 +1,6 @@
 (defproject swagger-petstore "1.0.0"
   :description "This is a sample server Petstore server.  You can find out more about Swagger at <a href=\"http://swagger.io\">http://swagger.io</a> or on irc.freenode.net, #swagger.  For this sample, you can use the api key \"special-key\" to test the authorization filters"
-  :license {:name "Apache 2.0"
+  :license {:name "Apache-2.0"
             :url "http://www.apache.org/licenses/LICENSE-2.0.html"}
   :dependencies [[org.clojure/clojure "1.7.0"]
                  [clj-http "3.6.0"]

--- a/samples/client/petstore/clojure/src/swagger_petstore/api/pet.clj
+++ b/samples/client/petstore/clojure/src/swagger_petstore/api/pet.clj
@@ -29,6 +29,7 @@
   "
   ([pet-id ] (delete-pet-with-http-info pet-id nil))
   ([pet-id {:keys [api-key ]}]
+   (check-required-params pet-id)
    (call-api "/pet/{petId}" :delete
              {:path-params   {"petId" pet-id }
               :header-params {"api_key" api-key }
@@ -91,6 +92,7 @@
   "Find pet by ID
   Returns a pet when ID < 10.  ID > 10 or nonintegers will simulate API error conditions"
   [pet-id ]
+  (check-required-params pet-id)
   (call-api "/pet/{petId}" :get
             {:path-params   {"petId" pet-id }
              :header-params {}
@@ -133,6 +135,7 @@
   "
   ([pet-id ] (update-pet-with-form-with-http-info pet-id nil))
   ([pet-id {:keys [name status ]}]
+   (check-required-params pet-id)
    (call-api "/pet/{petId}" :post
              {:path-params   {"petId" pet-id }
               :header-params {}
@@ -154,6 +157,7 @@
   "
   ([pet-id ] (upload-file-with-http-info pet-id nil))
   ([pet-id {:keys [additional-metadata ^File file ]}]
+   (check-required-params pet-id)
    (call-api "/pet/{petId}/uploadImage" :post
              {:path-params   {"petId" pet-id }
               :header-params {}

--- a/samples/client/petstore/clojure/src/swagger_petstore/api/store.clj
+++ b/samples/client/petstore/clojure/src/swagger_petstore/api/store.clj
@@ -6,6 +6,7 @@
   "Delete purchase order by ID
   For valid response try integer IDs with value < 1000. Anything above 1000 or nonintegers will generate API errors"
   [order-id ]
+  (check-required-params order-id)
   (call-api "/store/order/{orderId}" :delete
             {:path-params   {"orderId" order-id }
              :header-params {}
@@ -44,6 +45,7 @@
   "Find purchase order by ID
   For valid response try integer IDs with value <= 5 or > 10. Other values will generated exceptions"
   [order-id ]
+  (check-required-params order-id)
   (call-api "/store/order/{orderId}" :get
             {:path-params   {"orderId" order-id }
              :header-params {}

--- a/samples/client/petstore/clojure/src/swagger_petstore/api/user.clj
+++ b/samples/client/petstore/clojure/src/swagger_petstore/api/user.clj
@@ -72,6 +72,7 @@
   "Delete user
   This can only be done by the logged in user."
   [username ]
+  (check-required-params username)
   (call-api "/user/{username}" :delete
             {:path-params   {"username" username }
              :header-params {}
@@ -91,6 +92,7 @@
   "Get user by user name
   "
   [username ]
+  (check-required-params username)
   (call-api "/user/{username}" :get
             {:path-params   {"username" username }
              :header-params {}
@@ -151,6 +153,7 @@
   This can only be done by the logged in user."
   ([username ] (update-user-with-http-info username nil))
   ([username {:keys [body ]}]
+   (check-required-params username)
    (call-api "/user/{username}" :put
              {:path-params   {"username" username }
               :header-params {}

--- a/samples/client/petstore/clojure/src/swagger_petstore/core.clj
+++ b/samples/client/petstore/clojure/src/swagger_petstore/core.clj
@@ -169,6 +169,13 @@
        (map (fn [[k v]] [k (normalize-param v)]))
        (into {})))
 
+(defn default-to-json-mime
+  "Default to JSON MIME if given */* MIME"
+  [mime]
+  (if (= mime "*/*")
+    "application/json"
+    mime))
+
 (defn json-mime?
   "Check if the given MIME is a standard JSON MIME or :json."
   [mime]
@@ -182,7 +189,7 @@
   [mimes]
   (-> (filter json-mime? mimes)
       first
-      (or (first mimes))))
+      (or (default-to-json-mime (first mimes)))))
 
 (defn serialize
   "Serialize the given data according to content-type.


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [x] Filed the PR against the correct branch: `3.0.0` branch for changes related to OpenAPI spec 3.0. Default: `master`.

### Description of the PR

This PR defaults content-type wildcard `*/*` into `application/json` for Clojure client. Without this change it's impossible to call some of the generated API calls (see https://github.com/swagger-api/swagger-codegen/issues/8095)

