### PR TITLE
Map ByteArray to str for Flask server

### DIFF
--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/FlaskConnexionCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/FlaskConnexionCodegen.java
@@ -67,6 +67,10 @@ public class FlaskConnexionCodegen extends DefaultCodegen implements CodegenConf
         typeMapping.put("DateTime", "datetime");
         typeMapping.put("object", "object");
         typeMapping.put("file", "file");
+        // TODO binary should be mapped to byte array
+        // mapped to String as a workaround
+        typeMapping.put("binary", "str");
+        typeMapping.put("ByteArray", "str");
         typeMapping.put("UUID", "str");
 
         // from https://docs.python.org/3/reference/lexical_analysis.html#keywords


### PR DESCRIPTION
Fixes Issue #7255.

The Python client generation code had a mapping for `ByteArray` and `binary` that the Flask version was missing.  Put in the two missing definitions.  Maybe they should have a common parent class since it targets the same language but I made the simplest possible fix for now.

@kenjones-cisco technical committee for Python.