### PR TITLE
Fix go multipart formdata without file

### DIFF
--- a/modules/swagger-codegen/src/main/resources/go/client.mustache
+++ b/modules/swagger-codegen/src/main/resources/go/client.mustache
@@ -215,9 +215,9 @@ func (c *APIClient) prepareRequest(
 			if err != nil {
 				return nil, err
 			}
-			// Set the Boundary in the Content-Type
-			headerParams["Content-Type"] = w.FormDataContentType()
 		}
+		// Set the Boundary in the Content-Type
+		headerParams["Content-Type"] = w.FormDataContentType()
 
 		// Set Content-Length
 		headerParams["Content-Length"] = fmt.Sprintf("%d", body.Len())


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [x] Filed the PR against the correct branch: `3.0.0` branch for changes related to OpenAPI spec 3.0. Default: `master`.
- [x] Copied the [technical committee](https://github.com/swagger-api/swagger-codegen/#swagger-codegen-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

#### Changes

- Golang client
  - Add the boundary to the multipart/form-data content-type header anytime.

#### Problem

In golang client, the boundary was added to the multipart/form-data content-type header only when the form-data contains files.
The multipart/form-data content-type header without the boundary is invalid. ( https://stackoverflow.com/questions/43932900/multipart-form-data-without-a-boundary )
Actually some http servers (e.g. Rack) couldn't handle such a header.
So, we added the boundary to the multipart/form-data content-type header anytime.

#### Technical Committee of Go

no one