### PR TITLE
add output file options for swagger codegen

### DIFF
--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/SwaggerGenerator.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/SwaggerGenerator.java
@@ -2,7 +2,9 @@ package io.swagger.codegen.languages;
 
 import java.io.File;
 
+import io.swagger.codegen.CliOption;
 import org.apache.commons.io.FileUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -17,11 +19,20 @@ public class SwaggerGenerator extends DefaultCodegen implements CodegenConfig {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(SwaggerGenerator.class);
 
+    public static final String OUTPUT_NAME = "outputFile";
+
+    public static final String SWAGGER_FILENAME_DEFAULT_JSON = "swagger.json";
+
+    protected String outputFile = SWAGGER_FILENAME_DEFAULT_JSON;
+
     public SwaggerGenerator() {
         super();
         embeddedTemplateDir = templateDir = "swagger";
         outputFolder = "generated-code/swagger";
 
+        cliOptions.add(new CliOption(OUTPUT_NAME,
+                "output filename")
+                .defaultValue(SWAGGER_FILENAME_DEFAULT_JSON));
         supportingFiles.add(new SupportingFile("README.md", "", "README.md"));
     }
 
@@ -45,12 +56,25 @@ public class SwaggerGenerator extends DefaultCodegen implements CodegenConfig {
         String swaggerString = Json.pretty(swagger);
 
         try {
-            String outputFile = outputFolder + File.separator + "swagger.json";
+            String outputFile = outputFolder + File.separator + this.outputFile;
             FileUtils.writeStringToFile(new File(outputFile), swaggerString);
             LOGGER.debug("wrote file to " + outputFile);
         } catch (Exception e) {
             LOGGER.error(e.getMessage(), e);
         }
+    }
+
+    @Override
+    public void processOpts() {
+        super.processOpts();
+
+        if (additionalProperties.containsKey(OUTPUT_NAME) && !StringUtils.isBlank((String) additionalProperties.get(OUTPUT_NAME))) {
+            setOutputFile((String) additionalProperties.get(OUTPUT_NAME));
+        }
+    }
+
+    public void setOutputFile(String outputFile) {
+        this.outputFile = outputFile;
     }
 
     @Override

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/SwaggerYamlGenerator.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/SwaggerYamlGenerator.java
@@ -14,24 +14,31 @@ import io.swagger.models.Swagger;
 import io.swagger.util.DeserializationModule;
 import io.swagger.util.Yaml;
 import org.apache.commons.io.FileUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.File;
 
 public class SwaggerYamlGenerator extends DefaultCodegen implements CodegenConfig {
-    public static final String OUTPUT_NAME = "outputFile";
 
     private static final Logger LOGGER = LoggerFactory.getLogger(SwaggerYamlGenerator.class);
 
-    protected String outputFile = "swagger.yaml";
+    public static final String OUTPUT_NAME = "outputFile";
+
+    public static final String SWAGGER_FILENAME_DEFAULT_YAML = "swagger.yaml";
+
+    protected String outputFile = SWAGGER_FILENAME_DEFAULT_YAML;
+
 
     public SwaggerYamlGenerator() {
         super();
         embeddedTemplateDir = templateDir = "swagger";
         outputFolder = "generated-code/swagger";
 
-        cliOptions.add(new CliOption(OUTPUT_NAME, "output filename"));
+        cliOptions.add(new CliOption(OUTPUT_NAME,
+                "output filename")
+                .defaultValue(SWAGGER_FILENAME_DEFAULT_YAML));
 
         supportingFiles.add(new SupportingFile("README.md", "", "README.md"));
     }
@@ -51,13 +58,17 @@ public class SwaggerYamlGenerator extends DefaultCodegen implements CodegenConfi
         return "Creates a static swagger.yaml file.";
     }
 
-
     @Override
     public void processOpts() {
         super.processOpts();
-        if(additionalProperties.containsKey(OUTPUT_NAME)) {
-            this.outputFile = additionalProperties.get(OUTPUT_NAME).toString();
+
+        if (additionalProperties.containsKey(OUTPUT_NAME) && !StringUtils.isBlank((String) additionalProperties.get(OUTPUT_NAME))) {
+            setOutputFile((String) additionalProperties.get(OUTPUT_NAME));
         }
+    }
+
+    public void setOutputFile(String outputFile) {
+        this.outputFile = outputFile;
     }
 
     @Override

--- a/modules/swagger-codegen/src/test/java/io/swagger/codegen/options/SwaggerOptionsProvider.java
+++ b/modules/swagger-codegen/src/test/java/io/swagger/codegen/options/SwaggerOptionsProvider.java
@@ -3,12 +3,14 @@ package io.swagger.codegen.options;
 import io.swagger.codegen.CodegenConstants;
 
 import com.google.common.collect.ImmutableMap;
+import io.swagger.codegen.languages.SwaggerGenerator;
 
 import java.util.Map;
 
 public class SwaggerOptionsProvider implements OptionsProvider {
     public static final String SORT_PARAMS_VALUE = "false";
     public static final String ENSURE_UNIQUE_PARAMS_VALUE = "true";
+    public static final String OUTPUT_NAME = "swagger.json";
     public static final String ALLOW_UNICODE_IDENTIFIERS_VALUE = "false";
 
 
@@ -22,6 +24,7 @@ public class SwaggerOptionsProvider implements OptionsProvider {
         ImmutableMap.Builder<String, String> builder = new ImmutableMap.Builder<String, String>();
         return builder.put(CodegenConstants.SORT_PARAMS_BY_REQUIRED_FLAG, SORT_PARAMS_VALUE)
                 .put(CodegenConstants.ENSURE_UNIQUE_PARAMS, ENSURE_UNIQUE_PARAMS_VALUE)
+                .put(SwaggerGenerator.OUTPUT_NAME, OUTPUT_NAME)
                 .put(CodegenConstants.ALLOW_UNICODE_IDENTIFIERS, ALLOW_UNICODE_IDENTIFIERS_VALUE)
                 .build();
     }

--- a/modules/swagger-codegen/src/test/java/io/swagger/codegen/options/SwaggerYamlOptionsProvider.java
+++ b/modules/swagger-codegen/src/test/java/io/swagger/codegen/options/SwaggerYamlOptionsProvider.java
@@ -3,12 +3,14 @@ package io.swagger.codegen.options;
 import io.swagger.codegen.CodegenConstants;
 
 import com.google.common.collect.ImmutableMap;
+import io.swagger.codegen.languages.SwaggerYamlGenerator;
 
 import java.util.Map;
 
 public class SwaggerYamlOptionsProvider implements OptionsProvider {
     public static final String SORT_PARAMS_VALUE = "false";
     public static final String ENSURE_UNIQUE_PARAMS_VALUE = "true";
+    public static final String OUTPUT_NAME = "swagger.yaml";
     public static final String ALLOW_UNICODE_IDENTIFIERS_VALUE = "false";
 
     @Override
@@ -21,7 +23,7 @@ public class SwaggerYamlOptionsProvider implements OptionsProvider {
         ImmutableMap.Builder<String, String> builder = new ImmutableMap.Builder<String, String>();
         return builder.put(CodegenConstants.SORT_PARAMS_BY_REQUIRED_FLAG, SORT_PARAMS_VALUE)
                 .put(CodegenConstants.ENSURE_UNIQUE_PARAMS, ENSURE_UNIQUE_PARAMS_VALUE)
-                .put("outputFile", "swagger.yaml")
+                .put(SwaggerYamlGenerator.OUTPUT_NAME, OUTPUT_NAME)
                 .put(CodegenConstants.ALLOW_UNICODE_IDENTIFIERS, ALLOW_UNICODE_IDENTIFIERS_VALUE)
                 .build();
     }

--- a/modules/swagger-codegen/src/test/java/io/swagger/codegen/swagger/SwaggerOptionsTest.java
+++ b/modules/swagger-codegen/src/test/java/io/swagger/codegen/swagger/SwaggerOptionsTest.java
@@ -28,6 +28,8 @@ public class SwaggerOptionsTest extends AbstractOptionsTest {
         new Expectations(clientCodegen) {{
             clientCodegen.setSortParamsByRequiredFlag(Boolean.valueOf(SwaggerOptionsProvider.SORT_PARAMS_VALUE));
             times = 1;
+            clientCodegen.setOutputFile(SwaggerOptionsProvider.OUTPUT_NAME);
+            times = 1;
         }};
     }
 }

--- a/modules/swagger-codegen/src/test/java/io/swagger/codegen/swaggeryaml/SwaggerYamlOptionsTest.java
+++ b/modules/swagger-codegen/src/test/java/io/swagger/codegen/swaggeryaml/SwaggerYamlOptionsTest.java
@@ -28,6 +28,8 @@ public class SwaggerYamlOptionsTest extends AbstractOptionsTest {
         new Expectations(clientCodegen) {{
             clientCodegen.setSortParamsByRequiredFlag(Boolean.valueOf(SwaggerYamlOptionsProvider.SORT_PARAMS_VALUE));
             times = 1;
+            clientCodegen.setOutputFile(SwaggerYamlOptionsProvider.OUTPUT_NAME);
+            times = 1;
         }};
     }
 }


### PR DESCRIPTION
Add option to specify output filename for json/yaml targets (using `swagger.json`/`swagger.yaml` as defaults).