### PR TITLE
Fix #9396 [Pistache-server] Add response 400 for JSON error

### DIFF
--- a/modules/swagger-codegen/src/main/resources/pistache-server/api-source.mustache
+++ b/modules/swagger-codegen/src/main/resources/pistache-server/api-source.mustache
@@ -92,6 +92,10 @@ void {{classname}}::{{operationIdSnakeCase}}_handler(const Pistache::Rest::Reque
       //send a 400 error
       response.send(Pistache::Http::Code::Bad_Request, e.what());
       return;
+    } catch (nlohmann::detail::exception & e) {
+      //send a 400 error
+      response.send(Pistache::Http::Code::Bad_Request, e.what());
+      return;
     }
 
 }


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [ ] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
**NO: no ./bin/sercurity/pistache-server-pertstore.sh  the ./bin/pistache-server-petstore.sh has passed**
- [x] Filed the PR against the correct branch: `3.0.0` branch for changes related to OpenAPI spec 3.0. Default: `master`.
- [x] Copied the [technical committee](https://github.com/swagger-api/swagger-codegen/#swagger-codegen-technical-committee) to review the pull request if your PR is targeting a particular programming language.
@fvarose 

### Description of the PR
fix[#9396](https://github.com/swagger-api/swagger-codegen/issues/9396)
Return 400 when parseing requset body to JSON failure.
