### PR TITLE
#7763 Fix {{isEnum}} template variable for referenced enum properties

### DIFF
--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/DefaultCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/DefaultCodegen.java
@@ -3157,21 +3157,32 @@ public class DefaultCodegen {
                 cp.required = mandatory.contains(key) ? true : false;
                 m.hasRequired = m.hasRequired || cp.required;
                 m.hasOptional = m.hasOptional || !cp.required;
-                if (cp.isEnum) {
-                    // FIXME: if supporting inheritance, when called a second time for allProperties it is possible for
-                    // m.hasEnums to be set incorrectly if allProperties has enumerations but properties does not.
-                    m.hasEnums = true;
-                }
 
                 if (allDefinitions != null && prop instanceof RefProperty) {
                     RefProperty refProperty = (RefProperty) prop;
                     Model model =  allDefinitions.get(refProperty.getSimpleRef());
                     if (model instanceof ModelImpl) {
                         ModelImpl modelImpl = (ModelImpl) model;
+
+                        if (modelImpl.getType() != null) {
+                            Property p = PropertyBuilder.build(modelImpl.getType(), modelImpl.getFormat(), null);
+                            cp.datatype = getSwaggerType(p);
+                        }
+
+                        if(modelImpl.getEnum() != null && modelImpl.getEnum().size() > 0) {
+                            cp.isEnum = true;
+                        }
+
                         cp.pattern = modelImpl.getPattern();
                         cp.minLength = modelImpl.getMinLength();
                         cp.maxLength = modelImpl.getMaxLength();
                     }
+                }
+
+                if (cp.isEnum) {
+                    // FIXME: if supporting inheritance, when called a second time for allProperties it is possible for
+                    // m.hasEnums to be set incorrectly if allProperties has enumerations but properties does not.
+                    m.hasEnums = true;
                 }
 
                 // set model's hasOnlyReadOnly to false if the property is read-only


### PR DESCRIPTION
Change data type of referenced enum properties from datatype Object to string and set isEnum to true

### PR checklist

- [ ] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [ ] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [ ] Filed the PR against the correct branch: `3.0.0` branch for changes related to OpenAPI spec 3.0. Default: `master`.
- [ ] Copied the [technical committee](https://github.com/swagger-api/swagger-codegen/#swagger-codegen-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

See https://github.com/swagger-api/swagger-codegen/issues/7763

Example:
```
definitions:
  myEnum:
    type: string
    enum:
      - myEnumValue1
      - myEnumValue2
      - myEnumValue3
  myPostBody:
    type: object
    properties:
      myEnumProperty:
        $ref: '#/definitions/myEnum'
```

Previously, `{{isEnum}}` in the template `modelGeneric.mustache` would evaluate to `false`. Now, it evaluates to `true` because the CodegenModel resolves the referenced property.