### PR TITLE
Revert "Fix getter methods for Java model with additionalProperties"

### DIFF
--- a/modules/swagger-codegen/src/main/resources/Java/pojo.mustache
+++ b/modules/swagger-codegen/src/main/resources/Java/pojo.mustache
@@ -140,12 +140,7 @@ public class {{classname}} {{#parent}}extends {{{parent}}} {{/parent}}{{#parcela
   {{{vendorExtensions.extraAnnotation}}}
 {{/vendorExtensions.extraAnnotation}}
   public {{{datatypeWithEnum}}} {{#isBoolean}}is{{/isBoolean}}{{getter}}() {
-    {{#parent}}
-    return {{name}} == null ? ({{{datatypeWithEnum}}}) this.get("{{name}}") : {{name}};
-    {{/parent}}
-    {{^parent}}
     return {{name}};
-    {{/parent}}
   }
   {{^isReadOnly}}
 


### PR DESCRIPTION
Reverts swagger-api/swagger-codegen#8245

It's causing issue for `resteasy` clients. So best thing to do is revert it and decide what to do with this later.