### PR TITLE
fixed index out of bound exception for inline empty example field.

### DIFF
--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/InlineModelResolver.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/InlineModelResolver.java
@@ -219,7 +219,7 @@ public class InlineModelResolver {
     private void fixStringModel(ModelImpl m) {
         if (m.getType() != null && m.getType().equals("string") && m.getExample() != null) {
             String example = m.getExample().toString();
-            if (example.substring(0, 1).equals("\"") &&
+            if (!example.isEmpty() && example.substring(0, 1).equals("\"") &&
                     example.substring(example.length() - 1).equals("\"")) {
                 m.setExample(example.substring(1, example.length() - 1));
             }

--- a/modules/swagger-codegen/src/test/java/io/swagger/codegen/InlineModelResolverTest.java
+++ b/modules/swagger-codegen/src/test/java/io/swagger/codegen/InlineModelResolverTest.java
@@ -5,8 +5,10 @@ import io.swagger.models.parameters.BodyParameter;
 import io.swagger.models.parameters.Parameter;
 import io.swagger.models.properties.*;
 import io.swagger.util.Json;
+import org.apache.commons.lang3.StringUtils;
 import org.testng.annotations.Test;
 
+import java.util.HashMap;
 import java.util.Map;
 
 import static org.testng.AssertJUnit.*;
@@ -988,5 +990,24 @@ public class InlineModelResolverTest {
         assertTrue(inlineProp instanceof ObjectProperty);
         ObjectProperty op = (ObjectProperty) inlineProp;
         assertNull(op.getProperties());
-    }    
+    }
+
+    @Test
+    public void testEmptyExampleOnStrinngTypeModels() {
+        Swagger swagger = new Swagger();
+
+        RefProperty refProperty = new RefProperty();
+        refProperty.set$ref("#/definitions/Test");
+
+        swagger.path("/hello", new Path()
+                .get(new Operation()
+                        .response(200, new Response()
+                                .schema(new ArrayProperty()
+                                        .items(refProperty)))));
+
+        swagger.addDefinition("Test", new ModelImpl()
+                .example(StringUtils.EMPTY)
+                .type("string"));
+        new InlineModelResolver().flatten(swagger);
+    }
 }


### PR DESCRIPTION
### PR checklist

- [x ] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [x ] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [ x] Filed the PR against the correct branch: `3.0.0` branch for changes related to OpenAPI spec 3.0. Default: `master`.
- [ ] Copied the [technical committee](https://github.com/swagger-api/swagger-codegen/#swagger-codegen-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

fixes #8214.

