### PR TITLE
update typescript-node `package-lock.json`

### DIFF
--- a/samples/client/petstore/typescript-node/npm/package-lock.json
+++ b/samples/client/petstore/typescript-node/npm/package-lock.json
@@ -5,39 +5,51 @@
     "requires": true,
     "dependencies": {
         "@types/bluebird": {
-            "version": "3.5.18",
-            "resolved": "https://registry.npmjs.org/@types/bluebird/-/bluebird-3.5.18.tgz",
-            "integrity": "sha512-OTPWHmsyW18BhrnG5x8F7PzeZ2nFxmHGb42bZn79P9hl+GI5cMzyPgQTwNjbem0lJhoru/8vtjAFCUOu3+gE2w=="
+            "version": "3.5.20",
+            "resolved": "https://registry.npmjs.org/@types/bluebird/-/bluebird-3.5.20.tgz",
+            "integrity": "sha512-Wk41MVdF+cHBfVXj/ufUHJeO3BlIQr1McbHZANErMykaCWeDSZbH5erGjNBw2/3UlRdSxZbLfSuQTzFmPOYFsA=="
+        },
+        "@types/caseless": {
+            "version": "0.12.1",
+            "resolved": "https://registry.npmjs.org/@types/caseless/-/caseless-0.12.1.tgz",
+            "integrity": "sha512-FhlMa34NHp9K5MY1Uz8yb+ZvuX0pnvn3jScRSNAb75KHGB8d3rEU6hqMs3Z2vjuytcMfRg6c5CHMc3wtYyD2/A=="
         },
         "@types/form-data": {
             "version": "2.2.1",
             "resolved": "https://registry.npmjs.org/@types/form-data/-/form-data-2.2.1.tgz",
             "integrity": "sha512-JAMFhOaHIciYVh8fb5/83nmuO/AHwmto+Hq7a9y8FzLDcC1KCU344XDOMEmahnrTFlHjgh4L0WJFczNIX2GxnQ==",
             "requires": {
-                "@types/node": "8.0.51"
+                "@types/node": "10.0.5"
             }
         },
         "@types/node": {
-            "version": "8.0.51",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-8.0.51.tgz",
-            "integrity": "sha512-El3+WJk2D/ppWNd2X05aiP5l2k4EwF7KwheknQZls+I26eSICoWRhRIJ56jGgw2dqNGQ5LtNajmBU2ajS28EvQ=="
+            "version": "10.0.5",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-10.0.5.tgz",
+            "integrity": "sha512-he3QlF+xnGlmsnL1H8/CiM6r25kk0STky6U5yIqNh4Nnp9KlJBSdMMIiCzDYtAFLw2rWnJ4XKc1xB2/u/anYow=="
         },
         "@types/request": {
-            "version": "2.0.8",
-            "resolved": "https://registry.npmjs.org/@types/request/-/request-2.0.8.tgz",
-            "integrity": "sha512-fp8gsp0Qlq5wRas4UDjzayBxzWtQVcIumsMaHnNJzrk1Skx4WRpX5/HchSdZZf5/3Jp9m59EUBIGSI6mQEMOOg==",
+            "version": "2.47.0",
+            "resolved": "https://registry.npmjs.org/@types/request/-/request-2.47.0.tgz",
+            "integrity": "sha512-/KXM5oev+nNCLIgBjkwbk8VqxmzI56woD4VUxn95O+YeQ8hJzcSmIZ1IN3WexiqBb6srzDo2bdMbsXxgXNkz5Q==",
             "requires": {
+                "@types/caseless": "0.12.1",
                 "@types/form-data": "2.2.1",
-                "@types/node": "8.0.51"
+                "@types/node": "10.0.5",
+                "@types/tough-cookie": "2.3.2"
             }
         },
+        "@types/tough-cookie": {
+            "version": "2.3.2",
+            "resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-2.3.2.tgz",
+            "integrity": "sha512-vOVmaruQG5EatOU/jM6yU2uCp3Lz6mK1P5Ztu4iJjfM4SVHU9XYktPUQtKlIXuahqXHdEyUarMrBEwg5Cwu+bA=="
+        },
         "ajv": {
-            "version": "5.3.0",
-            "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.3.0.tgz",
-            "integrity": "sha1-RBT/dKUIecII7l/cgm4ywwNUnto=",
+            "version": "5.5.2",
+            "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
+            "integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
             "requires": {
                 "co": "4.6.0",
-                "fast-deep-equal": "1.0.0",
+                "fast-deep-equal": "1.1.0",
                 "fast-json-stable-stringify": "2.0.0",
                 "json-schema-traverse": "0.3.1"
             }
@@ -73,9 +85,9 @@
             "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg="
         },
         "aws4": {
-            "version": "1.6.0",
-            "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.6.0.tgz",
-            "integrity": "sha1-g+9cqGCysy5KDe7e6MdxudtXRx4="
+            "version": "1.7.0",
+            "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.7.0.tgz",
+            "integrity": "sha512-32NDda82rhwD9/JBCCkB+MRYDp0oSvlo2IL6rQWA10PQi7tDUM3eqMSltXmY+Oyl/7N3P3qNtAlv7X0d9bI28w=="
         },
         "babel-code-frame": {
             "version": "6.26.0",
@@ -88,9 +100,9 @@
             }
         },
         "babel-core": {
-            "version": "6.26.0",
-            "resolved": "https://registry.npmjs.org/babel-core/-/babel-core-6.26.0.tgz",
-            "integrity": "sha1-rzL3izGm/O8RnIew/Y2XU/A6C7g=",
+            "version": "6.26.3",
+            "resolved": "https://registry.npmjs.org/babel-core/-/babel-core-6.26.3.tgz",
+            "integrity": "sha512-6jyFLuDmeidKmUEb3NM+/yawG0M2bDZ9Z1qbZP59cyHLz8kYGKYwpJP0UwUKKUiTRNvxfLesJnTedqczP7cTDA==",
             "requires": {
                 "babel-code-frame": "6.26.0",
                 "babel-generator": "6.26.1",
@@ -105,7 +117,7 @@
                 "convert-source-map": "1.5.1",
                 "debug": "2.6.9",
                 "json5": "0.5.1",
-                "lodash": "4.17.5",
+                "lodash": "4.17.10",
                 "minimatch": "3.0.4",
                 "path-is-absolute": "1.0.1",
                 "private": "0.1.8",
@@ -123,7 +135,7 @@
                 "babel-types": "6.26.0",
                 "detect-indent": "4.0.0",
                 "jsesc": "1.3.0",
-                "lodash": "4.17.5",
+                "lodash": "4.17.10",
                 "source-map": "0.5.7",
                 "trim-right": "1.0.1"
             }
@@ -154,7 +166,7 @@
                 "babel-template": "6.26.0",
                 "babel-traverse": "6.26.0",
                 "babel-types": "6.26.0",
-                "lodash": "4.17.5"
+                "lodash": "4.17.10"
             }
         },
         "babel-register": {
@@ -162,11 +174,11 @@
             "resolved": "https://registry.npmjs.org/babel-register/-/babel-register-6.26.0.tgz",
             "integrity": "sha1-btAhFz4vy0htestFxgCahW9kcHE=",
             "requires": {
-                "babel-core": "6.26.0",
+                "babel-core": "6.26.3",
                 "babel-runtime": "6.26.0",
-                "core-js": "2.5.3",
+                "core-js": "2.5.6",
                 "home-or-tmp": "2.0.0",
-                "lodash": "4.17.5",
+                "lodash": "4.17.10",
                 "mkdirp": "0.5.1",
                 "source-map-support": "0.4.18"
             }
@@ -176,7 +188,7 @@
             "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
             "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
             "requires": {
-                "core-js": "2.5.3",
+                "core-js": "2.5.6",
                 "regenerator-runtime": "0.11.1"
             }
         },
@@ -189,7 +201,7 @@
                 "babel-traverse": "6.26.0",
                 "babel-types": "6.26.0",
                 "babylon": "6.18.0",
-                "lodash": "4.17.5"
+                "lodash": "4.17.10"
             }
         },
         "babel-traverse": {
@@ -205,7 +217,7 @@
                 "debug": "2.6.9",
                 "globals": "9.18.0",
                 "invariant": "2.2.4",
-                "lodash": "4.17.5"
+                "lodash": "4.17.10"
             }
         },
         "babel-types": {
@@ -215,7 +227,7 @@
             "requires": {
                 "babel-runtime": "6.26.0",
                 "esutils": "2.0.2",
-                "lodash": "4.17.5",
+                "lodash": "4.17.10",
                 "to-fast-properties": "1.0.3"
             }
         },
@@ -248,7 +260,7 @@
             "resolved": "https://registry.npmjs.org/boom/-/boom-4.3.1.tgz",
             "integrity": "sha1-T4owBctKfjiJ90kDD9JbluAdLjE=",
             "requires": {
-                "hoek": "4.2.0"
+                "hoek": "4.2.1"
             }
         },
         "brace-expansion": {
@@ -283,9 +295,9 @@
             "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ="
         },
         "combined-stream": {
-            "version": "1.0.5",
-            "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
-            "integrity": "sha1-k4NwpXtKUd6ix3wV1cX9+JUWQAk=",
+            "version": "1.0.6",
+            "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.6.tgz",
+            "integrity": "sha1-cj599ugBrFYTETp+RFqbactjKBg=",
             "requires": {
                 "delayed-stream": "1.0.0"
             }
@@ -301,9 +313,9 @@
             "integrity": "sha1-uCeAl7m8IpNl3lxiz1/K7YtVmeU="
         },
         "core-js": {
-            "version": "2.5.3",
-            "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.3.tgz",
-            "integrity": "sha1-isw4NFgk8W2DZbfJtCWRaOjtYD4="
+            "version": "2.5.6",
+            "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.6.tgz",
+            "integrity": "sha512-lQUVfQi0aLix2xpyjrrJEvfuYCqPc/HwmTKsC/VNf8q0zsjX7SQZtp4+oRONN5Tsur9GDETPjj+Ub2iDiGZfSQ=="
         },
         "core-util-is": {
             "version": "1.0.2",
@@ -323,7 +335,7 @@
                     "resolved": "https://registry.npmjs.org/boom/-/boom-5.2.0.tgz",
                     "integrity": "sha512-Z5BTk6ZRe4tXXQlkqftmsAUANpXmuwlsF5Oov8ThoMbQRzdGTA1ngYRW160GexgOgjsFOKJz0LYhoNi+2AMBUw==",
                     "requires": {
-                        "hoek": "4.2.0"
+                        "hoek": "4.2.1"
                     }
                 }
             }
@@ -387,9 +399,9 @@
             "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU="
         },
         "fast-deep-equal": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.0.0.tgz",
-            "integrity": "sha1-liVqO8l1WV6zbYLpkp0GDYk0Of8="
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz",
+            "integrity": "sha1-wFNHeBfIa1HaqFPIHgWbcz0CNhQ="
         },
         "fast-json-stable-stringify": {
             "version": "2.0.0",
@@ -402,13 +414,13 @@
             "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE="
         },
         "form-data": {
-            "version": "2.3.1",
-            "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.1.tgz",
-            "integrity": "sha1-b7lPvXGIUwbXPRXMSX/kzE7NRL8=",
+            "version": "2.3.2",
+            "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.2.tgz",
+            "integrity": "sha1-SXBJi+YEwgwAXU9cI67NIda0kJk=",
             "requires": {
                 "asynckit": "0.4.0",
-                "combined-stream": "1.0.5",
-                "mime-types": "2.1.17"
+                "combined-stream": "1.0.6",
+                "mime-types": "2.1.18"
             }
         },
         "getpass": {
@@ -434,7 +446,7 @@
             "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.0.3.tgz",
             "integrity": "sha1-ukAsJmGU8VlW7xXg/PJCmT9qff0=",
             "requires": {
-                "ajv": "5.3.0",
+                "ajv": "5.5.2",
                 "har-schema": "2.0.0"
             }
         },
@@ -453,14 +465,14 @@
             "requires": {
                 "boom": "4.3.1",
                 "cryptiles": "3.1.2",
-                "hoek": "4.2.0",
+                "hoek": "4.2.1",
                 "sntp": "2.1.0"
             }
         },
         "hoek": {
-            "version": "4.2.0",
-            "resolved": "https://registry.npmjs.org/hoek/-/hoek-4.2.0.tgz",
-            "integrity": "sha512-v0XCLxICi9nPfYrS9RL8HbYnXi9obYAeLbSP00BmnZwCK9+Ih9WOjoZ8YoHCoav2csqn4FOz4Orldsy2dmDwmQ=="
+            "version": "4.2.1",
+            "resolved": "https://registry.npmjs.org/hoek/-/hoek-4.2.1.tgz",
+            "integrity": "sha512-QLg82fGkfnJ/4iy1xZ81/9SIJiq1NGFUMGs6ParyjBZr6jW2Ufj/snDqTHixNlHdPNwN2RLVD0Pi3igeK9+JfA=="
         },
         "home-or-tmp": {
             "version": "2.0.0",
@@ -478,7 +490,7 @@
             "requires": {
                 "assert-plus": "1.0.0",
                 "jsprim": "1.4.1",
-                "sshpk": "1.13.1"
+                "sshpk": "1.14.1"
             }
         },
         "invariant": {
@@ -555,9 +567,9 @@
             }
         },
         "lodash": {
-            "version": "4.17.5",
-            "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.5.tgz",
-            "integrity": "sha512-svL3uiZf1RwhH+cWrfZn3A4+U58wbP0tGVTLQPbjplZxZ8ROD9VLuNgsRniTlLe7OlSqR79RUehXgpBW/s0IQw=="
+            "version": "4.17.10",
+            "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz",
+            "integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg=="
         },
         "loose-envify": {
             "version": "1.3.1",
@@ -568,16 +580,16 @@
             }
         },
         "mime-db": {
-            "version": "1.30.0",
-            "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.30.0.tgz",
-            "integrity": "sha1-dMZD2i3Z1qRTmZY0ZbJtXKfXHwE="
+            "version": "1.33.0",
+            "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.33.0.tgz",
+            "integrity": "sha512-BHJ/EKruNIqJf/QahvxwQZXKygOQ256myeN/Ew+THcAa5q+PjyTTMMeNQC4DZw5AwfvelsUrA6B67NKMqXDbzQ=="
         },
         "mime-types": {
-            "version": "2.1.17",
-            "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.17.tgz",
-            "integrity": "sha1-Cdejk/A+mVp5+K+Fe3Cp4KsWVXo=",
+            "version": "2.1.18",
+            "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.18.tgz",
+            "integrity": "sha512-lc/aahn+t4/SWV/qcmumYjymLsWfN3ELhpmVuUFjgsORruuZPVSwAQryq+HHGvO/SI2KVX26bx+En+zhM8g8hQ==",
             "requires": {
-                "mime-db": "1.30.0"
+                "mime-db": "1.33.0"
             }
         },
         "minimatch": {
@@ -647,9 +659,9 @@
             "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4="
         },
         "qs": {
-            "version": "6.5.1",
-            "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.1.tgz",
-            "integrity": "sha512-eRzhrN1WSINYCDCbrz796z37LOe3m5tmW7RQf6oBntukAG1nmovJvhnwHHRMAfeoItc1m2Hk02WER2aQ/iqs+A=="
+            "version": "6.5.2",
+            "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
+            "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA=="
         },
         "regenerator-runtime": {
             "version": "0.11.1",
@@ -665,32 +677,32 @@
             }
         },
         "request": {
-            "version": "2.83.0",
-            "resolved": "https://registry.npmjs.org/request/-/request-2.83.0.tgz",
-            "integrity": "sha512-lR3gD69osqm6EYLk9wB/G1W/laGWjzH90t1vEa2xuxHD5KUrSzp9pUSfTm+YC5Nxt2T8nMPEvKlhbQayU7bgFw==",
+            "version": "2.85.0",
+            "resolved": "https://registry.npmjs.org/request/-/request-2.85.0.tgz",
+            "integrity": "sha512-8H7Ehijd4js+s6wuVPLjwORxD4zeuyjYugprdOXlPSqaApmL/QOy+EB/beICHVCHkGMKNh5rvihb5ov+IDw4mg==",
             "requires": {
                 "aws-sign2": "0.7.0",
-                "aws4": "1.6.0",
+                "aws4": "1.7.0",
                 "caseless": "0.12.0",
-                "combined-stream": "1.0.5",
+                "combined-stream": "1.0.6",
                 "extend": "3.0.1",
                 "forever-agent": "0.6.1",
-                "form-data": "2.3.1",
+                "form-data": "2.3.2",
                 "har-validator": "5.0.3",
                 "hawk": "6.0.2",
                 "http-signature": "1.2.0",
                 "is-typedarray": "1.0.0",
                 "isstream": "0.1.2",
                 "json-stringify-safe": "5.0.1",
-                "mime-types": "2.1.17",
+                "mime-types": "2.1.18",
                 "oauth-sign": "0.8.2",
                 "performance-now": "2.1.0",
-                "qs": "6.5.1",
-                "safe-buffer": "5.1.1",
+                "qs": "6.5.2",
+                "safe-buffer": "5.1.2",
                 "stringstream": "0.0.5",
-                "tough-cookie": "2.3.3",
+                "tough-cookie": "2.3.4",
                 "tunnel-agent": "0.6.0",
-                "uuid": "3.1.0"
+                "uuid": "3.2.1"
             }
         },
         "rewire": {
@@ -698,14 +710,14 @@
             "resolved": "https://registry.npmjs.org/rewire/-/rewire-3.0.2.tgz",
             "integrity": "sha512-ejkkt3qYnsQ38ifc9llAAzuHiGM7kR8N5/mL3aHWgmWwet0OMFcmJB8aTsMV2PBHCWxNVTLCeRfBpEa8X2+1fw==",
             "requires": {
-                "babel-core": "6.26.0",
+                "babel-core": "6.26.3",
                 "babel-plugin-transform-es2015-block-scoping": "6.26.0"
             }
         },
         "safe-buffer": {
-            "version": "5.1.1",
-            "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
-            "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg=="
+            "version": "5.1.2",
+            "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+            "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
         },
         "slash": {
             "version": "1.0.0",
@@ -717,7 +729,7 @@
             "resolved": "https://registry.npmjs.org/sntp/-/sntp-2.1.0.tgz",
             "integrity": "sha512-FL1b58BDrqS3A11lJ0zEdnJ3UOKqVxawAkF3k7F0CVN7VQ34aZrV+G8BZ1WC9ZL7NyrwsW0oviwsWDgRuVYtJg==",
             "requires": {
-                "hoek": "4.2.0"
+                "hoek": "4.2.1"
             }
         },
         "source-map": {
@@ -734,9 +746,9 @@
             }
         },
         "sshpk": {
-            "version": "1.13.1",
-            "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.13.1.tgz",
-            "integrity": "sha1-US322mKHFEMW3EwY/hzx2UBzm+M=",
+            "version": "1.14.1",
+            "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.14.1.tgz",
+            "integrity": "sha1-Ew9Zde3a2WPx1W+SuaxsUfqfg+s=",
             "requires": {
                 "asn1": "0.2.3",
                 "assert-plus": "1.0.0",
@@ -772,9 +784,9 @@
             "integrity": "sha1-uDVx+k2MJbguIxsG46MFXeTKGkc="
         },
         "tough-cookie": {
-            "version": "2.3.3",
-            "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.3.tgz",
-            "integrity": "sha1-C2GKVWW23qkL80JdBNVe3EdadWE=",
+            "version": "2.3.4",
+            "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.4.tgz",
+            "integrity": "sha512-TZ6TTfI5NtZnuyy/Kecv+CnoROnyXn2DN97LontgQpCwsX2XyLYCC0ENhYkehSOwAp8rTQKc/NUIF7BkQ5rKLA==",
             "requires": {
                 "punycode": "1.4.1"
             }
@@ -789,7 +801,7 @@
             "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
             "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
             "requires": {
-                "safe-buffer": "5.1.1"
+                "safe-buffer": "5.1.2"
             }
         },
         "tweetnacl": {
@@ -805,9 +817,9 @@
             "dev": true
         },
         "uuid": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.1.0.tgz",
-            "integrity": "sha512-DIWtzUkw04M4k3bf1IcpS2tngXEL26YUD2M0tMDUpnUrz2hgzUBlD55a4FjdLGPvfHxS6uluGWvaVEqgBcVa+g=="
+            "version": "3.2.1",
+            "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.2.1.tgz",
+            "integrity": "sha512-jZnMwlb9Iku/O3smGWvZhauCf6cvvpKi4BKRiliS3cxnI+Gz9j5MEpTz2UFuXiKPJocb7gnsLHwiS05ige5BEA=="
         },
         "verror": {
             "version": "1.10.0",


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [ ] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [x] Filed the PR against the correct branch: `3.0.0` branch for changes related to OpenAPI spec 3.0. Default: `master`.
- [ ] Copied the [technical committee](https://github.com/swagger-api/swagger-codegen/#swagger-codegen-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

This PR updates typescript-node's `package-lock.json`, with the goal of avoiding an [insecure version of `hoek`](https://hackerone.com/reports/310439).