### PR TITLE
Add nullable property support from OAS 3.0 spec

### DIFF
--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/v3/CodegenParameter.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/v3/CodegenParameter.java
@@ -16,6 +16,7 @@ public class CodegenParameter extends CodegenObject {
     public List<String> _enum;
     public Map<String, Object> allowableValues;
     public CodegenProperty items;
+    public boolean nullable;
 
     /**
      * Determines whether this parameter is mandatory. If the parameter is in "path",
@@ -106,6 +107,7 @@ public class CodegenParameter extends CodegenObject {
         output.description = this.description;
         output.unescapedDescription = this.unescapedDescription;
         output.baseType = this.baseType;
+        output.nullable = this.nullable;
         output.required = this.required;
         output.maximum = this.maximum;
         output.exclusiveMaximum = this.exclusiveMaximum;
@@ -186,6 +188,8 @@ public class CodegenParameter extends CodegenObject {
             return false;
         if (vendorExtensions != null ? !vendorExtensions.equals(that.vendorExtensions) : that.vendorExtensions != null)
             return false;
+        if (nullable != that.nullable)
+            return false;
         if (required != that.required)
             return false;
         if (maximum != null ? !maximum.equals(that.maximum) : that.maximum != null)
@@ -232,6 +236,7 @@ public class CodegenParameter extends CodegenObject {
         result = 31 * result + (allowableValues != null ? allowableValues.hashCode() : 0);
         result = 31 * result + (items != null ? items.hashCode() : 0);
         result = 31 * result + (vendorExtensions != null ? vendorExtensions.hashCode() : 0);
+        result = 31 * result + (nullable ? 13:31);
         result = 31 * result + (required ? 13:31);
         result = 31 * result + (maximum != null ? maximum.hashCode() : 0);
         result = 31 * result + (exclusiveMaximum ? 13:31);
@@ -321,6 +326,10 @@ public class CodegenParameter extends CodegenObject {
 
     public CodegenProperty getItems() {
         return items;
+    }
+
+    public boolean getNullable() {
+        return nullable;
     }
 
     public boolean getRequired() {

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/v3/CodegenProperty.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/v3/CodegenProperty.java
@@ -37,6 +37,7 @@ public class CodegenProperty extends CodegenObject implements Cloneable {
     public boolean exclusiveMinimum;
     public boolean exclusiveMaximum;
     public boolean required, secondaryParam;
+    public boolean nullable;
 
     public List<String> _enum;
     public Map<String, Object> allowableValues;
@@ -279,6 +280,14 @@ public class CodegenProperty extends CodegenObject implements Cloneable {
         this.secondaryParam = secondaryParam;
     }
 
+    public boolean getNullable() {
+        return nullable;
+    }
+
+    public void setNullable(boolean nullable) {
+        this.nullable = nullable;
+    }
+
     public List<String> get_enum() {
         return _enum;
     }
@@ -403,6 +412,7 @@ public class CodegenProperty extends CodegenObject implements Cloneable {
         result = prime * result + ((pattern == null) ? 0 : pattern.hashCode());
         result = prime * result + ((required  ? 13:31));
         result = prime * result + ((secondaryParam ? 13:31));
+        result = prime * result + ((nullable  ? 13:31));
         result = prime * result + ((setter == null) ? 0 : setter.hashCode());
         result = prime * result + ((unescapedDescription == null) ? 0 : unescapedDescription.hashCode());
         result = prime * result + ((vendorExtensions == null) ? 0 : vendorExtensions.hashCode());
@@ -501,6 +511,9 @@ public class CodegenProperty extends CodegenObject implements Cloneable {
             return false;
         }
         if (this.secondaryParam != other.secondaryParam) {
+            return false;
+        }
+        if (this.nullable != other.nullable) {
             return false;
         }
         if (this._enum != other._enum && (this._enum == null || !this._enum.equals(other._enum))) {


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [x] Filed the PR against the correct branch: `3.0.0` branch for changes related to OpenAPI spec 3.0. Default: `master`.
- [x] ~Copied the [technical committee](https://github.com/swagger-api/swagger-codegen/#swagger-codegen-technical-committee) to review the pull request if your PR is targeting a particular programming language.~ _not applicable as this is generic support for an OAS 3.0 spec feature_

### Description of the PR

Add nullable to CodegenProperty to allow code generators to support the [nullable](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.0.md#schemaNullable) property in the 3.0.0, 3.0.1, and 3.0.2 specs.

Possibly Related: #2885, #4262, #6872, #7013, #7600, #8161, #8710