### PR TITLE
Add hasModel property to support file bundle

### DIFF
--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/v3/DefaultGenerator.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/v3/DefaultGenerator.java
@@ -682,6 +682,11 @@ public class DefaultGenerator extends AbstractGenerator implements Generator {
         bundle.put("contextPath", contextPath);
         bundle.put("apiInfo", apis);
         bundle.put("models", allModels);
+        boolean hasModel = true;
+        if (allModels == null || allModels.isEmpty()) {
+            hasModel = false;
+        }
+        bundle.put("hasModel", hasModel);
         bundle.put("apiFolder", config.apiPackage().replace('.', File.separatorChar));
         bundle.put("modelPackage", config.modelPackage());
 


### PR DESCRIPTION
### PR checklist

- [X] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [X] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [X] Filed the PR against the correct branch: `3.0.0` branch for changes related to OpenAPI spec 3.0. Default: `master`.

### Description of the PR

https://github.com/swagger-api/swagger-codegen/pull/9337 added `hasModel` to operations properties in `generateApis()`. This pull request adds the `hasModel` property to the support file bundle.
