### PR TITLE
issue-282_Enable_code_generation_for_openfeign_with_spring-boot_2

### DIFF
--- a/modules/swagger-codegen/src/main/resources/JavaSpring/libraries/spring-cloud/apiClient.mustache
+++ b/modules/swagger-codegen/src/main/resources/JavaSpring/libraries/spring-cloud/apiClient.mustache
@@ -1,6 +1,11 @@
 package {{package}};
 
-import org.springframework.cloud.netflix.feign.FeignClient;
+{{^isOpenFeign}}
+    import org.springframework.cloud.netflix.feign.FeignClient;
+{{/isOpenFeign}}
+{{#isOpenFeign}}
+    import org.springframework.cloud.openfeign.FeignClient;
+{{/isOpenFeign}}
 import {{configPackage}}.ClientConfiguration;
 
 {{=<% %>=}}

--- a/modules/swagger-codegen/src/test/java/io/swagger/codegen/options/SpringOptionsProvider.java
+++ b/modules/swagger-codegen/src/test/java/io/swagger/codegen/options/SpringOptionsProvider.java
@@ -1,16 +1,16 @@
 package io.swagger.codegen.options;
 
-import io.swagger.codegen.CodegenConstants;
-import io.swagger.codegen.languages.SpringCodegen;
-
 import java.util.HashMap;
 import java.util.Map;
+
+import io.swagger.codegen.CodegenConstants;
+import io.swagger.codegen.languages.SpringCodegen;
 
 public class SpringOptionsProvider extends JavaOptionsProvider {
     public static final String TITLE = "swagger";
     public static final String CONFIG_PACKAGE_VALUE = "configPackage";
     public static final String BASE_PACKAGE_VALUE = "basePackage";
-    public static final String LIBRARY_VALUE = "spring-mvc"; //FIXME hidding value from super class
+    public static final String LIBRARY_VALUE = "spring-mvc"; // FIXME hidding value from super class
     public static final String INTERFACE_ONLY = "true";
     public static final String DELEGATE_PATTERN = "true";
     public static final String SINGLE_CONTENT_TYPES = "true";
@@ -22,6 +22,7 @@ public class SpringOptionsProvider extends JavaOptionsProvider {
     public static final String IMPLICIT_HEADERS = "false";
     public static final String SWAGGER_DOCKET_CONFIG = "false";
     public static final String USE_OPTIONAL = "false";
+    public static final String TARGET_OPENFEIGN = "false";
 
     @Override
     public String getLanguage() {
@@ -46,6 +47,7 @@ public class SpringOptionsProvider extends JavaOptionsProvider {
         options.put(SpringCodegen.IMPLICIT_HEADERS, IMPLICIT_HEADERS);
         options.put(SpringCodegen.SWAGGER_DOCKET_CONFIG, SWAGGER_DOCKET_CONFIG);
         options.put(SpringCodegen.USE_OPTIONAL, USE_OPTIONAL);
+        options.put(SpringCodegen.TARGET_OPENFEIGN, TARGET_OPENFEIGN);
 
         return options;
     }


### PR DESCRIPTION
### PR checklist

- [X] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [ ] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [X] Filed the PR against the correct branch: `3.0.0` branch for changes related to OpenAPI spec 3.0. Default: `master`.
- [ ] Copied the [technical committee](https://github.com/swagger-api/swagger-codegen/#swagger-codegen-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR
#9118 
When using generation library spring-cloud, code will be generated with import:

`import org.springframework.cloud.netflix.feign.FeignClient;`

But when one wants to use open feign with spring boot 2, we need the following:

`import org.springframework.cloud.openfeign.FeignClient;`

Solution: Setup property to switch between both import statements (JavaSpring library "spring-cloud)" -> "apiClient.mustache".