### PR TITLE
Implemented thread safe storage of SessionManager for Alamofire

### DIFF
--- a/modules/swagger-codegen/src/main/resources/swift4/AlamofireImplementations.mustache
+++ b/modules/swagger-codegen/src/main/resources/swift4/AlamofireImplementations.mustache
@@ -19,6 +19,8 @@ class AlamofireRequestBuilderFactory: RequestBuilderFactory {
 
 // Store manager to retain its reference
 private var managerStore: [String: Alamofire.SessionManager] = [:]
+// Concurrent queue to save sessionmanagers thread safe
+private let concurrentQueue = DispatchQueue(label: "concurrentQueue", attributes: .concurrent)
 
 open class AlamofireRequestBuilder<T>: RequestBuilder<T> {
     required public init(method: String, URLString: String, parameters: [String : Any]?, isBody: Bool, headers: [String : String] = [:]) {
@@ -58,7 +60,9 @@ open class AlamofireRequestBuilder<T>: RequestBuilder<T> {
         let managerId:String = UUID().uuidString
         // Create a new manager for each request to customize its request header
         let manager = createSessionManager()
-        managerStore[managerId] = manager
+        concurrentQueue.async(flags: .barrier) {
+            managerStore[managerId] = manager
+        }
 
         let encoding:ParameterEncoding = isBody ? JSONDataEncoding() : URLEncoding()
 
@@ -112,7 +116,9 @@ open class AlamofireRequestBuilder<T>: RequestBuilder<T> {
         }
 
         let cleanupRequest = {
-            _ = managerStore.removeValue(forKey: managerId)
+            concurrentQueue.async(flags: .barrier) {
+                _ = managerStore.removeValue(forKey: managerId)
+            }
         }
 
         let validatedRequest = request.validate()
@@ -314,7 +320,9 @@ open class AlamofireDecodableRequestBuilder<T:Decodable>: AlamofireRequestBuilde
         }
 
         let cleanupRequest = {
-            _ = managerStore.removeValue(forKey: managerId)
+            concurrentQueue.async(flags: .barrier) {
+                _ = managerStore.removeValue(forKey: managerId)
+            }
         }
 
         let validatedRequest = request.validate()


### PR DESCRIPTION
### PR checklist

- [ ] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [ ] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [ ] Filed the PR against the correct branch: `3.0.0` branch for changes related to OpenAPI spec 3.0. Default: `master`.
- [x ] Copied the [technical committee](https://github.com/swagger-api/swagger-codegen/#swagger-codegen-technical-committee) to review the pull request if your PR is targeting a particular programming language. @ehyche

### Description of the PR

(details of the change, additional tests that have been done, reference to the issue for tracking, etc)

Fixed random cancelling Alamofire requests due to saving the references in a not thread safe dictionary. This occurs when doing multiple request at the same time. One or multiple requests are deallocated / cancelled when references are not correctly stored.