### PR TITLE
Add Dart client option to NOT convert model property names to camel case #9384

### DIFF
--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/DartClientCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/DartClientCodegen.java
@@ -26,11 +26,13 @@ public class DartClientCodegen extends DefaultCodegen implements CodegenConfig {
     public static final String PUB_VERSION = "pubVersion";
     public static final String PUB_DESCRIPTION = "pubDescription";
     public static final String USE_ENUM_EXTENSION = "useEnumExtension";
+    public static final String CAMEL_CASE_MODEL_PROPERTIES = "camelCaseModelProperties";
     protected boolean browserClient = true;
     protected String pubName = "swagger";
     protected String pubVersion = "1.0.0";
     protected String pubDescription = "Swagger API client";
     protected boolean useEnumExtension = false;
+    protected boolean camelCaseModelProperties = true;
     protected String sourceFolder = "";
     protected String apiDocPath = "docs/";
     protected String modelDocPath = "docs/";
@@ -107,6 +109,7 @@ public class DartClientCodegen extends DefaultCodegen implements CodegenConfig {
         cliOptions.add(new CliOption(PUB_DESCRIPTION, "Description in generated pubspec"));
         cliOptions.add(new CliOption(USE_ENUM_EXTENSION, "Allow the 'x-enum-values' extension for enums"));
         cliOptions.add(new CliOption(CodegenConstants.SOURCE_FOLDER, "source folder for generated code"));
+        cliOptions.add(new CliOption(CAMEL_CASE_MODEL_PROPERTIES, "Convert model property names to camel case"));
     }
 
     @Override
@@ -161,6 +164,13 @@ public class DartClientCodegen extends DefaultCodegen implements CodegenConfig {
         } else {
             // Not set, use to be passed to template.
             additionalProperties.put(USE_ENUM_EXTENSION, useEnumExtension);
+        }
+
+        if (additionalProperties.containsKey(CAMEL_CASE_MODEL_PROPERTIES)) {
+            this.setCamelCaseModelProperties(convertPropertyToBooleanAndWriteBack(CAMEL_CASE_MODEL_PROPERTIES));
+        } else {
+            // Not set, use to be passed to template.
+            additionalProperties.put(CAMEL_CASE_MODEL_PROPERTIES, camelCaseModelProperties);
         }
 
         if (additionalProperties.containsKey(CodegenConstants.SOURCE_FOLDER)) {
@@ -226,7 +236,9 @@ public class DartClientCodegen extends DefaultCodegen implements CodegenConfig {
 
         // camelize (lower first character) the variable name
         // pet_id => petId
-        name = camelize(name, true);
+        if (camelCaseModelProperties) {
+            name = camelize(name, true);
+        }
 
         if (name.matches("^\\d.*")) {
             name = "n" + name;
@@ -449,6 +461,10 @@ public class DartClientCodegen extends DefaultCodegen implements CodegenConfig {
 
     public void setUseEnumExtension(boolean useEnumExtension) {
         this.useEnumExtension = useEnumExtension;
+    }
+
+    public void setCamelCaseModelProperties(boolean camelCaseModelProperties) {
+        this.camelCaseModelProperties = camelCaseModelProperties;
     }
 
     public void setSourceFolder(String sourceFolder) {

--- a/modules/swagger-codegen/src/test/java/io/swagger/codegen/dart/DartClientOptionsTest.java
+++ b/modules/swagger-codegen/src/test/java/io/swagger/codegen/dart/DartClientOptionsTest.java
@@ -40,6 +40,8 @@ public class DartClientOptionsTest extends AbstractOptionsTest {
             times = 1;
             clientCodegen.setUseEnumExtension(Boolean.valueOf(DartClientOptionsProvider.USE_ENUM_EXTENSION));
             times = 1;
+            clientCodegen.setCamelCaseModelProperties(Boolean.valueOf(DartClientOptionsProvider.CAMEL_CASE_MODEL_PROPERTIES));
+            times = 1;
         }};
     }
 }

--- a/modules/swagger-codegen/src/test/java/io/swagger/codegen/options/DartClientOptionsProvider.java
+++ b/modules/swagger-codegen/src/test/java/io/swagger/codegen/options/DartClientOptionsProvider.java
@@ -17,6 +17,7 @@ public class DartClientOptionsProvider implements OptionsProvider {
     public static final String SOURCE_FOLDER_VALUE = "src";
     public static final String USE_ENUM_EXTENSION = "true";
     public static final String ALLOW_UNICODE_IDENTIFIERS_VALUE = "false";
+    public static final String CAMEL_CASE_MODEL_PROPERTIES = "true";
 
 
     @Override
@@ -36,6 +37,7 @@ public class DartClientOptionsProvider implements OptionsProvider {
                 .put(CodegenConstants.SOURCE_FOLDER, SOURCE_FOLDER_VALUE)
                 .put(DartClientCodegen.USE_ENUM_EXTENSION, USE_ENUM_EXTENSION)
                 .put(CodegenConstants.ALLOW_UNICODE_IDENTIFIERS, ALLOW_UNICODE_IDENTIFIERS_VALUE)
+                .put(DartClientCodegen.CAMEL_CASE_MODEL_PROPERTIES, CAMEL_CASE_MODEL_PROPERTIES)
                 .build();
     }
 


### PR DESCRIPTION
Add Dart client option to NOT convert model property names to camel case #9384

### PR checklist

Copying the technical committee for Dart, @ircecho, to review the pull request

### Description of the PR

Model property names are converted to camel case. There should be an option to use the original case.
