### PR TITLE
use `withXml` into additionalProperties on codegen maven plugin in or…

### DIFF
--- a/modules/swagger-codegen-maven-plugin/src/main/java/io/swagger/codegen/plugin/CodeGenMojo.java
+++ b/modules/swagger-codegen-maven-plugin/src/main/java/io/swagger/codegen/plugin/CodeGenMojo.java
@@ -29,6 +29,7 @@ import static io.swagger.codegen.config.CodegenConfiguratorUtils.applyReservedWo
 import static org.apache.commons.lang3.StringUtils.isNotEmpty;
 
 import java.io.File;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -483,6 +484,16 @@ public class CodeGenMojo extends AbstractMojo {
         //Apply Language Specific Primitives
         if (languageSpecificPrimitives != null && !configOptions.containsKey("language-specific-primitives")) {
             applyLanguageSpecificPrimitivesCsvList(languageSpecificPrimitives, configurator);
+        }
+
+        if (withXml != null && withXml) {
+            if (additionalProperties == null) {
+                additionalProperties = new ArrayList<>();
+            }
+            additionalProperties.add("withXml=" + withXml.toString());
+            if (configOptions == null) {
+                configOptions = new HashMap<>();
+            }
         }
 
         //Apply Additional Properties


### PR DESCRIPTION
…der to fix issue.

### PR checklist

- [x ] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [ x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [ x] Filed the PR against the correct branch: `3.0.0` branch for changes related to OpenAPI spec 3.0. Default: `master`.
- [ ] Copied the [technical committee](https://github.com/swagger-api/swagger-codegen/#swagger-codegen-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

(details of the change, additional tests that have been done, reference to the issue for tracking, etc)

