### PR TITLE
Add `CodegenConfig.shouldSkipModel()` method

### DIFF
--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/CodegenConfig.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/CodegenConfig.java
@@ -169,6 +169,8 @@ public interface CodegenConfig {
 
     boolean isSkipOverwrite();
 
+    boolean shouldSkipModel(CodegenModel model);
+
     void setSkipOverwrite(boolean skipOverwrite);
 
     boolean isRemoveOperationIdPrefix();

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/DefaultCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/DefaultCodegen.java
@@ -2947,6 +2947,10 @@ public class DefaultCodegen implements CodegenConfig {
         this.skipOverwrite = skipOverwrite;
     }
 
+    public boolean shouldSkipModel(CodegenModel model) {
+        return false;
+    }
+
     public boolean isRemoveOperationIdPrefix() {
         return removeOperationIdPrefix;
     }

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/DefaultGenerator.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/DefaultGenerator.java
@@ -376,13 +376,10 @@ public class DefaultGenerator extends AbstractGenerator implements Generator {
                     continue;
                 }
                 Map<String, Object> modelTemplate = (Map<String, Object>) ((List<Object>) models.get("models")).get(0);
-                if (isJavaCodegen(config.getName())) {
-                    // Special handling of aliases only applies to Java
-                    if (modelTemplate != null && modelTemplate.containsKey("model")) {
-                        CodegenModel codegenModel = (CodegenModel) modelTemplate.get("model");
-                        if (ExtensionHelper.getBooleanValue(codegenModel, CodegenConstants.IS_ALIAS_EXT_NAME)) {
-                            continue;  // Don't create user-defined classes for aliases
-                        }
+                if (modelTemplate != null && modelTemplate.containsKey("model")) {
+                    CodegenModel codegenModel = (CodegenModel) modelTemplate.get("model");
+                    if (config.shouldSkipModel(codegenModel)) {
+                        continue;
                     }
                 }
                 allModels.add(modelTemplate);
@@ -1020,11 +1017,6 @@ public class DefaultGenerator extends AbstractGenerator implements Generator {
         final Handlebars handlebars = new Handlebars(templateLoader);
         config.addHandlebarHelpers(handlebars);
         return handlebars.compile(templateFile);
-    }
-
-    private boolean isJavaCodegen(String name) {
-        return name.equalsIgnoreCase("java")
-                || name.equalsIgnoreCase("inflector");
     }
 
     private Boolean getCustomOptionBooleanValue(String option) {


### PR DESCRIPTION
### PR checklist
- [x] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [ ] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [x] Filed the PR against the correct branch: `3.0.0` branch for changes related to OpenAPI spec 3.0. Default: `master`.
- [ ] Copied the [technical committee](https://github.com/swagger-api/swagger-codegen/#swagger-codegen-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR
The addition of this method allows a generator to specify that specific models should not generate an output file. This also replaces the hardcoded check in `DefaultGenerator` for skipping alias models if the language is `java` or `inflector`. There are many more Java-based 'languages` which need this functionality - it should be possible for the generators to control skipped models themselves.

Note that the skipping of alias models in Java-based languages should
now be controlled downstream in `swagger-codegen-generators`.

This fixes #8373.