### PR TITLE
[rust-server] typo: enum naming code was disabled

### DIFF
--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/RustServerCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/RustServerCodegen.java
@@ -402,8 +402,12 @@ public class RustServerCodegen extends DefaultCodegen implements CodegenConfig {
             var = varName;
         }
 
+        else {
+            var = value;
+        }
+
         // string
-        var = value.replaceAll("\\W+", "_").toUpperCase();
+        var = var.replaceAll("\\W+", "_").toUpperCase();
         if (var.matches("\\d.*")) {
             var = "_" + var;
         } else {


### PR DESCRIPTION
The `value.replaceAll` here needs to be `var.replaceAll`, or all of the previous processing of `var` is ignored. IntelliJ generates a warning (unused assignment) for this.

This breaks enums with empty values, as seen in [docker's swagger.yaml](https://github.com/moby/moby/blob/71cd53e4a197b303c6ba086bd584ffd67a884281/api/swagger.yaml#L4193):

```yaml
  LocalNodeState:
    description: "Current local status of this node."
    type: "string"
    default: ""
    enum:
      - ""
      - "inactive"
      - "pending"
      - "active"
      - "error"
      - "locked"
    example: "active"
```

(It is, by far, not the only thing broken while processing Docker's .yaml.)

This enables a lot of code which was previously untested, only some of which is needed for this usecase. I choose to trust the original author that this code was supposed to be there, and was tested at some point.