### PR TITLE
WIP: Elixir codegen-fixes

### DIFF
--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/ElixirClientCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/ElixirClientCodegen.java
@@ -690,6 +690,8 @@ public class ElixirClientCodegen extends DefaultCodegen implements CodegenConfig
             // Primitive return type, don't even try to decode
             if (returnBaseType == null || (returnSimpleType && returnTypeIsPrimitive)) {
                 return "false";
+            } else if (isListContainer && languageSpecificPrimitives().contains(returnBaseType)) {
+                return "[]";
             }
             StringBuilder sb = new StringBuilder();
             if (isListContainer) {

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/ElixirClientCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/ElixirClientCodegen.java
@@ -654,6 +654,8 @@ public class ElixirClientCodegen extends DefaultCodegen implements CodegenConfig
                 sb.append(param.dataType);
             } else if (param.isFile) {
                 sb.append("String.t");
+            } else if (param.dataFormat != null) {
+                sb.append(param.dataType);
             } else {
                 // <module>.Model.<type>.t
                 sb.append(moduleName);

--- a/modules/swagger-codegen/src/main/resources/elixir/model.mustache
+++ b/modules/swagger-codegen/src/main/resources/elixir/model.mustache
@@ -11,7 +11,7 @@
   ]
 
   @type t :: %__MODULE__{
-    {{#vars}}:"{{baseName}}" => {{{datatype}}}{{#hasMore}},
+    {{#vars}}:"{{baseName}}" => {{{datatype}}}{{^isRequired}} | nil{{/isRequired}}{{#hasMore}},
     {{/hasMore}}{{/vars}}
   }
 end

--- a/modules/swagger-codegen/src/main/resources/elixir/request_builder.ex.mustache
+++ b/modules/swagger-codegen/src/main/resources/elixir/request_builder.ex.mustache
@@ -85,6 +85,10 @@ defmodule {{moduleName}}.RequestBuilder do
     |> Map.put_new_lazy(:body, &Tesla.Multipart.new/0)
     |> Map.update!(:body, &(Tesla.Multipart.add_field(&1, key, Poison.encode!(value), headers: [{:"Content-Type", "application/json"}])))
   end
+  def add_param(request, :headers, key, value) do
+    request
+    |> Map.update(:headers, %{key => value}, &(Map.put(&1, key, value)))
+  end
   def add_param(request, :file, name, path) do
     request
     |> Map.put_new_lazy(:body, &Tesla.Multipart.new/0)


### PR DESCRIPTION
### PR checklist

- [ ] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [ ] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [ ] Filed the PR against the correct branch: `3.0.0` branch for changes related to OpenAPI spec 3.0. Default: `master`.
- [ ] Copied the [technical committee](https://github.com/swagger-api/swagger-codegen/#swagger-codegen-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR
STILL **WIP** - DO NOT MERGE

This PR tackels multiple issues with the elixir codegen
 - primitiv Types will be "ignored" during the doc generateion - see: samples/client/petstore/elixir/lib/swagger_petstore/api/user.ex:155 (TODO: Create issue)
- Adds the ability to set header params (TODO: Create issue)
- Allows null-values for struct-attributes which are not marked as required (TODO: Create issue)
- Handles primitivs with format same as primitivs without during the typedoc generation
- primitivs in a list will be handles as simple models, which will result in e compile error since - for example - *.Mode.String does not exist
