### PR TITLE
v3 cli paths have changed

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -8,7 +8,7 @@ JAVA_OPTS=${JAVA_OPTS:-"-Xmx1024M -Dlogback.configurationFile=conf/logback.xml"}
 
 cli="${GEN_DIR}/modules/swagger-codegen-cli"
 codegen="${cli}/target/swagger-codegen-cli.jar"
-cmdsrc="${cli}/src/main/java/io/swagger/codegen/cmd"
+cmdsrc="${cli}/src/main/java/io/swagger/codegen/v3/cli/cmd"
 
 pattern="${1^} implements Runnable"
 if expr "x$1" : 'x[a-z][a-z-]*$' > /dev/null && fgrep -qe "$pattern" "$cmdsrc"/*.java || expr "$1" = 'help' > /dev/null; then


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [x] Filed the PR against the correct branch: `3.0.0` branch for changes related to OpenAPI spec 3.0. Default: `master`.
- [ ] Copied the [technical committee](https://github.com/swagger-api/swagger-codegen/#swagger-codegen-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

This PR doesn't refers to the generator or a language. The run-in-docker entrypoint is broken for 3.0.0 because the path to the CMD Java-files changed from `codegen/cmd` to `codegen/v3/cli/cmd`.