### PR TITLE
Fixed DefaultGenerator.getHandleBars to not use a regex string for the templateDir 

### DIFF
--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/DefaultGenerator.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/DefaultGenerator.java
@@ -1011,7 +1011,7 @@ public class DefaultGenerator extends AbstractGenerator implements Generator {
 
     private com.github.jknack.handlebars.Template getHandlebars(String templateFile) throws IOException {
         if (templateFile.startsWith(config.templateDir())) {
-            templateFile = templateFile.replaceFirst(config.templateDir(), StringUtils.EMPTY);
+            templateFile = StringUtils.replaceOnce(templateFile, config.templateDir(), StringUtils.EMPTY);
         }
         TemplateLoader templateLoader = null;
         if (config.additionalProperties().get(CodegenConstants.TEMPLATE_DIR) != null) {


### PR DESCRIPTION
(in Windows) path delimiters `\` would be interpreted as escape sequences for a regex parameter.

Replaced `replaceFirst()` with `StringUtils.replaceOnce()`

This fixes #8218

