### PR TITLE
Make SwaggerCodeGen serialize subclasses properly

### DIFF
--- a/modules/swagger-codegen/src/main/resources/typescript-node/api.mustache
+++ b/modules/swagger-codegen/src/main/resources/typescript-node/api.mustache
@@ -47,7 +47,12 @@ class ObjectSerializer {
                 return expectedType; // the type does not have a discriminator. use it.
             } else {
                 if (data[discriminatorProperty]) {
-                    return data[discriminatorProperty]; // use the type given in the discriminator
+                    var discriminatorType = data[discriminatorProperty];
+                    if(typeMap[discriminatorType]){
+                        return data[discriminatorProperty]; // use the type given in the discriminator
+                    } else {
+                        return expectedType; // discriminator did not map to a type
+                    }
                 } else {
                     return expectedType; // discriminator was not present (or an empty string)
                 }
@@ -78,6 +83,9 @@ class ObjectSerializer {
             if (!typeMap[type]) { // in case we dont know the type
                 return data;
             }
+
+            // Get the actual type of this object
+            type = this.findCorrectType(data, type);
 
             // get the map for the correct type.
             let attributeTypes = typeMap[type].getAttributeTypeMap();

--- a/samples/client/petstore/typescript-node/default/api.ts
+++ b/samples/client/petstore/typescript-node/default/api.ts
@@ -56,7 +56,12 @@ class ObjectSerializer {
                 return expectedType; // the type does not have a discriminator. use it.
             } else {
                 if (data[discriminatorProperty]) {
-                    return data[discriminatorProperty]; // use the type given in the discriminator
+                    var discriminatorType = data[discriminatorProperty];
+                    if(typeMap[discriminatorType]){
+                        return data[discriminatorProperty]; // use the type given in the discriminator
+                    } else {
+                        return expectedType; // discriminator did not map to a type
+                    }
                 } else {
                     return expectedType; // discriminator was not present (or an empty string)
                 }
@@ -87,6 +92,9 @@ class ObjectSerializer {
             if (!typeMap[type]) { // in case we dont know the type
                 return data;
             }
+
+            // Get the actual type of this object
+            type = this.findCorrectType(data, type);
 
             // get the map for the correct type.
             let attributeTypes = typeMap[type].getAttributeTypeMap();


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [x] Filed the PR against the correct branch: `3.0.0` branch for changes related to OpenAPI spec 3.0. Default: `master`.
- [x] Copied the [technical committee](https://github.com/swagger-api/swagger-codegen/#swagger-codegen-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

Motivation
----
Previously, when serializing as subclass of a property, generated swagger clients would only serialize properties of the parent class causing some values to not be pass through

Modifications
----
Before serializing attributes of a given type, we check to see if there is a specific type to be serialized so that we don't miss any properties.

Issue: https://github.com/swagger-api/swagger-codegen/issues/8203