### PR TITLE
#6785 Extend Configuration with IFormatProvider 

### DIFF
--- a/modules/swagger-codegen/src/main/resources/csharp/ApiClient.mustache
+++ b/modules/swagger-codegen/src/main/resources/csharp/ApiClient.mustache
@@ -308,7 +308,7 @@ namespace {{packageName}}.Client
                 return flattenedString.ToString();
             }
             else
-                return Convert.ToString (obj);
+                return Convert.ToString (obj, Configuration.FormatProvider);
         }
 
         /// <summary>

--- a/modules/swagger-codegen/src/main/resources/csharp/Configuration.mustache
+++ b/modules/swagger-codegen/src/main/resources/csharp/Configuration.mustache
@@ -5,6 +5,7 @@ using System.Reflection;
 using System.Collections.Concurrent;
 {{/net35}}
 using System.Collections.Generic;
+using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Text;
@@ -107,6 +108,7 @@ namespace {{packageName}}.Client
         /// </summary>
         public Configuration()
         {
+            FormatProvider = CultureInfo.CurrentCulture;
             UserAgent = "{{#httpUserAgent}}{{.}}{{/httpUserAgent}}{{^httpUserAgent}}Swagger-Codegen/{{packageVersion}}/csharp{{/httpUserAgent}}";
             BasePath = "{{{basePath}}}";
             DefaultHeader = new {{^net35}}Concurrent{{/net35}}Dictionary<string, string>();
@@ -347,6 +349,12 @@ namespace {{packageName}}.Client
                 _dateTimeFormat = value;
             }
         }
+
+        /// <summary>
+        /// Gets or sets the format provider that is used for converting values into strings. Defaults to the CultureInfo.CurrentCulture format provider.
+        /// </summary>
+        /// <value>The desired FormatProvider.</value>
+        public IFormatProvider FormatProvider { get; set; }
 
         /// <summary>
         /// Gets or sets the prefix (e.g. Token) of the API key based on the authentication name.

--- a/modules/swagger-codegen/src/main/resources/csharp/IReadableConfiguration.mustache
+++ b/modules/swagger-codegen/src/main/resources/csharp/IReadableConfiguration.mustache
@@ -1,5 +1,6 @@
 {{>partial_header}}
 
+using System;
 using System.Collections.Generic;
 
 namespace {{packageName}}.Client
@@ -38,6 +39,12 @@ namespace {{packageName}}.Client
         /// </summary>
         /// <value>Date time foramt.</value>
         string DateTimeFormat { get; }
+
+        /// <summary>
+        /// Gets the format provider.
+        /// </summary>
+        /// <value>Format provider.</value>
+        IFormatProvider FormatProvider { get; }
 
         /// <summary>
         /// Gets the default header.


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [x] Filed the PR against the correct branch: `3.0.0` branch for changes related to OpenAPI spec 3.0. Default: `master`.
- [x] Copied the [technical committee](https://github.com/swagger-api/swagger-codegen/#swagger-codegen-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

I added a new property to the Configuration so that it is possible to specify an IFormatProvider that is used by the ApiClient to convert values into strings. The property defaults to the CultureInfo.CurrentCulture.

@mandrean