### PR TITLE
#8159: Correctly handle multiple valid responses

### DIFF
--- a/modules/swagger-codegen/src/main/resources/php/api.mustache
+++ b/modules/swagger-codegen/src/main/resources/php/api.mustache
@@ -176,9 +176,9 @@ use {{invokerPackage}}\ObjectSerializer;
                         $response->getHeaders()
                     ];
             {{/dataType}}
-            {{#-first}}
+            {{#-last}}
             }
-            {{/-first}}
+            {{/-last}}
         {{/responses}}
 
             return [null, $statusCode, $response->getHeaders()];

--- a/modules/swagger-codegen/src/main/resources/php/api.mustache
+++ b/modules/swagger-codegen/src/main/resources/php/api.mustache
@@ -95,7 +95,7 @@ use {{invokerPackage}}\ObjectSerializer;
      *
      * @throws \{{invokerPackage}}\ApiException on non-2xx response
      * @throws \InvalidArgumentException
-     * @return {{#returnType}}{{{returnType}}}{{/returnType}}{{^returnType}}void{{/returnType}}
+     * @return {{#responses}}{{^-first}}|{{/-first}}{{{dataType}}}{{/responses}}{{^responses}}void{{/responses}}
      */
     public function {{operationId}}({{#allParams}}${{paramName}}{{^required}} = {{#defaultValue}}'{{{.}}}'{{/defaultValue}}{{^defaultValue}}null{{/defaultValue}}{{/required}}{{#hasMore}}, {{/hasMore}}{{/allParams}})
     {
@@ -120,11 +120,10 @@ use {{invokerPackage}}\ObjectSerializer;
      *
      * @throws \{{invokerPackage}}\ApiException on non-2xx response
      * @throws \InvalidArgumentException
-     * @return array of {{#returnType}}{{{returnType}}}{{/returnType}}{{^returnType}}null{{/returnType}}, HTTP status code, HTTP response headers (array of strings)
+     * @return array of {{#responses}}{{^-first}}|{{/-first}}{{{dataType}}}{{/responses}}{{^responses}}null{{/responses}}, HTTP status code, HTTP response headers (array of strings)
      */
     public function {{operationId}}WithHttpInfo({{#allParams}}${{paramName}}{{^required}} = {{#defaultValue}}'{{{.}}}'{{/defaultValue}}{{^defaultValue}}null{{/defaultValue}}{{/required}}{{#hasMore}}, {{/hasMore}}{{/allParams}})
     {
-        $returnType = '{{returnType}}';
         $request = $this->{{operationId}}Request({{#allParams}}${{paramName}}{{#hasMore}}, {{/hasMore}}{{/allParams}});
 
         try {
@@ -154,27 +153,35 @@ use {{invokerPackage}}\ObjectSerializer;
                     $response->getBody()
                 );
             }
+        {{#responses}}
+            {{#-first}}
 
-            {{#returnType}}
             $responseBody = $response->getBody();
-            if ($returnType === '\SplFileObject') {
-                $content = $responseBody; //stream goes to serializer
-            } else {
-                $content = $responseBody->getContents();
-                if ($returnType !== 'string') {
-                    $content = json_decode($content);
-                }
-            }
+            switch($statusCode) {
+            {{/-first}}
+            {{#dataType}}
+                {{^isWildcard}}case {{code}}:{{/isWildcard}}{{#isWildcard}}default:{{/isWildcard}}
+                    if ('{{dataType}}' === '\SplFileObject') {
+                        $content = $responseBody; //stream goes to serializer
+                    } else {
+                        $content = $responseBody->getContents();
+                        if ('{{dataType}}' !== 'string') {
+                            $content = json_decode($content);
+                        }
+                    }
 
-            return [
-                ObjectSerializer::deserialize($content, $returnType, []),
-                $response->getStatusCode(),
-                $response->getHeaders()
-            ];
-            {{/returnType}}
-            {{^returnType}}
+                    return [
+                        ObjectSerializer::deserialize($content, '{{dataType}}', []),
+                        $response->getStatusCode(),
+                        $response->getHeaders()
+                    ];
+            {{/dataType}}
+            {{#-first}}
+            }
+            {{/-first}}
+        {{/responses}}
+
             return [null, $statusCode, $response->getHeaders()];
-            {{/returnType}}
 
         } catch (ApiException $e) {
             switch ($e->getCode()) {


### PR DESCRIPTION
### PR checklist

- [X] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [X] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [X] Filed the PR against the correct branch: `3.0.0` branch for changes related to OpenAPI spec 3.0. Default: `master`.
- [X] Copied the [technical committee](https://github.com/swagger-api/swagger-codegen/#swagger-codegen-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

Fixed issue #8159 

### Technical Committee
- @jebentier
- @dkarlovi
- @mandrean
- @jfastnacht
- @ackintosh