### PR TITLE
[Java] Getter/Setter naming convention not followed in generated models (#8282)

### DIFF
--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/DefaultCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/DefaultCodegen.java
@@ -1256,7 +1256,7 @@ public class DefaultCodegen {
     }
 
     /**
-     * Output the Getter name, e.g. getSize
+     * Output the Setter name, e.g. setSize
      *
      * @param name the name of the property
      * @return setter name based on naming convention

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/AbstractJavaCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/AbstractJavaCodegen.java
@@ -1317,14 +1317,29 @@ public abstract class AbstractJavaCodegen extends DefaultCodegen implements Code
         additionalProperties.put(propertyKey, value);
     }
 
-    /**
-     * Output the partial Getter name for boolean property, e.g. Active
-     *
-     * @param name the name of the property
-     * @return partial getter name based on naming convention
-     */
+    @Override
     public String toBooleanGetter(String name) {
         return getterAndSetterCapitalize(name);
+    }
+
+    /**
+     * Camelize the method name of the getter and setter for Java
+     * Except when the second letter of the field name is already uppercase
+     * Refer to section 8.8: Capitalization of inferred names of the JavaBeans API specification
+     * http://download.oracle.com/otn-pub/jcp/7224-javabeans-1.01-fr-spec-oth-JSpec/beans.101.pdf)
+     *
+     * @param name string to be camelized
+     * @return Camelized string
+     */
+    @Override
+    public String getterAndSetterCapitalize(String name) {
+        if (name == null || name.length() == 0) {
+            return name;
+        }
+        if (name.length() > 1 && Character.isUpperCase(name.charAt(1))){
+            return name;
+        }
+        return camelize(toVarName(name));
     }
 
     @Override

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/AbstractJavaCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/AbstractJavaCodegen.java
@@ -1300,10 +1300,12 @@ public abstract class AbstractJavaCodegen extends DefaultCodegen implements Code
         this.supportJava6 = value;
     }
 
+    @Override
     public String toRegularExpression(String pattern) {
         return escapeText(pattern);
     }
 
+    @Override
     public boolean convertPropertyToBoolean(String propertyKey) {
         boolean booleanValue = false;
         if (additionalProperties.containsKey(propertyKey)) {
@@ -1313,10 +1315,17 @@ public abstract class AbstractJavaCodegen extends DefaultCodegen implements Code
        return booleanValue;
     }
 
+    @Override
     public void writePropertyBack(String propertyKey, boolean value) {
         additionalProperties.put(propertyKey, value);
     }
 
+    /**
+     * Output the partial Getter name for boolean property, e.g. Active
+     *
+     * @param name the name of the property
+     * @return partial getter name based on naming convention
+     */
     @Override
     public String toBooleanGetter(String name) {
         return getterAndSetterCapitalize(name);

--- a/modules/swagger-codegen/src/main/resources/JavaSpring/beanValidationCore.mustache
+++ b/modules/swagger-codegen/src/main/resources/JavaSpring/beanValidationCore.mustache
@@ -1,4 +1,4 @@
-{{#pattern}}@Pattern(regexp="{{{pattern}}}") {{/pattern}}{{!
+{{#pattern}}@Pattern(regexp="{{{pattern}}}"{{#vendorExtensions.x-pattern-message}}, message="{{vendorExtensions.x-pattern-message}}"{{/vendorExtensions.x-pattern-message}}) {{/pattern}}{{!
 minLength && maxLength set
 }}{{#minLength}}{{#maxLength}}@Size(min={{minLength}},max={{maxLength}}) {{/maxLength}}{{/minLength}}{{!
 minLength set, maxLength not

--- a/modules/swagger-codegen/src/test/java/io/swagger/codegen/java/JavaModelTest.java
+++ b/modules/swagger-codegen/src/test/java/io/swagger/codegen/java/JavaModelTest.java
@@ -387,8 +387,8 @@ public class JavaModelTest {
 
         final CodegenProperty property = cm.vars.get(0);
         Assert.assertEquals(property.baseName, "pId");
-        Assert.assertEquals(property.getter, "getPId");
-        Assert.assertEquals(property.setter, "setPId");
+        Assert.assertEquals(property.getter, "getpId");
+        Assert.assertEquals(property.setter, "setpId");
         Assert.assertEquals(property.datatype, "String");
         Assert.assertEquals(property.name, "pId");
         Assert.assertEquals(property.defaultValue, "null");
@@ -413,8 +413,8 @@ public class JavaModelTest {
 
         final CodegenProperty property = cm.vars.get(0);
         Assert.assertEquals(property.baseName, "ATTName");
-        Assert.assertEquals(property.getter, "getAtTName");
-        Assert.assertEquals(property.setter, "setAtTName");
+        Assert.assertEquals(property.getter, "getATTName");
+        Assert.assertEquals(property.setter, "setATTName");
         Assert.assertEquals(property.datatype, "String");
         Assert.assertEquals(property.name, "atTName");
         Assert.assertEquals(property.defaultValue, "null");


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [x] Filed the PR against the correct branch: `3.0.0` branch for changes related to OpenAPI spec 3.0. Default: `master`.
- (N/A) Copied the [technical committee](https://github.com/swagger-api/swagger-codegen/#swagger-codegen-technical-committee) to review the pull request if your PR is targeting a particular programming language. -> nobody for Java

### Description of the PR

[Java] Getter/Setter naming convention not followed in generated models #8282

fix the getter/setter when the second letter of the field name is already uppercase (following the JavaBeans API specification)

Details : 
Override `getterAndSetterCapitalize` class in the `JavaCodeGen` class
Change Java test `convert a model with a 2nd char upper-case property names` and `convert a model starting with two upper-case letter property names` (getter and setter expected results)

useful links : 
- https://download.oracle.com/otn-pub/jcp/7224-javabeans-1.01-fr-spec-oth-JSpec/beans.101.pdf?AuthParam=1548672501_cd9f95cc049ee0220b70f6c448b2a095 (chapter 8)
- https://dertompson.com/2013/04/29/java-bean-getterssetters/
