### PR TITLE
Fix for uncompilable java client if no model definitions is specified …

### DIFF
--- a/modules/swagger-codegen/src/main/resources/Java/JSON.mustache
+++ b/modules/swagger-codegen/src/main/resources/Java/JSON.mustache
@@ -25,7 +25,9 @@ import org.threeten.bp.OffsetDateTime;
 import org.threeten.bp.format.DateTimeFormatter;
 {{/threetenbp}}
 
+{{#parent.length}}
 import {{modelPackage}}.*;
+{{/parent.length}}
 import okio.ByteString;
 
 import java.io.IOException;

--- a/modules/swagger-codegen/src/main/resources/Java/libraries/retrofit2/JSON.mustache
+++ b/modules/swagger-codegen/src/main/resources/Java/libraries/retrofit2/JSON.mustache
@@ -25,7 +25,9 @@ import org.threeten.bp.OffsetDateTime;
 import org.threeten.bp.format.DateTimeFormatter;
 {{/threetenbp}}
 
+{{#parent.length}}
 import {{modelPackage}}.*;
+{{/parent.length}}
 
 import java.io.IOException;
 import java.io.StringReader;


### PR DESCRIPTION
…(#7836)

After fixes for #6636 the gson based clients would not compile if the
swagger json did not have any model definitions. This can be the case
if the API only uses simple datastructures for input and output. (int,
String, List, Map etc.)

I have not updated the pet-store-clients for this PR. The reason is that the change does not affect the pet store api in any way, since this is fix is for apis with no model definitions.

### PR checklist

- [x] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [x] Filed the PR against the correct branch: `3.0.0` branch for changes related to OpenAPI spec 3.0. Default: `master`.
- [x] Copied the [technical committee](https://github.com/swagger-api/swagger-codegen/#swagger-codegen-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

(details of the change, additional tests that have been done, reference to the issue for tracking, etc)
