### PR TITLE
Added constant for ApiKey in cookie.

### DIFF
--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/v3/CodegenConstants.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/v3/CodegenConstants.java
@@ -297,6 +297,7 @@ public class CodegenConstants {
     public static final String IS_API_KEY_EXT_NAME = PREFIX_IS + "api-key";
     public static final String IS_KEY_IN_QUERY_EXT_NAME = PREFIX_IS + "key-in-query";
     public static final String IS_KEY_IN_HEADER_EXT_NAME = PREFIX_IS + "key-in-header";
+    public static final String IS_KEY_IN_COOKIE_EXT_NAME = PREFIX_IS + "key-in-cookie";
     public static final String IS_CODE_EXT_NAME = PREFIX_IS + "code";
     public static final String IS_PASSWORD_EXT_NAME = PREFIX_IS + "password";
     public static final String IS_APPLICATION_EXT_NAME = PREFIX_IS + "application";


### PR DESCRIPTION
### PR checklist

- [X] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [X] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [X] Filed the PR against the correct branch: `3.0.0` branch for changes related to OpenAPI spec 3.0. Default: `master`.
- [X] Copied the [technical committee](https://github.com/swagger-api/swagger-codegen/#swagger-codegen-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

For handling ApiKey definitions with location "cookie" a further constant is needed. I will send a PR for the generators, too, so that RestTemplate clients can be generated with cookie-based ApiKeys.