### PR TITLE
Fix php symfony controller container existence #8896

### DIFF
--- a/modules/swagger-codegen/src/main/resources/php-symfony/Controller.mustache
+++ b/modules/swagger-codegen/src/main/resources/php-symfony/Controller.mustache
@@ -34,9 +34,20 @@ use {{servicePackage}}\ValidatorInterface;
  */
 class Controller
 {
+    private $container;
     protected $validator;
     protected $serializer;
     protected $apiServer;
+
+    /**
+     * Controller constructor.
+     *
+     * @param $container
+     */
+    public function __construct($container)
+    {
+        $this->container = $container;
+    }
 
     public function setValidator(ValidatorInterface $validator)
     {

--- a/modules/swagger-codegen/src/main/resources/php-symfony/services.mustache
+++ b/modules/swagger-codegen/src/main/resources/php-symfony/services.mustache
@@ -14,10 +14,10 @@ services:
         class: {{modelPackage}}\ModelSerializer
 
     {{bundleAlias}}.service.serializer:
-        class: %{{bundleAlias}}.serializer%
+        class: '%{{bundleAlias}}.serializer%'
 
     {{bundleAlias}}.service.validator:
-        class: %{{bundleAlias}}.validator%
+        class: '%{{bundleAlias}}.validator%'
 
 {{#apiInfo}}
 {{#apis}}

--- a/modules/swagger-codegen/src/main/resources/php-symfony/services.mustache
+++ b/modules/swagger-codegen/src/main/resources/php-symfony/services.mustache
@@ -24,6 +24,8 @@ services:
 {{#operations}}
     {{bundleAlias}}.controller.{{pathPrefix}}:
         class: {{controllerPackage}}\{{baseName}}Controller
+        arguments:
+          $container: '@service_container'
         calls:
          - [setSerializer, ['@{{bundleAlias}}.service.serializer']]
          - [setValidator,  ['@{{bundleAlias}}.service.validator']]


### PR DESCRIPTION
### PR checklist

- [ ] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [ ] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [ ] Filed the PR against the correct branch: `3.0.0` branch for changes related to OpenAPI spec 3.0. Default: `master`.
- [ ] Copied the [technical committee](https://github.com/swagger-api/swagger-codegen/#swagger-codegen-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

Add Controller::container property and injecting service_container dependecy in services.yml

Aim to fix: #8896

@HugoMario 

Technical commitee: @dkarlovi @mandrean 


I cant generate the Petstore sample, cause the compiler thrown an error.
```
javax.xml.bind.annotation.adapters does not exist
```