### PR TITLE
Java Generator: Pojo: Add @JsonProperty to Getter 

### DIFF
--- a/modules/swagger-codegen/src/main/resources/Java/pojo.mustache
+++ b/modules/swagger-codegen/src/main/resources/Java/pojo.mustache
@@ -139,6 +139,7 @@ public class {{classname}} {{#parent}}extends {{{parent}}} {{/parent}}{{#parcela
 {{#vendorExtensions.extraAnnotation}}
   {{{vendorExtensions.extraAnnotation}}}
 {{/vendorExtensions.extraAnnotation}}
+  @JsonProperty("{{baseName}}")
   public {{{datatypeWithEnum}}} {{#isBoolean}}is{{/isBoolean}}{{getter}}() {
     {{#parent}}
     return {{name}} == null ? ({{{datatypeWithEnum}}}) this.get("{{name}}") : {{name}};


### PR DESCRIPTION
This fixes a problem with extension Attribute (e.g. 'x-customAttribute'):

### PR checklist

- [x]  Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [x] Filed the PR against the correct branch: `3.0.0` branch for changes related to OpenAPI spec 3.0. Default: `master`.
- [x] Copied the [technical committee](https://github.com/swagger-api/swagger-codegen/#swagger-codegen-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

When using this Code Generator to generate a Pojo which can handle the Swagger Spec itself, there is one problem:
The extension attributes need a hyphen, but Jackson/Spring is generating two Versions of the same variable, on with the hyphen after the x (e.g. 'x-customAttribute') and same file one without the hypen (e.g. 'xcustomAttribute'). Adding the @JsonProperty Annotation the the Getter solves this Problem.
