### PR TITLE
[swift4] The podspec docset_url attribute has been removed from the CocoaPods...

### DIFF
--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/Swift4Codegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/Swift4Codegen.java
@@ -47,7 +47,6 @@ public class Swift4Codegen extends DefaultCodegen implements CodegenConfig {
     public static final String POD_SOURCE = "podSource";
     public static final String POD_AUTHORS = "podAuthors";
     public static final String POD_SOCIAL_MEDIA_URL = "podSocialMediaURL";
-    public static final String POD_DOCSET_URL = "podDocsetURL";
     public static final String POD_LICENSE = "podLicense";
     public static final String POD_HOMEPAGE = "podHomepage";
     public static final String POD_SUMMARY = "podSummary";
@@ -229,7 +228,6 @@ public class Swift4Codegen extends DefaultCodegen implements CodegenConfig {
         cliOptions.add(new CliOption(CodegenConstants.POD_VERSION, "Version used for Podspec"));
         cliOptions.add(new CliOption(POD_AUTHORS, "Authors used for Podspec"));
         cliOptions.add(new CliOption(POD_SOCIAL_MEDIA_URL, "Social Media URL used for Podspec"));
-        cliOptions.add(new CliOption(POD_DOCSET_URL, "Docset URL used for Podspec"));
         cliOptions.add(new CliOption(POD_LICENSE, "License used for Podspec"));
         cliOptions.add(new CliOption(POD_HOMEPAGE, "Homepage used for Podspec"));
         cliOptions.add(new CliOption(POD_SUMMARY, "Summary used for Podspec"));

--- a/modules/swagger-codegen/src/main/resources/swift4/Podspec.mustache
+++ b/modules/swagger-codegen/src/main/resources/swift4/Podspec.mustache
@@ -7,8 +7,7 @@ Pod::Spec.new do |s|
   s.version = '{{#podVersion}}{{podVersion}}{{/podVersion}}{{^podVersion}}0.0.1{{/podVersion}}'
   s.source = {{#podSource}}{{& podSource}}{{/podSource}}{{^podSource}}{ :git => 'git@github.com:swagger-api/swagger-mustache.git', :tag => 'v1.0.0' }{{/podSource}}{{#podAuthors}}
   s.authors = '{{podAuthors}}'{{/podAuthors}}{{#podSocialMediaURL}}
-  s.social_media_url = '{{podSocialMediaURL}}'{{/podSocialMediaURL}}{{#podDocsetURL}}
-  s.docset_url = '{{podDocsetURL}}'{{/podDocsetURL}}
+  s.social_media_url = '{{podSocialMediaURL}}'{{/podSocialMediaURL}}
   s.license = {{#podLicense}}{{& podLicense}}{{/podLicense}}{{^podLicense}}'Proprietary'{{/podLicense}}{{#podHomepage}}
   s.homepage = '{{podHomepage}}'{{/podHomepage}}{{#podSummary}}
   s.summary = '{{podSummary}}'{{/podSummary}}{{#podDescription}}

--- a/modules/swagger-codegen/src/test/java/io/swagger/codegen/options/Swift4OptionsProvider.java
+++ b/modules/swagger-codegen/src/test/java/io/swagger/codegen/options/Swift4OptionsProvider.java
@@ -20,7 +20,6 @@ public class Swift4OptionsProvider implements OptionsProvider {
     public static final String POD_VERSION_VALUE = "v1.0.0-SNAPSHOT";
     public static final String POD_AUTHORS_VALUE = "podAuthors";
     public static final String POD_SOCIAL_MEDIA_URL_VALUE = "podSocialMediaURL";
-    public static final String POD_DOCSET_URL_VALUE = "podDocsetURL";
     public static final String POD_LICENSE_VALUE = "'Apache License, Version 2.0'";
     public static final String POD_HOMEPAGE_VALUE = "podHomepage";
     public static final String POD_SUMMARY_VALUE = "podSummary";
@@ -49,7 +48,6 @@ public class Swift4OptionsProvider implements OptionsProvider {
                 .put(CodegenConstants.POD_VERSION, POD_VERSION_VALUE)
                 .put(Swift4Codegen.POD_AUTHORS, POD_AUTHORS_VALUE)
                 .put(Swift4Codegen.POD_SOCIAL_MEDIA_URL, POD_SOCIAL_MEDIA_URL_VALUE)
-                .put(Swift4Codegen.POD_DOCSET_URL, POD_DOCSET_URL_VALUE)
                 .put(Swift4Codegen.POD_LICENSE, POD_LICENSE_VALUE)
                 .put(Swift4Codegen.POD_HOMEPAGE, POD_HOMEPAGE_VALUE)
                 .put(Swift4Codegen.POD_SUMMARY, POD_SUMMARY_VALUE)


### PR DESCRIPTION
…Specification DSL, so the podDocsetURL swift4 config option can be removed.

### PR checklist

- ✅ Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- ✅ Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- ✅ Filed the PR against the correct branch: `3.0.0` branch for changes related to OpenAPI spec 3.0. Default: `master`.
- ✅ Copied the [technical committee](https://github.com/swagger-api/swagger-codegen/#swagger-codegen-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

Issue: #8315 : Remove podDocsetURL config option for swift4

There is a config option in the swift4 language, `podDocsetURL`, which is used to specify a `docset_url` attribute in the generated podspec. `docset_url` has been removed from the CocoaPods Specification DSL ([CocoaPods/Core#284](https://github.com/CocoaPods/Core/issues/284)), so this config option can be removed from swagger-codegen.

/cc swift technical committee: @ehyche 