### PR TITLE
Add config property "enumPropertyNaming" to TypeScript codegens.

### DIFF
--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/DefaultCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/DefaultCodegen.java
@@ -1188,6 +1188,14 @@ public class DefaultCodegen {
     }
 
     /**
+     * Capitalise first character of string
+     */
+    @SuppressWarnings("static-method")
+    public static String titleCase(final String input) {
+        return input.substring(0, 1).toUpperCase() + input.substring(1);
+    }
+
+    /**
      * Capitalize the string
      *
      * @param name string to be capitalized

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/AbstractKotlinCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/AbstractKotlinCodegen.java
@@ -3,7 +3,9 @@ package io.swagger.codegen.languages;
 import io.swagger.codegen.CliOption;
 import io.swagger.codegen.CodegenConfig;
 import io.swagger.codegen.CodegenConstants;
+import io.swagger.codegen.CodegenConstants.ENUM_PROPERTY_NAMING_TYPE;
 import io.swagger.codegen.DefaultCodegen;
+import io.swagger.codegen.utils.EnumPropertyNamingUtils;
 import io.swagger.models.properties.ArrayProperty;
 import io.swagger.models.properties.MapProperty;
 import io.swagger.models.properties.Property;
@@ -218,15 +220,7 @@ public abstract class AbstractKotlinCodegen extends DefaultCodegen implements Co
      * @param enumPropertyNamingType The string representation of the naming convention, as defined by {@link CodegenConstants.ENUM_PROPERTY_NAMING_TYPE}
      */
     public void setEnumPropertyNaming(final String enumPropertyNamingType) {
-        try {
-            this.enumPropertyNaming = CodegenConstants.ENUM_PROPERTY_NAMING_TYPE.valueOf(enumPropertyNamingType);
-        } catch (IllegalArgumentException ex) {
-            StringBuilder sb = new StringBuilder(enumPropertyNamingType + " is an invalid enum property naming option. Please choose from:");
-            for (CodegenConstants.ENUM_PROPERTY_NAMING_TYPE t : CodegenConstants.ENUM_PROPERTY_NAMING_TYPE.values()) {
-                sb.append("\n  ").append(t.name());
-            }
-            throw new RuntimeException(sb.toString());
-        }
+        this.enumPropertyNaming = EnumPropertyNamingUtils.parseEnumPropertyNaming(enumPropertyNamingType);
     }
 
     /**
@@ -376,28 +370,11 @@ public abstract class AbstractKotlinCodegen extends DefaultCodegen implements Co
             modified = sanitizeKotlinSpecificNames(modified);
         }
 
-        switch (getEnumPropertyNaming()) {
-            case original:
-                // NOTE: This is provided as a last-case allowance, but will still result in reserved words being escaped.
-                modified = value;
-                break;
-            case camelCase:
-                // NOTE: Removes hyphens and underscores
-                modified = camelize(modified, true);
-                break;
-            case PascalCase:
-                // NOTE: Removes hyphens and underscores
-                String result = camelize(modified);
-                modified = titleCase(result);
-                break;
-            case snake_case:
-                // NOTE: Removes hyphens
-                modified = underscore(modified);
-                break;
-            case UPPERCASE:
-                modified = modified.toUpperCase();
-                break;
+        if (getEnumPropertyNaming() == ENUM_PROPERTY_NAMING_TYPE.original) {
+          // NOTE: This is provided as a last-case allowance, but will still result in reserved words being escaped.
+            modified = value;
         }
+        modified = EnumPropertyNamingUtils.applyEnumPropertyCapitalisation(modified, getEnumPropertyNaming());
 
         if (reservedWords.contains(modified)) {
             return escapeReservedWord(modified);
@@ -514,10 +491,6 @@ public abstract class AbstractKotlinCodegen extends DefaultCodegen implements Co
         }
 
         return word;
-    }
-
-    private String titleCase(final String input) {
-        return input.substring(0, 1).toUpperCase() + input.substring(1);
     }
 
     @Override

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/utils/EnumPropertyNamingUtils.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/utils/EnumPropertyNamingUtils.java
@@ -1,0 +1,40 @@
+package io.swagger.codegen.utils;
+
+import io.swagger.codegen.CodegenConstants.ENUM_PROPERTY_NAMING_TYPE;
+import io.swagger.codegen.DefaultCodegen;
+
+public final class EnumPropertyNamingUtils {
+
+    /** Apply the given {@link ENUM_PROPERTY_NAMING_TYPE} to get the correct capitalisation and underscore-usage for an enum name. */
+    public static String applyEnumPropertyCapitalisation(String value, final ENUM_PROPERTY_NAMING_TYPE enumPropertyNaming) {
+        switch (enumPropertyNaming) {
+            case original:
+                return value;
+            case camelCase:
+                // NOTE: Removes hyphens and underscores
+                return DefaultCodegen.camelize(value, true);
+            case PascalCase:
+                // NOTE: Removes hyphens and underscores
+                return DefaultCodegen.titleCase(DefaultCodegen.camelize(value));
+            case snake_case:
+                // NOTE: Removes hyphens
+                return DefaultCodegen.underscore(value);
+            case UPPERCASE:
+                return value.toUpperCase();
+            default:
+                return value;
+        }
+    }
+
+    public static ENUM_PROPERTY_NAMING_TYPE parseEnumPropertyNaming(final String enumPropertyNamingType) {
+        try {
+            return ENUM_PROPERTY_NAMING_TYPE.valueOf(enumPropertyNamingType);
+        } catch (IllegalArgumentException ex) {
+            StringBuilder sb = new StringBuilder(enumPropertyNamingType + " is an invalid enum property naming option. Please choose from:");
+            for (ENUM_PROPERTY_NAMING_TYPE t : ENUM_PROPERTY_NAMING_TYPE.values()) {
+                sb.append("\n  ").append(t.name());
+            }
+            throw new RuntimeException(sb.toString());
+        }
+    }
+}

--- a/modules/swagger-codegen/src/test/java/io/swagger/codegen/options/TypeScriptAngularClientOptionsProvider.java
+++ b/modules/swagger-codegen/src/test/java/io/swagger/codegen/options/TypeScriptAngularClientOptionsProvider.java
@@ -12,6 +12,7 @@ public class TypeScriptAngularClientOptionsProvider implements OptionsProvider {
     public static final String SORT_PARAMS_VALUE = "false";
     public static final String ENSURE_UNIQUE_PARAMS_VALUE = "true";
     public static final String MODEL_PROPERTY_NAMING_VALUE = "camelCase";
+    public static final String ENUM_PROPERTY_NAMING_VALUE = "snake_case";
     private static final String NMP_NAME = "npmName";
     private static final String NMP_VERSION = "1.1.2";
     private static final String NPM_REPOSITORY = "https://registry.npmjs.org";
@@ -30,6 +31,7 @@ public class TypeScriptAngularClientOptionsProvider implements OptionsProvider {
         return builder.put(CodegenConstants.SORT_PARAMS_BY_REQUIRED_FLAG, SORT_PARAMS_VALUE)
                 .put(CodegenConstants.ENSURE_UNIQUE_PARAMS, ENSURE_UNIQUE_PARAMS_VALUE)
                 .put(CodegenConstants.MODEL_PROPERTY_NAMING, MODEL_PROPERTY_NAMING_VALUE)
+                .put(CodegenConstants.ENUM_PROPERTY_NAMING, ENUM_PROPERTY_NAMING_VALUE)
                 .put(CodegenConstants.SUPPORTS_ES6, SUPPORTS_ES6_VALUE)
                 .put(TypeScriptAngularClientCodegen.NPM_NAME, NMP_NAME)
                 .put(TypeScriptAngularClientCodegen.NPM_VERSION, NMP_VERSION)

--- a/modules/swagger-codegen/src/test/java/io/swagger/codegen/options/TypeScriptAngularJsClientOptionsProvider.java
+++ b/modules/swagger-codegen/src/test/java/io/swagger/codegen/options/TypeScriptAngularJsClientOptionsProvider.java
@@ -11,6 +11,7 @@ public class TypeScriptAngularJsClientOptionsProvider implements OptionsProvider
     public static final String SORT_PARAMS_VALUE = "false";
     public static final String ENSURE_UNIQUE_PARAMS_VALUE = "true";
     public static final String MODEL_PROPERTY_NAMING_VALUE = "camelCase";
+    public static final String ENUM_PROPERTY_NAMING_VALUE = "snake_case";
     public static final String ALLOW_UNICODE_IDENTIFIERS_VALUE = "false";
 
     @Override
@@ -25,6 +26,7 @@ public class TypeScriptAngularJsClientOptionsProvider implements OptionsProvider
                 .put(CodegenConstants.SUPPORTS_ES6, SUPPORTS_ES6_VALUE)
                 .put(CodegenConstants.ENSURE_UNIQUE_PARAMS, ENSURE_UNIQUE_PARAMS_VALUE)
                 .put(CodegenConstants.MODEL_PROPERTY_NAMING, MODEL_PROPERTY_NAMING_VALUE)
+                .put(CodegenConstants.ENUM_PROPERTY_NAMING, ENUM_PROPERTY_NAMING_VALUE)
                 .put(CodegenConstants.ALLOW_UNICODE_IDENTIFIERS, ALLOW_UNICODE_IDENTIFIERS_VALUE)
                 .build();
     }

--- a/modules/swagger-codegen/src/test/java/io/swagger/codegen/options/TypeScriptAureliaClientOptionsProvider.java
+++ b/modules/swagger-codegen/src/test/java/io/swagger/codegen/options/TypeScriptAureliaClientOptionsProvider.java
@@ -11,6 +11,7 @@ public class TypeScriptAureliaClientOptionsProvider implements OptionsProvider {
     public static final String ENSURE_UNIQUE_PARAMS_VALUE = "true";
     public static final Boolean SUPPORTS_ES6_VALUE = false;
     public static final String MODEL_PROPERTY_NAMING_VALUE = "camelCase";
+    public static final String ENUM_PROPERTY_NAMING_VALUE = "snake_case";
     private static final String NMP_NAME = "npmName";
     private static final String NMP_VERSION = "1.0.0";
     public static final String ALLOW_UNICODE_IDENTIFIERS_VALUE = "false";
@@ -27,6 +28,7 @@ public class TypeScriptAureliaClientOptionsProvider implements OptionsProvider {
         return builder.put(CodegenConstants.SORT_PARAMS_BY_REQUIRED_FLAG, SORT_PARAMS_VALUE)
                 .put(CodegenConstants.ENSURE_UNIQUE_PARAMS, ENSURE_UNIQUE_PARAMS_VALUE)
                 .put(CodegenConstants.MODEL_PROPERTY_NAMING, MODEL_PROPERTY_NAMING_VALUE)
+                .put(CodegenConstants.ENUM_PROPERTY_NAMING, ENUM_PROPERTY_NAMING_VALUE)
                 .put(CodegenConstants.SUPPORTS_ES6, String.valueOf(SUPPORTS_ES6_VALUE))
                 .put(TypeScriptAureliaClientCodegen.NPM_NAME, NMP_NAME)
                 .put(TypeScriptAureliaClientCodegen.NPM_VERSION, NMP_VERSION)

--- a/modules/swagger-codegen/src/test/java/io/swagger/codegen/options/TypeScriptFetchClientOptionsProvider.java
+++ b/modules/swagger-codegen/src/test/java/io/swagger/codegen/options/TypeScriptFetchClientOptionsProvider.java
@@ -11,6 +11,7 @@ public class TypeScriptFetchClientOptionsProvider implements OptionsProvider {
     public static final String ENSURE_UNIQUE_PARAMS_VALUE = "true";
     public static final Boolean SUPPORTS_ES6_VALUE = false;
     public static final String MODEL_PROPERTY_NAMING_VALUE = "camelCase";
+    public static final String ENUM_PROPERTY_NAMING_VALUE = "snake_case";
     private static final String NMP_NAME = "npmName";
     private static final String NMP_VERSION = "1.0.0";
     private static final String NPM_REPOSITORY = "https://registry.npmjs.org";
@@ -28,6 +29,7 @@ public class TypeScriptFetchClientOptionsProvider implements OptionsProvider {
         return builder.put(CodegenConstants.SORT_PARAMS_BY_REQUIRED_FLAG, SORT_PARAMS_VALUE)
                 .put(CodegenConstants.ENSURE_UNIQUE_PARAMS, ENSURE_UNIQUE_PARAMS_VALUE)
                 .put(CodegenConstants.MODEL_PROPERTY_NAMING, MODEL_PROPERTY_NAMING_VALUE)
+                .put(CodegenConstants.ENUM_PROPERTY_NAMING, ENUM_PROPERTY_NAMING_VALUE)
                 .put(CodegenConstants.SUPPORTS_ES6, String.valueOf(SUPPORTS_ES6_VALUE))
                 .put(TypeScriptFetchClientCodegen.NPM_NAME, NMP_NAME)
                 .put(TypeScriptFetchClientCodegen.NPM_VERSION, NMP_VERSION)

--- a/modules/swagger-codegen/src/test/java/io/swagger/codegen/options/TypeScriptInversifyClientOptionsProvider.java
+++ b/modules/swagger-codegen/src/test/java/io/swagger/codegen/options/TypeScriptInversifyClientOptionsProvider.java
@@ -12,6 +12,7 @@ public class TypeScriptInversifyClientOptionsProvider implements OptionsProvider
     public static final String SORT_PARAMS_VALUE = "false";
     public static final String ENSURE_UNIQUE_PARAMS_VALUE = "true";
     public static final String MODEL_PROPERTY_NAMING_VALUE = "camelCase";
+    public static final String ENUM_PROPERTY_NAMING_VALUE = "snake_case";
     private static final String NMP_NAME = "npmName";
     private static final String NMP_VERSION = "1.1.2";
     private static final String NPM_REPOSITORY = "https://registry.npmjs.org";
@@ -31,6 +32,7 @@ public class TypeScriptInversifyClientOptionsProvider implements OptionsProvider
         return builder.put(CodegenConstants.SORT_PARAMS_BY_REQUIRED_FLAG, SORT_PARAMS_VALUE)
                 .put(CodegenConstants.ENSURE_UNIQUE_PARAMS, ENSURE_UNIQUE_PARAMS_VALUE)
                 .put(CodegenConstants.MODEL_PROPERTY_NAMING, MODEL_PROPERTY_NAMING_VALUE)
+                .put(CodegenConstants.ENUM_PROPERTY_NAMING, ENUM_PROPERTY_NAMING_VALUE)
                 .put(CodegenConstants.SUPPORTS_ES6, SUPPORTS_ES6_VALUE)
                 .put(TypeScriptInversifyClientCodegen.NPM_NAME, NMP_NAME)
                 .put(TypeScriptInversifyClientCodegen.NPM_VERSION, NMP_VERSION)

--- a/modules/swagger-codegen/src/test/java/io/swagger/codegen/options/TypeScriptNodeClientOptionsProvider.java
+++ b/modules/swagger-codegen/src/test/java/io/swagger/codegen/options/TypeScriptNodeClientOptionsProvider.java
@@ -13,6 +13,7 @@ public class TypeScriptNodeClientOptionsProvider implements OptionsProvider {
     public static final String SORT_PARAMS_VALUE = "false";
     public static final String ENSURE_UNIQUE_PARAMS_VALUE = "true";
     public static final String MODEL_PROPERTY_NAMING_VALUE = "camelCase";
+    public static final String ENUM_PROPERTY_NAMING_VALUE = "snake_case";
 
     private static final String NMP_NAME = "npmName";
     private static final String NMP_VERSION = "1.1.2";
@@ -32,6 +33,7 @@ public class TypeScriptNodeClientOptionsProvider implements OptionsProvider {
                 .put(CodegenConstants.SUPPORTS_ES6, SUPPORTS_ES6_VALUE)
                 .put(CodegenConstants.ENSURE_UNIQUE_PARAMS, ENSURE_UNIQUE_PARAMS_VALUE)
                 .put(CodegenConstants.MODEL_PROPERTY_NAMING, MODEL_PROPERTY_NAMING_VALUE)
+                .put(CodegenConstants.ENUM_PROPERTY_NAMING, ENUM_PROPERTY_NAMING_VALUE)
                 .put(TypeScriptAngularClientCodegen.NPM_NAME, NMP_NAME)
                 .put(TypeScriptAngularClientCodegen.NPM_VERSION, NMP_VERSION)
                 .put(TypeScriptAngularClientCodegen.SNAPSHOT, Boolean.FALSE.toString())

--- a/modules/swagger-codegen/src/test/java/io/swagger/codegen/typescript/aurelia/TypeScriptAureliaClientOptionsTest.java
+++ b/modules/swagger-codegen/src/test/java/io/swagger/codegen/typescript/aurelia/TypeScriptAureliaClientOptionsTest.java
@@ -29,6 +29,8 @@ public class TypeScriptAureliaClientOptionsTest extends AbstractOptionsTest {
             times = 1;
             clientCodegen.setModelPropertyNaming(TypeScriptAureliaClientOptionsProvider.MODEL_PROPERTY_NAMING_VALUE);
             times = 1;
+            clientCodegen.setEnumPropertyNaming(TypeScriptAureliaClientOptionsProvider.ENUM_PROPERTY_NAMING_VALUE);
+            times = 1;
             clientCodegen.setSupportsES6(TypeScriptAureliaClientOptionsProvider.SUPPORTS_ES6_VALUE);
             times = 1;
         }};

--- a/modules/swagger-codegen/src/test/java/io/swagger/codegen/typescript/fetch/TypeScriptFetchClientOptionsTest.java
+++ b/modules/swagger-codegen/src/test/java/io/swagger/codegen/typescript/fetch/TypeScriptFetchClientOptionsTest.java
@@ -29,6 +29,8 @@ public class TypeScriptFetchClientOptionsTest extends AbstractOptionsTest {
             times = 1;
             clientCodegen.setModelPropertyNaming(TypeScriptFetchClientOptionsProvider.MODEL_PROPERTY_NAMING_VALUE);
             times = 1;
+            clientCodegen.setEnumPropertyNaming(TypeScriptFetchClientOptionsProvider.ENUM_PROPERTY_NAMING_VALUE);
+            times = 1;
             clientCodegen.setSupportsES6(TypeScriptFetchClientOptionsProvider.SUPPORTS_ES6_VALUE);
             times = 1;
         }};

--- a/modules/swagger-codegen/src/test/java/io/swagger/codegen/typescript/typescriptangular/TypeScriptAngularClientOptionsTest.java
+++ b/modules/swagger-codegen/src/test/java/io/swagger/codegen/typescript/typescriptangular/TypeScriptAngularClientOptionsTest.java
@@ -29,6 +29,8 @@ public class TypeScriptAngularClientOptionsTest extends AbstractOptionsTest {
             times = 1;
             clientCodegen.setModelPropertyNaming(TypeScriptAngularClientOptionsProvider.MODEL_PROPERTY_NAMING_VALUE);
             times = 1;
+            clientCodegen.setEnumPropertyNaming(TypeScriptAngularClientOptionsProvider.ENUM_PROPERTY_NAMING_VALUE);
+            times = 1;
             clientCodegen.setSupportsES6(Boolean.valueOf(TypeScriptAngularClientOptionsProvider.SUPPORTS_ES6_VALUE));
             times = 1;
         }};

--- a/modules/swagger-codegen/src/test/java/io/swagger/codegen/typescript/typescriptangularjs/TypeScriptAngularJsClientOptionsTest.java
+++ b/modules/swagger-codegen/src/test/java/io/swagger/codegen/typescript/typescriptangularjs/TypeScriptAngularJsClientOptionsTest.java
@@ -30,6 +30,8 @@ public class TypeScriptAngularJsClientOptionsTest extends AbstractOptionsTest {
             times = 1;
             clientCodegen.setModelPropertyNaming(TypeScriptAngularJsClientOptionsProvider.MODEL_PROPERTY_NAMING_VALUE);
             times = 1;
+            clientCodegen.setEnumPropertyNaming(TypeScriptAngularJsClientOptionsProvider.ENUM_PROPERTY_NAMING_VALUE);
+            times = 1;
             clientCodegen.setSupportsES6(Boolean.valueOf(TypeScriptAngularJsClientOptionsProvider.SUPPORTS_ES6_VALUE));
             times = 1;
         }};

--- a/modules/swagger-codegen/src/test/java/io/swagger/codegen/typescript/typescriptinversify/TypeScriptInversifyClientOptionsTest.java
+++ b/modules/swagger-codegen/src/test/java/io/swagger/codegen/typescript/typescriptinversify/TypeScriptInversifyClientOptionsTest.java
@@ -29,6 +29,8 @@ public class TypeScriptInversifyClientOptionsTest extends AbstractOptionsTest {
             times = 1;
             clientCodegen.setModelPropertyNaming(TypeScriptInversifyClientOptionsProvider.MODEL_PROPERTY_NAMING_VALUE);
             times = 1;
+            clientCodegen.setEnumPropertyNaming(TypeScriptInversifyClientOptionsProvider.ENUM_PROPERTY_NAMING_VALUE);
+            times = 1;
             clientCodegen.setSupportsES6(Boolean.valueOf(TypeScriptInversifyClientOptionsProvider.SUPPORTS_ES6_VALUE));
             times = 1;
         }};

--- a/modules/swagger-codegen/src/test/java/io/swagger/codegen/typescript/typescriptnode/TypeScriptNodeClientOptionsTest.java
+++ b/modules/swagger-codegen/src/test/java/io/swagger/codegen/typescript/typescriptnode/TypeScriptNodeClientOptionsTest.java
@@ -30,6 +30,8 @@ public class TypeScriptNodeClientOptionsTest extends AbstractOptionsTest {
             times = 1;
             clientCodegen.setModelPropertyNaming(TypeScriptNodeClientOptionsProvider.MODEL_PROPERTY_NAMING_VALUE);
             times = 1;
+            clientCodegen.setEnumPropertyNaming(TypeScriptNodeClientOptionsProvider.ENUM_PROPERTY_NAMING_VALUE);
+            times = 1;
             clientCodegen.setSupportsES6(Boolean.valueOf(TypeScriptNodeClientOptionsProvider.SUPPORTS_ES6_VALUE));
             times = 1;
         }};


### PR DESCRIPTION
### PR checklist

- [ ] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [ ] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [ ] Filed the PR against the correct branch: `3.0.0` branch for changes related to OpenAPI spec 3.0. Default: `master`.
- [ ] Copied the [technical committee](https://github.com/swagger-api/swagger-codegen/#swagger-codegen-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

The new config property "enumPropertyNaming" allows overriding
how enum member names are capitalised or
snake_cased in generated code.  It works very similarly to the Kotlin
generator's property of the same name.

The config property, when set to "original", will fix issue #8494.

