### PR TITLE
[PHP client]Fix README.mustache template for php

### DIFF
--- a/modules/swagger-codegen/src/main/resources/php/README.mustache
+++ b/modules/swagger-codegen/src/main/resources/php/README.mustache
@@ -30,7 +30,7 @@ To install the bindings via [Composer](http://getcomposer.org/), add the followi
 {
   "repositories": [
     {
-      "type": "git",
+      "type": "vcs",
       "url": "https://github.com/{{#composerVendorName}}{{.}}{{/composerVendorName}}{{^composerVendorName}}{{gitUserId}}{{/composerVendorName}}/{{#composerProjectName}}{{.}}{{/composerProjectName}}{{^composerProjectName}}{{gitRepoId}}{{/composerProjectName}}.git"
     }
   ],

--- a/samples/client/petstore-security-test/php/SwaggerClient-php/README.md
+++ b/samples/client/petstore-security-test/php/SwaggerClient-php/README.md
@@ -19,7 +19,7 @@ To install the bindings via [Composer](http://getcomposer.org/), add the followi
 {
   "repositories": [
     {
-      "type": "git",
+      "type": "vcs",
       "url": "https://github.com/GIT_USER_ID/GIT_REPO_ID.git"
     }
   ],

--- a/samples/client/petstore/php/SwaggerClient-php/README.md
+++ b/samples/client/petstore/php/SwaggerClient-php/README.md
@@ -19,7 +19,7 @@ To install the bindings via [Composer](http://getcomposer.org/), add the followi
 {
   "repositories": [
     {
-      "type": "git",
+      "type": "vcs",
       "url": "https://github.com/GIT_USER_ID/GIT_REPO_ID.git"
     }
   ],


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [ ] Filed the PR against the correct branch: `3.0.0` branch for changes related to OpenAPI spec 3.0. Default: `master`.
- [x] Copied the [technical committee](https://github.com/swagger-api/swagger-codegen/#swagger-codegen-technical-committee) to review the pull request if your PR is targeting a particular programming language.
@dkarlovi @mandrean

> Filed the PR against the correct branch: `3.0.0`

Should I chose `3.0.0`? But now I use v2.3.x

### Description of the PR

I fixed README.mustache template for php.

Because `Installation & Usage` section is wrong.

Please see composer document bellow.
https://getcomposer.org/doc/05-repositories.md#loading-a-package-from-a-vcs-repository