### PR TITLE
Handle when response is a file URL in AlamofireDecodableRequestBuilder.

### DIFF
--- a/modules/swagger-codegen/src/main/resources/swift4/AlamofireImplementations.mustache
+++ b/modules/swagger-codegen/src/main/resources/swift4/AlamofireImplementations.mustache
@@ -340,6 +340,56 @@ open class AlamofireDecodableRequestBuilder<T:Decodable>: AlamofireRequestBuilde
                     nil
                 )
             })
+        case is URL.Type:
+            validatedRequest.responseData(completionHandler: { (dataResponse) in
+                cleanupRequest()
+                
+                do {
+                    
+                    guard !dataResponse.result.isFailure else {
+                        throw DownloadException.responseFailed
+                    }
+                    
+                    guard let data = dataResponse.data else {
+                        throw DownloadException.responseDataMissing
+                    }
+                    
+                    guard let request = request.request else {
+                        throw DownloadException.requestMissing
+                    }
+                    
+                    let fileManager = FileManager.default
+                    let urlRequest = try request.asURLRequest()
+                    let documentsDirectory = fileManager.urls(for: .documentDirectory, in: .userDomainMask)[0]
+                    let requestURL = try self.getURL(from: urlRequest)
+                    
+                    var requestPath = try self.getPath(from: requestURL)
+                    
+                    if let headerFileName = self.getFileName(fromContentDisposition: dataResponse.response?.allHeaderFields["Content-Disposition"] as? String) {
+                        requestPath = requestPath.appending("/\(headerFileName)")
+                    }
+                    
+                    let filePath = documentsDirectory.appendingPathComponent(requestPath)
+                    let directoryPath = filePath.deletingLastPathComponent().path
+                    
+                    try fileManager.createDirectory(atPath: directoryPath, withIntermediateDirectories: true, attributes: nil)
+                    try data.write(to: filePath, options: .atomic)
+                    
+                    completion(
+                        Response(
+                            response: dataResponse.response!,
+                            body: (filePath as! T)
+                        ),
+                        nil
+                    )
+                    
+                } catch let requestParserError as DownloadException {
+                    completion(nil, ErrorResponse.error(400, dataResponse.data, requestParserError))
+                } catch let error {
+                    completion(nil, ErrorResponse.error(400, dataResponse.data, error))
+                }
+                return
+            })
         case is Void.Type:
             validatedRequest.responseData(completionHandler: { (voidResponse) in
                 cleanupRequest()

--- a/samples/client/petstore/swift4/default/PetstoreClient/Classes/Swaggers/AlamofireImplementations.swift
+++ b/samples/client/petstore/swift4/default/PetstoreClient/Classes/Swaggers/AlamofireImplementations.swift
@@ -340,6 +340,56 @@ open class AlamofireDecodableRequestBuilder<T:Decodable>: AlamofireRequestBuilde
                     nil
                 )
             })
+        case is URL.Type:
+            validatedRequest.responseData(completionHandler: { (dataResponse) in
+                cleanupRequest()
+                
+                do {
+                    
+                    guard !dataResponse.result.isFailure else {
+                        throw DownloadException.responseFailed
+                    }
+                    
+                    guard let data = dataResponse.data else {
+                        throw DownloadException.responseDataMissing
+                    }
+                    
+                    guard let request = request.request else {
+                        throw DownloadException.requestMissing
+                    }
+                    
+                    let fileManager = FileManager.default
+                    let urlRequest = try request.asURLRequest()
+                    let documentsDirectory = fileManager.urls(for: .documentDirectory, in: .userDomainMask)[0]
+                    let requestURL = try self.getURL(from: urlRequest)
+                    
+                    var requestPath = try self.getPath(from: requestURL)
+                    
+                    if let headerFileName = self.getFileName(fromContentDisposition: dataResponse.response?.allHeaderFields["Content-Disposition"] as? String) {
+                        requestPath = requestPath.appending("/\(headerFileName)")
+                    }
+                    
+                    let filePath = documentsDirectory.appendingPathComponent(requestPath)
+                    let directoryPath = filePath.deletingLastPathComponent().path
+                    
+                    try fileManager.createDirectory(atPath: directoryPath, withIntermediateDirectories: true, attributes: nil)
+                    try data.write(to: filePath, options: .atomic)
+                    
+                    completion(
+                        Response(
+                            response: dataResponse.response!,
+                            body: (filePath as! T)
+                        ),
+                        nil
+                    )
+                    
+                } catch let requestParserError as DownloadException {
+                    completion(nil, ErrorResponse.error(400, dataResponse.data, requestParserError))
+                } catch let error {
+                    completion(nil, ErrorResponse.error(400, dataResponse.data, error))
+                }
+                return
+            })
         case is Void.Type:
             validatedRequest.responseData(completionHandler: { (voidResponse) in
                 cleanupRequest()

--- a/samples/client/petstore/swift4/promisekit/PetstoreClient/Classes/Swaggers/AlamofireImplementations.swift
+++ b/samples/client/petstore/swift4/promisekit/PetstoreClient/Classes/Swaggers/AlamofireImplementations.swift
@@ -340,6 +340,56 @@ open class AlamofireDecodableRequestBuilder<T:Decodable>: AlamofireRequestBuilde
                     nil
                 )
             })
+        case is URL.Type:
+            validatedRequest.responseData(completionHandler: { (dataResponse) in
+                cleanupRequest()
+                
+                do {
+                    
+                    guard !dataResponse.result.isFailure else {
+                        throw DownloadException.responseFailed
+                    }
+                    
+                    guard let data = dataResponse.data else {
+                        throw DownloadException.responseDataMissing
+                    }
+                    
+                    guard let request = request.request else {
+                        throw DownloadException.requestMissing
+                    }
+                    
+                    let fileManager = FileManager.default
+                    let urlRequest = try request.asURLRequest()
+                    let documentsDirectory = fileManager.urls(for: .documentDirectory, in: .userDomainMask)[0]
+                    let requestURL = try self.getURL(from: urlRequest)
+                    
+                    var requestPath = try self.getPath(from: requestURL)
+                    
+                    if let headerFileName = self.getFileName(fromContentDisposition: dataResponse.response?.allHeaderFields["Content-Disposition"] as? String) {
+                        requestPath = requestPath.appending("/\(headerFileName)")
+                    }
+                    
+                    let filePath = documentsDirectory.appendingPathComponent(requestPath)
+                    let directoryPath = filePath.deletingLastPathComponent().path
+                    
+                    try fileManager.createDirectory(atPath: directoryPath, withIntermediateDirectories: true, attributes: nil)
+                    try data.write(to: filePath, options: .atomic)
+                    
+                    completion(
+                        Response(
+                            response: dataResponse.response!,
+                            body: (filePath as! T)
+                        ),
+                        nil
+                    )
+                    
+                } catch let requestParserError as DownloadException {
+                    completion(nil, ErrorResponse.error(400, dataResponse.data, requestParserError))
+                } catch let error {
+                    completion(nil, ErrorResponse.error(400, dataResponse.data, error))
+                }
+                return
+            })
         case is Void.Type:
             validatedRequest.responseData(completionHandler: { (voidResponse) in
                 cleanupRequest()

--- a/samples/client/petstore/swift4/rxswift/PetstoreClient/Classes/Swaggers/AlamofireImplementations.swift
+++ b/samples/client/petstore/swift4/rxswift/PetstoreClient/Classes/Swaggers/AlamofireImplementations.swift
@@ -340,6 +340,56 @@ open class AlamofireDecodableRequestBuilder<T:Decodable>: AlamofireRequestBuilde
                     nil
                 )
             })
+        case is URL.Type:
+            validatedRequest.responseData(completionHandler: { (dataResponse) in
+                cleanupRequest()
+                
+                do {
+                    
+                    guard !dataResponse.result.isFailure else {
+                        throw DownloadException.responseFailed
+                    }
+                    
+                    guard let data = dataResponse.data else {
+                        throw DownloadException.responseDataMissing
+                    }
+                    
+                    guard let request = request.request else {
+                        throw DownloadException.requestMissing
+                    }
+                    
+                    let fileManager = FileManager.default
+                    let urlRequest = try request.asURLRequest()
+                    let documentsDirectory = fileManager.urls(for: .documentDirectory, in: .userDomainMask)[0]
+                    let requestURL = try self.getURL(from: urlRequest)
+                    
+                    var requestPath = try self.getPath(from: requestURL)
+                    
+                    if let headerFileName = self.getFileName(fromContentDisposition: dataResponse.response?.allHeaderFields["Content-Disposition"] as? String) {
+                        requestPath = requestPath.appending("/\(headerFileName)")
+                    }
+                    
+                    let filePath = documentsDirectory.appendingPathComponent(requestPath)
+                    let directoryPath = filePath.deletingLastPathComponent().path
+                    
+                    try fileManager.createDirectory(atPath: directoryPath, withIntermediateDirectories: true, attributes: nil)
+                    try data.write(to: filePath, options: .atomic)
+                    
+                    completion(
+                        Response(
+                            response: dataResponse.response!,
+                            body: (filePath as! T)
+                        ),
+                        nil
+                    )
+                    
+                } catch let requestParserError as DownloadException {
+                    completion(nil, ErrorResponse.error(400, dataResponse.data, requestParserError))
+                } catch let error {
+                    completion(nil, ErrorResponse.error(400, dataResponse.data, error))
+                }
+                return
+            })
         case is Void.Type:
             validatedRequest.responseData(completionHandler: { (voidResponse) in
                 cleanupRequest()


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [x] Filed the PR against the correct branch: `3.0.0` branch for changes related to OpenAPI spec 3.0. Default: `master`.
- [x] Copied the [technical committee](https://github.com/swagger-api/swagger-codegen/#swagger-codegen-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR
@ehyche 
This is the equivalent change in the AlamofireDecodableRequestBuilder to the change which was made in the non-decodable request in this PR:

https://github.com/swagger-api/swagger-codegen/pull/6469

This updates AlamofireImplementations.mustache to handle when the response is an URL. It also makes changes in the generated sample code for:

default configuration (no promisekit or rxswift)
promisekit
rxswift