### PR TITLE
Changes to mustache files to prevent type errors when compiling

### DIFF
--- a/modules/swagger-codegen/src/main/resources/typescript-jquery/api.mustache
+++ b/modules/swagger-codegen/src/main/resources/typescript-jquery/api.mustache
@@ -22,7 +22,7 @@ import { Configuration } from '../configuration';
 export class {{classname}} {
     protected basePath = '{{{basePath}}}';
     public defaultHeaders: Array<string> = [];
-    public defaultExtraJQueryAjaxSettings?: JQueryAjaxSettings = null;
+    public defaultExtraJQueryAjaxSettings?: JQueryAjaxSettings = {};
     public configuration: Configuration = new Configuration();
 
     constructor(basePath?: string, configuration?: Configuration, defaultExtraJQueryAjaxSettings?: JQueryAjaxSettings) {

--- a/modules/swagger-codegen/src/main/resources/typescript-jquery/configuration.mustache
+++ b/modules/swagger-codegen/src/main/resources/typescript-jquery/configuration.mustache
@@ -1,6 +1,6 @@
 export class Configuration {
-    apiKey: string;
-    username: string;
-    password: string;
-    accessToken: string | (() => string);
+    apiKey: string = '';
+    username: string = '';
+    password: string = '';
+    accessToken: string | (() => string) = '';
 }


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [x] Filed the PR against the correct branch: `3.0.0` branch for changes related to OpenAPI spec 3.0. Default: `master`.
- [x] Copied the [technical committee](https://github.com/swagger-api/swagger-codegen/#swagger-codegen-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

(details of the change, additional tests that have been done, reference to the issue for tracking, etc)

Syntax changes for the jquery typescript templates, prior to this type errors were thrown.