### PR TITLE
[Symfony] Avoid JMS serializer dependence

### DIFF
--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/SymfonyServerCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/SymfonyServerCodegen.java
@@ -276,6 +276,7 @@ public class SymfonyServerCodegen extends AbstractPhpCodegen implements CodegenC
         // Serialization components
         supportingFiles.add(new SupportingFile("serialization/SerializerInterface.mustache", toPackagePath(servicePackage, srcBasePath), "SerializerInterface.php"));
         supportingFiles.add(new SupportingFile("serialization/JmsSerializer.mustache", toPackagePath(servicePackage, srcBasePath), "JmsSerializer.php"));
+        supportingFiles.add(new SupportingFile("serialization/BundleSerializer.mustache", toPackagePath(servicePackage, srcBasePath), "BundleSerializer.php"));
         supportingFiles.add(new SupportingFile("serialization/StrictJsonDeserializationVisitor.mustache", toPackagePath(servicePackage, srcBasePath), "StrictJsonDeserializationVisitor.php"));
         supportingFiles.add(new SupportingFile("serialization/TypeMismatchException.mustache", toPackagePath(servicePackage, srcBasePath), "TypeMismatchException.php"));
         // Validation components

--- a/modules/swagger-codegen/src/main/resources/php-symfony/serialization/BundleSerializer.mustache
+++ b/modules/swagger-codegen/src/main/resources/php-symfony/serialization/BundleSerializer.mustache
@@ -1,0 +1,115 @@
+<?php
+
+namespace {{servicePackage}};
+
+use JMS\Serializer\SerializerBuilder;
+use JMS\Serializer\Naming\CamelCaseNamingStrategy;
+use JMS\Serializer\Naming\SerializedNameAnnotationStrategy;
+use JMS\Serializer\XmlDeserializationVisitor;
+
+class JmsSerializer implements SerializerInterface
+{
+    protected $serializer;
+
+    public function __construct()
+    {
+        $naming_strategy = new SerializedNameAnnotationStrategy(new CamelCaseNamingStrategy());
+        $this->serializer = SerializerBuilder::create()
+            ->setDeserializationVisitor('json', new StrictJsonDeserializationVisitor($naming_strategy))
+            ->setDeserializationVisitor('xml', new XmlDeserializationVisitor($naming_strategy))
+            ->build();
+    }
+
+    public function serialize($data, $format)
+    {
+        return SerializerBuilder::create()->build()->serialize($data, $this->convertFormat($format));
+    }
+
+    public function deserialize($data, $type, $format)
+    {
+        if ($format == 'string') {
+            return $this->deserializeString($data, $type);           
+        }
+
+        // If we end up here, let JMS serializer handle the deserialization
+        return $this->serializer->deserialize($data, $type, $this->convertFormat($format));
+    }
+
+    private function convertFormat($format)
+    {
+        switch ($format) {
+            case 'application/json':
+                return 'json';
+            case 'application/xml':
+                return 'xml';
+        }
+
+        return null;
+    }
+
+    private function deserializeString($data, $type)
+    {
+        // Figure out if we have an array format
+        if (1 === preg_match('/array<(csv|ssv|tsv|pipes),(int|string)>/i', $type, $matches)) {
+            return $this->deserializeArrayString($matches[1], $matches[2], $data);
+        }
+
+        switch ($type) {
+            case 'int':
+            case 'integer':
+                if (is_int($data)) {
+                    return $data;
+                }
+
+                if (is_numeric($data)) {
+                    return $data + 0;
+                }
+
+                break;
+            case 'string':
+                break;
+            case 'boolean':
+            case 'bool':
+                if (strtolower($data) === 'true') {
+                    return true;
+                }
+
+                if (strtolower($data) === 'false') {
+                    return false;
+                }
+
+                break;
+        }
+
+        // If we end up here, just return data
+        return $data;
+    }
+
+    private function deserializeArrayString($format, $type, $data)
+    {
+        // Parse the string using the correct separator
+        switch ($format) {
+            case 'csv':
+                $data = explode(',', $data);
+                break;
+            case 'ssv':
+                $data = explode(' ', $data);
+                break;
+            case 'tsv':
+                $data = explode("\t", $data);
+                break;
+            case 'pipes':
+                $data = explode('|', $data);
+                break;
+            default;
+                $data = [];
+        }
+
+        // Deserialize each of the array elements
+        foreach ($data as $key => $item) {
+            $data[$key] = $this->deserializeString($item, $type);
+        }
+
+        return $data;
+    }
+}

--- a/samples/server/petstore/php-symfony/SymfonyBundle-php/Service/BundleSerializer.php
+++ b/samples/server/petstore/php-symfony/SymfonyBundle-php/Service/BundleSerializer.php
@@ -1,0 +1,96 @@
+<?php
+namespace Swagger\Server\Service;
+use JMS\Serializer\SerializerBuilder;
+use JMS\Serializer\Naming\CamelCaseNamingStrategy;
+use JMS\Serializer\Naming\SerializedNameAnnotationStrategy;
+use JMS\Serializer\XmlDeserializationVisitor;
+class BundleSerializer implements SerializerInterface
+{
+    protected $serializer;
+    public function __construct()
+    {
+        $naming_strategy = new SerializedNameAnnotationStrategy(new CamelCaseNamingStrategy());
+        $this->serializer = SerializerBuilder::create()
+            ->setDeserializationVisitor('json', new StrictJsonDeserializationVisitor($naming_strategy))
+            ->setDeserializationVisitor('xml', new XmlDeserializationVisitor($naming_strategy))
+            ->build();
+    }
+    public function serialize($data, $format)
+    {
+        return SerializerBuilder::create()->build()->serialize($data, $this->convertFormat($format));
+    }
+    public function deserialize($data, $type, $format)
+    {
+        if ($format == 'string') {
+            return $this->deserializeString($data, $type);           
+        }
+        // If we end up here, let JMS serializer handle the deserialization
+        return $this->serializer->deserialize($data, $type, $this->convertFormat($format));
+    }
+    private function convertFormat($format)
+    {
+        switch ($format) {
+            case 'application/json':
+                return 'json';
+            case 'application/xml':
+                return 'xml';
+        }
+        return null;
+    }
+    private function deserializeString($data, $type)
+    {
+        // Figure out if we have an array format
+        if (1 === preg_match('/array<(csv|ssv|tsv|pipes),(int|string)>/i', $type, $matches)) {
+            return $this->deserializeArrayString($matches[1], $matches[2], $data);
+        }
+        switch ($type) {
+            case 'int':
+            case 'integer':
+                if (is_int($data)) {
+                    return $data;
+                }
+                if (is_numeric($data)) {
+                    return $data + 0;
+                }
+                break;
+            case 'string':
+                break;
+            case 'boolean':
+            case 'bool':
+                if (strtolower($data) === 'true') {
+                    return true;
+                }
+                if (strtolower($data) === 'false') {
+                    return false;
+                }
+                break;
+        }
+        // If we end up here, just return data
+        return $data;
+    }
+    private function deserializeArrayString($format, $type, $data)
+    {
+        // Parse the string using the correct separator
+        switch ($format) {
+            case 'csv':
+                $data = explode(',', $data);
+                break;
+            case 'ssv':
+                $data = explode(' ', $data);
+                break;
+            case 'tsv':
+                $data = explode("\t", $data);
+                break;
+            case 'pipes':
+                $data = explode('|', $data);
+                break;
+            default;
+                $data = [];
+        }
+        // Deserialize each of the array elements
+        foreach ($data as $key => $item) {
+            $data[$key] = $this->deserializeString($item, $type);
+        }
+        return $data;
+    }
+}


### PR DESCRIPTION
### PR checklist

- [ ] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [ ] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [ ] Filed the PR against the correct branch: `3.0.0` branch for changes related to OpenAPI spec 3.0. Default: `master`.
- [ ] Copied the [technical committee](https://github.com/swagger-api/swagger-codegen/#swagger-codegen-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

(details of the change, additional tests that have been done, reference to the issue for tracking, etc)

With this PR, we are now able to use another serializer instead of JMS, for example Symfony one, without the need to update the JAVA code to automaticaly have another serializer (without it, we can update the template file but the filename is always related to JMS...)
