### PR TITLE
Codegen param tweak

### DIFF
--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/v3/CodegenParameter.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/v3/CodegenParameter.java
@@ -15,7 +15,6 @@ public class CodegenParameter extends CodegenObject {
     public List<String> _enum;
     public Map<String, Object> allowableValues;
     public CodegenProperty items;
-    public Map<String, Object> vendorExtensions = new HashMap<>();
 
     /**
      * Determines whether this parameter is mandatory. If the parameter is in "path",
@@ -320,10 +319,6 @@ public class CodegenParameter extends CodegenObject {
 
     public CodegenProperty getItems() {
         return items;
-    }
-
-    public Map<String, Object> getVendorExtensions() {
-        return vendorExtensions;
     }
 
     public boolean getRequired() {


### PR DESCRIPTION
### PR checklist

- [ x] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [ x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [ x] Filed the PR against the correct branch: `3.0.0` branch for changes related to OpenAPI spec 3.0. Default: `master`.
- [ x] Copied the [technical committee](https://github.com/swagger-api/swagger-codegen/#swagger-codegen-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR
removed vendor extension map from codegen parameter object to fix error on templates.