### PR TITLE
Adding ability to CodeGens to post-process CodegenModels

### DIFF
--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/DefaultCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/DefaultCodegen.java
@@ -360,6 +360,11 @@ public class DefaultCodegen {
     public void postProcessModelProperty(CodegenModel model, CodegenProperty property){
     }
 
+    // override to post-process any model properties
+    @SuppressWarnings("unused")
+    public void postProcessModel(CodegenModel model){
+    }
+
     // override to post-process any parameters
     @SuppressWarnings("unused")
     public void postProcessParameter(CodegenParameter parameter){
@@ -1466,6 +1471,7 @@ public class DefaultCodegen {
                 postProcessModelProperty(m, prop);
             }
         }
+        postProcessModel(m);
         return m;
     }
 


### PR DESCRIPTION
### Description of the PR

Added a post-processing method for Models.

This allows a CodeGenerator to add/process a Model's properties without overriding core functionality/methods.

While this could be done by subclasses overriding `fromModel`, the postProcessing model is used elsewhere and improves clarity as to how that type of change should be implemented.