### PR TITLE
Update badges to link to latest swagger-codegen v3 version

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 [![Windows Test](https://ci.appveyor.com/api/projects/status/github/swagger-api/swagger-codegen?branch=3.0.0&svg=true&passingText=Windows%20Test%20-%20OK&failingText=Windows%20Test%20-%20Fails)](https://ci.appveyor.com/project/swaggerhub-bot/swagger-codegen)
 
 
-[![Maven Central](https://maven-badges.herokuapp.com/maven-central/io.swagger/swagger-codegen-project/badge.svg?style=plastic)](https://maven-badges.herokuapp.com/maven-central/io.swagger/swagger-codegen-project)
+[![Maven Central](https://maven-badges.herokuapp.com/maven-central/io.swagger.codegen.v3/swagger-codegen/badge.svg?style=plastic)](https://maven-badges.herokuapp.com/maven-central/io.swagger.codegen.v3/swagger-codegen/)
 [![PR Stats](http://issuestats.com/github/swagger-api/swagger-codegen/badge/pr)](http://issuestats.com/github/swagger-api/swagger-codegen) [![Issue Stats](http://issuestats.com/github/swagger-api/swagger-codegen/badge/issue)](http://issuestats.com/github/swagger-api/swagger-codegen)
 
 :star::star::star: If you would like to contribute, please refer to [guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md) and a list of [open tasks](https://github.com/swagger-api/swagger-codegen/issues?q=is%3Aopen+is%3Aissue+label%3A%22help+wanted%22).:star::star::star:


### PR DESCRIPTION
The goal of this PR is to fix the badges available on the README.md file.
When opening the [github project](https://github.com/swagger-api/swagger-codegen) you won't find the latest version on mvncentral but only `3.0.0-rc1` which is _old_ considering that 3.0.3 has been released.
This was caused by the fact that swagger-codegen v3+ has changed the maven group and artifact identifier