### PR TITLE
added value to required property on test data.

### DIFF
--- a/samples/client/petstore/python/tests/test_deserialization.py
+++ b/samples/client/petstore/python/tests/test_deserialization.py
@@ -27,6 +27,7 @@ class DeserializationTests(unittest.TestCase):
         data = {
             'enum_test': {
                 "enum_string": "UPPER",
+                "enum_string_required": "UPPER",
                 "enum_integer": 1,
                 "enum_number": 1.1,
                 "outerEnum": "placed"
@@ -38,6 +39,7 @@ class DeserializationTests(unittest.TestCase):
         self.assertTrue(isinstance(deserialized['enum_test'], petstore_api.EnumTest))
         self.assertEqual(deserialized['enum_test'],
                          petstore_api.EnumTest(enum_string="UPPER",
+                                               enum_string_required="UPPER", 
                                                enum_integer=1,
                                                enum_number=1.1,
                                                outer_enum=petstore_api.OuterEnum.PLACED))


### PR DESCRIPTION
### PR checklist

- [x ] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [ x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [ x] Filed the PR against the correct branch: `3.0.0` branch for changes related to OpenAPI spec 3.0. Default: `master`.
- [ ] Copied the [technical committee](https://github.com/swagger-api/swagger-codegen/#swagger-codegen-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR
updating sample tests related to changes on #8414 
(details of the change, additional tests that have been done, reference to the issue for tracking, etc)

