### PR TITLE
Replace custom dateformatter property with dateDecodingStrategy to al…

### DIFF
--- a/modules/swagger-codegen/src/main/resources/swift4/CodableHelper.mustache
+++ b/modules/swagger-codegen/src/main/resources/swift4/CodableHelper.mustache
@@ -11,15 +11,15 @@ public typealias EncodeResult = (data: Data?, error: Error?)
 
 open class CodableHelper {
 
-    open static var dateformatter: DateFormatter?
+    open static var dateDecodingStrategy: JSONDecoder.DateDecodingStrategy?
 
     open class func decode<T>(_ type: T.Type, from data: Data) -> (decodableObj: T?, error: Error?) where T : Decodable {
         var returnedDecodable: T? = nil
         var returnedError: Error? = nil
 
-        let decoder = JSONDecoder()
-        if let df = self.dateformatter {
-            decoder.dateDecodingStrategy = .formatted(df)
+        let decoder = JSONDecoder()        
+        if let strategy = self.dateDecodingStrategy {
+            decoder.dateDecodingStrategy = strategy
         } else {
             decoder.dataDecodingStrategy = .base64
             let formatter = DateFormatter()

--- a/samples/client/petstore/swift4/default/PetstoreClient/Classes/Swaggers/APIs/FakeAPI.swift
+++ b/samples/client/petstore/swift4/default/PetstoreClient/Classes/Swaggers/APIs/FakeAPI.swift
@@ -148,6 +148,46 @@ open class FakeAPI {
     }
 
     /**
+
+     - parameter body: (body)  
+     - parameter query: (query)  
+     - parameter completion: completion handler to receive the data and the error objects
+     */
+    open class func testBodyWithQueryParams(body: User, query: String, completion: @escaping ((_ data: Void?,_ error: Error?) -> Void)) {
+        testBodyWithQueryParamsWithRequestBuilder(body: body, query: query).execute { (response, error) -> Void in
+            if error == nil {
+                completion((), error)
+            } else {
+                completion(nil, error)
+            }
+        }
+    }
+
+
+    /**
+     - PUT /fake/body-with-query-params
+     
+     - parameter body: (body)  
+     - parameter query: (query)  
+
+     - returns: RequestBuilder<Void> 
+     */
+    open class func testBodyWithQueryParamsWithRequestBuilder(body: User, query: String) -> RequestBuilder<Void> {
+        let path = "/fake/body-with-query-params"
+        let URLString = PetstoreClientAPI.basePath + path
+        let parameters = JSONEncodingHelper.encodingParameters(forEncodableObject: body)
+
+        var url = URLComponents(string: URLString)
+        url?.queryItems = APIHelper.mapValuesToQueryItems([
+            "query": query
+        ])
+
+        let requestBuilder: RequestBuilder<Void>.Type = PetstoreClientAPI.requestBuilderFactory.getNonDecodableBuilder()
+
+        return requestBuilder.init(method: "PUT", URLString: (url?.string ?? URLString), parameters: parameters, isBody: true)
+    }
+
+    /**
      To test \"client\" model
      
      - parameter body: (body) client model 

--- a/samples/client/petstore/swift4/default/PetstoreClient/Classes/Swaggers/CodableHelper.swift
+++ b/samples/client/petstore/swift4/default/PetstoreClient/Classes/Swaggers/CodableHelper.swift
@@ -11,15 +11,15 @@ public typealias EncodeResult = (data: Data?, error: Error?)
 
 open class CodableHelper {
 
-    open static var dateformatter: DateFormatter?
+    open static var dateDecodingStrategy: JSONDecoder.DateDecodingStrategy?
 
     open class func decode<T>(_ type: T.Type, from data: Data) -> (decodableObj: T?, error: Error?) where T : Decodable {
         var returnedDecodable: T? = nil
         var returnedError: Error? = nil
 
-        let decoder = JSONDecoder()
-        if let df = self.dateformatter {
-            decoder.dateDecodingStrategy = .formatted(df)
+        let decoder = JSONDecoder()        
+        if let strategy = self.dateDecodingStrategy {
+            decoder.dateDecodingStrategy = strategy
         } else {
             decoder.dataDecodingStrategy = .base64
             let formatter = DateFormatter()

--- a/samples/client/petstore/swift4/objcCompatible/PetstoreClient/Classes/Swaggers/APIs/FakeAPI.swift
+++ b/samples/client/petstore/swift4/objcCompatible/PetstoreClient/Classes/Swaggers/APIs/FakeAPI.swift
@@ -148,6 +148,46 @@ open class FakeAPI {
     }
 
     /**
+
+     - parameter body: (body)  
+     - parameter query: (query)  
+     - parameter completion: completion handler to receive the data and the error objects
+     */
+    open class func testBodyWithQueryParams(body: User, query: String, completion: @escaping ((_ data: Void?,_ error: Error?) -> Void)) {
+        testBodyWithQueryParamsWithRequestBuilder(body: body, query: query).execute { (response, error) -> Void in
+            if error == nil {
+                completion((), error)
+            } else {
+                completion(nil, error)
+            }
+        }
+    }
+
+
+    /**
+     - PUT /fake/body-with-query-params
+     
+     - parameter body: (body)  
+     - parameter query: (query)  
+
+     - returns: RequestBuilder<Void> 
+     */
+    open class func testBodyWithQueryParamsWithRequestBuilder(body: User, query: String) -> RequestBuilder<Void> {
+        let path = "/fake/body-with-query-params"
+        let URLString = PetstoreClientAPI.basePath + path
+        let parameters = JSONEncodingHelper.encodingParameters(forEncodableObject: body)
+
+        var url = URLComponents(string: URLString)
+        url?.queryItems = APIHelper.mapValuesToQueryItems([
+            "query": query
+        ])
+
+        let requestBuilder: RequestBuilder<Void>.Type = PetstoreClientAPI.requestBuilderFactory.getNonDecodableBuilder()
+
+        return requestBuilder.init(method: "PUT", URLString: (url?.string ?? URLString), parameters: parameters, isBody: true)
+    }
+
+    /**
      To test \"client\" model
      
      - parameter body: (body) client model 

--- a/samples/client/petstore/swift4/objcCompatible/PetstoreClient/Classes/Swaggers/CodableHelper.swift
+++ b/samples/client/petstore/swift4/objcCompatible/PetstoreClient/Classes/Swaggers/CodableHelper.swift
@@ -11,15 +11,15 @@ public typealias EncodeResult = (data: Data?, error: Error?)
 
 open class CodableHelper {
 
-    open static var dateformatter: DateFormatter?
+    open static var dateDecodingStrategy: JSONDecoder.DateDecodingStrategy?
 
     open class func decode<T>(_ type: T.Type, from data: Data) -> (decodableObj: T?, error: Error?) where T : Decodable {
         var returnedDecodable: T? = nil
         var returnedError: Error? = nil
 
-        let decoder = JSONDecoder()
-        if let df = self.dateformatter {
-            decoder.dateDecodingStrategy = .formatted(df)
+        let decoder = JSONDecoder()        
+        if let strategy = self.dateDecodingStrategy {
+            decoder.dateDecodingStrategy = strategy
         } else {
             decoder.dataDecodingStrategy = .base64
             let formatter = DateFormatter()

--- a/samples/client/petstore/swift4/promisekit/PetstoreClient/Classes/Swaggers/APIs/FakeAPI.swift
+++ b/samples/client/petstore/swift4/promisekit/PetstoreClient/Classes/Swaggers/APIs/FakeAPI.swift
@@ -213,6 +213,63 @@ open class FakeAPI {
     }
 
     /**
+
+     - parameter body: (body)  
+     - parameter query: (query)  
+     - parameter completion: completion handler to receive the data and the error objects
+     */
+    open class func testBodyWithQueryParams(body: User, query: String, completion: @escaping ((_ data: Void?,_ error: Error?) -> Void)) {
+        testBodyWithQueryParamsWithRequestBuilder(body: body, query: query).execute { (response, error) -> Void in
+            if error == nil {
+                completion((), error)
+            } else {
+                completion(nil, error)
+            }
+        }
+    }
+
+    /**
+
+     - parameter body: (body)  
+     - parameter query: (query)  
+     - returns: Promise<Void>
+     */
+    open class func testBodyWithQueryParams( body: User,  query: String) -> Promise<Void> {
+        let deferred = Promise<Void>.pending()
+        testBodyWithQueryParams(body: body, query: query) { data, error in
+            if let error = error {
+                deferred.reject(error)
+            } else {
+                deferred.fulfill(data!)
+            }
+        }
+        return deferred.promise
+    }
+
+    /**
+     - PUT /fake/body-with-query-params
+     
+     - parameter body: (body)  
+     - parameter query: (query)  
+
+     - returns: RequestBuilder<Void> 
+     */
+    open class func testBodyWithQueryParamsWithRequestBuilder(body: User, query: String) -> RequestBuilder<Void> {
+        let path = "/fake/body-with-query-params"
+        let URLString = PetstoreClientAPI.basePath + path
+        let parameters = JSONEncodingHelper.encodingParameters(forEncodableObject: body)
+
+        var url = URLComponents(string: URLString)
+        url?.queryItems = APIHelper.mapValuesToQueryItems([
+            "query": query
+        ])
+
+        let requestBuilder: RequestBuilder<Void>.Type = PetstoreClientAPI.requestBuilderFactory.getNonDecodableBuilder()
+
+        return requestBuilder.init(method: "PUT", URLString: (url?.string ?? URLString), parameters: parameters, isBody: true)
+    }
+
+    /**
      To test \"client\" model
      
      - parameter body: (body) client model 

--- a/samples/client/petstore/swift4/promisekit/PetstoreClient/Classes/Swaggers/CodableHelper.swift
+++ b/samples/client/petstore/swift4/promisekit/PetstoreClient/Classes/Swaggers/CodableHelper.swift
@@ -11,15 +11,15 @@ public typealias EncodeResult = (data: Data?, error: Error?)
 
 open class CodableHelper {
 
-    open static var dateformatter: DateFormatter?
+    open static var dateDecodingStrategy: JSONDecoder.DateDecodingStrategy?
 
     open class func decode<T>(_ type: T.Type, from data: Data) -> (decodableObj: T?, error: Error?) where T : Decodable {
         var returnedDecodable: T? = nil
         var returnedError: Error? = nil
 
-        let decoder = JSONDecoder()
-        if let df = self.dateformatter {
-            decoder.dateDecodingStrategy = .formatted(df)
+        let decoder = JSONDecoder()        
+        if let strategy = self.dateDecodingStrategy {
+            decoder.dateDecodingStrategy = strategy
         } else {
             decoder.dataDecodingStrategy = .base64
             let formatter = DateFormatter()

--- a/samples/client/petstore/swift4/rxswift/PetstoreClient/Classes/Swaggers/APIs/FakeAPI.swift
+++ b/samples/client/petstore/swift4/rxswift/PetstoreClient/Classes/Swaggers/APIs/FakeAPI.swift
@@ -221,6 +221,65 @@ open class FakeAPI {
     }
 
     /**
+
+     - parameter body: (body)  
+     - parameter query: (query)  
+     - parameter completion: completion handler to receive the data and the error objects
+     */
+    open class func testBodyWithQueryParams(body: User, query: String, completion: @escaping ((_ data: Void?,_ error: Error?) -> Void)) {
+        testBodyWithQueryParamsWithRequestBuilder(body: body, query: query).execute { (response, error) -> Void in
+            if error == nil {
+                completion((), error)
+            } else {
+                completion(nil, error)
+            }
+        }
+    }
+
+    /**
+
+     - parameter body: (body)  
+     - parameter query: (query)  
+     - returns: Observable<Void>
+     */
+    open class func testBodyWithQueryParams(body: User, query: String) -> Observable<Void> {
+        return Observable.create { observer -> Disposable in
+            testBodyWithQueryParams(body: body, query: query) { data, error in
+                if let error = error {
+                    observer.on(.error(error))
+                } else {
+                    observer.on(.next(data!))
+                }
+                observer.on(.completed)
+            }
+            return Disposables.create()
+        }
+    }
+
+    /**
+     - PUT /fake/body-with-query-params
+     
+     - parameter body: (body)  
+     - parameter query: (query)  
+
+     - returns: RequestBuilder<Void> 
+     */
+    open class func testBodyWithQueryParamsWithRequestBuilder(body: User, query: String) -> RequestBuilder<Void> {
+        let path = "/fake/body-with-query-params"
+        let URLString = PetstoreClientAPI.basePath + path
+        let parameters = JSONEncodingHelper.encodingParameters(forEncodableObject: body)
+
+        var url = URLComponents(string: URLString)
+        url?.queryItems = APIHelper.mapValuesToQueryItems([
+            "query": query
+        ])
+
+        let requestBuilder: RequestBuilder<Void>.Type = PetstoreClientAPI.requestBuilderFactory.getNonDecodableBuilder()
+
+        return requestBuilder.init(method: "PUT", URLString: (url?.string ?? URLString), parameters: parameters, isBody: true)
+    }
+
+    /**
      To test \"client\" model
      
      - parameter body: (body) client model 

--- a/samples/client/petstore/swift4/rxswift/PetstoreClient/Classes/Swaggers/CodableHelper.swift
+++ b/samples/client/petstore/swift4/rxswift/PetstoreClient/Classes/Swaggers/CodableHelper.swift
@@ -11,15 +11,15 @@ public typealias EncodeResult = (data: Data?, error: Error?)
 
 open class CodableHelper {
 
-    open static var dateformatter: DateFormatter?
+    open static var dateDecodingStrategy: JSONDecoder.DateDecodingStrategy?
 
     open class func decode<T>(_ type: T.Type, from data: Data) -> (decodableObj: T?, error: Error?) where T : Decodable {
         var returnedDecodable: T? = nil
         var returnedError: Error? = nil
 
-        let decoder = JSONDecoder()
-        if let df = self.dateformatter {
-            decoder.dateDecodingStrategy = .formatted(df)
+        let decoder = JSONDecoder()        
+        if let strategy = self.dateDecodingStrategy {
+            decoder.dateDecodingStrategy = strategy
         } else {
             decoder.dataDecodingStrategy = .base64
             let formatter = DateFormatter()


### PR DESCRIPTION
…low setting .iso8601 as strategy

### PR checklist

- [x] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [x] Filed the PR against the correct branch: `3.0.0` branch for changes related to OpenAPI spec 3.0. Default: `master`.
- [x] Copied the [technical committee](https://github.com/swagger-api/swagger-codegen/#swagger-codegen-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

To be able to set `.iso8601` as a `JSONDecoder.DateDecodingStrategy` I replaced the custom static `dateformatter` property inside `CodableHelper.swift` with the strategy.

You only have to change your code if you were using this property. If yes, just encapsulate your existing `DateFormatter` like this:

```
CodableHelper.dateDecodingStragegy = .formatted(myPreviousDateFormatter)
```

The benefits of this is to be able to set the new strategy available from iOS 10 which fits all my date decoding needs :).
```
CodableHelper.dateDecodingStragegy = .iso8601
```