### PR TITLE
Support for current versions of RestSharp (Swagger 2.0 spec)

### DIFF
--- a/modules/swagger-codegen/src/main/resources/csharp/ApiClient.mustache
+++ b/modules/swagger-codegen/src/main/resources/csharp/ApiClient.mustache
@@ -153,12 +153,12 @@ namespace {{packageName}}.Client
                 {{/netStandard}}
                 {{^netStandard}}
                 {{^supportsUWP}}
-                request.AddFile(param.Value.Name, param.Value.Writer, param.Value.FileName, param.Value.ContentType);
+                request.AddFile(param.Value.Name, param.Value.Writer, param.Value.FileName, param.Value.ContentLength, param.Value.ContentType);
                 {{/supportsUWP}}
                 {{#supportsUWP}}
                 byte[] paramWriter = null;
                 param.Value.Writer = delegate (Stream stream) { paramWriter = ToByteArray(stream); };
-                request.AddFile(param.Value.Name, paramWriter, param.Value.FileName, param.Value.ContentType);
+                request.AddFile(param.Value.Name, paramWriter, param.Value.FileName, param.Value.ContentLength, param.Value.ContentType);
                 {{/supportsUWP}}
                 {{/netStandard}}
             }


### PR DESCRIPTION
Tried using RestSharp 106.6.9.

Without this fix, the build fails (wrong method signature)