### PR TITLE
For polymorphism with Jackson, use the As.EXISTING_PROPERTY feature

### DIFF
--- a/modules/swagger-codegen/src/main/resources/Java/typeInfoAnnotation.mustache
+++ b/modules/swagger-codegen/src/main/resources/Java/typeInfoAnnotation.mustache
@@ -1,5 +1,5 @@
 {{#jackson}}
-@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.PROPERTY, property = "{{discriminator}}", visible = true )
+@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.EXISTING_PROPERTY, property = "{{discriminator}}", visible = true )
 @JsonSubTypes({
   {{#children}}
   @JsonSubTypes.Type(value = {{classname}}.class, name = "{{^vendorExtensions.x-discriminator-value}}{{name}}{{/vendorExtensions.x-discriminator-value}}{{#vendorExtensions.x-discriminator-value}}{{{vendorExtensions.x-discriminator-value}}}{{/vendorExtensions.x-discriminator-value}}"),

--- a/samples/client/petstore/java/google-api-client/docs/EnumTest.md
+++ b/samples/client/petstore/java/google-api-client/docs/EnumTest.md
@@ -5,6 +5,7 @@
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **enumString** | [**EnumStringEnum**](#EnumStringEnum) |  |  [optional]
+**enumStringRequired** | [**EnumStringRequiredEnum**](#EnumStringRequiredEnum) |  | 
 **enumInteger** | [**EnumIntegerEnum**](#EnumIntegerEnum) |  |  [optional]
 **enumNumber** | [**EnumNumberEnum**](#EnumNumberEnum) |  |  [optional]
 **outerEnum** | [**OuterEnum**](OuterEnum.md) |  |  [optional]
@@ -12,6 +13,15 @@ Name | Type | Description | Notes
 
 <a name="EnumStringEnum"></a>
 ## Enum: EnumStringEnum
+Name | Value
+---- | -----
+UPPER | &quot;UPPER&quot;
+LOWER | &quot;lower&quot;
+EMPTY | &quot;&quot;
+
+
+<a name="EnumStringRequiredEnum"></a>
+## Enum: EnumStringRequiredEnum
 Name | Value
 ---- | -----
 UPPER | &quot;UPPER&quot;

--- a/samples/client/petstore/java/google-api-client/docs/FakeApi.md
+++ b/samples/client/petstore/java/google-api-client/docs/FakeApi.md
@@ -8,6 +8,7 @@ Method | HTTP request | Description
 [**fakeOuterCompositeSerialize**](FakeApi.md#fakeOuterCompositeSerialize) | **POST** /fake/outer/composite | 
 [**fakeOuterNumberSerialize**](FakeApi.md#fakeOuterNumberSerialize) | **POST** /fake/outer/number | 
 [**fakeOuterStringSerialize**](FakeApi.md#fakeOuterStringSerialize) | **POST** /fake/outer/string | 
+[**testBodyWithQueryParams**](FakeApi.md#testBodyWithQueryParams) | **PUT** /fake/body-with-query-params | 
 [**testClientModel**](FakeApi.md#testClientModel) | **PATCH** /fake | To test \&quot;client\&quot; model
 [**testEndpointParameters**](FakeApi.md#testEndpointParameters) | **POST** /fake | Fake endpoint for testing various parameters 假端點 偽のエンドポイント 가짜 엔드 포인트 
 [**testEnumParameters**](FakeApi.md#testEnumParameters) | **GET** /fake | To test enum parameters
@@ -193,6 +194,50 @@ No authorization required
 ### HTTP request headers
 
  - **Content-Type**: Not defined
+ - **Accept**: Not defined
+
+<a name="testBodyWithQueryParams"></a>
+# **testBodyWithQueryParams**
+> testBodyWithQueryParams(body, query)
+
+
+
+### Example
+```java
+// Import classes:
+//import io.swagger.client.ApiException;
+//import io.swagger.client.api.FakeApi;
+
+
+FakeApi apiInstance = new FakeApi();
+User body = new User(); // User | 
+String query = "query_example"; // String | 
+try {
+    apiInstance.testBodyWithQueryParams(body, query);
+} catch (ApiException e) {
+    System.err.println("Exception when calling FakeApi#testBodyWithQueryParams");
+    e.printStackTrace();
+}
+```
+
+### Parameters
+
+Name | Type | Description  | Notes
+------------- | ------------- | ------------- | -------------
+ **body** | [**User**](User.md)|  |
+ **query** | **String**|  |
+
+### Return type
+
+null (empty response body)
+
+### Authorization
+
+No authorization required
+
+### HTTP request headers
+
+ - **Content-Type**: application/json
  - **Accept**: Not defined
 
 <a name="testClientModel"></a>

--- a/samples/client/petstore/java/google-api-client/src/main/java/io/swagger/client/api/FakeApi.java
+++ b/samples/client/petstore/java/google-api-client/src/main/java/io/swagger/client/api/FakeApi.java
@@ -7,6 +7,7 @@ import io.swagger.client.model.Client;
 import org.threeten.bp.LocalDate;
 import org.threeten.bp.OffsetDateTime;
 import io.swagger.client.model.OuterComposite;
+import io.swagger.client.model.User;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.google.api.client.http.GenericUrl;
@@ -361,6 +362,123 @@ public class FakeApi {
 
         HttpContent content = apiClient.new JacksonJsonHttpContent(body);
         return apiClient.getHttpRequestFactory().buildRequest(HttpMethods.POST, genericUrl, content).execute();
+    }
+
+
+  /**
+    * <p><b>200</b> - Success
+    * @param body The body parameter
+    * @param query The query parameter
+    * @throws IOException if an error occurs while attempting to invoke the API
+    **/
+    public void testBodyWithQueryParams(User body, String query) throws IOException {
+        testBodyWithQueryParamsForHttpResponse(body, query);
+    }
+
+  /**
+    * <p><b>200</b> - Success
+    * @param body The body parameter
+    * @param query The query parameter
+    * @param params Map of query params. A collection will be interpreted as passing in multiple instances of the same query param.
+    * @throws IOException if an error occurs while attempting to invoke the API
+    **/
+    public void testBodyWithQueryParams(User body, String query, Map<String, Object> params) throws IOException {
+        testBodyWithQueryParamsForHttpResponse(body, query, params);
+    }
+
+    public HttpResponse testBodyWithQueryParamsForHttpResponse(User body, String query) throws IOException {
+        // verify the required parameter 'body' is set
+        if (body == null) {
+            throw new IllegalArgumentException("Missing the required parameter 'body' when calling testBodyWithQueryParams");
+        }// verify the required parameter 'query' is set
+        if (query == null) {
+            throw new IllegalArgumentException("Missing the required parameter 'query' when calling testBodyWithQueryParams");
+        }
+        UriBuilder uriBuilder = UriBuilder.fromUri(apiClient.getBasePath() + "/fake/body-with-query-params");
+        if (query != null) {
+            String key = "query";
+            Object value = query;
+            if (value instanceof Collection) {
+                uriBuilder = uriBuilder.queryParam(key, ((Collection) value).toArray());
+            } else if (value instanceof Object[]) {
+                uriBuilder = uriBuilder.queryParam(key, (Object[]) value);
+            } else {
+                uriBuilder = uriBuilder.queryParam(key, value);
+            }
+        }
+
+        String url = uriBuilder.build().toString();
+        GenericUrl genericUrl = new GenericUrl(url);
+
+        HttpContent content = apiClient.new JacksonJsonHttpContent(body);
+        return apiClient.getHttpRequestFactory().buildRequest(HttpMethods.PUT, genericUrl, content).execute();
+    }
+
+      public HttpResponse testBodyWithQueryParamsForHttpResponse(java.io.InputStream body, String query, String mediaType) throws IOException {
+          // verify the required parameter 'body' is set
+              if (body == null) {
+              throw new IllegalArgumentException("Missing the required parameter 'body' when calling testBodyWithQueryParams");
+              }// verify the required parameter 'query' is set
+              if (query == null) {
+              throw new IllegalArgumentException("Missing the required parameter 'query' when calling testBodyWithQueryParams");
+              }
+              UriBuilder uriBuilder = UriBuilder.fromUri(apiClient.getBasePath() + "/fake/body-with-query-params");
+              if (query != null) {
+                  String key = "query";
+                  Object value = query;
+                  if (value instanceof Collection) {
+                    uriBuilder = uriBuilder.queryParam(key, ((Collection) value).toArray());
+                  } else if (value instanceof Object[]) {
+                    uriBuilder = uriBuilder.queryParam(key, (Object[]) value);
+                  } else {
+                    uriBuilder = uriBuilder.queryParam(key, value);
+                  }
+              }
+
+              String url = uriBuilder.build().toString();
+              GenericUrl genericUrl = new GenericUrl(url);
+
+              HttpContent content = body == null ?
+                apiClient.new JacksonJsonHttpContent(null) :
+                new InputStreamContent(mediaType == null ? Json.MEDIA_TYPE : mediaType, body);
+              return apiClient.getHttpRequestFactory().buildRequest(HttpMethods.PUT, genericUrl, content).execute();
+      }
+
+    public HttpResponse testBodyWithQueryParamsForHttpResponse(User body, String query, Map<String, Object> params) throws IOException {
+        // verify the required parameter 'body' is set
+        if (body == null) {
+            throw new IllegalArgumentException("Missing the required parameter 'body' when calling testBodyWithQueryParams");
+        }// verify the required parameter 'query' is set
+        if (query == null) {
+            throw new IllegalArgumentException("Missing the required parameter 'query' when calling testBodyWithQueryParams");
+        }
+        UriBuilder uriBuilder = UriBuilder.fromUri(apiClient.getBasePath() + "/fake/body-with-query-params");
+
+        // Copy the params argument if present, to allow passing in immutable maps
+        Map<String, Object> allParams = params == null ? new HashMap<String, Object>() : new HashMap<String, Object>(params);
+        // Add the required query param 'query' to the map of query params
+        allParams.put("query", query);
+
+        for (Map.Entry<String, Object> entry: allParams.entrySet()) {
+            String key = entry.getKey();
+            Object value = entry.getValue();
+
+            if (key != null && value != null) {
+                if (value instanceof Collection) {
+                    uriBuilder = uriBuilder.queryParam(key, ((Collection) value).toArray());
+                } else if (value instanceof Object[]) {
+                    uriBuilder = uriBuilder.queryParam(key, (Object[]) value);
+                } else {
+                    uriBuilder = uriBuilder.queryParam(key, value);
+                }
+            }
+        }
+
+        String url = uriBuilder.build().toString();
+        GenericUrl genericUrl = new GenericUrl(url);
+
+        HttpContent content = apiClient.new JacksonJsonHttpContent(body);
+        return apiClient.getHttpRequestFactory().buildRequest(HttpMethods.PUT, genericUrl, content).execute();
     }
 
 

--- a/samples/client/petstore/java/google-api-client/src/main/java/io/swagger/client/api/FakeClassnameTags123Api.java
+++ b/samples/client/petstore/java/google-api-client/src/main/java/io/swagger/client/api/FakeClassnameTags123Api.java
@@ -76,6 +76,7 @@ public class FakeClassnameTags123Api {
         }
         UriBuilder uriBuilder = UriBuilder.fromUri(apiClient.getBasePath() + "/fake_classname_test");
 
+
         String url = uriBuilder.build().toString();
         GenericUrl genericUrl = new GenericUrl(url);
 
@@ -89,6 +90,7 @@ public class FakeClassnameTags123Api {
               throw new IllegalArgumentException("Missing the required parameter 'body' when calling testClassname");
               }
               UriBuilder uriBuilder = UriBuilder.fromUri(apiClient.getBasePath() + "/fake_classname_test");
+
 
               String url = uriBuilder.build().toString();
               GenericUrl genericUrl = new GenericUrl(url);

--- a/samples/client/petstore/java/google-api-client/src/main/java/io/swagger/client/model/Animal.java
+++ b/samples/client/petstore/java/google-api-client/src/main/java/io/swagger/client/model/Animal.java
@@ -26,7 +26,7 @@ import io.swagger.annotations.ApiModelProperty;
 /**
  * Animal
  */
-@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.PROPERTY, property = "className", visible = true )
+@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.EXISTING_PROPERTY, property = "className", visible = true )
 @JsonSubTypes({
   @JsonSubTypes.Type(value = Dog.class, name = "Dog"),
   @JsonSubTypes.Type(value = Cat.class, name = "Cat"),

--- a/samples/client/petstore/java/google-api-client/src/main/java/io/swagger/client/model/EnumTest.java
+++ b/samples/client/petstore/java/google-api-client/src/main/java/io/swagger/client/model/EnumTest.java
@@ -68,6 +68,46 @@ public class EnumTest {
   private EnumStringEnum enumString = null;
 
   /**
+   * Gets or Sets enumStringRequired
+   */
+  public enum EnumStringRequiredEnum {
+    UPPER("UPPER"),
+    
+    LOWER("lower"),
+    
+    EMPTY("");
+
+    private String value;
+
+    EnumStringRequiredEnum(String value) {
+      this.value = value;
+    }
+
+    @JsonValue
+    public String getValue() {
+      return value;
+    }
+
+    @Override
+    public String toString() {
+      return String.valueOf(value);
+    }
+
+    @JsonCreator
+    public static EnumStringRequiredEnum fromValue(String text) {
+      for (EnumStringRequiredEnum b : EnumStringRequiredEnum.values()) {
+        if (String.valueOf(b.value).equals(text)) {
+          return b;
+        }
+      }
+      return null;
+    }
+  }
+
+  @JsonProperty("enum_string_required")
+  private EnumStringRequiredEnum enumStringRequired = null;
+
+  /**
    * Gets or Sets enumInteger
    */
   public enum EnumIntegerEnum {
@@ -164,6 +204,24 @@ public class EnumTest {
     this.enumString = enumString;
   }
 
+  public EnumTest enumStringRequired(EnumStringRequiredEnum enumStringRequired) {
+    this.enumStringRequired = enumStringRequired;
+    return this;
+  }
+
+   /**
+   * Get enumStringRequired
+   * @return enumStringRequired
+  **/
+  @ApiModelProperty(required = true, value = "")
+  public EnumStringRequiredEnum getEnumStringRequired() {
+    return enumStringRequired;
+  }
+
+  public void setEnumStringRequired(EnumStringRequiredEnum enumStringRequired) {
+    this.enumStringRequired = enumStringRequired;
+  }
+
   public EnumTest enumInteger(EnumIntegerEnum enumInteger) {
     this.enumInteger = enumInteger;
     return this;
@@ -229,6 +287,7 @@ public class EnumTest {
     }
     EnumTest enumTest = (EnumTest) o;
     return Objects.equals(this.enumString, enumTest.enumString) &&
+        Objects.equals(this.enumStringRequired, enumTest.enumStringRequired) &&
         Objects.equals(this.enumInteger, enumTest.enumInteger) &&
         Objects.equals(this.enumNumber, enumTest.enumNumber) &&
         Objects.equals(this.outerEnum, enumTest.outerEnum);
@@ -236,7 +295,7 @@ public class EnumTest {
 
   @Override
   public int hashCode() {
-    return Objects.hash(enumString, enumInteger, enumNumber, outerEnum);
+    return Objects.hash(enumString, enumStringRequired, enumInteger, enumNumber, outerEnum);
   }
 
 
@@ -246,6 +305,7 @@ public class EnumTest {
     sb.append("class EnumTest {\n");
     
     sb.append("    enumString: ").append(toIndentedString(enumString)).append("\n");
+    sb.append("    enumStringRequired: ").append(toIndentedString(enumStringRequired)).append("\n");
     sb.append("    enumInteger: ").append(toIndentedString(enumInteger)).append("\n");
     sb.append("    enumNumber: ").append(toIndentedString(enumNumber)).append("\n");
     sb.append("    outerEnum: ").append(toIndentedString(outerEnum)).append("\n");


### PR DESCRIPTION
We were seeing duplicate fields serialized in the JSON from generated Swagger Codegen model classes, because in the newer versions of Jackson you have to use `As.EXISTING_PROPERTY` in the `@JsonSubTypes` annotation if the discriminant is also a normal serialized field.

These settings should be fine to fix the issue; the only caveat being that Jackson 2.5.0 or above must be used. I'll investigate if this is an issue. We should be able to ensure we never use an older version than that.

### PR checklist

- [ ] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [ ] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [ ] Filed the PR against the correct branch: `3.0.0` branch for changes related to OpenAPI spec 3.0. Default: `master`.
- [ ] Copied the [technical committee](https://github.com/swagger-api/swagger-codegen/#swagger-codegen-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

(details of the change, additional tests that have been done, reference to the issue for tracking, etc)

