### PR TITLE
[Java][RESTEasy] Fixed setting of custom headers

### DIFF
--- a/modules/swagger-codegen/src/main/resources/Java/libraries/resteasy/ApiClient.mustache
+++ b/modules/swagger-codegen/src/main/resources/Java/libraries/resteasy/ApiClient.mustache
@@ -598,7 +598,7 @@ public class ApiClient {
 
     for (Entry<String, String> defaultHeaderEnrty: defaultHeaderMap.entrySet()) {
       if (!headerParams.containsKey(defaultHeaderEnrty.getKey())) {
-        String value = defaultHeaderEnrty.getKey();
+        String value = defaultHeaderEnrty.getValue();
         if (value != null) {
           invocationBuilder = invocationBuilder.header(defaultHeaderEnrty.getKey(), value);
         }


### PR DESCRIPTION
Set request headers as key:value. Was key:key

See issue: #8359 