### PR TITLE
[BUG] [CRITICAL] [PHP] Symfony server incorrect validation: min contstraint in max condition

### DIFF
--- a/modules/swagger-codegen/src/main/resources/php-symfony/model_variables.mustache
+++ b/modules/swagger-codegen/src/main/resources/php-symfony/model_variables.mustache
@@ -67,10 +67,10 @@
     {{/minimum}}
     {{#maximum}}
     {{#exclusiveMaximum}}
-     * @Assert\LessThan({{minimum}})
+     * @Assert\LessThan({{maximum}})
     {{/exclusiveMaximum}}
     {{^exclusiveMaximum}}
-     * @Assert\LessThanOrEqual({{minimum}})
+     * @Assert\LessThanOrEqual({{maximum}})
     {{/exclusiveMaximum}}
     {{/maximum}}
     {{#pattern}}


### PR DESCRIPTION
fix LessThan & LessThanOrEqual conditions

@dkarlovi @mandrean 

