### PR TITLE
Add kotlin parcelize cli option

### DIFF
--- a/bin/kotlin-client-petstore.sh
+++ b/bin/kotlin-client-petstore.sh
@@ -26,6 +26,6 @@ fi
 
 # if you've executed sbt assembly previously it will use that instead.
 export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
-ags="generate -t modules/swagger-codegen/src/main/resources/kotlin-client -i modules/swagger-codegen/src/test/resources/2_0/petstore.yaml -l kotlin --artifact-id kotlin-petstore-client -D dateLibrary=java8 -o samples/client/petstore/kotlin $@"
+ags="generate -t modules/swagger-codegen/src/main/resources/kotlin-client -i modules/swagger-codegen/src/test/resources/2_0/petstore.yaml -l kotlin --artifact-id kotlin-petstore-client -D dateLibrary=java8 -D parcelizeModels=true -o samples/client/petstore/kotlin $@"
 
 java ${JAVA_OPTS} -jar ${executable} ${ags}

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/AbstractKotlinCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/AbstractKotlinCodegen.java
@@ -18,6 +18,7 @@ import java.util.Map;
 
 public abstract class AbstractKotlinCodegen extends DefaultCodegen implements CodegenConfig {
     static Logger LOGGER = LoggerFactory.getLogger(AbstractKotlinCodegen.class);
+    public static final String PARCELIZE_MODELS = "parcelizeModels";
 
     protected String artifactId;
     protected String artifactVersion = "1.0.0";
@@ -28,6 +29,7 @@ public abstract class AbstractKotlinCodegen extends DefaultCodegen implements Co
 
     protected String apiDocPath = "docs/";
     protected String modelDocPath = "docs/";
+    protected boolean parcelizeModels = false;
 
     protected CodegenConstants.ENUM_PROPERTY_NAMING_TYPE enumPropertyNaming = CodegenConstants.ENUM_PROPERTY_NAMING_TYPE.camelCase;
 
@@ -179,6 +181,7 @@ public abstract class AbstractKotlinCodegen extends DefaultCodegen implements Co
 
         CliOption enumPropertyNamingOpt = new CliOption(CodegenConstants.ENUM_PROPERTY_NAMING, CodegenConstants.ENUM_PROPERTY_NAMING_DESC);
         cliOptions.add(enumPropertyNamingOpt.defaultValue(enumPropertyNaming.name()));
+        cliOptions.add(new CliOption(PARCELIZE_MODELS, "boolean - toggle \"@Parcelize\" for generated models"));
     }
 
     @Override
@@ -332,6 +335,12 @@ public abstract class AbstractKotlinCodegen extends DefaultCodegen implements Co
             LOGGER.warn(CodegenConstants.INVOKER_PACKAGE + " with " + this.getName() + " generator is ignored. Use " + CodegenConstants.PACKAGE_NAME + ".");
         }
 
+        if (additionalProperties.containsKey(PARCELIZE_MODELS)) {
+            this.setParcelizeModels(Boolean.valueOf((String)additionalProperties.get(PARCELIZE_MODELS)));
+        } else {
+            additionalProperties.put(PARCELIZE_MODELS, parcelizeModels);
+        }
+
         additionalProperties.put(CodegenConstants.API_PACKAGE, apiPackage());
         additionalProperties.put(CodegenConstants.MODEL_PACKAGE, modelPackage());
 
@@ -357,6 +366,14 @@ public abstract class AbstractKotlinCodegen extends DefaultCodegen implements Co
 
     public void setSourceFolder(String sourceFolder) {
         this.sourceFolder = sourceFolder;
+    }
+
+    public Boolean getParcelizeModels() {
+        return parcelizeModels;
+    }
+
+    public void setParcelizeModels(Boolean parcelizeModels) {
+        this.parcelizeModels = parcelizeModels;
     }
 
     /**

--- a/modules/swagger-codegen/src/main/resources/kotlin-client/data_class.mustache
+++ b/modules/swagger-codegen/src/main/resources/kotlin-client/data_class.mustache
@@ -1,19 +1,27 @@
 {{#hasEnums}}
 import com.squareup.moshi.Json
 {{/hasEnums}}
+{{#parcelizeModels}}
+import android.os.Parcelable
+import kotlinx.android.parcel.Parcelize
+{{/parcelizeModels}}
+
 /**
  * {{{description}}}
 {{#vars}}
  * @param {{name}} {{{description}}}
 {{/vars}}
  */
+{{#parcelizeModels}}
+@Parcelize
+{{/parcelizeModels}}
 data class {{classname}} (
 {{#requiredVars}}
 {{>data_class_req_var}}{{^-last}},
 {{/-last}}{{/requiredVars}}{{#hasRequired}}{{#hasOptional}},
 {{/hasOptional}}{{/hasRequired}}{{#optionalVars}}{{>data_class_opt_var}}{{^-last}},
 {{/-last}}{{/optionalVars}}
-) {
+){{#parcelizeModels}} : Parcelable{{/parcelizeModels}} {
 {{#hasEnums}}{{#vars}}{{#isEnum}}
     /**
     * {{{description}}}

--- a/modules/swagger-codegen/src/main/resources/kotlin-server/data_class.mustache
+++ b/modules/swagger-codegen/src/main/resources/kotlin-server/data_class.mustache
@@ -1,16 +1,24 @@
+{{#parcelizeModels}}
+import android.os.Parcelable
+import kotlinx.android.parcel.Parcelize
+{{/parcelizeModels}}
+
 /**
  * {{{description}}}
 {{#vars}}
  * @param {{name}} {{{description}}}
 {{/vars}}
  */
+{{#parcelizeModels}}
+@Parcelize
+{{/parcelizeModels}}
 data class {{classname}} (
 {{#requiredVars}}
 {{>data_class_req_var}}{{^-last}},
 {{/-last}}{{/requiredVars}}{{#hasRequired}}{{#hasOptional}},
 {{/hasOptional}}{{/hasRequired}}{{#optionalVars}}{{>data_class_opt_var}}{{^-last}},
 {{/-last}}{{/optionalVars}}
-) {
+){{#parcelizeModels}} : Parcelable{{/parcelizeModels}} {
 {{#hasEnums}}{{#vars}}{{#isEnum}}
     /**
     * {{{description}}}

--- a/modules/swagger-codegen/src/test/java/io/swagger/codegen/options/KotlinClientCodegenOptionsProvider.java
+++ b/modules/swagger-codegen/src/test/java/io/swagger/codegen/options/KotlinClientCodegenOptionsProvider.java
@@ -15,6 +15,7 @@ public class KotlinClientCodegenOptionsProvider implements OptionsProvider {
     public static final String SOURCE_FOLDER = "./generated/kotlin";
     public static final String ENUM_PROPERTY_NAMING = "camelCase";
     public static final String DATE_LIBRARY = KotlinClientCodegen.DateLibrary.JAVA8.value;
+    public static final String PARCELIZE_MOELS = "false";
 
     @Override
     public String getLanguage() {
@@ -32,6 +33,7 @@ public class KotlinClientCodegenOptionsProvider implements OptionsProvider {
                 .put(CodegenConstants.SOURCE_FOLDER, SOURCE_FOLDER)
                 .put(CodegenConstants.ENUM_PROPERTY_NAMING, ENUM_PROPERTY_NAMING)
                 .put(KotlinClientCodegen.DATE_LIBRARY, DATE_LIBRARY)
+                .put(KotlinClientCodegen.PARCELIZE_MODELS, PARCELIZE_MOELS)
                 .build();
     }
 

--- a/samples/client/petstore/kotlin/README.md
+++ b/samples/client/petstore/kotlin/README.md
@@ -31,7 +31,7 @@ This runs all tests and packages the library.
 <a name="documentation-for-api-endpoints"></a>
 ## Documentation for API Endpoints
 
-All URIs are relative to *https://petstore.swagger.io/v2*
+All URIs are relative to *http://petstore.swagger.io/v2*
 
 Class | Method | HTTP request | Description
 ------------ | ------------- | ------------- | -------------
@@ -60,8 +60,10 @@ Class | Method | HTTP request | Description
 <a name="documentation-for-models"></a>
 ## Documentation for Models
 
+ - [io.swagger.client.models.Amount](docs/Amount.md)
  - [io.swagger.client.models.ApiResponse](docs/ApiResponse.md)
  - [io.swagger.client.models.Category](docs/Category.md)
+ - [io.swagger.client.models.Currency](docs/Currency.md)
  - [io.swagger.client.models.Order](docs/Order.md)
  - [io.swagger.client.models.Pet](docs/Pet.md)
  - [io.swagger.client.models.Tag](docs/Tag.md)
@@ -83,7 +85,7 @@ Class | Method | HTTP request | Description
 
 - **Type**: OAuth
 - **Flow**: implicit
-- **Authorization URL**: https://petstore.swagger.io/oauth/dialog
+- **Authorization URL**: http://petstore.swagger.io/api/oauth/dialog
 - **Scopes**: 
   - write:pets: modify pets in your account
   - read:pets: read your pets

--- a/samples/client/petstore/kotlin/docs/Amount.md
+++ b/samples/client/petstore/kotlin/docs/Amount.md
@@ -1,0 +1,11 @@
+
+# Amount
+
+## Properties
+Name | Type | Description | Notes
+------------ | ------------- | ------------- | -------------
+**value** | **kotlin.Double** | some description  | 
+**currency** | [**Currency**](Currency.md) |  | 
+
+
+

--- a/samples/client/petstore/kotlin/docs/Currency.md
+++ b/samples/client/petstore/kotlin/docs/Currency.md
@@ -1,0 +1,9 @@
+
+# Currency
+
+## Properties
+Name | Type | Description | Notes
+------------ | ------------- | ------------- | -------------
+
+
+

--- a/samples/client/petstore/kotlin/docs/PetApi.md
+++ b/samples/client/petstore/kotlin/docs/PetApi.md
@@ -1,6 +1,6 @@
 # PetApi
 
-All URIs are relative to *https://petstore.swagger.io/v2*
+All URIs are relative to *http://petstore.swagger.io/v2*
 
 Method | HTTP request | Description
 ------------- | ------------- | -------------
@@ -161,7 +161,7 @@ Name | Type | Description  | Notes
 
 Finds Pets by tags
 
-Muliple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
+Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
 
 ### Example
 ```kotlin

--- a/samples/client/petstore/kotlin/docs/StoreApi.md
+++ b/samples/client/petstore/kotlin/docs/StoreApi.md
@@ -1,6 +1,6 @@
 # StoreApi
 
-All URIs are relative to *https://petstore.swagger.io/v2*
+All URIs are relative to *http://petstore.swagger.io/v2*
 
 Method | HTTP request | Description
 ------------- | ------------- | -------------
@@ -16,7 +16,7 @@ Method | HTTP request | Description
 
 Delete purchase order by ID
 
-For valid response try integer IDs with positive integer value. Negative or non-integer values will generate API errors
+For valid response try integer IDs with value &lt; 1000. Anything above 1000 or nonintegers will generate API errors
 
 ### Example
 ```kotlin
@@ -25,7 +25,7 @@ For valid response try integer IDs with positive integer value. Negative or non-
 //import io.swagger.client.models.*
 
 val apiInstance = StoreApi()
-val orderId : kotlin.Long = 789 // kotlin.Long | ID of the order that needs to be deleted
+val orderId : kotlin.String = orderId_example // kotlin.String | ID of the order that needs to be deleted
 try {
     apiInstance.deleteOrder(orderId)
 } catch (e: ClientException) {
@@ -41,7 +41,7 @@ try {
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
- **orderId** | **kotlin.Long**| ID of the order that needs to be deleted |
+ **orderId** | **kotlin.String**| ID of the order that needs to be deleted |
 
 ### Return type
 
@@ -105,7 +105,7 @@ This endpoint does not need any parameter.
 
 Find purchase order by ID
 
-For valid response try integer IDs with value &gt;&#x3D; 1 and &lt;&#x3D; 10. Other values will generated exceptions
+For valid response try integer IDs with value &lt;&#x3D; 5 or &gt; 10. Other values will generated exceptions
 
 ### Example
 ```kotlin

--- a/samples/client/petstore/kotlin/docs/UserApi.md
+++ b/samples/client/petstore/kotlin/docs/UserApi.md
@@ -1,6 +1,6 @@
 # UserApi
 
-All URIs are relative to *https://petstore.swagger.io/v2*
+All URIs are relative to *http://petstore.swagger.io/v2*
 
 Method | HTTP request | Description
 ------------- | ------------- | -------------
@@ -213,7 +213,7 @@ Get user by user name
 //import io.swagger.client.models.*
 
 val apiInstance = UserApi()
-val username : kotlin.String = username_example // kotlin.String | The name that needs to be fetched. Use user1 for testing. 
+val username : kotlin.String = username_example // kotlin.String | The name that needs to be fetched. Use user1 for testing.
 try {
     val result : User = apiInstance.getUserByName(username)
     println(result)
@@ -230,7 +230,7 @@ try {
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
- **username** | **kotlin.String**| The name that needs to be fetched. Use user1 for testing.  |
+ **username** | **kotlin.String**| The name that needs to be fetched. Use user1 for testing. |
 
 ### Return type
 
@@ -351,7 +351,7 @@ This can only be done by the logged in user.
 //import io.swagger.client.models.*
 
 val apiInstance = UserApi()
-val username : kotlin.String = username_example // kotlin.String | name that need to be updated
+val username : kotlin.String = username_example // kotlin.String | name that need to be deleted
 val body : User =  // User | Updated user object
 try {
     apiInstance.updateUser(username, body)
@@ -368,7 +368,7 @@ try {
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
- **username** | **kotlin.String**| name that need to be updated |
+ **username** | **kotlin.String**| name that need to be deleted |
  **body** | [**User**](User.md)| Updated user object |
 
 ### Return type

--- a/samples/client/petstore/kotlin/settings.gradle
+++ b/samples/client/petstore/kotlin/settings.gradle
@@ -1,1 +1,1 @@
-rootProject.name = 'kotlin-client'
+rootProject.name = 'kotlin-petstore-client'

--- a/samples/client/petstore/kotlin/src/main/kotlin/io/swagger/client/apis/PetApi.kt
+++ b/samples/client/petstore/kotlin/src/main/kotlin/io/swagger/client/apis/PetApi.kt
@@ -16,7 +16,7 @@ import io.swagger.client.models.Pet
 
 import io.swagger.client.infrastructure.*
 
-class PetApi(basePath: kotlin.String = "https://petstore.swagger.io/v2") : ApiClient(basePath) {
+class PetApi(basePath: kotlin.String = "http://petstore.swagger.io/v2") : ApiClient(basePath) {
 
     /**
     * Add a new pet to the store
@@ -102,7 +102,7 @@ class PetApi(basePath: kotlin.String = "https://petstore.swagger.io/v2") : ApiCl
     @Suppress("UNCHECKED_CAST")
     fun findPetsByStatus(status: kotlin.Array<kotlin.String>) : kotlin.Array<Pet> {
         val localVariableBody: kotlin.Any? = null
-        val localVariableQuery: MultiValueMap = mapOf("status" to toMultiValue(status.toList(), "multi"))
+        val localVariableQuery: MultiValueMap = mapOf("status" to toMultiValue(status.toList(), "csv"))
         
         val contentHeaders: kotlin.collections.Map<kotlin.String,kotlin.String> = mapOf()
         val acceptsHeaders: kotlin.collections.Map<kotlin.String,kotlin.String> = mapOf("Accept" to "application/xml, application/json")
@@ -133,14 +133,14 @@ class PetApi(basePath: kotlin.String = "https://petstore.swagger.io/v2") : ApiCl
 
     /**
     * Finds Pets by tags
-    * Muliple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
+    * Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
     * @param tags Tags to filter by 
     * @return kotlin.Array<Pet>
     */
     @Suppress("UNCHECKED_CAST")
     fun findPetsByTags(tags: kotlin.Array<kotlin.String>) : kotlin.Array<Pet> {
         val localVariableBody: kotlin.Any? = null
-        val localVariableQuery: MultiValueMap = mapOf("tags" to toMultiValue(tags.toList(), "multi"))
+        val localVariableQuery: MultiValueMap = mapOf("tags" to toMultiValue(tags.toList(), "csv"))
         
         val contentHeaders: kotlin.collections.Map<kotlin.String,kotlin.String> = mapOf()
         val acceptsHeaders: kotlin.collections.Map<kotlin.String,kotlin.String> = mapOf("Accept" to "application/xml, application/json")

--- a/samples/client/petstore/kotlin/src/main/kotlin/io/swagger/client/apis/StoreApi.kt
+++ b/samples/client/petstore/kotlin/src/main/kotlin/io/swagger/client/apis/StoreApi.kt
@@ -15,15 +15,15 @@ import io.swagger.client.models.Order
 
 import io.swagger.client.infrastructure.*
 
-class StoreApi(basePath: kotlin.String = "https://petstore.swagger.io/v2") : ApiClient(basePath) {
+class StoreApi(basePath: kotlin.String = "http://petstore.swagger.io/v2") : ApiClient(basePath) {
 
     /**
     * Delete purchase order by ID
-    * For valid response try integer IDs with positive integer value. Negative or non-integer values will generate API errors
+    * For valid response try integer IDs with value &lt; 1000. Anything above 1000 or nonintegers will generate API errors
     * @param orderId ID of the order that needs to be deleted 
     * @return void
     */
-    fun deleteOrder(orderId: kotlin.Long) : Unit {
+    fun deleteOrder(orderId: kotlin.String) : Unit {
         val localVariableBody: kotlin.Any? = null
         val localVariableQuery: MultiValueMap = mapOf()
         
@@ -93,7 +93,7 @@ class StoreApi(basePath: kotlin.String = "https://petstore.swagger.io/v2") : Api
 
     /**
     * Find purchase order by ID
-    * For valid response try integer IDs with value &gt;&#x3D; 1 and &lt;&#x3D; 10. Other values will generated exceptions
+    * For valid response try integer IDs with value &lt;&#x3D; 5 or &gt; 10. Other values will generated exceptions
     * @param orderId ID of pet that needs to be fetched 
     * @return Order
     */

--- a/samples/client/petstore/kotlin/src/main/kotlin/io/swagger/client/apis/UserApi.kt
+++ b/samples/client/petstore/kotlin/src/main/kotlin/io/swagger/client/apis/UserApi.kt
@@ -15,7 +15,7 @@ import io.swagger.client.models.User
 
 import io.swagger.client.infrastructure.*
 
-class UserApi(basePath: kotlin.String = "https://petstore.swagger.io/v2") : ApiClient(basePath) {
+class UserApi(basePath: kotlin.String = "http://petstore.swagger.io/v2") : ApiClient(basePath) {
 
     /**
     * Create user
@@ -168,7 +168,7 @@ class UserApi(basePath: kotlin.String = "https://petstore.swagger.io/v2") : ApiC
     /**
     * Get user by user name
     * 
-    * @param username The name that needs to be fetched. Use user1 for testing.  
+    * @param username The name that needs to be fetched. Use user1 for testing. 
     * @return User
     */
     @Suppress("UNCHECKED_CAST")
@@ -281,7 +281,7 @@ class UserApi(basePath: kotlin.String = "https://petstore.swagger.io/v2") : ApiC
     /**
     * Updated user
     * This can only be done by the logged in user.
-    * @param username name that need to be updated 
+    * @param username name that need to be deleted 
     * @param body Updated user object 
     * @return void
     */

--- a/samples/client/petstore/kotlin/src/main/kotlin/io/swagger/client/models/Amount.kt
+++ b/samples/client/petstore/kotlin/src/main/kotlin/io/swagger/client/models/Amount.kt
@@ -11,21 +11,21 @@
 */
 package io.swagger.client.models
 
+import io.swagger.client.models.Currency
 
 import android.os.Parcelable
 import kotlinx.android.parcel.Parcelize
 
 /**
- * Describes the result of uploading an image resource
- * @param code 
- * @param type 
- * @param message 
+ * some description 
+ * @param value some description 
+ * @param currency 
  */
 @Parcelize
-data class ApiResponse (
-    val code: kotlin.Int? = null,
-    val type: kotlin.String? = null,
-    val message: kotlin.String? = null
+data class Amount (
+    /* some description  */
+    val value: kotlin.Double,
+    val currency: Currency
 ) : Parcelable {
 
 }

--- a/samples/client/petstore/kotlin/src/main/kotlin/io/swagger/client/models/Category.kt
+++ b/samples/client/petstore/kotlin/src/main/kotlin/io/swagger/client/models/Category.kt
@@ -12,15 +12,19 @@
 package io.swagger.client.models
 
 
+import android.os.Parcelable
+import kotlinx.android.parcel.Parcelize
+
 /**
- * 
+ * A category for a pet
  * @param id 
  * @param name 
  */
+@Parcelize
 data class Category (
     val id: kotlin.Long? = null,
     val name: kotlin.String? = null
-) {
+) : Parcelable {
 
 }
 

--- a/samples/client/petstore/kotlin/src/main/kotlin/io/swagger/client/models/Currency.kt
+++ b/samples/client/petstore/kotlin/src/main/kotlin/io/swagger/client/models/Currency.kt
@@ -12,21 +12,4 @@
 package io.swagger.client.models
 
 
-import android.os.Parcelable
-import kotlinx.android.parcel.Parcelize
-
-/**
- * Describes the result of uploading an image resource
- * @param code 
- * @param type 
- * @param message 
- */
-@Parcelize
-data class ApiResponse (
-    val code: kotlin.Int? = null,
-    val type: kotlin.String? = null,
-    val message: kotlin.String? = null
-) : Parcelable {
-
-}
-
+typealias Currency = kotlin.String

--- a/samples/client/petstore/kotlin/src/main/kotlin/io/swagger/client/models/Order.kt
+++ b/samples/client/petstore/kotlin/src/main/kotlin/io/swagger/client/models/Order.kt
@@ -13,8 +13,11 @@ package io.swagger.client.models
 
 
 import com.squareup.moshi.Json
+import android.os.Parcelable
+import kotlinx.android.parcel.Parcelize
+
 /**
- * 
+ * An order for a pets from the pet store
  * @param id 
  * @param petId 
  * @param quantity 
@@ -22,6 +25,7 @@ import com.squareup.moshi.Json
  * @param status Order Status
  * @param complete 
  */
+@Parcelize
 data class Order (
     val id: kotlin.Long? = null,
     val petId: kotlin.Long? = null,
@@ -30,7 +34,7 @@ data class Order (
     /* Order Status */
     val status: Order.Status? = null,
     val complete: kotlin.Boolean? = null
-) {
+) : Parcelable {
 
     /**
     * Order Status

--- a/samples/client/petstore/kotlin/src/main/kotlin/io/swagger/client/models/Pet.kt
+++ b/samples/client/petstore/kotlin/src/main/kotlin/io/swagger/client/models/Pet.kt
@@ -15,8 +15,11 @@ import io.swagger.client.models.Category
 import io.swagger.client.models.Tag
 
 import com.squareup.moshi.Json
+import android.os.Parcelable
+import kotlinx.android.parcel.Parcelize
+
 /**
- * 
+ * A pet for sale in the pet store
  * @param id 
  * @param category 
  * @param name 
@@ -24,6 +27,7 @@ import com.squareup.moshi.Json
  * @param tags 
  * @param status pet status in the store
  */
+@Parcelize
 data class Pet (
     val name: kotlin.String,
     val photoUrls: kotlin.Array<kotlin.String>,
@@ -32,7 +36,7 @@ data class Pet (
     val tags: kotlin.Array<Tag>? = null,
     /* pet status in the store */
     val status: Pet.Status? = null
-) {
+) : Parcelable {
 
     /**
     * pet status in the store

--- a/samples/client/petstore/kotlin/src/main/kotlin/io/swagger/client/models/Tag.kt
+++ b/samples/client/petstore/kotlin/src/main/kotlin/io/swagger/client/models/Tag.kt
@@ -12,15 +12,19 @@
 package io.swagger.client.models
 
 
+import android.os.Parcelable
+import kotlinx.android.parcel.Parcelize
+
 /**
- * 
+ * A tag for a pet
  * @param id 
  * @param name 
  */
+@Parcelize
 data class Tag (
     val id: kotlin.Long? = null,
     val name: kotlin.String? = null
-) {
+) : Parcelable {
 
 }
 

--- a/samples/client/petstore/kotlin/src/main/kotlin/io/swagger/client/models/User.kt
+++ b/samples/client/petstore/kotlin/src/main/kotlin/io/swagger/client/models/User.kt
@@ -12,8 +12,11 @@
 package io.swagger.client.models
 
 
+import android.os.Parcelable
+import kotlinx.android.parcel.Parcelize
+
 /**
- * 
+ * A User who is purchasing from the pet store
  * @param id 
  * @param username 
  * @param firstName 
@@ -23,6 +26,7 @@ package io.swagger.client.models
  * @param phone 
  * @param userStatus User Status
  */
+@Parcelize
 data class User (
     val id: kotlin.Long? = null,
     val username: kotlin.String? = null,
@@ -33,7 +37,7 @@ data class User (
     val phone: kotlin.String? = null,
     /* User Status */
     val userStatus: kotlin.Int? = null
-) {
+) : Parcelable {
 
 }
 


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [ ] Filed the PR against the correct branch: `3.0.0` branch for changes related to OpenAPI spec 3.0. Default: `master`.
- [ ] Copied the [technical committee](https://github.com/swagger-api/swagger-codegen/#swagger-codegen-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

With cli option `parcelizeModels` (false by default) allow the use of kotlin's parcelize feature which generates all boilerplate automatically.

Similar to request on https://github.com/swagger-api/swagger-codegen/issues/3302 but with far less work because most of it is done by the parcelization feature.
