### PR TITLE
Updated to .NET Core 2.1

### DIFF
--- a/modules/swagger-codegen/src/main/resources/aspnetcore/Project.csproj.mustache
+++ b/modules/swagger-codegen/src/main/resources/aspnetcore/Project.csproj.mustache
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <Description>{{packageName}}</Description>
     <Copyright>{{packageName}}</Copyright>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <PreserveCompilationContext>true</PreserveCompilationContext>
     <AssemblyName>{{packageName}}</AssemblyName>
@@ -12,14 +12,9 @@
     <Folder Include="wwwroot\"/>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.All" Version="2.0.3"/>
-    <PackageReference Include="Swashbuckle.AspNetCore" Version="1.1.0"/>
-    <PackageReference Include="Newtonsoft.Json" Version="10.0.3"/>
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="2.0.1"/>
-  </ItemGroup>
-  <ItemGroup>
-    <DotNetCliToolReference Include="Microsoft.Extensions.SecretManager.Tools" Version="2.0.0"/>
-    <DotNetCliToolReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Tools" Version="2.0.1"/>
-    <DotNetCliToolReference Include="Microsoft.DotNet.Watcher.Tools" Version="2.0.0"/>
+    <PackageReference Include="Microsoft.AspNetCore.All" Version="2.1.4"/>
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="3.0.0"/>
+    <PackageReference Include="Newtonsoft.Json" Version="11.0.2"/>
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="2.1.3"/>
   </ItemGroup>
 </Project>


### PR DESCRIPTION
### PR checklist

- [X] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [X] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [X] Filed the PR against the correct branch: `3.0.0` branch for changes related to OpenAPI spec 3.0. Default: `master`.
- [X] Copied the [technical committee](https://github.com/swagger-api/swagger-codegen/#swagger-codegen-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

Updated ASPNET Core Generator to support .NET Core 2.1.
As per https://docs.microsoft.com/en-us/dotnet/core/migration/20-21

@jimschubert @wing328 