### PR TITLE
Frozenstep kotlin void response type

### DIFF
--- a/modules/swagger-codegen/src/main/resources/kotlin-client/api.mustache
+++ b/modules/swagger-codegen/src/main/resources/kotlin-client/api.mustache
@@ -36,7 +36,7 @@ class {{classname}}(basePath: kotlin.String = "{{{basePath}}}") : ApiClient(base
             query = localVariableQuery,
             headers = localVariableHeaders
         )
-        val response = request<{{#returnType}}{{{returnType}}}{{/returnType}}{{^returnType}}Any?{{/returnType}}>(
+        val response = request<{{#returnType}}{{{returnType}}}{{/returnType}}{{^returnType}}Unit{{/returnType}}>(
             localVariableConfig,
             localVariableBody
         )

--- a/modules/swagger-codegen/src/main/resources/kotlin-client/infrastructure/ApiClient.kt.mustache
+++ b/modules/swagger-codegen/src/main/resources/kotlin-client/infrastructure/ApiClient.kt.mustache
@@ -58,6 +58,8 @@ open class ApiClient(val baseUrl: String) {
         
         if(T::class.java == java.io.File::class.java){
             return downloadFileFromResponse(response) as T
+        } else if(T::class == kotlin.Unit::class) {
+            return kotlin.Unit as T
         }
         
         var contentType = response.headers().get("Content-Type")

--- a/samples/client/petstore/kotlin/README.md
+++ b/samples/client/petstore/kotlin/README.md
@@ -31,7 +31,7 @@ This runs all tests and packages the library.
 <a name="documentation-for-api-endpoints"></a>
 ## Documentation for API Endpoints
 
-All URIs are relative to *https://petstore.swagger.io/v2*
+All URIs are relative to *http://petstore.swagger.io/v2*
 
 Class | Method | HTTP request | Description
 ------------ | ------------- | ------------- | -------------
@@ -60,8 +60,10 @@ Class | Method | HTTP request | Description
 <a name="documentation-for-models"></a>
 ## Documentation for Models
 
+ - [io.swagger.client.models.Amount](docs/Amount.md)
  - [io.swagger.client.models.ApiResponse](docs/ApiResponse.md)
  - [io.swagger.client.models.Category](docs/Category.md)
+ - [io.swagger.client.models.Currency](docs/Currency.md)
  - [io.swagger.client.models.Order](docs/Order.md)
  - [io.swagger.client.models.Pet](docs/Pet.md)
  - [io.swagger.client.models.Tag](docs/Tag.md)
@@ -83,7 +85,7 @@ Class | Method | HTTP request | Description
 
 - **Type**: OAuth
 - **Flow**: implicit
-- **Authorization URL**: https://petstore.swagger.io/oauth/dialog
+- **Authorization URL**: http://petstore.swagger.io/api/oauth/dialog
 - **Scopes**: 
   - write:pets: modify pets in your account
   - read:pets: read your pets

--- a/samples/client/petstore/kotlin/docs/Amount.md
+++ b/samples/client/petstore/kotlin/docs/Amount.md
@@ -1,0 +1,11 @@
+
+# Amount
+
+## Properties
+Name | Type | Description | Notes
+------------ | ------------- | ------------- | -------------
+**value** | **kotlin.Double** | some description  | 
+**currency** | [**Currency**](Currency.md) |  | 
+
+
+

--- a/samples/client/petstore/kotlin/docs/Currency.md
+++ b/samples/client/petstore/kotlin/docs/Currency.md
@@ -1,0 +1,9 @@
+
+# Currency
+
+## Properties
+Name | Type | Description | Notes
+------------ | ------------- | ------------- | -------------
+
+
+

--- a/samples/client/petstore/kotlin/docs/PetApi.md
+++ b/samples/client/petstore/kotlin/docs/PetApi.md
@@ -1,6 +1,6 @@
 # PetApi
 
-All URIs are relative to *https://petstore.swagger.io/v2*
+All URIs are relative to *http://petstore.swagger.io/v2*
 
 Method | HTTP request | Description
 ------------- | ------------- | -------------
@@ -161,7 +161,7 @@ Name | Type | Description  | Notes
 
 Finds Pets by tags
 
-Muliple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
+Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
 
 ### Example
 ```kotlin

--- a/samples/client/petstore/kotlin/docs/StoreApi.md
+++ b/samples/client/petstore/kotlin/docs/StoreApi.md
@@ -1,6 +1,6 @@
 # StoreApi
 
-All URIs are relative to *https://petstore.swagger.io/v2*
+All URIs are relative to *http://petstore.swagger.io/v2*
 
 Method | HTTP request | Description
 ------------- | ------------- | -------------
@@ -16,7 +16,7 @@ Method | HTTP request | Description
 
 Delete purchase order by ID
 
-For valid response try integer IDs with positive integer value. Negative or non-integer values will generate API errors
+For valid response try integer IDs with value &lt; 1000. Anything above 1000 or nonintegers will generate API errors
 
 ### Example
 ```kotlin
@@ -25,7 +25,7 @@ For valid response try integer IDs with positive integer value. Negative or non-
 //import io.swagger.client.models.*
 
 val apiInstance = StoreApi()
-val orderId : kotlin.Long = 789 // kotlin.Long | ID of the order that needs to be deleted
+val orderId : kotlin.String = orderId_example // kotlin.String | ID of the order that needs to be deleted
 try {
     apiInstance.deleteOrder(orderId)
 } catch (e: ClientException) {
@@ -41,7 +41,7 @@ try {
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
- **orderId** | **kotlin.Long**| ID of the order that needs to be deleted |
+ **orderId** | **kotlin.String**| ID of the order that needs to be deleted |
 
 ### Return type
 
@@ -105,7 +105,7 @@ This endpoint does not need any parameter.
 
 Find purchase order by ID
 
-For valid response try integer IDs with value &gt;&#x3D; 1 and &lt;&#x3D; 10. Other values will generated exceptions
+For valid response try integer IDs with value &lt;&#x3D; 5 or &gt; 10. Other values will generated exceptions
 
 ### Example
 ```kotlin

--- a/samples/client/petstore/kotlin/docs/UserApi.md
+++ b/samples/client/petstore/kotlin/docs/UserApi.md
@@ -1,6 +1,6 @@
 # UserApi
 
-All URIs are relative to *https://petstore.swagger.io/v2*
+All URIs are relative to *http://petstore.swagger.io/v2*
 
 Method | HTTP request | Description
 ------------- | ------------- | -------------
@@ -213,7 +213,7 @@ Get user by user name
 //import io.swagger.client.models.*
 
 val apiInstance = UserApi()
-val username : kotlin.String = username_example // kotlin.String | The name that needs to be fetched. Use user1 for testing. 
+val username : kotlin.String = username_example // kotlin.String | The name that needs to be fetched. Use user1 for testing.
 try {
     val result : User = apiInstance.getUserByName(username)
     println(result)
@@ -230,7 +230,7 @@ try {
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
- **username** | **kotlin.String**| The name that needs to be fetched. Use user1 for testing.  |
+ **username** | **kotlin.String**| The name that needs to be fetched. Use user1 for testing. |
 
 ### Return type
 
@@ -351,7 +351,7 @@ This can only be done by the logged in user.
 //import io.swagger.client.models.*
 
 val apiInstance = UserApi()
-val username : kotlin.String = username_example // kotlin.String | name that need to be updated
+val username : kotlin.String = username_example // kotlin.String | name that need to be deleted
 val body : User =  // User | Updated user object
 try {
     apiInstance.updateUser(username, body)
@@ -368,7 +368,7 @@ try {
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
- **username** | **kotlin.String**| name that need to be updated |
+ **username** | **kotlin.String**| name that need to be deleted |
  **body** | [**User**](User.md)| Updated user object |
 
 ### Return type

--- a/samples/client/petstore/kotlin/settings.gradle
+++ b/samples/client/petstore/kotlin/settings.gradle
@@ -1,1 +1,1 @@
-rootProject.name = 'kotlin-client'
+rootProject.name = 'kotlin-petstore-client'

--- a/samples/client/petstore/kotlin/src/main/kotlin/io/swagger/client/apis/PetApi.kt
+++ b/samples/client/petstore/kotlin/src/main/kotlin/io/swagger/client/apis/PetApi.kt
@@ -16,7 +16,7 @@ import io.swagger.client.models.Pet
 
 import io.swagger.client.infrastructure.*
 
-class PetApi(basePath: kotlin.String = "https://petstore.swagger.io/v2") : ApiClient(basePath) {
+class PetApi(basePath: kotlin.String = "http://petstore.swagger.io/v2") : ApiClient(basePath) {
 
     /**
     * Add a new pet to the store
@@ -40,7 +40,7 @@ class PetApi(basePath: kotlin.String = "https://petstore.swagger.io/v2") : ApiCl
             query = localVariableQuery,
             headers = localVariableHeaders
         )
-        val response = request<Any?>(
+        val response = request<Unit>(
             localVariableConfig,
             localVariableBody
         )
@@ -78,7 +78,7 @@ class PetApi(basePath: kotlin.String = "https://petstore.swagger.io/v2") : ApiCl
             query = localVariableQuery,
             headers = localVariableHeaders
         )
-        val response = request<Any?>(
+        val response = request<Unit>(
             localVariableConfig,
             localVariableBody
         )
@@ -102,7 +102,7 @@ class PetApi(basePath: kotlin.String = "https://petstore.swagger.io/v2") : ApiCl
     @Suppress("UNCHECKED_CAST")
     fun findPetsByStatus(status: kotlin.Array<kotlin.String>) : kotlin.Array<Pet> {
         val localVariableBody: kotlin.Any? = null
-        val localVariableQuery: MultiValueMap = mapOf("status" to toMultiValue(status.toList(), "multi"))
+        val localVariableQuery: MultiValueMap = mapOf("status" to toMultiValue(status.toList(), "csv"))
         
         val contentHeaders: kotlin.collections.Map<kotlin.String,kotlin.String> = mapOf()
         val acceptsHeaders: kotlin.collections.Map<kotlin.String,kotlin.String> = mapOf("Accept" to "application/xml, application/json")
@@ -133,14 +133,14 @@ class PetApi(basePath: kotlin.String = "https://petstore.swagger.io/v2") : ApiCl
 
     /**
     * Finds Pets by tags
-    * Muliple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
+    * Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
     * @param tags Tags to filter by 
     * @return kotlin.Array<Pet>
     */
     @Suppress("UNCHECKED_CAST")
     fun findPetsByTags(tags: kotlin.Array<kotlin.String>) : kotlin.Array<Pet> {
         val localVariableBody: kotlin.Any? = null
-        val localVariableQuery: MultiValueMap = mapOf("tags" to toMultiValue(tags.toList(), "multi"))
+        val localVariableQuery: MultiValueMap = mapOf("tags" to toMultiValue(tags.toList(), "csv"))
         
         val contentHeaders: kotlin.collections.Map<kotlin.String,kotlin.String> = mapOf()
         val acceptsHeaders: kotlin.collections.Map<kotlin.String,kotlin.String> = mapOf("Accept" to "application/xml, application/json")
@@ -229,7 +229,7 @@ class PetApi(basePath: kotlin.String = "https://petstore.swagger.io/v2") : ApiCl
             query = localVariableQuery,
             headers = localVariableHeaders
         )
-        val response = request<Any?>(
+        val response = request<Unit>(
             localVariableConfig,
             localVariableBody
         )
@@ -268,7 +268,7 @@ class PetApi(basePath: kotlin.String = "https://petstore.swagger.io/v2") : ApiCl
             query = localVariableQuery,
             headers = localVariableHeaders
         )
-        val response = request<Any?>(
+        val response = request<Unit>(
             localVariableConfig,
             localVariableBody
         )

--- a/samples/client/petstore/kotlin/src/main/kotlin/io/swagger/client/apis/StoreApi.kt
+++ b/samples/client/petstore/kotlin/src/main/kotlin/io/swagger/client/apis/StoreApi.kt
@@ -15,15 +15,15 @@ import io.swagger.client.models.Order
 
 import io.swagger.client.infrastructure.*
 
-class StoreApi(basePath: kotlin.String = "https://petstore.swagger.io/v2") : ApiClient(basePath) {
+class StoreApi(basePath: kotlin.String = "http://petstore.swagger.io/v2") : ApiClient(basePath) {
 
     /**
     * Delete purchase order by ID
-    * For valid response try integer IDs with positive integer value. Negative or non-integer values will generate API errors
+    * For valid response try integer IDs with value &lt; 1000. Anything above 1000 or nonintegers will generate API errors
     * @param orderId ID of the order that needs to be deleted 
     * @return void
     */
-    fun deleteOrder(orderId: kotlin.Long) : Unit {
+    fun deleteOrder(orderId: kotlin.String) : Unit {
         val localVariableBody: kotlin.Any? = null
         val localVariableQuery: MultiValueMap = mapOf()
         
@@ -39,7 +39,7 @@ class StoreApi(basePath: kotlin.String = "https://petstore.swagger.io/v2") : Api
             query = localVariableQuery,
             headers = localVariableHeaders
         )
-        val response = request<Any?>(
+        val response = request<Unit>(
             localVariableConfig,
             localVariableBody
         )
@@ -93,7 +93,7 @@ class StoreApi(basePath: kotlin.String = "https://petstore.swagger.io/v2") : Api
 
     /**
     * Find purchase order by ID
-    * For valid response try integer IDs with value &gt;&#x3D; 1 and &lt;&#x3D; 10. Other values will generated exceptions
+    * For valid response try integer IDs with value &lt;&#x3D; 5 or &gt; 10. Other values will generated exceptions
     * @param orderId ID of pet that needs to be fetched 
     * @return Order
     */

--- a/samples/client/petstore/kotlin/src/main/kotlin/io/swagger/client/apis/UserApi.kt
+++ b/samples/client/petstore/kotlin/src/main/kotlin/io/swagger/client/apis/UserApi.kt
@@ -15,7 +15,7 @@ import io.swagger.client.models.User
 
 import io.swagger.client.infrastructure.*
 
-class UserApi(basePath: kotlin.String = "https://petstore.swagger.io/v2") : ApiClient(basePath) {
+class UserApi(basePath: kotlin.String = "http://petstore.swagger.io/v2") : ApiClient(basePath) {
 
     /**
     * Create user
@@ -39,7 +39,7 @@ class UserApi(basePath: kotlin.String = "https://petstore.swagger.io/v2") : ApiC
             query = localVariableQuery,
             headers = localVariableHeaders
         )
-        val response = request<Any?>(
+        val response = request<Unit>(
             localVariableConfig,
             localVariableBody
         )
@@ -76,7 +76,7 @@ class UserApi(basePath: kotlin.String = "https://petstore.swagger.io/v2") : ApiC
             query = localVariableQuery,
             headers = localVariableHeaders
         )
-        val response = request<Any?>(
+        val response = request<Unit>(
             localVariableConfig,
             localVariableBody
         )
@@ -113,7 +113,7 @@ class UserApi(basePath: kotlin.String = "https://petstore.swagger.io/v2") : ApiC
             query = localVariableQuery,
             headers = localVariableHeaders
         )
-        val response = request<Any?>(
+        val response = request<Unit>(
             localVariableConfig,
             localVariableBody
         )
@@ -150,7 +150,7 @@ class UserApi(basePath: kotlin.String = "https://petstore.swagger.io/v2") : ApiC
             query = localVariableQuery,
             headers = localVariableHeaders
         )
-        val response = request<Any?>(
+        val response = request<Unit>(
             localVariableConfig,
             localVariableBody
         )
@@ -168,7 +168,7 @@ class UserApi(basePath: kotlin.String = "https://petstore.swagger.io/v2") : ApiC
     /**
     * Get user by user name
     * 
-    * @param username The name that needs to be fetched. Use user1 for testing.  
+    * @param username The name that needs to be fetched. Use user1 for testing. 
     * @return User
     */
     @Suppress("UNCHECKED_CAST")
@@ -263,7 +263,7 @@ class UserApi(basePath: kotlin.String = "https://petstore.swagger.io/v2") : ApiC
             query = localVariableQuery,
             headers = localVariableHeaders
         )
-        val response = request<Any?>(
+        val response = request<Unit>(
             localVariableConfig,
             localVariableBody
         )
@@ -281,7 +281,7 @@ class UserApi(basePath: kotlin.String = "https://petstore.swagger.io/v2") : ApiC
     /**
     * Updated user
     * This can only be done by the logged in user.
-    * @param username name that need to be updated 
+    * @param username name that need to be deleted 
     * @param body Updated user object 
     * @return void
     */
@@ -301,7 +301,7 @@ class UserApi(basePath: kotlin.String = "https://petstore.swagger.io/v2") : ApiC
             query = localVariableQuery,
             headers = localVariableHeaders
         )
-        val response = request<Any?>(
+        val response = request<Unit>(
             localVariableConfig,
             localVariableBody
         )

--- a/samples/client/petstore/kotlin/src/main/kotlin/io/swagger/client/infrastructure/ApiClient.kt
+++ b/samples/client/petstore/kotlin/src/main/kotlin/io/swagger/client/infrastructure/ApiClient.kt
@@ -58,6 +58,8 @@ open class ApiClient(val baseUrl: String) {
         
         if(T::class.java == java.io.File::class.java){
             return downloadFileFromResponse(response) as T
+        } else if(T::class == kotlin.Unit::class) {
+            return kotlin.Unit as T
         }
         
         var contentType = response.headers().get("Content-Type")

--- a/samples/client/petstore/kotlin/src/main/kotlin/io/swagger/client/models/Amount.kt
+++ b/samples/client/petstore/kotlin/src/main/kotlin/io/swagger/client/models/Amount.kt
@@ -11,28 +11,17 @@
 */
 package io.swagger.client.models
 
+import io.swagger.client.models.Currency
 
 /**
- * A User who is purchasing from the pet store
- * @param id 
- * @param username 
- * @param firstName 
- * @param lastName 
- * @param email 
- * @param password 
- * @param phone 
- * @param userStatus User Status
+ * some description 
+ * @param value some description 
+ * @param currency 
  */
-data class User (
-    val id: kotlin.Long? = null,
-    val username: kotlin.String? = null,
-    val firstName: kotlin.String? = null,
-    val lastName: kotlin.String? = null,
-    val email: kotlin.String? = null,
-    val password: kotlin.String? = null,
-    val phone: kotlin.String? = null,
-    /* User Status */
-    val userStatus: kotlin.Int? = null
+data class Amount (
+    /* some description  */
+    val value: kotlin.Double,
+    val currency: Currency
 ) {
 
 }

--- a/samples/client/petstore/kotlin/src/main/kotlin/io/swagger/client/models/ApiResponse.kt
+++ b/samples/client/petstore/kotlin/src/main/kotlin/io/swagger/client/models/ApiResponse.kt
@@ -13,7 +13,7 @@ package io.swagger.client.models
 
 
 /**
- * 
+ * Describes the result of uploading an image resource
  * @param code 
  * @param type 
  * @param message 

--- a/samples/client/petstore/kotlin/src/main/kotlin/io/swagger/client/models/Category.kt
+++ b/samples/client/petstore/kotlin/src/main/kotlin/io/swagger/client/models/Category.kt
@@ -13,7 +13,7 @@ package io.swagger.client.models
 
 
 /**
- * 
+ * A category for a pet
  * @param id 
  * @param name 
  */

--- a/samples/client/petstore/kotlin/src/main/kotlin/io/swagger/client/models/Currency.kt
+++ b/samples/client/petstore/kotlin/src/main/kotlin/io/swagger/client/models/Currency.kt
@@ -12,15 +12,4 @@
 package io.swagger.client.models
 
 
-/**
- * A tag for a pet
- * @param id 
- * @param name 
- */
-data class Tag (
-    val id: kotlin.Long? = null,
-    val name: kotlin.String? = null
-) {
-
-}
-
+typealias Currency = kotlin.String

--- a/samples/client/petstore/kotlin/src/main/kotlin/io/swagger/client/models/Order.kt
+++ b/samples/client/petstore/kotlin/src/main/kotlin/io/swagger/client/models/Order.kt
@@ -14,7 +14,7 @@ package io.swagger.client.models
 
 import com.squareup.moshi.Json
 /**
- * 
+ * An order for a pets from the pet store
  * @param id 
  * @param petId 
  * @param quantity 

--- a/samples/client/petstore/kotlin/src/main/kotlin/io/swagger/client/models/Pet.kt
+++ b/samples/client/petstore/kotlin/src/main/kotlin/io/swagger/client/models/Pet.kt
@@ -16,7 +16,7 @@ import io.swagger.client.models.Tag
 
 import com.squareup.moshi.Json
 /**
- * 
+ * A pet for sale in the pet store
  * @param id 
  * @param category 
  * @param name 


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [x] Filed the PR against the correct branch: `3.0.0` branch for changes related to OpenAPI spec 3.0. Default: `master`.
- [x] Copied the [technical committee](https://github.com/swagger-api/swagger-codegen/#swagger-codegen-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

When our server responded with a 204 message, but the body had no json content, an EOF exception would be thrown because it tried to deserialize json that did not exist. 

Our solution was to follow a similar practice as some other languages, when the the expected response type of an API call is void (for kotlin, it's Unit), then simply return void from the response deserializer. 

@HugoMario Here's a similar PR

