### PR TITLE
Scala codegen: avoid processing when REST call fail

### DIFF
--- a/modules/swagger-codegen/src/main/resources/scala/api.mustache
+++ b/modules/swagger-codegen/src/main/resources/scala/api.mustache
@@ -10,7 +10,7 @@ import {{invokerPackage}}.{ApiInvoker, ApiException}
 import com.sun.jersey.multipart.FormDataMultiPart
 import com.sun.jersey.multipart.file.FileDataBodyPart
 
-import javax.ws.rs.core.MediaType
+import javax.ws.rs.core.{MediaType, Response}
 
 import java.io.File
 import java.util.Date
@@ -26,6 +26,7 @@ import java.net.URI
 
 import com.wordnik.swagger.client.ClientResponseReaders.Json4sFormatsReader._
 import com.wordnik.swagger.client.RequestWriters.Json4sFormatsWriter._
+import javax.ws.rs.core.Response.Status.Family
 
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent._
@@ -150,7 +151,11 @@ class {{classname}}AsyncHelper(client: TransportClient, config: SwaggerConfig) e
 
     val resFuture = client.submit("{{httpMethod}}", path, queryParams.toMap, headerParams.toMap, {{#bodyParam}}writer.write({{paramName}}){{/bodyParam}}{{^bodyParam}}"{{emptyBodyParam}}"{{/bodyParam}})
     resFuture flatMap { resp =>
-      process(reader.read(resp))
+      val status = Response.Status.fromStatusCode(resp.statusCode)
+      status.getFamily match {
+        case Family.SUCCESSFUL => process(reader.read(resp))
+        case _ => throw new ApiException(resp.statusCode, resp.statusText)
+      }
     }
   }
 


### PR DESCRIPTION
Mimic what the Java codegen does for processing the response body:
- extract the status family
- only when family is SUCCESSFUL body gets processed

### PR checklist

- [ ] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [ ] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [ ] Filed the PR against the correct branch: `3.0.0` branch for changes related to OpenAPI spec 3.0. Default: `master`.
- [ ] Copied the [technical committee](https://github.com/swagger-api/swagger-codegen/#swagger-codegen-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

(details of the change, additional tests that have been done, reference to the issue for tracking, etc)

