### PR TITLE
Fix for OutOfMemoryError #6394

### DIFF
--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/examples/ExampleGenerator.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/examples/ExampleGenerator.java
@@ -157,6 +157,12 @@ public class ExampleGenerator {
             Property innerType = ((ArrayProperty) property).getItems();
             if (innerType != null) {
                 int arrayLength = null == ((ArrayProperty) property).getMaxItems() ? 2 : ((ArrayProperty) property).getMaxItems();
+				// swagger-jersey2-jaxrs generated spec may contain maxItem = 2147483647
+				// semantically this means there is no upper limit
+				// treating this as if the property was not present at all
+				if (arrayLength == Integer.MAX_VALUE) {
+					arrayLength = 2;
+				}
                 Object[] objectProperties = new Object[arrayLength];
                 Object objProperty = resolvePropertyToExample(propertyName, mediaType, innerType, processedModels);
                 for(int i=0; i < arrayLength; i++) {


### PR DESCRIPTION
swagger-jersey2-jaxrs generated spec may contain maxItem = 2147483647. Semantically this means there is no upper limit. Treating this as if the property was not present at all

### PR checklist

- [ ] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [ ] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [ ] Filed the PR against the correct branch: `3.0.0` branch for changes related to OpenAPI spec 3.0. Default: `master`.
- [ ] Copied the [technical committee](https://github.com/swagger-api/swagger-codegen/#swagger-codegen-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

(details of the change, additional tests that have been done, reference to the issue for tracking, etc)

