### PR TITLE
[Angular] Codegen compilation error (rxjs 6.4.0) #9135

### DIFF
--- a/modules/swagger-codegen/src/main/resources/typescript-angular/package.mustache
+++ b/modules/swagger-codegen/src/main/resources/typescript-angular/package.mustache
@@ -42,7 +42,7 @@
     "reflect-metadata": "^0.1.3",
     "rxjs": "{{#useRxJS6}}^6.1.0{{/useRxJS6}}{{^useRxJS6}}^5.4.0{{/useRxJS6}}",
     "zone.js": "^0.7.6",
-    "typescript": ">=2.1.5 <2.8"
+    "typescript": ">=2.1.5 <3.0"
   }{{#npmRepository}},{{/npmRepository}}
 {{#npmRepository}}
   "publishConfig": {


### PR DESCRIPTION
fix the typescript version dependencies for rjxs 6.4 (need typescript >= 2.8)

### PR checklist

- [x] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [x] Filed the PR against the correct branch: `3.0.0` branch for changes related to OpenAPI spec 3.0. Default: `master`.
- [x] Copied the [technical committee](https://github.com/swagger-api/swagger-codegen/#swagger-codegen-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

I tested all the generated typescript-angular client (angular 4/5/6) and the "npm run build" work with a typescript 2.9.2

