### PR TITLE
Fix typo in dynamic HTML CSS

### DIFF
--- a/modules/swagger-codegen/src/main/resources/swagger-static/assets/css/style.css
+++ b/modules/swagger-codegen/src/main/resources/swagger-static/assets/css/style.css
@@ -22,7 +22,7 @@
   display: none;
 }
 
-.main_content {
+.main-content {
   margin-top: 80px;
   margin-left: 25px;
   margin-right: 25px;


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [ ] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [x] Filed the PR against the correct branch: `3.0.0` branch for changes related to OpenAPI spec 3.0. Default: `master`.
- [ ] Copied the [technical committee](https://github.com/swagger-api/swagger-codegen/#swagger-codegen-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

Corrects a typo in `style.css` that prevented styles from being applied to the `main-content` div in generated HTML pages.

Fixes issue #8650

_Shell script was not run because this is not a behavioral change_