### PR TITLE
prevent deserialiser from losing array keys during parsing response.

### DIFF
--- a/modules/swagger-codegen/src/main/resources/php/ObjectSerializer.mustache
+++ b/modules/swagger-codegen/src/main/resources/php/ObjectSerializer.mustache
@@ -234,7 +234,7 @@ class ObjectSerializer
             $subClass = substr($class, 0, -2);
             $values = [];
             foreach ($data as $key => $value) {
-                $values[] = self::deserialize($value, $subClass, null);
+                $values[$key] = self::deserialize($value, $subClass, null);
             }
             return $values;
         } elseif ($class === 'object') {

--- a/samples/client/petstore-security-test/php/SwaggerClient-php/lib/ObjectSerializer.php
+++ b/samples/client/petstore-security-test/php/SwaggerClient-php/lib/ObjectSerializer.php
@@ -244,7 +244,7 @@ class ObjectSerializer
             $subClass = substr($class, 0, -2);
             $values = [];
             foreach ($data as $key => $value) {
-                $values[] = self::deserialize($value, $subClass, null);
+                $values[$key] = self::deserialize($value, $subClass, null);
             }
             return $values;
         } elseif ($class === 'object') {

--- a/samples/client/petstore/php/SwaggerClient-php/lib/ObjectSerializer.php
+++ b/samples/client/petstore/php/SwaggerClient-php/lib/ObjectSerializer.php
@@ -244,7 +244,7 @@ class ObjectSerializer
             $subClass = substr($class, 0, -2);
             $values = [];
             foreach ($data as $key => $value) {
-                $values[] = self::deserialize($value, $subClass, null);
+                $values[$key] = self::deserialize($value, $subClass, null);
             }
             return $values;
         } elseif ($class === 'object') {


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [x] Filed the PR against the correct branch: `3.0.0` branch for changes related to OpenAPI spec 3.0. Default: `master`.
- [x] Copied the [technical committee](https://github.com/swagger-api/swagger-codegen/#swagger-codegen-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

In my case deserialize function was losing array keys send in responce, these keys where the ids of sent entities.

see the difference

```json
{
    "stats": {
        "1274220846": {
            "item_views": 11,
            "contact_views": 0
        },
        "1512155577": {
            "item_views": 1,
            "contact_views": 1
        }
    }
}

{
    "stats": [
        {
            "item_views": 14,
            "contact_views": 1
        },
        {
            "item_views": 17,
            "contact_views": 1
        }
    ]
}
```

@mandrean 