### PR TITLE
[PHP] add support deprecated phpdoc tag

### DIFF
--- a/modules/swagger-codegen/src/main/resources/php-symfony/api.mustache
+++ b/modules/swagger-codegen/src/main/resources/php-symfony/api.mustache
@@ -46,6 +46,9 @@ interface {{classname}}
     {{#operation}}
 
     /**
+    {{#isDeprecated}}
+     * @deprecated
+    {{/isDeprecated}}
      * Operation {{{operationId}}}
     {{#summary}}
      *


### PR DESCRIPTION
for php-symfony server codegen.

@dkarlovi
@mandrean

also see 
https://github.com/swagger-api/swagger-codegen/pull/8730
https://github.com/swagger-api/swagger-codegen/pull/8535