### PR TITLE
update autotest-fsevent for Ruby testing on Mojave and High Sierra

### DIFF
--- a/samples/client/petstore/ruby/Gemfile.lock
+++ b/samples/client/petstore/ruby/Gemfile.lock
@@ -13,7 +13,7 @@ GEM
       public_suffix (~> 2.0, >= 2.0.2)
     autotest (4.4.6)
       ZenTest (>= 4.4.1)
-    autotest-fsevent (0.2.12)
+    autotest-fsevent (0.2.14)
       sys-uname
     autotest-growl (0.2.16)
     autotest-rails-pure (4.1.2)
@@ -22,7 +22,7 @@ GEM
     diff-lcs (1.3)
     ethon (0.10.1)
       ffi (>= 1.3.0)
-    ffi (1.9.18)
+    ffi (1.10.0)
     hashdiff (0.3.4)
     json (2.1.0)
     public_suffix (2.0.5)
@@ -41,7 +41,7 @@ GEM
       rspec-support (~> 3.6.0)
     rspec-support (3.6.0)
     safe_yaml (1.0.4)
-    sys-uname (1.0.3)
+    sys-uname (1.0.4)
       ffi (>= 1.0.0)
     typhoeus (1.1.2)
       ethon (>= 0.9.0)
@@ -64,3 +64,6 @@ DEPENDENCIES
   rspec (~> 3.6, >= 3.6.0)
   vcr (~> 3.0, >= 3.0.1)
   webmock (~> 1.24, >= 1.24.3)
+
+BUNDLED WITH
+   1.17.3


### PR DESCRIPTION
- [x] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [ ] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [x] Filed the PR against the correct branch: `3.0.0` branch for changes related to OpenAPI spec 3.0. Default: `master`.
- [ ] Copied the [technical committee](https://github.com/swagger-api/swagger-codegen/#swagger-codegen-technical-committee) to review the pull request if your PR is targeting a particular programming language.


Fix #9097.

Update autotest-fsevent to test Ruby Petstore client sample on Mojave and High Sierra.
To update it, I ran `bundle update autotest-fsevent`.