### PR TITLE
Fix Elixir :body handling (swagger-api/swagger-codegen#8138)

### DIFF
--- a/modules/swagger-codegen/src/main/resources/elixir/api.mustache
+++ b/modules/swagger-codegen/src/main/resources/elixir/api.mustache
@@ -43,7 +43,7 @@ defmodule {{moduleName}}.Api.{{classname}} do
     |> url("{{replacedPathName}}")
 {{#allParams}}
 {{#required}}
-{{^isPathParam}}    |> add_param({{#isBodyParam}}:body{{/isBodyParam}}{{#isFormParam}}{{#isMultipart}}{{#isFile}}:file{{/isFile}}{{^isFile}}:form{{/isFile}}{{/isMultipart}}{{^isMultipart}}:form{{/isMultipart}}{{/isFormParam}}{{#isQueryParam}}:query{{/isQueryParam}}{{#isHeaderParam}}:headers{{/isHeaderParam}}, :"{{baseName}}", {{#underscored}}{{paramName}}{{/underscored}})
+{{^isPathParam}}    |> add_param({{#isBodyParam}}:body{{/isBodyParam}}{{#isFormParam}}{{#isMultipart}}{{#isFile}}:file{{/isFile}}{{^isFile}}:form{{/isFile}}{{/isMultipart}}{{^isMultipart}}:form{{/isMultipart}}{{/isFormParam}}{{#isQueryParam}}:query{{/isQueryParam}}{{#isHeaderParam}}:headers{{/isHeaderParam}}, {{#isBodyParam}}:"body", {{/isBodyParam}}{{^isBodyParam}}:"{{baseName}}", {{/isBodyParam}}{{#underscored}}{{paramName}}{{/underscored}})
 {{/isPathParam}}
 {{/required}}
 {{/allParams}}


### PR DESCRIPTION
Fix swagger-api/swagger-codegen#8138

When JSON payload needs to be in the body (`"in": "body"`), it must not generate a multi-part body, but embed directly in HTTP body.