### PR TITLE
Use uppercase enum name for CodegenVersion in GenerationRequest

### DIFF
--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/v3/service/GenerationRequest.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/v3/service/GenerationRequest.java
@@ -9,7 +9,7 @@ public class GenerationRequest implements Serializable {
     private String specURL = null;
     private Options options = new Options();
     private Type type = Type.CLIENT;
-    private CodegenVersion codegenVersion = CodegenVersion.v3;
+    private CodegenVersion codegenVersion = CodegenVersion.V3;
 
     public enum Type {
         CLIENT("client"), SERVER("server");
@@ -26,17 +26,7 @@ public class GenerationRequest implements Serializable {
     }
 
     public enum CodegenVersion {
-        v2("V2"), v3("V3");
-
-        private String name;
-
-        CodegenVersion(String name) {
-            this.name = name;
-        }
-
-        public String getCodegenVersionName() {
-            return name;
-        }
+        V2, V3;
     }
 
     public GenerationRequest spec(Object spec) {

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/v3/service/GeneratorService.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/v3/service/GeneratorService.java
@@ -18,7 +18,7 @@ public class GeneratorService {
 
     public GeneratorService generationRequest(GenerationRequest generationRequest) {
         this.generationRequest = generationRequest;
-        if (GenerationRequest.CodegenVersion.v2.equals(generationRequest.getCodegenVersion())) {
+        if (GenerationRequest.CodegenVersion.V2.equals(generationRequest.getCodegenVersion())) {
             final io.swagger.codegen.ClientOptInput clientOptInputV2;
             try {
                 clientOptInputV2 = GeneratorUtil.getClientOptInputV2(generationRequest);

--- a/modules/swagger-codegen/src/test/java/io/swagger/codegen/v3/service/GeneratorServiceTest.java
+++ b/modules/swagger-codegen/src/test/java/io/swagger/codegen/v3/service/GeneratorServiceTest.java
@@ -21,7 +21,7 @@ public class GeneratorServiceTest {
 
         GenerationRequest request = new GenerationRequest();
         request
-                .codegenVersion(GenerationRequest.CodegenVersion.v3)
+                .codegenVersion(GenerationRequest.CodegenVersion.V3)
                 .type(GenerationRequest.Type.SERVER)
                 .spec(loadSpecAsNode("3_0_0/petstore.json", false, false))
                 .options(
@@ -38,7 +38,7 @@ public class GeneratorServiceTest {
 
         GenerationRequest request = new GenerationRequest();
         request
-                .codegenVersion(GenerationRequest.CodegenVersion.v2)
+                .codegenVersion(GenerationRequest.CodegenVersion.V2)
                 .type(GenerationRequest.Type.SERVER)
                 .spec(loadSpecAsNode("2_0/petstore.json", false, true))
                 .options(
@@ -55,7 +55,7 @@ public class GeneratorServiceTest {
 
         GenerationRequest request = new GenerationRequest();
         request
-                .codegenVersion(GenerationRequest.CodegenVersion.v3)
+                .codegenVersion(GenerationRequest.CodegenVersion.V3)
                 .type(GenerationRequest.Type.SERVER)
                 .spec(loadSpecAsNode("2_0/petstore.json", false, true))
                 .options(
@@ -71,7 +71,7 @@ public class GeneratorServiceTest {
     public void testGeneratorServiceJava3RefSpec() {
         GenerationRequest request = new GenerationRequest();
         request
-                .codegenVersion(GenerationRequest.CodegenVersion.v3)
+                .codegenVersion(GenerationRequest.CodegenVersion.V3)
                 .type(GenerationRequest.Type.SERVER)
                 .specURL("3_0_0/petstore.json")
                 .options(
@@ -89,7 +89,7 @@ public class GeneratorServiceTest {
 
         GenerationRequest request = new GenerationRequest();
         request
-                .codegenVersion(GenerationRequest.CodegenVersion.v3)
+                .codegenVersion(GenerationRequest.CodegenVersion.V3)
                 .type(GenerationRequest.Type.CLIENT)
                 .spec(loadSpecAsNode("3_0_0/petstore.json", false, false))
                 .options(
@@ -109,7 +109,7 @@ public class GeneratorServiceTest {
     public void testGeneratorServiceJavaClient2() {
         GenerationRequest request = new GenerationRequest();
         request
-                .codegenVersion(GenerationRequest.CodegenVersion.v2)
+                .codegenVersion(GenerationRequest.CodegenVersion.V2)
                 .type(GenerationRequest.Type.CLIENT)
                 .spec(loadSpecAsNode("2_0/petstore.json", false, true))
                 .options(


### PR DESCRIPTION
Enum name needs to be in uppercase for CodegenVersion.
