### PR TITLE
Dirty hack to use Rails nested parameters in node.js client.

### DIFF
--- a/modules/swagger-codegen/src/main/resources/nodejs/controller.mustache
+++ b/modules/swagger-codegen/src/main/resources/nodejs/controller.mustache
@@ -6,10 +6,11 @@ var {{classname}} = require('../{{implFolder}}/{{classname}}Service');
 {{#operation}}
 
 module.exports.{{nickname}} = function {{nickname}} (req, res, next) {
+  var params = {};
   {{#allParams}}
-  var {{paramName}} = req.swagger.params['{{baseName}}'].value;
+  params["{{paramName}}"] = req.swagger.params['{{baseName}}'].value;
   {{/allParams}}
-  {{classname}}.{{nickname}}({{#allParams}}{{paramName}}{{#hasMore}},{{/hasMore}}{{/allParams}})
+  {{classname}}.{{nickname}}(params)
     .then(function (response) {
       utils.writeJson(res, response);
     })

--- a/modules/swagger-codegen/src/main/resources/nodejs/service.mustache
+++ b/modules/swagger-codegen/src/main/resources/nodejs/service.mustache
@@ -12,7 +12,7 @@
  {{/notes}}
  *
 {{#allParams}}
- * {{paramName}} {{{dataType}}} {{{description}}}{{^required}} (optional){{/required}}
+ * params["{{paramName}}"] {{{dataType}}} {{{description}}}{{^required}} (optional){{/required}}
 {{/allParams}}
 {{^returnType}}
  * no response value expected for this operation
@@ -21,7 +21,7 @@
  * returns {{{returnType}}}
 {{/returnType}}
  **/
-exports.{{{operationId}}} = function({{#allParams}}{{paramName}}{{#hasMore}},{{/hasMore}}{{/allParams}}) {
+exports.{{{operationId}}} = function(params) {
   return new Promise(function(resolve, reject) {
   {{#returnType}}
     var examples = {};


### PR DESCRIPTION
node.js で swagger-codegen に Rails の nested parameter ( `q[foo][bar][]=123` ) を渡すと、生成された server が JavaScript の syntax error になって起動できないので、とりあえず動くように変更。

```
$ npm run start

> swagger-petstore@1.0.0 prestart /Users/yoda/Documents/hoge
> npm install

audited 401 packages in 1.77s
found 4 vulnerabilities (2 low, 1 moderate, 1 high)
  run `npm audit fix` to fix them, or `npm audit` for details

> swagger-petstore@1.0.0 start /Users/yoda/Documents/hoge
> node index.js

Error initializing middleware
/Users/yoda/Documents/hoge/controllers/Pet.js:31
  var q[foo][] = req.swagger.params['q[foo][]'].value;
       ^

SyntaxError: Unexpected token [
    at new Script (vm.js:80:7)
    at createScript (vm.js:274:10)
    at Object.runInThisContext (vm.js:326:10)
    at Module._compile (internal/modules/cjs/loader.js:664:28)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:712:10)
    at Module.load (internal/modules/cjs/loader.js:600:32)
    at tryModuleLoad (internal/modules/cjs/loader.js:539:12)
    at Function.Module._load (internal/modules/cjs/loader.js:531:3)
    at Module.require (internal/modules/cjs/loader.js:637:17)
    at require (internal/modules/cjs/helpers.js:22:18)
npm ERR! code ELIFECYCLE
npm ERR! errno 1
npm ERR! swagger-petstore@1.0.0 start: `node index.js`
npm ERR! Exit status 1
npm ERR! 
npm ERR! Failed at the swagger-petstore@1.0.0 start script.
npm ERR! This is probably not a problem with npm. There is likely additional logging output above.

npm ERR! A complete log of this run can be found in:
npm ERR!     /Users/yoda/.npm/_logs/2019-05-11T05_03_02_058Z-debug.log
```
