### PR TITLE
Adding proxy header options for configuration and rest client

### DIFF
--- a/modules/swagger-codegen/src/main/resources/python/configuration.mustache
+++ b/modules/swagger-codegen/src/main/resources/python/configuration.mustache
@@ -85,6 +85,8 @@ class Configuration(object):
 
         # Proxy URL
         self.proxy = None
+        # Proxy Headers
+        self.proxy_headers = None
         # Safe chars for path_param
         self.safe_chars_for_path_param = ''
 

--- a/modules/swagger-codegen/src/main/resources/python/rest.mustache
+++ b/modules/swagger-codegen/src/main/resources/python/rest.mustache
@@ -83,6 +83,7 @@ class RESTClientObject(object):
                 cert_file=configuration.cert_file,
                 key_file=configuration.key_file,
                 proxy_url=configuration.proxy,
+                proxy_headers=configuration.proxy_headers,
                 **addition_pool_args
             )
         else:


### PR DESCRIPTION
Added proxy headers option for urllib3. Added this in configuration object and Rest Client Object. 
This is regarding a PR in Kubernetes client and addresses this issue. https://github.com/kubernetes-client/python/issues/735. And related to this PR https://github.com/kubernetes-client/python/pull/779

