### PR TITLE
Var Namings with Numbers

### DIFF
--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/AbstractJavaCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/AbstractJavaCodegen.java
@@ -549,7 +549,7 @@ public abstract class AbstractJavaCodegen extends DefaultCodegen implements Code
         }
 
         // if it's all uppper case, do nothing
-        if (name.matches("^[A-Z_]*$")) {
+        if (name.matches("^[A-Z0-9_]*$")) {
             return name;
         }
 


### PR DESCRIPTION
Currently if the name of the elements contains a number, it does not work correctly for the elements that are all capitalized, and puts the first 2 letters in minuscule.

They should be able to contain numbers in one word all in capital letters

