### PR TITLE
Fix #8336 swift4

### DIFF
--- a/modules/swagger-codegen/src/main/resources/swift4/APIs.mustache
+++ b/modules/swagger-codegen/src/main/resources/swift4/APIs.mustache
@@ -7,10 +7,10 @@
 import Foundation
 
 open class {{projectName}}API {
-    open static var basePath = "{{{basePath}}}"
-    open static var credential: URLCredential?
-    open static var customHeaders: [String:String] = [:]
-    open static var requestBuilderFactory: RequestBuilderFactory = AlamofireRequestBuilderFactory()
+    public static var basePath = "{{{basePath}}}"
+    public static var credential: URLCredential?
+    public static var customHeaders: [String:String] = [:]
+    public static var requestBuilderFactory: RequestBuilderFactory = AlamofireRequestBuilderFactory()
 }
 
 open class RequestBuilder<T> {

--- a/modules/swagger-codegen/src/main/resources/swift4/AlamofireImplementations.mustache
+++ b/modules/swagger-codegen/src/main/resources/swift4/AlamofireImplementations.mustache
@@ -125,7 +125,7 @@ open class AlamofireRequestBuilder<T>: RequestBuilder<T> {
                 if stringResponse.result.isFailure {
                     completion(
                         nil,
-                        ErrorResponse.error(stringResponse.response?.statusCode ?? 500, stringResponse.data, stringResponse.result.error as Error!)
+                        ErrorResponse.error(stringResponse.response?.statusCode ?? 500, stringResponse.data, stringResponse.result.error!)
                     )
                     return
                 }
@@ -327,7 +327,7 @@ open class AlamofireDecodableRequestBuilder<T:Decodable>: AlamofireRequestBuilde
                 if stringResponse.result.isFailure {
                     completion(
                         nil,
-                        ErrorResponse.error(stringResponse.response?.statusCode ?? 500, stringResponse.data, stringResponse.result.error as Error!)
+                        ErrorResponse.error(stringResponse.response?.statusCode ?? 500, stringResponse.data, stringResponse.result.error!)
                     )
                     return
                 }

--- a/modules/swagger-codegen/src/main/resources/swift4/CodableHelper.mustache
+++ b/modules/swagger-codegen/src/main/resources/swift4/CodableHelper.mustache
@@ -11,7 +11,7 @@ public typealias EncodeResult = (data: Data?, error: Error?)
 
 open class CodableHelper {
 
-    open static var dateformatter: DateFormatter?
+    public static var dateformatter: DateFormatter?
 
     open class func decode<T>(_ type: T.Type, from data: Data) -> (decodableObj: T?, error: Error?) where T : Decodable {
         var returnedDecodable: T? = nil

--- a/modules/swagger-codegen/src/main/resources/swift4/Configuration.mustache
+++ b/modules/swagger-codegen/src/main/resources/swift4/Configuration.mustache
@@ -10,6 +10,6 @@ open class Configuration {
 	
 	// This value is used to configure the date formatter that is used to serialize dates into JSON format. 
 	// You must set it prior to encoding any dates, and it will only be read once. 
-    open static var dateFormat = "yyyy-MM-dd'T'HH:mm:ss.SSSZZZZZ"
+    public static var dateFormat = "yyyy-MM-dd'T'HH:mm:ss.SSSZZZZZ"
     
 }

--- a/modules/swagger-codegen/src/main/resources/swift4/Models.mustache
+++ b/modules/swagger-codegen/src/main/resources/swift4/Models.mustache
@@ -15,9 +15,9 @@ public enum ErrorResponse : Error {
 }
 
 open class Response<T> {
-    open let statusCode: Int
-    open let header: [String: String]
-    open let body: T?
+    public let statusCode: Int
+    public let header: [String: String]
+    public let body: T?
 
     public init(statusCode: Int, header: [String: String], body: T?) {
         self.statusCode = statusCode

--- a/samples/client/petstore/swift4/default/PetstoreClient/Classes/Swaggers/APIs.swift
+++ b/samples/client/petstore/swift4/default/PetstoreClient/Classes/Swaggers/APIs.swift
@@ -7,10 +7,10 @@
 import Foundation
 
 open class PetstoreClientAPI {
-    open static var basePath = "http://petstore.swagger.io:80/v2"
-    open static var credential: URLCredential?
-    open static var customHeaders: [String:String] = [:]
-    open static var requestBuilderFactory: RequestBuilderFactory = AlamofireRequestBuilderFactory()
+    public static var basePath = "http://petstore.swagger.io:80/v2"
+    public static var credential: URLCredential?
+    public static var customHeaders: [String:String] = [:]
+    public static var requestBuilderFactory: RequestBuilderFactory = AlamofireRequestBuilderFactory()
 }
 
 open class RequestBuilder<T> {

--- a/samples/client/petstore/swift4/default/PetstoreClient/Classes/Swaggers/APIs/FakeAPI.swift
+++ b/samples/client/petstore/swift4/default/PetstoreClient/Classes/Swaggers/APIs/FakeAPI.swift
@@ -148,6 +148,46 @@ open class FakeAPI {
     }
 
     /**
+
+     - parameter body: (body)  
+     - parameter query: (query)  
+     - parameter completion: completion handler to receive the data and the error objects
+     */
+    open class func testBodyWithQueryParams(body: User, query: String, completion: @escaping ((_ data: Void?,_ error: Error?) -> Void)) {
+        testBodyWithQueryParamsWithRequestBuilder(body: body, query: query).execute { (response, error) -> Void in
+            if error == nil {
+                completion((), error)
+            } else {
+                completion(nil, error)
+            }
+        }
+    }
+
+
+    /**
+     - PUT /fake/body-with-query-params
+     
+     - parameter body: (body)  
+     - parameter query: (query)  
+
+     - returns: RequestBuilder<Void> 
+     */
+    open class func testBodyWithQueryParamsWithRequestBuilder(body: User, query: String) -> RequestBuilder<Void> {
+        let path = "/fake/body-with-query-params"
+        let URLString = PetstoreClientAPI.basePath + path
+        let parameters = JSONEncodingHelper.encodingParameters(forEncodableObject: body)
+
+        var url = URLComponents(string: URLString)
+        url?.queryItems = APIHelper.mapValuesToQueryItems([
+            "query": query
+        ])
+
+        let requestBuilder: RequestBuilder<Void>.Type = PetstoreClientAPI.requestBuilderFactory.getNonDecodableBuilder()
+
+        return requestBuilder.init(method: "PUT", URLString: (url?.string ?? URLString), parameters: parameters, isBody: true)
+    }
+
+    /**
      To test \"client\" model
      
      - parameter body: (body) client model 

--- a/samples/client/petstore/swift4/default/PetstoreClient/Classes/Swaggers/APIs/FakeClassnameTags123API.swift
+++ b/samples/client/petstore/swift4/default/PetstoreClient/Classes/Swaggers/APIs/FakeClassnameTags123API.swift
@@ -44,7 +44,9 @@ open class FakeClassnameTags123API {
         let URLString = PetstoreClientAPI.basePath + path
         let parameters = JSONEncodingHelper.encodingParameters(forEncodableObject: body)
 
-        let url = URLComponents(string: URLString)
+        var url = URLComponents(string: URLString)
+        url?.queryItems = APIHelper.mapValuesToQueryItems([
+        ])
 
         let requestBuilder: RequestBuilder<Client>.Type = PetstoreClientAPI.requestBuilderFactory.getBuilder()
 

--- a/samples/client/petstore/swift4/default/PetstoreClient/Classes/Swaggers/AlamofireImplementations.swift
+++ b/samples/client/petstore/swift4/default/PetstoreClient/Classes/Swaggers/AlamofireImplementations.swift
@@ -125,7 +125,7 @@ open class AlamofireRequestBuilder<T>: RequestBuilder<T> {
                 if stringResponse.result.isFailure {
                     completion(
                         nil,
-                        ErrorResponse.error(stringResponse.response?.statusCode ?? 500, stringResponse.data, stringResponse.result.error as Error!)
+                        ErrorResponse.error(stringResponse.response?.statusCode ?? 500, stringResponse.data, stringResponse.result.error!)
                     )
                     return
                 }
@@ -327,7 +327,7 @@ open class AlamofireDecodableRequestBuilder<T:Decodable>: AlamofireRequestBuilde
                 if stringResponse.result.isFailure {
                     completion(
                         nil,
-                        ErrorResponse.error(stringResponse.response?.statusCode ?? 500, stringResponse.data, stringResponse.result.error as Error!)
+                        ErrorResponse.error(stringResponse.response?.statusCode ?? 500, stringResponse.data, stringResponse.result.error!)
                     )
                     return
                 }

--- a/samples/client/petstore/swift4/default/PetstoreClient/Classes/Swaggers/CodableHelper.swift
+++ b/samples/client/petstore/swift4/default/PetstoreClient/Classes/Swaggers/CodableHelper.swift
@@ -11,7 +11,7 @@ public typealias EncodeResult = (data: Data?, error: Error?)
 
 open class CodableHelper {
 
-    open static var dateformatter: DateFormatter?
+    public static var dateformatter: DateFormatter?
 
     open class func decode<T>(_ type: T.Type, from data: Data) -> (decodableObj: T?, error: Error?) where T : Decodable {
         var returnedDecodable: T? = nil

--- a/samples/client/petstore/swift4/default/PetstoreClient/Classes/Swaggers/Configuration.swift
+++ b/samples/client/petstore/swift4/default/PetstoreClient/Classes/Swaggers/Configuration.swift
@@ -10,6 +10,6 @@ open class Configuration {
 	
 	// This value is used to configure the date formatter that is used to serialize dates into JSON format. 
 	// You must set it prior to encoding any dates, and it will only be read once. 
-    open static var dateFormat = "yyyy-MM-dd'T'HH:mm:ss.SSSZZZZZ"
+    public static var dateFormat = "yyyy-MM-dd'T'HH:mm:ss.SSSZZZZZ"
     
 }

--- a/samples/client/petstore/swift4/default/PetstoreClient/Classes/Swaggers/Models.swift
+++ b/samples/client/petstore/swift4/default/PetstoreClient/Classes/Swaggers/Models.swift
@@ -15,9 +15,9 @@ public enum ErrorResponse : Error {
 }
 
 open class Response<T> {
-    open let statusCode: Int
-    open let header: [String: String]
-    open let body: T?
+    public let statusCode: Int
+    public let header: [String: String]
+    public let body: T?
 
     public init(statusCode: Int, header: [String: String], body: T?) {
         self.statusCode = statusCode


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [x] Filed the PR against the correct branch: `3.0.0` branch for changes related to OpenAPI spec 3.0. Default: `master`.
- [x] Copied the [technical committee](https://github.com/swagger-api/swagger-codegen/#swagger-codegen-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

This PR fixes issue #8336. 

Adjusts the templates for Swift 4.2 to address warnings that “Static declarations are implicitly final; use ‘public’ instead of ‘open’”. I have substituted `public` in place of `open` where these warnings appeared.

Also addresses warnings in `AlamofireImplementations.mustache` that “Using ‘!’ here is deprecated and will be removed in a future release". Rather than casting the optional error as `Error!`, simply implicitly unwrap it.

Copying in @ehyche from the technical committee for the Swift4 generator.
