### PR TITLE
dock3r: use an official docker base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,8 @@
-FROM jimschubert/8-jdk-alpine-mvn:1.0
+FROM openjdk:8-jdk-alpine
 
-RUN set -x && \
-    apk add --no-cache bash
+RUN set -x \
+ && apk update && apk upgrade \
+ && apk add --no-cache bash ca-certificates maven
 
 ENV GEN_DIR /opt/swagger-codegen
 WORKDIR ${GEN_DIR}


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [x] Filed the PR against the correct branch: `3.0.0` branch for changes related to OpenAPI spec 3.0. Default: `master`.
- [x] Copied the [technical committee](https://github.com/swagger-api/swagger-codegen/#swagger-codegen-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

Follow up work after investigation on #8368. This does not fix any issue, just gets rid of a dependency on an unmaintained docker image.