### PR TITLE
fix #8128 - added apisToGenerate parameter

### DIFF
--- a/modules/swagger-codegen-maven-plugin/README.md
+++ b/modules/swagger-codegen-maven-plugin/README.md
@@ -54,6 +54,7 @@ mvn clean compile
 - `generateApiTests` - generate the api tests (`true` by default. Only available if `generateApis` is `true`)
 - `generateApiDocumentation` - generate the api documentation (`true` by default. Only available if `generateApis` is `true`)
 - `generateModels` - generate the models (`true` by default)
+- `apisToGenerate` - A comma separated list of apis to generate. All apis is the default.
 - `modelsToGenerate` - A comma separated list of models to generate.  All models is the default.
 - `generateModelTests` - generate the model tests (`true` by default. Only available if `generateModels` is `true`)
 - `generateModelDocumentation` - generate the model documentation (`true` by default. Only available if `generateModels` is `true`)

--- a/modules/swagger-codegen-maven-plugin/src/main/java/io/swagger/codegen/plugin/CodeGenMojo.java
+++ b/modules/swagger-codegen-maven-plugin/src/main/java/io/swagger/codegen/plugin/CodeGenMojo.java
@@ -242,6 +242,12 @@ public class CodeGenMojo extends AbstractMojo {
     private String modelsToGenerate = "";
 
     /**
+     * A comma separated list of apis to generate. All apis is the default.
+     */
+    @Parameter(name = "apisToGenerate", required = false)
+    private String apisToGenerate = "";
+
+    /**
      * Generate the supporting files
      */
     @Parameter(name = "generateSupportingFiles", required = false)
@@ -408,7 +414,7 @@ public class CodeGenMojo extends AbstractMojo {
 
         // Set generation options
         if (null != generateApis && generateApis) {
-            System.setProperty(CodegenConstants.APIS, "");
+            System.setProperty(CodegenConstants.APIS, apisToGenerate);
         } else {
             System.clearProperty(CodegenConstants.APIS);
         }


### PR DESCRIPTION
### PR checklist

- [ ] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [ ] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [ ] Filed the PR against the correct branch: `3.0.0` branch for changes related to OpenAPI spec 3.0. Default: `master`.
- [ ] Copied the [technical committee](https://github.com/swagger-api/swagger-codegen/#swagger-codegen-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

(details of the change, additional tests that have been done, reference to the issue for tracking, etc)

