### PR TITLE
fix(security): bump superagent dependency 3.5.2 -> 3.7.0

### DIFF
--- a/modules/swagger-codegen/src/main/resources/Javascript/es6/package.mustache
+++ b/modules/swagger-codegen/src/main/resources/Javascript/es6/package.mustache
@@ -13,7 +13,7 @@
   "dependencies": {
     "babel": "^6.23.0",
     "babel-cli": "^6.26.0",
-    "superagent": "3.5.2"
+    "superagent": "3.7.0"
   },
   "devDependencies": {
     "babel-core": "6.26.0",

--- a/modules/swagger-codegen/src/main/resources/Javascript/package.mustache
+++ b/modules/swagger-codegen/src/main/resources/Javascript/package.mustache
@@ -11,7 +11,7 @@
     "fs": false
   },
   "dependencies": {
-    "superagent": "3.5.2"
+    "superagent": "3.7.0"
   },
   "devDependencies": {
     "mocha": "~2.3.4",

--- a/samples/client/petstore-security-test/javascript/package.json
+++ b/samples/client/petstore-security-test/javascript/package.json
@@ -11,7 +11,7 @@
     "fs": false
   },
   "dependencies": {
-    "superagent": "3.5.2"
+    "superagent": "3.7.0"
   },
   "devDependencies": {
     "mocha": "~2.3.4",

--- a/samples/client/petstore/javascript-es6/package.json
+++ b/samples/client/petstore/javascript-es6/package.json
@@ -13,7 +13,7 @@
   "dependencies": {
     "babel": "^6.23.0",
     "babel-cli": "^6.26.0",
-    "superagent": "3.5.2"
+    "superagent": "3.7.0"
   },
   "devDependencies": {
     "babel-core": "6.26.0",

--- a/samples/client/petstore/javascript-promise-es6/package.json
+++ b/samples/client/petstore/javascript-promise-es6/package.json
@@ -13,7 +13,7 @@
   "dependencies": {
     "babel": "^6.23.0",
     "babel-cli": "^6.26.0",
-    "superagent": "3.5.2"
+    "superagent": "3.7.0"
   },
   "devDependencies": {
     "babel-core": "6.26.0",

--- a/samples/client/petstore/javascript-promise/package.json
+++ b/samples/client/petstore/javascript-promise/package.json
@@ -11,7 +11,7 @@
     "fs": false
   },
   "dependencies": {
-    "superagent": "3.5.2"
+    "superagent": "3.7.0"
   },
   "devDependencies": {
     "mocha": "~2.3.4",

--- a/samples/client/petstore/javascript/package.json
+++ b/samples/client/petstore/javascript/package.json
@@ -11,7 +11,7 @@
     "fs": false
   },
   "dependencies": {
-    "superagent": "3.5.2"
+    "superagent": "3.7.0"
   },
   "devDependencies": {
     "mocha": "~2.3.4",


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [ ] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [ ] Filed the PR against the correct branch: `3.0.0` branch for changes related to OpenAPI spec 3.0. Default: `master`.
- [ ] Copied the [technical committee](https://github.com/swagger-api/swagger-codegen/#swagger-codegen-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

This PR bumps the pinned version for superagent to avoid [`CVE-2017-16129`](https://nvd.nist.gov/vuln/detail/CVE-2017-16129):

> ...superagent is vulnerable to ZIP bomb attacks. In a ZIP bomb attack, the HTTP server replies with a compressed response that becomes several magnitudes larger once uncompressed. If a client does not take special care when processing such responses, it may result in excessive CPU and/or memory consumption.