### PR TITLE
[python-asyncio] client supports _preload_content

### DIFF
--- a/modules/swagger-codegen/src/main/resources/python/asyncio/rest.mustache
+++ b/modules/swagger-codegen/src/main/resources/python/asyncio/rest.mustache
@@ -152,15 +152,17 @@ class RESTClientObject(object):
                          declared content type."""
                 raise ApiException(status=0, reason=msg)
 
-        async with self.pool_manager.request(**args) as r:
+        r = await self.pool_manager.request(**args)
+        if _preload_content:
+
             data = await r.text()
             r = RESTResponse(r, data)
 
-        # log response body
-        logger.debug("response body: %s", r.data)
+            # log response body
+            logger.debug("response body: %s", r.data)
 
-        if not 200 <= r.status <= 299:
-            raise ApiException(http_resp=r)
+            if not 200 <= r.status <= 299:
+                raise ApiException(http_resp=r)
 
         return r
 

--- a/samples/client/petstore/python-asyncio/README.md
+++ b/samples/client/petstore/python-asyncio/README.md
@@ -50,8 +50,9 @@ import time
 import petstore_api
 from petstore_api.rest import ApiException
 from pprint import pprint
+
 # create an instance of the API class
-api_instance = petstore_api.AnotherFakeApi()
+api_instance = petstore_api.AnotherFakeApi(petstore_api.ApiClient(configuration))
 body = petstore_api.Client() # Client | client model
 
 try:
@@ -74,6 +75,7 @@ Class | Method | HTTP request | Description
 *FakeApi* | [**fake_outer_composite_serialize**](docs/FakeApi.md#fake_outer_composite_serialize) | **POST** /fake/outer/composite | 
 *FakeApi* | [**fake_outer_number_serialize**](docs/FakeApi.md#fake_outer_number_serialize) | **POST** /fake/outer/number | 
 *FakeApi* | [**fake_outer_string_serialize**](docs/FakeApi.md#fake_outer_string_serialize) | **POST** /fake/outer/string | 
+*FakeApi* | [**test_body_with_query_params**](docs/FakeApi.md#test_body_with_query_params) | **PUT** /fake/body-with-query-params | 
 *FakeApi* | [**test_client_model**](docs/FakeApi.md#test_client_model) | **PATCH** /fake | To test \&quot;client\&quot; model
 *FakeApi* | [**test_endpoint_parameters**](docs/FakeApi.md#test_endpoint_parameters) | **POST** /fake | Fake endpoint for testing various parameters 假端點 偽のエンドポイント 가짜 엔드 포인트 
 *FakeApi* | [**test_enum_parameters**](docs/FakeApi.md#test_enum_parameters) | **GET** /fake | To test enum parameters

--- a/samples/client/petstore/python-asyncio/docs/EnumTest.md
+++ b/samples/client/petstore/python-asyncio/docs/EnumTest.md
@@ -4,6 +4,7 @@
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **enum_string** | **str** |  | [optional] 
+**enum_string_required** | **str** |  | 
 **enum_integer** | **int** |  | [optional] 
 **enum_number** | **float** |  | [optional] 
 **outer_enum** | [**OuterEnum**](OuterEnum.md) |  | [optional] 

--- a/samples/client/petstore/python-asyncio/docs/FakeApi.md
+++ b/samples/client/petstore/python-asyncio/docs/FakeApi.md
@@ -8,6 +8,7 @@ Method | HTTP request | Description
 [**fake_outer_composite_serialize**](FakeApi.md#fake_outer_composite_serialize) | **POST** /fake/outer/composite | 
 [**fake_outer_number_serialize**](FakeApi.md#fake_outer_number_serialize) | **POST** /fake/outer/number | 
 [**fake_outer_string_serialize**](FakeApi.md#fake_outer_string_serialize) | **POST** /fake/outer/string | 
+[**test_body_with_query_params**](FakeApi.md#test_body_with_query_params) | **PUT** /fake/body-with-query-params | 
 [**test_client_model**](FakeApi.md#test_client_model) | **PATCH** /fake | To test \&quot;client\&quot; model
 [**test_endpoint_parameters**](FakeApi.md#test_endpoint_parameters) | **POST** /fake | Fake endpoint for testing various parameters 假端點 偽のエンドポイント 가짜 엔드 포인트 
 [**test_enum_parameters**](FakeApi.md#test_enum_parameters) | **GET** /fake | To test enum parameters
@@ -199,6 +200,52 @@ No authorization required
 ### HTTP request headers
 
  - **Content-Type**: Not defined
+ - **Accept**: Not defined
+
+[[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
+
+# **test_body_with_query_params**
+> test_body_with_query_params(body, query)
+
+
+
+### Example
+```python
+from __future__ import print_function
+import time
+import petstore_api
+from petstore_api.rest import ApiException
+from pprint import pprint
+
+# create an instance of the API class
+api_instance = petstore_api.FakeApi()
+body = petstore_api.User() # User | 
+query = 'query_example' # str | 
+
+try:
+    api_instance.test_body_with_query_params(body, query)
+except ApiException as e:
+    print("Exception when calling FakeApi->test_body_with_query_params: %s\n" % e)
+```
+
+### Parameters
+
+Name | Type | Description  | Notes
+------------- | ------------- | ------------- | -------------
+ **body** | [**User**](User.md)|  | 
+ **query** | **str**|  | 
+
+### Return type
+
+void (empty response body)
+
+### Authorization
+
+No authorization required
+
+### HTTP request headers
+
+ - **Content-Type**: application/json
  - **Accept**: Not defined
 
 [[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)

--- a/samples/client/petstore/python-asyncio/petstore_api/api/fake_api.py
+++ b/samples/client/petstore/python-asyncio/petstore_api/api/fake_api.py
@@ -381,6 +381,107 @@ class FakeApi(object):
             _request_timeout=params.get('_request_timeout'),
             collection_formats=collection_formats)
 
+    def test_body_with_query_params(self, body, query, **kwargs):  # noqa: E501
+        """test_body_with_query_params  # noqa: E501
+
+        This method makes a synchronous HTTP request by default. To make an
+        asynchronous HTTP request, please pass async=True
+        >>> thread = api.test_body_with_query_params(body, query, async=True)
+        >>> result = thread.get()
+
+        :param async bool
+        :param User body: (required)
+        :param str query: (required)
+        :return: None
+                 If the method is called asynchronously,
+                 returns the request thread.
+        """
+        kwargs['_return_http_data_only'] = True
+        if kwargs.get('async'):
+            return self.test_body_with_query_params_with_http_info(body, query, **kwargs)  # noqa: E501
+        else:
+            (data) = self.test_body_with_query_params_with_http_info(body, query, **kwargs)  # noqa: E501
+            return data
+
+    def test_body_with_query_params_with_http_info(self, body, query, **kwargs):  # noqa: E501
+        """test_body_with_query_params  # noqa: E501
+
+        This method makes a synchronous HTTP request by default. To make an
+        asynchronous HTTP request, please pass async=True
+        >>> thread = api.test_body_with_query_params_with_http_info(body, query, async=True)
+        >>> result = thread.get()
+
+        :param async bool
+        :param User body: (required)
+        :param str query: (required)
+        :return: None
+                 If the method is called asynchronously,
+                 returns the request thread.
+        """
+
+        all_params = ['body', 'query']  # noqa: E501
+        all_params.append('async')
+        all_params.append('_return_http_data_only')
+        all_params.append('_preload_content')
+        all_params.append('_request_timeout')
+
+        params = locals()
+        for key, val in six.iteritems(params['kwargs']):
+            if key not in all_params:
+                raise TypeError(
+                    "Got an unexpected keyword argument '%s'"
+                    " to method test_body_with_query_params" % key
+                )
+            params[key] = val
+        del params['kwargs']
+        # verify the required parameter 'body' is set
+        if ('body' not in params or
+                params['body'] is None):
+            raise ValueError("Missing the required parameter `body` when calling `test_body_with_query_params`")  # noqa: E501
+        # verify the required parameter 'query' is set
+        if ('query' not in params or
+                params['query'] is None):
+            raise ValueError("Missing the required parameter `query` when calling `test_body_with_query_params`")  # noqa: E501
+
+        collection_formats = {}
+
+        path_params = {}
+
+        query_params = []
+        if 'query' in params:
+            query_params.append(('query', params['query']))  # noqa: E501
+
+        header_params = {}
+
+        form_params = []
+        local_var_files = {}
+
+        body_params = None
+        if 'body' in params:
+            body_params = params['body']
+        # HTTP header `Content-Type`
+        header_params['Content-Type'] = self.api_client.select_header_content_type(  # noqa: E501
+            ['application/json'])  # noqa: E501
+
+        # Authentication setting
+        auth_settings = []  # noqa: E501
+
+        return self.api_client.call_api(
+            '/fake/body-with-query-params', 'PUT',
+            path_params,
+            query_params,
+            header_params,
+            body=body_params,
+            post_params=form_params,
+            files=local_var_files,
+            response_type=None,  # noqa: E501
+            auth_settings=auth_settings,
+            async=params.get('async'),
+            _return_http_data_only=params.get('_return_http_data_only'),
+            _preload_content=params.get('_preload_content', True),
+            _request_timeout=params.get('_request_timeout'),
+            collection_formats=collection_formats)
+
     def test_client_model(self, body, **kwargs):  # noqa: E501
         """To test \&quot;client\&quot; model  # noqa: E501
 

--- a/samples/client/petstore/python-asyncio/petstore_api/models/enum_test.py
+++ b/samples/client/petstore/python-asyncio/petstore_api/models/enum_test.py
@@ -34,6 +34,7 @@ class EnumTest(object):
     """
     swagger_types = {
         'enum_string': 'str',
+        'enum_string_required': 'str',
         'enum_integer': 'int',
         'enum_number': 'float',
         'outer_enum': 'OuterEnum'
@@ -41,15 +42,17 @@ class EnumTest(object):
 
     attribute_map = {
         'enum_string': 'enum_string',
+        'enum_string_required': 'enum_string_required',
         'enum_integer': 'enum_integer',
         'enum_number': 'enum_number',
         'outer_enum': 'outerEnum'
     }
 
-    def __init__(self, enum_string=None, enum_integer=None, enum_number=None, outer_enum=None):  # noqa: E501
+    def __init__(self, enum_string=None, enum_string_required=None, enum_integer=None, enum_number=None, outer_enum=None):  # noqa: E501
         """EnumTest - a model defined in Swagger"""  # noqa: E501
 
         self._enum_string = None
+        self._enum_string_required = None
         self._enum_integer = None
         self._enum_number = None
         self._outer_enum = None
@@ -57,6 +60,7 @@ class EnumTest(object):
 
         if enum_string is not None:
             self.enum_string = enum_string
+        self.enum_string_required = enum_string_required
         if enum_integer is not None:
             self.enum_integer = enum_integer
         if enum_number is not None:
@@ -90,6 +94,35 @@ class EnumTest(object):
             )
 
         self._enum_string = enum_string
+
+    @property
+    def enum_string_required(self):
+        """Gets the enum_string_required of this EnumTest.  # noqa: E501
+
+
+        :return: The enum_string_required of this EnumTest.  # noqa: E501
+        :rtype: str
+        """
+        return self._enum_string_required
+
+    @enum_string_required.setter
+    def enum_string_required(self, enum_string_required):
+        """Sets the enum_string_required of this EnumTest.
+
+
+        :param enum_string_required: The enum_string_required of this EnumTest.  # noqa: E501
+        :type: str
+        """
+        if enum_string_required is None:
+            raise ValueError("Invalid value for `enum_string_required`, must not be `None`")  # noqa: E501
+        allowed_values = ["UPPER", "lower", ""]  # noqa: E501
+        if enum_string_required not in allowed_values:
+            raise ValueError(
+                "Invalid value for `enum_string_required` ({0}), must be one of {1}"  # noqa: E501
+                .format(enum_string_required, allowed_values)
+            )
+
+        self._enum_string_required = enum_string_required
 
     @property
     def enum_integer(self):

--- a/samples/client/petstore/python-asyncio/petstore_api/rest.py
+++ b/samples/client/petstore/python-asyncio/petstore_api/rest.py
@@ -161,15 +161,17 @@ class RESTClientObject(object):
                          declared content type."""
                 raise ApiException(status=0, reason=msg)
 
-        async with self.pool_manager.request(**args) as r:
+        r = await self.pool_manager.request(**args)
+        if _preload_content:
+
             data = await r.text()
             r = RESTResponse(r, data)
 
-        # log response body
-        logger.debug("response body: %s", r.data)
+            # log response body
+            logger.debug("response body: %s", r.data)
 
-        if not 200 <= r.status <= 299:
-            raise ApiException(http_resp=r)
+            if not 200 <= r.status <= 299:
+                raise ApiException(http_resp=r)
 
         return r
 


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [ ] Filed the PR against the correct branch: `3.0.0` branch for changes related to OpenAPI spec 3.0. Default: `master`.
- [x] Copied the [technical committee](https://github.com/swagger-api/swagger-codegen/#swagger-codegen-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

* add support for parameters `_preload_content` in python-asyncio client
* regenerate sample code

PTAL @kenjones-cisco