### PR TITLE
[JAVA] Generate and use variable name for setting discriminator and fix #9205

### DIFF
--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/CodegenModel.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/CodegenModel.java
@@ -21,7 +21,7 @@ public class CodegenModel {
     public String name, classname, title, description, classVarName, modelJson, dataType, xmlPrefix, xmlNamespace, xmlName;
     public String classFilename; // store the class file name, mainly used for import
     public String unescapedDescription;
-    public String discriminator;
+    public String discriminator, discriminatorClassVarName;
     public String defaultValue;
     public String arrayModelType;
     public boolean isAlias; // Is this effectively an alias of another simple type

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/DefaultCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/DefaultCodegen.java
@@ -1334,7 +1334,9 @@ public class DefaultCodegen {
         if (model instanceof ModelImpl) {
             ModelImpl modelImpl = (ModelImpl) model;
             m.discriminator = modelImpl.getDiscriminator();
-
+            if (m.discriminator != null) {
+                m.discriminatorClassVarName = toParamName(m.discriminator);
+            }
             if (modelImpl.getXml() != null) {
                 m.xmlPrefix = modelImpl.getXml().getPrefix();
                 m.xmlNamespace = modelImpl.getXml().getNamespace();
@@ -1366,6 +1368,9 @@ public class DefaultCodegen {
                         ModelImpl modelImpl = (ModelImpl) innerModel;
                         if (m.discriminator == null) {
                             m.discriminator = modelImpl.getDiscriminator();
+                            if (m.discriminator != null) {
+                                m.discriminatorClassVarName = toParamName(m.discriminator);
+                            }
                         }
                         if (modelImpl.getXml() != null) {
                             m.xmlPrefix = modelImpl.getXml().getPrefix();

--- a/modules/swagger-codegen/src/main/resources/Java/pojo.mustache
+++ b/modules/swagger-codegen/src/main/resources/Java/pojo.mustache
@@ -74,7 +74,7 @@ public class {{classname}} {{#parent}}extends {{{parent}}} {{/parent}}{{#parcela
   {{/parent}}
   {{#gson}}
   {{#discriminator}}
-    this.{{discriminator}} = this.getClass().getSimpleName();
+    this.{{discriminatorClassVarName}} = this.getClass().getSimpleName();
   {{/discriminator}}
   {{/gson}}
   }
@@ -83,7 +83,7 @@ public class {{classname}} {{#parent}}extends {{{parent}}} {{/parent}}{{#parcela
   {{#gson}}
   {{#discriminator}}
   public {{classname}}() {
-    this.{{discriminator}} = this.getClass().getSimpleName();
+    this.{{discriminatorClassVarName}} = this.getClass().getSimpleName();
   }
   {{/discriminator}}
   {{/gson}}


### PR DESCRIPTION
### PR checklist

- [X] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [X] Filed the PR against the correct branch: `3.0.0` branch for changes related to OpenAPI spec 3.0. Default: `master`.
- [ ] Copied the [technical committee](https://github.com/swagger-api/swagger-codegen/#swagger-codegen-technical-committee) to review the pull request if your PR is targeting a particular programming language.

Doesn't seem to be a name on the technical committee for Java.
The original change was made by @SergeyLyakhov and the person who authorized it @wing328  

### Description of the PR

This fixes a bug with discriminators that are specified with underscores.

In v2.4.0 a change was made which automatically populated the discriminator variable
with the class name. However whilst the variable name was converted from the model to
a java friendly variable, for example object_type to objectType in the parent class
the set variable didn't translate accordingly and so leaves uncompilable code.

As a result the generated code produced was...

```
  public ParentObject() {
    this.object_type = this.getClass().getSimpleName();
  }
  public ParentObject objectType(String objectType) {
    this.objectType = objectType;
    return this;
  }
```
and not

```
    this.objectType = this.getClass().getSimpleName();
```

I created new discriminatorClassVarName variable in the CodegenModel to store the converted discriminator name and populated it with the discriminator value converted to the correct style by calling the existing toParamName method.

I'm happy to refactor that code before merging in as the nested ifs are getting a bit nasty but didn't want to do that until someone had signed off on the approach as I don't know the code base and might be missing a better solution. 

Also change the pojo mustache template to use the new variable rather than the plain discriminator value currently used.

If the PR is missing info you need apologies it's my first.