### PR TITLE
OAS 3.0 - Fixing the 'useOas2' option override in case of Codegen Maven plugin usage

### DIFF
--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/DefaultGenerator.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/DefaultGenerator.java
@@ -193,7 +193,11 @@ public class DefaultGenerator extends AbstractGenerator implements Generator {
 
         config.additionalProperties().put(CodegenConstants.GENERATE_API_DOCS, generateApiDocumentation);
         config.additionalProperties().put(CodegenConstants.GENERATE_MODEL_DOCS, generateModelDocumentation);
-        config.additionalProperties().put(CodegenConstants.USE_OAS2, useOas2);
+        
+        // Additional properties could be set already (f.e. using Maven plugin)
+        if (useOas2Option != null || !config.additionalProperties().containsKey(CodegenConstants.USE_OAS2)) {
+            config.additionalProperties().put(CodegenConstants.USE_OAS2, useOas2);
+        }
 
         if(!generateApiTests && !generateModelTests) {
             config.additionalProperties().put(CodegenConstants.EXCLUDE_TESTS, true);


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [x] Filed the PR against the correct branch: `3.0.0` branch for changes related to OpenAPI spec 3.0. Default: `master`.

### Description of the PR

Found out that when Maven plugin is being used, the options may come already set from `additionalProperties` but the `DefaultGenerator` will override it with the default settings nonetheless. This small PR fixes that (followup for https://github.com/swagger-api/swagger-codegen/pull/8397)

