### PR TITLE
fixed example fields addition

### DIFF
--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/SwaggerGenerator.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/SwaggerGenerator.java
@@ -3,6 +3,7 @@ package io.swagger.codegen.languages;
 import java.io.File;
 
 import io.swagger.codegen.CliOption;
+import io.swagger.codegen.CodegenConstants;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
@@ -34,6 +35,8 @@ public class SwaggerGenerator extends DefaultCodegen implements CodegenConfig {
                 "output filename")
                 .defaultValue(SWAGGER_FILENAME_DEFAULT_JSON));
         supportingFiles.add(new SupportingFile("README.md", "", "README.md"));
+
+        System.setProperty(CodegenConstants.SUPPORTING_FILES, Boolean.TRUE.toString());
     }
 
     @Override

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/SwaggerYamlGenerator.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/SwaggerYamlGenerator.java
@@ -41,6 +41,8 @@ public class SwaggerYamlGenerator extends DefaultCodegen implements CodegenConfi
                 .defaultValue(SWAGGER_FILENAME_DEFAULT_YAML));
 
         supportingFiles.add(new SupportingFile("README.md", "", "README.md"));
+
+        System.setProperty(CodegenConstants.SUPPORTING_FILES, Boolean.TRUE.toString());
     }
 
     @Override


### PR DESCRIPTION
### PR checklist

- [x ] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [ x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [ x] Filed the PR against the correct branch: `3.0.0` branch for changes related to OpenAPI spec 3.0. Default: `master`.
- [ x] Copied the [technical committee](https://github.com/swagger-api/swagger-codegen/#swagger-codegen-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

fixed the example fields addition, disabling api generation for `swagger` and swagger-yaml generation.

