### PR TITLE
[Fix #8858][Python] Discriminator value is no longer converted to lowercase

### DIFF
--- a/modules/swagger-codegen/src/main/resources/python/model.mustache
+++ b/modules/swagger-codegen/src/main/resources/python/model.mustache
@@ -169,7 +169,9 @@ class {{classname}}({{#parent}}{{parent}}{{/parent}}{{^parent}}object{{/parent}}
 {{#discriminator}}
     def get_real_child_model(self, data):
         """Returns the real base class specified by the discriminator"""
-        discriminator_value = data[self.discriminator].lower()
+        discriminator_value = None
+        if self.discriminator is not None:
+            discriminator_value = data[self.discriminator]
         return self.discriminator_value_class_map.get(discriminator_value)
 
 {{/discriminator}}

--- a/samples/client/petstore-security-test/python/petstore_api/api/fake_api.py
+++ b/samples/client/petstore-security-test/python/petstore_api/api/fake_api.py
@@ -34,35 +34,35 @@ class FakeApi(object):
         self.api_client = api_client
 
     def test_code_inject____end__rn_n_r(self, **kwargs):  # noqa: E501
-        """To test code injection */ &#39; \&quot; &#x3D;end -- \\r\\n \\n \\r  # noqa: E501
+        """To test code injection */ ' \" =end -- \\r\\n \\n \\r  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.test_code_inject____end__rn_n_r(async=True)
+        asynchronous HTTP request, please pass async_req=True
+        >>> thread = api.test_code_inject____end__rn_n_r(async_req=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param async_req bool
         :param str test_code_inject____end____rn_n_r: To test code injection */ ' \" =end -- \\r\\n \\n \\r
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('async_req'):
             return self.test_code_inject____end__rn_n_r_with_http_info(**kwargs)  # noqa: E501
         else:
             (data) = self.test_code_inject____end__rn_n_r_with_http_info(**kwargs)  # noqa: E501
             return data
 
     def test_code_inject____end__rn_n_r_with_http_info(self, **kwargs):  # noqa: E501
-        """To test code injection */ &#39; \&quot; &#x3D;end -- \\r\\n \\n \\r  # noqa: E501
+        """To test code injection */ ' \" =end -- \\r\\n \\n \\r  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.test_code_inject____end__rn_n_r_with_http_info(async=True)
+        asynchronous HTTP request, please pass async_req=True
+        >>> thread = api.test_code_inject____end__rn_n_r_with_http_info(async_req=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param async_req bool
         :param str test_code_inject____end____rn_n_r: To test code injection */ ' \" =end -- \\r\\n \\n \\r
         :return: None
                  If the method is called asynchronously,
@@ -70,7 +70,7 @@ class FakeApi(object):
         """
 
         all_params = ['test_code_inject____end____rn_n_r']  # noqa: E501
-        all_params.append('async')
+        all_params.append('async_req')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -120,7 +120,7 @@ class FakeApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            async_req=params.get('async_req'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),

--- a/samples/client/petstore-security-test/python/petstore_api/api_client.py
+++ b/samples/client/petstore-security-test/python/petstore_api/api_client.py
@@ -245,12 +245,12 @@ class ApiClient(object):
 
         if type(klass) == str:
             if klass.startswith('list['):
-                sub_kls = re.match('list\[(.*)\]', klass).group(1)
+                sub_kls = re.match(r'list\[(.*)\]', klass).group(1)
                 return [self.__deserialize(sub_data, sub_kls)
                         for sub_data in data]
 
             if klass.startswith('dict('):
-                sub_kls = re.match('dict\(([^,]*), (.*)\)', klass).group(2)
+                sub_kls = re.match(r'dict\(([^,]*), (.*)\)', klass).group(2)
                 return {k: self.__deserialize(v, sub_kls)
                         for k, v in six.iteritems(data)}
 
@@ -274,12 +274,12 @@ class ApiClient(object):
     def call_api(self, resource_path, method,
                  path_params=None, query_params=None, header_params=None,
                  body=None, post_params=None, files=None,
-                 response_type=None, auth_settings=None, async=None,
+                 response_type=None, auth_settings=None, async_req=None,
                  _return_http_data_only=None, collection_formats=None,
                  _preload_content=True, _request_timeout=None):
         """Makes the HTTP request (synchronous) and returns deserialized data.
 
-        To make an async request, set the async parameter.
+        To make an async request, set the async_req parameter.
 
         :param resource_path: Path to method endpoint.
         :param method: Method to call.
@@ -294,7 +294,7 @@ class ApiClient(object):
         :param response: Response data type.
         :param files dict: key -> filename, value -> filepath,
             for `multipart/form-data`.
-        :param async bool: execute request asynchronously
+        :param async_req bool: execute request asynchronously
         :param _return_http_data_only: response data without head status code
                                        and headers
         :param collection_formats: dict of collection formats for path, query,
@@ -307,13 +307,13 @@ class ApiClient(object):
                                  timeout. It can also be a pair (tuple) of
                                  (connection, read) timeouts.
         :return:
-            If async parameter is True,
+            If async_req parameter is True,
             the request will be called asynchronously.
             The method will return the request thread.
-            If parameter async is False or missing,
+            If parameter async_req is False or missing,
             then the method will return the response directly.
         """
-        if not async:
+        if not async_req:
             return self.__call_api(resource_path, method,
                                    path_params, query_params, header_params,
                                    body, post_params, files,

--- a/samples/client/petstore/python-asyncio/petstore_api/models/animal.py
+++ b/samples/client/petstore/python-asyncio/petstore_api/models/animal.py
@@ -102,7 +102,9 @@ class Animal(object):
 
     def get_real_child_model(self, data):
         """Returns the real base class specified by the discriminator"""
-        discriminator_value = data[self.discriminator].lower()
+        discriminator_value = None
+        if self.discriminator is not None:
+            discriminator_value = data[self.discriminator]
         return self.discriminator_value_class_map.get(discriminator_value)
 
     def to_dict(self):

--- a/samples/client/petstore/python-tornado/petstore_api/models/animal.py
+++ b/samples/client/petstore/python-tornado/petstore_api/models/animal.py
@@ -102,7 +102,9 @@ class Animal(object):
 
     def get_real_child_model(self, data):
         """Returns the real base class specified by the discriminator"""
-        discriminator_value = data[self.discriminator].lower()
+        discriminator_value = None
+        if self.discriminator is not None:
+            discriminator_value = data[self.discriminator]
         return self.discriminator_value_class_map.get(discriminator_value)
 
     def to_dict(self):

--- a/samples/client/petstore/python/petstore_api/models/animal.py
+++ b/samples/client/petstore/python/petstore_api/models/animal.py
@@ -102,7 +102,9 @@ class Animal(object):
 
     def get_real_child_model(self, data):
         """Returns the real base class specified by the discriminator"""
-        discriminator_value = data[self.discriminator].lower()
+        discriminator_value = None
+        if self.discriminator is not None:
+            discriminator_value = data[self.discriminator]
         return self.discriminator_value_class_map.get(discriminator_value)
 
     def to_dict(self):


### PR DESCRIPTION
### Fix #8858

The discriminator values were converted to lowercase prior to selecting the appropriate class to instantiate and no match was found in the class map.

https://github.com/swagger-api/swagger-codegen/blob/7a049041e237099db112d3652ac67220a2566a0f/modules/swagger-codegen/src/main/resources/python/model.mustache#L51-L54

https://github.com/swagger-api/swagger-codegen/blob/7a049041e237099db112d3652ac67220a2566a0f/modules/swagger-codegen/src/main/resources/python/model.mustache#L170-L173
As a result, the base class was always instantiated and not the subclasses corresponding to the discriminator values.

The model.mustache template has been modified and the discriminator values are no longer converted to lowercase. As subclasses override the discriminator to None and get_real_child_model is executed once for the base class and once for the subclass, get_real_child_model has been modified to return None in case the discriminator is None to avoid a KeyError.

https://github.com/CristianPop/swagger-codegen/blob/f48b669159990f644914e42e2abe18704c158a64/modules/swagger-codegen/src/main/resources/python/model.mustache#L170-L175

The subclasses are now appropriately selected and instantiated based on the discriminator.

The petstore sample has been updated.

@kenjones-cisco 

 

