### PR TITLE
Fix "configuration" in python doc

### DIFF
--- a/modules/swagger-codegen/src/main/resources/python/api_doc.mustache
+++ b/modules/swagger-codegen/src/main/resources/python/api_doc.mustache
@@ -39,7 +39,7 @@ configuration = {{{packageName}}}.Configuration()
 configuration.access_token = 'YOUR_ACCESS_TOKEN'{{/isOAuth}}{{/authMethods}}
 
 # create an instance of the API class
-api_instance = {{{packageName}}}.{{{classname}}}({{{packageName}}}.ApiClient(configuration))
+api_instance = {{{packageName}}}.{{{classname}}}({{{packageName}}}.ApiClient(configuration=configuration))
 {{#allParams}}{{paramName}} = {{{example}}} # {{{dataType}}} | {{{description}}}{{^required}} (optional){{/required}}{{#defaultValue}} (default to {{{.}}}){{/defaultValue}}
 {{/allParams}}
 {{/hasAuthMethods}}


### PR DESCRIPTION
### PR checklist


- [x] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [x] Filed the PR against the correct branch: `3.0.0` branch for changes related to OpenAPI spec 3.0. Default: `master`.
- [x] Copied the [technical committee](https://github.com/swagger-api/swagger-codegen/#swagger-codegen-technical-committee) to review the pull request if your PR is targeting a particular programming language. @kenjones-cisco 

### Description of the PR

In the generated docs, change (configuration) into (configuration=configuration) in response to kubernetes-client/python#662.

