### PR TITLE
[Python] Update Minimum Required Versions in setup.mustache

### DIFF
--- a/modules/swagger-codegen/src/main/resources/python/setup.mustache
+++ b/modules/swagger-codegen/src/main/resources/python/setup.mustache
@@ -16,7 +16,13 @@ VERSION = "{{packageVersion}}"
 # prerequisite: setuptools
 # http://pypi.python.org/pypi/setuptools
 
-REQUIRES = ["urllib3 >= 1.15", "six >= 1.10", "certifi", "python-dateutil"]
+REQUIRES = [
+    "certifi>=2017.4.17",
+    "python-dateutil>=2.1",
+    "six>=1.10",
+    "urllib3>=1.23"
+]
+    
 {{#asyncio}}
 REQUIRES.append("aiohttp")
 {{/asyncio}}


### PR DESCRIPTION
Set `certifi` to be not older than `2017.4.17` (it's the minimum version required by popular `requests` package)
Set `python-dateutil` minimum version to `2.1` (it's also minimum version required by `botocore` package)
Bump `urllib3` minimum required version to `1.23` as there were known vulnerabilities in lesser versions
PyUp Safety DB https://pyupio.github.io/safety-db/ (look for urllib3)
Snyk Vulnerability DB https://snyk.io/vuln/search?q=urllib3&type=pip

Resolves #9201

### PR checklist

- [x] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [x] Filed the PR against the correct branch: `3.0.0` branch for changes related to OpenAPI spec 3.0. Default: `master`.
- [x] Copied the [technical committee](https://github.com/swagger-api/swagger-codegen/#swagger-codegen-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

(details of the change, additional tests that have been done, reference to the issue for tracking, etc)

