### PR TITLE
Adding CMake configuration for the Qt project generation

### DIFF
--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/Qt5CPPGenerator.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/Qt5CPPGenerator.java
@@ -120,6 +120,7 @@ public class Qt5CPPGenerator extends AbstractCppCodegen implements CodegenConfig
         supportingFiles.add(new SupportingFile("QObjectWrapper.h.mustache", sourceFolder, PREFIX + "QObjectWrapper.h"));
         if (optionalProjectFileFlag) {
             supportingFiles.add(new SupportingFile("Project.mustache", sourceFolder, "client.pri"));
+            supportingFiles.add(new SupportingFile("ProjectCMake.mustache", sourceFolder, "CMakeLists.txt"));
         }
 
         super.typeMapping = new HashMap<String, String>();

--- a/modules/swagger-codegen/src/main/resources/qt5cpp/ProjectCMake.mustache
+++ b/modules/swagger-codegen/src/main/resources/qt5cpp/ProjectCMake.mustache
@@ -1,0 +1,43 @@
+project(swagger_client)
+
+set(CMAKE_AUTOMOC ON)
+
+set(SOURCES
+{{#models}}
+{{#model}}
+            {{classname}}.cpp
+{{/model}}
+{{/models}}
+{{#apiInfo}}
+{{#apis}}
+{{#operations}}
+            {{classname}}.cpp
+{{/operations}}
+{{/apis}}
+{{/apiInfo}}
+            {{prefix}}Helpers.cpp
+            {{prefix}}HttpRequest.cpp
+)
+
+set(HEADERS
+{{#models}}
+{{#model}}
+            {{classname}}.h
+{{/model}}
+{{/models}}
+{{#apiInfo}}
+{{#apis}}
+{{#operations}}
+            {{classname}}.h
+{{/operations}}
+{{/apis}}
+{{/apiInfo}}
+            {{prefix}}Helpers.h
+            {{prefix}}HttpRequest.h
+            {{prefix}}ModelFactory.h
+            {{prefix}}Object.h
+            {{prefix}}QObjectWrapper.h
+)
+
+add_library(${PROJECT_NAME} ${SOURCES} ${HEADERS})
+target_link_libraries(${PROJECT_NAME} Qt5::Network Qt5::Core)


### PR DESCRIPTION
### PR checklist

- [ ] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [ ] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [ ] Filed the PR against the correct branch: `3.0.0` branch for changes related to OpenAPI spec 3.0. Default: `master`.
- [ ] Copied the [technical committee](https://github.com/swagger-api/swagger-codegen/#swagger-codegen-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

(details of the change, additional tests that have been done, reference to the issue for tracking, etc)

