### PR TITLE
Fix getter methods for Java model with additionalProperties

### DIFF
--- a/modules/swagger-codegen/src/main/resources/Java/pojo.mustache
+++ b/modules/swagger-codegen/src/main/resources/Java/pojo.mustache
@@ -140,7 +140,12 @@ public class {{classname}} {{#parent}}extends {{{parent}}} {{/parent}}{{#parcela
   {{{vendorExtensions.extraAnnotation}}}
 {{/vendorExtensions.extraAnnotation}}
   public {{{datatypeWithEnum}}} {{#isBoolean}}is{{/isBoolean}}{{getter}}() {
+    {{#parent}}
+    return {{name}} == null ? ({{{datatypeWithEnum}}}) this.get("{{name}}") : {{name}};
+    {{/parent}}
+    {{^parent}}
     return {{name}};
+    {{/parent}}
   }
   {{^isReadOnly}}
 


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [ ] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`. **Did not generate petstore example because that would significantly increase the diff**
- [x] Filed the PR against the correct branch: `3.0.0` branch for changes related to OpenAPI spec 3.0. Default: `master`.
- [ ] Copied the [technical committee](https://github.com/swagger-api/swagger-codegen/#swagger-codegen-technical-committee) to review the pull request if your PR is targeting a particular programming language. **No members left in the technical committee for Java, including @HugoMario because he has merged other PRs**

### Description of the PR

When a model class is configured with additionalProperties, getters for non-dynamic properties always return null because values have been set as properties of the map instead of the class. As a workaround, this commit ensures that we these values are retrieved from the underlying map.

This (partially) fixes #4970, fixes #5259, and fixes #5187

The issue of `additionalProperties` is not completely solved by this PR, however, we support the situation where `additionalProperties` is of type `object`, or all fields are of the same type as `additionalProperties`. I.e. it will not work if we have properties of type `integer` and `additionalProperties` of type `array` due to incorrect type casting.