### PR TITLE
[PHP] update php-symfony/services.mustache

### DIFF
--- a/modules/swagger-codegen/src/main/resources/php-symfony/services.mustache
+++ b/modules/swagger-codegen/src/main/resources/php-symfony/services.mustache
@@ -14,10 +14,10 @@ services:
         class: {{modelPackage}}\ModelSerializer
 
     {{bundleAlias}}.service.serializer:
-        class: %{{bundleAlias}}.serializer%
+        class: "%{{bundleAlias}}.serializer%"
 
     {{bundleAlias}}.service.validator:
-        class: %{{bundleAlias}}.validator%
+        class: "%{{bundleAlias}}.validator%"
 
 {{#apiInfo}}
 {{#apis}}


### PR DESCRIPTION
fix 2 deprecated messages:

"User Deprecated: Not quoting the scalar "%swagger_server.validator%" starting with the "%" indicator character is deprecated since Symfony 3.1 and will throw a ParseException in 4.0 on line 20."

"User Deprecated: Not quoting the scalar "%swagger_server.serializer%" starting with the "%" indicator character is deprecated since Symfony 3.1 and will throw a ParseException in 4.0 in "swagger/server-bundle/Resources/config/services.yml" on line 17."

@dkarlovi 
@mandrean 