### PR TITLE
[Swift3] Fix PromiseKit missing fulfil parameter

### DIFF
--- a/modules/swagger-codegen/src/main/resources/swift3/api.mustache
+++ b/modules/swagger-codegen/src/main/resources/swift3/api.mustache
@@ -61,7 +61,7 @@ open class {{classname}}: APIBase {
             if let error = error {
                 deferred.reject(error)
             } else {
-                deferred.fulfill({{#returnType}}data!{{/returnType}})
+                deferred.fulfill({{#returnType}}data!{{/returnType}}{{^returnType}}(){{/returnType}})
             }
         }
         return deferred.promise

--- a/samples/client/petstore/swift3/promisekit/PetstoreClient/Classes/Swaggers/APIs/FakeAPI.swift
+++ b/samples/client/petstore/swift3/promisekit/PetstoreClient/Classes/Swaggers/APIs/FakeAPI.swift
@@ -298,7 +298,7 @@ open class FakeAPI: APIBase {
             if let error = error {
                 deferred.reject(error)
             } else {
-                deferred.fulfill()
+                deferred.fulfill(())
             }
         }
         return deferred.promise
@@ -460,7 +460,7 @@ open class FakeAPI: APIBase {
             if let error = error {
                 deferred.reject(error)
             } else {
-                deferred.fulfill()
+                deferred.fulfill(())
             }
         }
         return deferred.promise
@@ -495,8 +495,8 @@ open class FakeAPI: APIBase {
         
         var url = URLComponents(string: URLString)
         url?.queryItems = APIHelper.mapValuesToQueryItems(values:[
-            "enum_query_string_array": enumQueryStringArray, 
-            "enum_query_string": enumQueryString?.rawValue, 
+            "enum_query_string_array": enumQueryStringArray,
+            "enum_query_string": enumQueryString?.rawValue,
             "enum_query_integer": enumQueryInteger?.rawValue
         ])
         let nillableHeaders: [String: Any?] = [
@@ -534,7 +534,7 @@ open class FakeAPI: APIBase {
             if let error = error {
                 deferred.reject(error)
             } else {
-                deferred.fulfill()
+                deferred.fulfill(())
             }
         }
         return deferred.promise

--- a/samples/client/petstore/swift3/promisekit/PetstoreClient/Classes/Swaggers/APIs/PetAPI.swift
+++ b/samples/client/petstore/swift3/promisekit/PetstoreClient/Classes/Swaggers/APIs/PetAPI.swift
@@ -33,7 +33,7 @@ open class PetAPI: APIBase {
             if let error = error {
                 deferred.reject(error)
             } else {
-                deferred.fulfill()
+                deferred.fulfill(())
             }
         }
         return deferred.promise
@@ -85,7 +85,7 @@ open class PetAPI: APIBase {
             if let error = error {
                 deferred.reject(error)
             } else {
-                deferred.fulfill()
+                deferred.fulfill(())
             }
         }
         return deferred.promise
@@ -531,7 +531,7 @@ open class PetAPI: APIBase {
             if let error = error {
                 deferred.reject(error)
             } else {
-                deferred.fulfill()
+                deferred.fulfill(())
             }
         }
         return deferred.promise
@@ -585,7 +585,7 @@ open class PetAPI: APIBase {
             if let error = error {
                 deferred.reject(error)
             } else {
-                deferred.fulfill()
+                deferred.fulfill(())
             }
         }
         return deferred.promise

--- a/samples/client/petstore/swift3/promisekit/PetstoreClient/Classes/Swaggers/APIs/StoreAPI.swift
+++ b/samples/client/petstore/swift3/promisekit/PetstoreClient/Classes/Swaggers/APIs/StoreAPI.swift
@@ -33,7 +33,7 @@ open class StoreAPI: APIBase {
             if let error = error {
                 deferred.reject(error)
             } else {
-                deferred.fulfill()
+                deferred.fulfill(())
             }
         }
         return deferred.promise

--- a/samples/client/petstore/swift3/promisekit/PetstoreClient/Classes/Swaggers/APIs/UserAPI.swift
+++ b/samples/client/petstore/swift3/promisekit/PetstoreClient/Classes/Swaggers/APIs/UserAPI.swift
@@ -33,7 +33,7 @@ open class UserAPI: APIBase {
             if let error = error {
                 deferred.reject(error)
             } else {
-                deferred.fulfill()
+                deferred.fulfill(())
             }
         }
         return deferred.promise
@@ -81,7 +81,7 @@ open class UserAPI: APIBase {
             if let error = error {
                 deferred.reject(error)
             } else {
-                deferred.fulfill()
+                deferred.fulfill(())
             }
         }
         return deferred.promise
@@ -129,7 +129,7 @@ open class UserAPI: APIBase {
             if let error = error {
                 deferred.reject(error)
             } else {
-                deferred.fulfill()
+                deferred.fulfill(())
             }
         }
         return deferred.promise
@@ -177,7 +177,7 @@ open class UserAPI: APIBase {
             if let error = error {
                 deferred.reject(error)
             } else {
-                deferred.fulfill()
+                deferred.fulfill(())
             }
         }
         return deferred.promise
@@ -345,7 +345,7 @@ open class UserAPI: APIBase {
         
         var url = URLComponents(string: URLString)
         url?.queryItems = APIHelper.mapValuesToQueryItems(values:[
-            "username": username, 
+            "username": username,
             "password": password
         ])
 
@@ -374,7 +374,7 @@ open class UserAPI: APIBase {
             if let error = error {
                 deferred.reject(error)
             } else {
-                deferred.fulfill()
+                deferred.fulfill(())
             }
         }
         return deferred.promise
@@ -423,7 +423,7 @@ open class UserAPI: APIBase {
             if let error = error {
                 deferred.reject(error)
             } else {
-                deferred.fulfill()
+                deferred.fulfill(())
             }
         }
         return deferred.promise


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [x] Filed the PR against the correct branch: `3.0.0` branch for changes related to OpenAPI spec 3.0. Default: `master`.
- [x] Copied the [technical committee](https://github.com/swagger-api/swagger-codegen/#swagger-codegen-technical-committee) to review the pull request if your PR is targeting a particular programming language.
@ehyche

### Description of the PR

The swagger-codegen swift3 language using PromiseKit currently leaves the `.fulfill` arguments empty if there is no `returnType`.

This pull request fixes this to return `Void` by calling `()` when there is no `returnType`.

#### Related

- [#7005](https://github.com/swagger-api/swagger-codegen/issues/7005)