### PR TITLE
Modify Rest client so able to send body in Delete Rest call

### DIFF
--- a/modules/swagger-codegen/src/main/resources/csharp-dotnet2/ApiClient.mustache
+++ b/modules/swagger-codegen/src/main/resources/csharp-dotnet2/ApiClient.mustache
@@ -116,7 +116,7 @@ namespace {{clientPackage}}
         /// <returns>Escaped string.</returns>
         public string EscapeString(string str)
         {
-            return RestSharp.Contrib.HttpUtility.UrlEncode(str);
+             return str.ToString();
         }
     
         /// <summary>
@@ -217,7 +217,7 @@ namespace {{clientPackage}}
         {
             try
             {
-                return obj != null ? JsonConvert.SerializeObject(obj) : null;
+                return obj != null ? JsonConvert.SerializeObject(obj, new JsonSerializerSettings() { NullValueHandling = NullValueHandling.Ignore }) : null;
             }
             catch (Exception e)
             {

--- a/modules/swagger-codegen/src/main/resources/csharp-dotnet2/api.mustache
+++ b/modules/swagger-codegen/src/main/resources/csharp-dotnet2/api.mustache
@@ -17,9 +17,10 @@ namespace {{apiPackage}}
         /// <summary>
         /// {{summary}} {{notes}}
         /// </summary>
-        {{#allParams}}/// <param name="{{paramName}}">{{description}}</param>
+        /// <exception cref="{{packageName}}.Client.ApiException">Thrown when fails to make API call</exception>
+        {{#allParams}}/// <param name="{{paramName}}">{{description}}{{^required}} (optional{{#defaultValue}}, default to {{.}}{{/defaultValue}}){{/required}}</param>
         {{/allParams}}/// <returns>{{#returnType}}{{returnType}}{{/returnType}}</returns>
-        {{#returnType}}{{{returnType}}}{{/returnType}}{{^returnType}}void{{/returnType}} {{nickname}} ({{#allParams}}{{{dataType}}} {{paramName}}{{#hasMore}}, {{/hasMore}}{{/allParams}});
+        {{#returnType}}{{{returnType}}}{{/returnType}}{{^returnType}}void{{/returnType}} {{nickname}} ({{#allParams}}{{{dataType}}} {{paramName}}{{^required}}{{#paramName}} = null{{/paramName}}{{/required}}{{#hasMore}}, {{/hasMore}}{{/allParams}});
         {{/operation}}
     }
   
@@ -49,7 +50,7 @@ namespace {{apiPackage}}
         {
             this.ApiClient = new ApiClient(basePath);
         }
-    
+
         /// <summary>
         /// Sets the base path of the API client.
         /// </summary>
@@ -57,7 +58,9 @@ namespace {{apiPackage}}
         /// <value>The base path</value>
         public void SetBasePath(String basePath)
         {
-            this.ApiClient.BasePath = basePath;
+            if (String.IsNullOrEmpty(basePath))
+                throw new ArgumentException("basePath cannot be empty");
+            this.ApiClient = new ApiClient(basePath);
         }
     
         /// <summary>
@@ -75,14 +78,15 @@ namespace {{apiPackage}}
         /// </summary>
         /// <value>An instance of the ApiClient</value>
         public ApiClient ApiClient {get; set;}
-    
+
         {{#operation}}
         /// <summary>
         /// {{summary}} {{notes}}
         /// </summary>
-        {{#allParams}}/// <param name="{{paramName}}">{{description}}</param> 
-        {{/allParams}}/// <returns>{{#returnType}}{{returnType}}{{/returnType}}</returns>            
-        public {{#returnType}}{{{returnType}}}{{/returnType}}{{^returnType}}void{{/returnType}} {{nickname}} ({{#allParams}}{{{dataType}}} {{paramName}}{{#hasMore}}, {{/hasMore}}{{/allParams}})
+        /// <exception cref="{{packageName}}.Client.ApiException">Thrown when fails to make API call</exception>
+        {{#allParams}}/// <param name="{{paramName}}">{{description}}{{^required}} (optional{{#defaultValue}}, default to {{.}}{{/defaultValue}}){{/required}}</param>
+        {{/allParams}}/// <returns>{{#returnType}}{{returnType}}{{/returnType}}</returns>
+        public {{#returnType}}{{{returnType}}}{{/returnType}}{{^returnType}}void{{/returnType}} {{nickname}} ({{#allParams}}{{{dataType}}} {{paramName}}{{^required}}{{#paramName}} = null{{/paramName}}{{/required}}{{#hasMore}}, {{/hasMore}}{{/allParams}})
         {
             {{#allParams}}{{#required}}
             // verify the required parameter '{{paramName}}' is set

--- a/modules/swagger-codegen/src/main/resources/csharp-dotnet2/compile-mono.sh.mustache
+++ b/modules/swagger-codegen/src/main/resources/csharp-dotnet2/compile-mono.sh.mustache
@@ -1,12 +1,38 @@
-wget -nc https://dist.nuget.org/win-x86-commandline/latest/nuget.exe;
-mozroots --import --sync
-mono nuget.exe install vendor/packages.config -o vendor;
-mkdir -p bin;
+#!/usr/bin/env bash
+
+
+nuget_cmd=nuget
+
+if ! type nuget &>/dev/null; then
+    echo "[INFO] Download nuget and packages"
+    wget -nc https://dist.nuget.org/win-x86-commandline/latest/nuget.exe;
+    nuget_cmd="mono nuget.exe"
+fi
+
+cert-sync /etc/ssl/certs/ca-certificates.crt
+${nuget_cmd} install vendor/packages.config -o vendor;
+mkdir -p lib;
+
+echo "[INFO] Copy DLLs to the 'lib' folder"
+cp vendor/Newtonsoft.Json.7.0.1/lib/net20/Newtonsoft.Json.dll lib/Newtonsoft.Json.dll;
+cp vendor/RestSharp.Net20.105.2.3.3/lib/net20/RestSharp.Net20.dll lib/RestSharp.Net20.dll;
+
+echo "[INFO] Run 'mcs' to build lib/Ens.Sdk.dll"
+
 mcs -sdk:2 -r:vendor/Newtonsoft.Json.7.0.1/lib/net20/Newtonsoft.Json.dll,\
-vendor/RestSharp.Net2.1.1.11/lib/net20/RestSharp.Net2.dll,\
-System.Runtime.Serialization.dll \
+vendor/RestSharp.Net20.105.2.3.3/lib/net20/RestSharp.Net20.dll,\
+System.Runtime.Serialization.dll, \
 -target:library \
--out:bin/{{packageName}}.dll \
+-out:lib/{{packageName}}.dll \
 -recurse:'src/*.cs' \
--doc:bin/{{packageName}}.xml \
+-doc:lib/{{packageName}}.xml \
 -platform:anycpu
+
+
+if [ $? -ne 0 ]
+then
+  echo "[ERROR] Compilation failed with exit code $?"
+  exit 1
+else
+  echo "[INFO] lib/Ens.Sdk.dll was created successfully"
+fi

--- a/modules/swagger-codegen/src/main/resources/csharp-dotnet2/model.mustache
+++ b/modules/swagger-codegen/src/main/resources/csharp-dotnet2/model.mustache
@@ -14,6 +14,38 @@ namespace {{modelPackage}} {
   /// </summary>
   [DataContract]
   public class {{classname}}{{#parent}} : {{{parent}}}{{/parent}} {
+
+
+    /// <summary>
+    /// {{summary}} {{notes}}
+    /// </summary>
+    public {{classname}} ({{#vars}}{{{datatype}}} {{name}}{{^required}}{{#name}} = null{{/name}}{{/required}} {{#required}}{{#name}} = null{{/name}}{{/required}}{{#hasMore}}, {{/hasMore}}{{/vars}}){
+            {{#vars}}
+            {{^isInherited}}
+            {{^isReadOnly}}
+            {{#required}}
+            {{#defaultValue}}// do not set value if  "{{name}}" not provided
+            if ({{name}} != null) this.{{name}} = {{name}};
+            {{/defaultValue}}
+            {{/required}}
+            {{/isReadOnly}}
+            {{/isInherited}}
+            {{/vars}}
+            {{#vars}}
+            {{^isInherited}}
+            {{^isReadOnly}}
+            {{^required}}
+            {{#defaultValue}}// do not set value if  "{{name}}" not provided
+            if ({{name}} != null) this.{{name}} = {{name}};
+            {{/defaultValue}}
+            {{/required}}
+            {{/isReadOnly}}
+            {{/isInherited}}
+            {{/vars}}
+
+    }
+
+
     {{#vars}}
     /// <summary>
     /// {{^description}}Gets or Sets {{{name}}}{{/description}}{{#description}}{{{description}}}{{/description}}
@@ -33,7 +65,7 @@ namespace {{modelPackage}} {
       var sb = new StringBuilder();
       sb.Append("class {{classname}} {\n");
       {{#vars}}
-      sb.Append("  {{name}}: ").Append({{name}}).Append("\n");
+      if ({{name}} != null) sb.Append("  {{name}}: ").Append({{name}}).Append("\n");
       {{/vars}}
       sb.Append("}\n");
       return sb.ToString();
@@ -44,7 +76,7 @@ namespace {{modelPackage}} {
     /// </summary>
     /// <returns>JSON string presentation of the object</returns>
     public {{#parent}} new {{/parent}}string ToJson() {
-      return JsonConvert.SerializeObject(this, Formatting.Indented);
+      return JsonConvert.SerializeObject(this, Formatting.Indented , new JsonSerializerSettings() { NullValueHandling = NullValueHandling.Ignore });
     }
 
 }

--- a/modules/swagger-codegen/src/main/resources/csharp-dotnet2/packages.config.mustache
+++ b/modules/swagger-codegen/src/main/resources/csharp-dotnet2/packages.config.mustache
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="RestSharp.Net2" version="1.1.11" targetFramework="net20" developmentDependency="true" />
+  <package id="RestSharp.Net20" version="105.2.3.3" targetFramework="net20" developmentDependency="true" />
   <package id="Newtonsoft.Json" version="7.0.1" targetFramework="net20" developmentDependency="true" />
 </packages>


### PR DESCRIPTION
Modify Rest client so send body in Delete rest call, and can set value in model using constructor

### PR checklist

- [ ] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [ ] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [ ] Filed the PR against the correct branch: `3.0.0` branch for changes related to OpenAPI spec 3.0. Default: `master`.
- [ ] Copied the [technical committee](https://github.com/swagger-api/swagger-codegen/#swagger-codegen-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

Modify Rest client so send body in Delete rest call, 
and now user can set value in model using constructor

(details of the change, additional tests that have been done, reference to the issue for tracking, etc)

