### PR TITLE
An expression of type 'void' cannot be tested for truthiness

### DIFF
--- a/modules/swagger-codegen/src/main/resources/typescript-angular/api.service.mustache
+++ b/modules/swagger-codegen/src/main/resources/typescript-angular/api.service.mustache
@@ -262,7 +262,8 @@ export class {{classname}} {
 {{#hasFormParams}}
         const canConsumeForm = this.canConsumeForm(consumes);
 
-        let formParams: { append(param: string, value: any): void; };
+        let formParams: FormParams;
+        let append = getAppender();
         let useForm = false;
         let convertFormParamsToString = false;
 {{#formParams}}
@@ -277,6 +278,7 @@ export class {{classname}} {
         } else {
 {{#useHttpClient}}
             formParams = new HttpParams({encoder: new CustomHttpUrlEncodingCodec()});
+            append = getAppender(true);
 {{/useHttpClient}}
 {{^useHttpClient}}
             // TODO: this fails if a parameter is a file, the api can't consume "multipart/form-data" and a blob is passed.
@@ -286,23 +288,22 @@ export class {{classname}} {
             headers.set('Content-Type', 'application/x-www-form-urlencoded;charset=UTF-8');
 {{/useHttpClient}}
         }
-
 {{#formParams}}
         {{#isListContainer}}
         if ({{paramName}}) {
         {{#isCollectionFormatMulti}}
             {{paramName}}.forEach((element) => {
-                {{#useHttpClient}}formParams = {{/useHttpClient}}formParams.append('{{baseName}}', <any>element){{#useHttpClient}} || formParams{{/useHttpClient}};
+                {{#useHttpClient}}formParams = {{/useHttpClient}}append(formParams, '{{baseName}}', <any>element);
             })
         {{/isCollectionFormatMulti}}
         {{^isCollectionFormatMulti}}
-            {{#useHttpClient}}formParams = {{/useHttpClient}}formParams.append('{{baseName}}', {{paramName}}.join(COLLECTION_FORMATS['{{collectionFormat}}'])){{#useHttpClient}} || formParams{{/useHttpClient}};
+            {{#useHttpClient}}formParams = {{/useHttpClient}}append(formParams, '{{baseName}}', {{paramName}}.join(COLLECTION_FORMATS['{{collectionFormat}}']));
         {{/isCollectionFormatMulti}}
         }
         {{/isListContainer}}
         {{^isListContainer}}
         if ({{paramName}} !== undefined) {
-            {{#useHttpClient}}formParams = {{/useHttpClient}}formParams.append('{{baseName}}', <any>{{paramName}}){{#useHttpClient}} || formParams{{/useHttpClient}};
+            {{#useHttpClient}}formParams = {{/useHttpClient}}append(formParams, '{{baseName}}', <any>{{paramName}});
         }
         {{/isListContainer}}
 {{/formParams}}
@@ -354,3 +355,10 @@ export class {{classname}} {
 
 {{/operation}}}
 {{/operations}}
+
+    getAppender(useReturnValue = false) {
+        return (formParams: FormParams, param: string, value: any) =>
+            useReturnValue ? formParams.append(param, value) : formParams.append(param, value), formParams;
+    }
+
+    type FormParams = HttpParams | URLSearchParams | FormData;


### PR DESCRIPTION
Closes #8968 .
See PR by @navneetkarnani for more details and trial.

### PR checklist

- [x] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [ ] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/typescript-angular-all-petstore.sh` and `./bin/security/{LANG}-petstore.sh`.
- [x] Filed the PR against the correct branch: `3.0.0` branch for changes related to OpenAPI spec 3.0. Default: `master`.
- [x] Copied the [technical committee](https://github.com/swagger-api/swagger-codegen/#swagger-codegen-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

The Typescript 3.1 compiler (one that is used with Angular 7 onwards), has a check for void functions being checked for Truthiness.
This change drops the or (`||`) operator altogether, extracts the assignment code to runtime and utilizes the comma (`,`) operator instead.
