### PR TITLE
[Elm] Fix elm format in Byte.mustache

### DIFF
--- a/modules/swagger-codegen/src/main/resources/elm/Byte.mustache
+++ b/modules/swagger-codegen/src/main/resources/elm/Byte.mustache
@@ -4,7 +4,8 @@ import Json.Decode as Decode exposing (Decoder)
 import Json.Encode as Encode
 
 
-type alias Byte = String
+type alias Byte =
+    String
 
 
 byteDecoder : Decoder Byte
@@ -15,4 +16,3 @@ byteDecoder =
 byteEncoder : Byte -> Encode.Value
 byteEncoder model =
     Encode.string model
-


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [ ] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [ ] Filed the PR against the correct branch: `3.0.0` branch for changes related to OpenAPI spec 3.0. Default: `master`.
- [x] Copied the [technical committee](https://github.com/swagger-api/swagger-codegen/#swagger-codegen-technical-committee) to review the pull request if your PR is targeting a particular programming language.
(There is nobody)

### Description of the PR

I created a minor fix. The format in the file did not match the defacto standard of `elm-format`. I changed it and want to get into the implementation.

