### PR TITLE
Make html generator create UTF-8 compatible pages

### DIFF
--- a/modules/swagger-codegen/src/main/resources/htmlDocs/index.mustache
+++ b/modules/swagger-codegen/src/main/resources/htmlDocs/index.mustache
@@ -2,6 +2,7 @@
 <html>
   <head>
     <title>{{{appName}}}</title>
+    <meta charset="utf-8">
     <style type="text/css">
       {{>style.css}}
     </style>


### PR DESCRIPTION
Otherwise if there are for example Umlauts (öäüß) in the contracts, Ã¶ etc. is shown.