### PR TITLE
[Swift4] Use thread safe manager dictionary (#8583)

### DIFF
--- a/modules/swagger-codegen/src/main/resources/swift4/AlamofireImplementations.mustache
+++ b/modules/swagger-codegen/src/main/resources/swift4/AlamofireImplementations.mustache
@@ -17,8 +17,37 @@ class AlamofireRequestBuilderFactory: RequestBuilderFactory {
     }
 }
 
+private struct SynchronizedDictionary<K: Hashable, V> {
+
+    private var dictionary = [K: V]()
+    private let queue = DispatchQueue(
+        label: "SynchronizedDictionary",
+        qos: DispatchQoS.userInitiated,
+        attributes: [DispatchQueue.Attributes.concurrent],
+        autoreleaseFrequency: DispatchQueue.AutoreleaseFrequency.inherit,
+        target: nil
+    )
+
+    public subscript(key: K) -> V? {
+        get {
+            var value: V?
+
+            queue.sync {
+                value = self.dictionary[key]
+            }
+
+            return value
+        }
+        set {
+            queue.sync(flags: DispatchWorkItemFlags.barrier) {
+                self.dictionary[key] = newValue
+            }
+        }
+    }
+}
+
 // Store manager to retain its reference
-private var managerStore: [String: Alamofire.SessionManager] = [:]
+private var managerStore = SynchronizedDictionary<String, Alamofire.SessionManager>()
 
 open class AlamofireRequestBuilder<T>: RequestBuilder<T> {
     required public init(method: String, URLString: String, parameters: [String : Any]?, isBody: Bool, headers: [String : String] = [:]) {
@@ -112,7 +141,7 @@ open class AlamofireRequestBuilder<T>: RequestBuilder<T> {
         }
 
         let cleanupRequest = {
-            _ = managerStore.removeValue(forKey: managerId)
+            managerStore[managerId] = nil
         }
 
         let validatedRequest = request.validate()
@@ -314,7 +343,7 @@ open class AlamofireDecodableRequestBuilder<T:Decodable>: AlamofireRequestBuilde
         }
 
         let cleanupRequest = {
-            _ = managerStore.removeValue(forKey: managerId)
+          managerStore[managerId] = nil
         }
 
         let validatedRequest = request.validate()

--- a/samples/client/petstore/swift4/default/PetstoreClient/Classes/Swaggers/AlamofireImplementations.swift
+++ b/samples/client/petstore/swift4/default/PetstoreClient/Classes/Swaggers/AlamofireImplementations.swift
@@ -17,8 +17,37 @@ class AlamofireRequestBuilderFactory: RequestBuilderFactory {
     }
 }
 
+private struct SynchronizedDictionary<K: Hashable, V> {
+
+    private var dictionary = [K: V]()
+    private let queue = DispatchQueue(
+        label: "SynchronizedDictionary",
+        qos: DispatchQoS.userInitiated,
+        attributes: [DispatchQueue.Attributes.concurrent],
+        autoreleaseFrequency: DispatchQueue.AutoreleaseFrequency.inherit,
+        target: nil
+    )
+
+    public subscript(key: K) -> V? {
+        get {
+            var value: V?
+
+            queue.sync {
+                value = self.dictionary[key]
+            }
+
+            return value
+        }
+        set {
+            queue.sync(flags: DispatchWorkItemFlags.barrier) {
+                self.dictionary[key] = newValue
+            }
+        }
+    }
+}
+
 // Store manager to retain its reference
-private var managerStore: [String: Alamofire.SessionManager] = [:]
+private var managerStore = SynchronizedDictionary<String, Alamofire.SessionManager>()
 
 open class AlamofireRequestBuilder<T>: RequestBuilder<T> {
     required public init(method: String, URLString: String, parameters: [String : Any]?, isBody: Bool, headers: [String : String] = [:]) {
@@ -112,7 +141,7 @@ open class AlamofireRequestBuilder<T>: RequestBuilder<T> {
         }
 
         let cleanupRequest = {
-            _ = managerStore.removeValue(forKey: managerId)
+            managerStore[managerId] = nil
         }
 
         let validatedRequest = request.validate()
@@ -314,7 +343,7 @@ open class AlamofireDecodableRequestBuilder<T:Decodable>: AlamofireRequestBuilde
         }
 
         let cleanupRequest = {
-            _ = managerStore.removeValue(forKey: managerId)
+          managerStore[managerId] = nil
         }
 
         let validatedRequest = request.validate()


### PR DESCRIPTION
### PR checklist

- [x ] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [ x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [ x] Filed the PR against the correct branch: `3.0.0` branch for changes related to OpenAPI spec 3.0. Default: `master`.
- [ x] Copied the [technical committee](https://github.com/swagger-api/swagger-codegen/#swagger-codegen-technical-committee) to review the pull request if your PR is targeting a particular programming language. @ehyche @jgavris 

### Description of the PR

Client crashes due to concurrent access of managerStore dictionary.
Swift2 and Swift3 had been enhanced respectively with the following pull requests:
#3873 #5610
