### PR TITLE
Improve symfony 4.1 compatibility for code generator

### DIFF
--- a/modules/swagger-codegen/src/main/resources/php-symfony/composer.mustache
+++ b/modules/swagger-codegen/src/main/resources/php-symfony/composer.mustache
@@ -25,7 +25,7 @@
         "ext-mbstring": "*",
         "symfony/validator": "*",
         "jms/serializer-bundle": "*",
-        "symfony/framework-bundle": "^2.3|^3.0"
+        "symfony/framework-bundle": "^2.3|^3.0|^4.1"
     },
     "require-dev": {
         "phpunit/phpunit": "~4.8",

--- a/modules/swagger-codegen/src/main/resources/php-symfony/services.mustache
+++ b/modules/swagger-codegen/src/main/resources/php-symfony/services.mustache
@@ -14,10 +14,10 @@ services:
         class: {{modelPackage}}\ModelSerializer
 
     {{bundleAlias}}.service.serializer:
-        class: %{{bundleAlias}}.serializer%
+        class: '%{{bundleAlias}}.serializer%'
 
     {{bundleAlias}}.service.validator:
-        class: %{{bundleAlias}}.validator%
+        class: '%{{bundleAlias}}.validator%'
 
 {{#apiInfo}}
 {{#apis}}

--- a/samples/server/petstore/php-symfony/SymfonyBundle-php/Resources/config/services.yml
+++ b/samples/server/petstore/php-symfony/SymfonyBundle-php/Resources/config/services.yml
@@ -14,10 +14,10 @@ services:
         class: Swagger\Server\Model\ModelSerializer
 
     swagger_server.service.serializer:
-        class: %swagger_server.serializer%
+        class: '%swagger_server.serializer%'
 
     swagger_server.service.validator:
-        class: %swagger_server.validator%
+        class: '%swagger_server.validator%'
 
     swagger_server.controller.pet:
         class: Swagger\Server\Controller\PetController

--- a/samples/server/petstore/php-symfony/SymfonyBundle-php/composer.json
+++ b/samples/server/petstore/php-symfony/SymfonyBundle-php/composer.json
@@ -22,7 +22,7 @@
         "ext-mbstring": "*",
         "symfony/validator": "*",
         "jms/serializer-bundle": "*",
-        "symfony/framework-bundle": "^2.3|^3.0"
+        "symfony/framework-bundle": "^2.3|^3.0|^4.1"
     },
     "require-dev": {
         "phpunit/phpunit": "~4.8",


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [x ] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [x ] Filed the PR against the correct branch: `3.0.0` branch for changes related to OpenAPI spec 3.0. Default: `master`.
- [x ] Copied the [technical committee](https://github.com/swagger-api/swagger-codegen/#swagger-codegen-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

Two changes here:

1. Allow for 4.1 dependency
2. Quote the params in container

Both should be safe, bc compatible changes. See related issue for more details.

cc @dkarlovi @mandrean 