### PR TITLE
refactor `getHandlebars` method to handle properly files paths.

### DIFF
--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/DefaultGenerator.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/DefaultGenerator.java
@@ -575,17 +575,12 @@ public class DefaultGenerator extends AbstractGenerator implements Generator {
                 }
 
                 if(ignoreProcessor.allowsFile(new File(outputFilename))) {
-                    templateFile = templateFile.replaceAll("//", "/").replace('/', File.separatorChar);
                     if (templateFile.endsWith("mustache")) {
-                        String templateName = templateFile;
-                        final com.github.jknack.handlebars.Template hTemplate = getHandlebars(templateName.replace(config.templateDir(), StringUtils.EMPTY));
+                        final com.github.jknack.handlebars.Template hTemplate = getHandlebars(templateFile);
                         String rendered = hTemplate.apply(bundle);
                         writeToFile(outputFilename, rendered);
-
-                        // writeToFile(outputFilename, tmpl.execute(bundle));
                         files.add(new File(outputFilename));
                     } else {
-                        templateFile = templateFile.replace("\\", "/");
                         InputStream in = null;
 
                         try {
@@ -1011,19 +1006,19 @@ public class DefaultGenerator extends AbstractGenerator implements Generator {
     }
 
     private com.github.jknack.handlebars.Template getHandlebars(String templateFile) throws IOException {
-        if (templateFile.startsWith(config.templateDir())) {
-            templateFile = StringUtils.replaceOnce(templateFile, config.templateDir(), StringUtils.EMPTY);
+        templateFile = templateFile.replace(".mustache", StringUtils.EMPTY).replace("\\", "/");
+        String templateDir = config.templateDir().replace(".mustache", StringUtils.EMPTY).replace("\\", "/");
+        if (templateFile.startsWith(templateDir)) {
+            templateFile = StringUtils.replaceOnce(templateFile, templateDir, StringUtils.EMPTY);
         }
         TemplateLoader templateLoader = null;
         if (config.additionalProperties().get(CodegenConstants.TEMPLATE_DIR) != null) {
-            templateLoader = new FileTemplateLoader(config.templateDir(), ".mustache");
+            templateLoader = new FileTemplateLoader(templateDir, ".mustache");
         } else {
-            templateLoader = new ClassPathTemplateLoader("/" + config.templateDir().replace("\\", "/"), ".mustache");
+            templateLoader = new ClassPathTemplateLoader("/" + templateDir, ".mustache");
         }
         final Handlebars handlebars = new Handlebars(templateLoader);
         config.addHandlebarHelpers(handlebars);
-
-        templateFile = templateFile.replace(".mustache", StringUtils.EMPTY).replace("\\", "/");
         return handlebars.compile(templateFile);
     }
 


### PR DESCRIPTION
### PR checklist

- [x ] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [ x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [ x] Filed the PR against the correct branch: `3.0.0` branch for changes related to OpenAPI spec 3.0. Default: `master`.
- [ ] Copied the [technical committee](https://github.com/swagger-api/swagger-codegen/#swagger-codegen-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

fixes #8324 

