### PR TITLE
[RUBY] Skip defining hash method if model contains "hash" property/attribute

### DIFF
--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/CodegenModel.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/CodegenModel.java
@@ -41,6 +41,7 @@ public class CodegenModel {
     public Set<String> imports = new TreeSet<String>();
     public boolean hasVars, emptyVars, hasMoreModels, hasEnums, isEnum, hasRequired, hasOptional, isArrayModel, hasChildren;
     public boolean hasOnlyReadOnly = true; // true if all properties are read-only
+    public boolean hasHashProperty = false; // true if there exists a property with the name "hash"
     public ExternalDocs externalDocs;
 
     public Map<String, Object> vendorExtensions;
@@ -135,6 +136,8 @@ public class CodegenModel {
             return false;
         if (!Objects.equals(hasOnlyReadOnly, that.hasOnlyReadOnly))
             return false;
+        if (!Objects.equals(hasHashProperty, that.hasHashProperty))
+            return false;
         if (!Objects.equals(hasChildren, that.hasChildren))
             return false;
         if (!Objects.equals(parentVars, that.parentVars))
@@ -179,6 +182,7 @@ public class CodegenModel {
         result = 31 * result + (isEnum ? 13:31);
         result = 31 * result + (externalDocs != null ? externalDocs.hashCode() : 0);
         result = 31 * result + (vendorExtensions != null ? vendorExtensions.hashCode() : 0);
+        result = 31 * result + Objects.hash(hasHashProperty);
         result = 31 * result + Objects.hash(hasOnlyReadOnly);
         result = 31 * result + Objects.hash(hasChildren);
         result = 31 * result + Objects.hash(parentVars);

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/CodegenProperty.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/CodegenProperty.java
@@ -39,7 +39,7 @@ public class CodegenProperty implements Cloneable {
     public boolean hasMore, required, secondaryParam;
     public boolean hasMoreNonReadOnly; // for model constructor, true if next properyt is not readonly
     public boolean isPrimitiveType, isContainer, isNotContainer;
-    public boolean isString, isNumeric, isInteger, isLong, isNumber, isFloat, isDouble, isByteArray, isBinary, isFile, isBoolean, isDate, isDateTime, isUuid;
+    public boolean isString, isHashName, isNumeric, isInteger, isLong, isNumber, isFloat, isDouble, isByteArray, isBinary, isFile, isBoolean, isDate, isDateTime, isUuid;
     public boolean isListContainer, isMapContainer;
     public boolean isEnum;
     public boolean isReadOnly = false;
@@ -116,6 +116,7 @@ public class CodegenProperty implements Cloneable {
         result = prime * result + ((vendorExtensions == null) ? 0 : vendorExtensions.hashCode());
         result = prime * result + ((hasValidation  ? 13:31));
         result = prime * result + ((isString  ? 13:31));
+        result = prime * result + ((isHashName ? 13:31));
         result = prime * result + ((isNumeric ? 13:31));
         result = prime * result + ((isInteger ? 13:31));
         result = prime * result + ((isLong  ?13:31));
@@ -263,6 +264,10 @@ public class CodegenProperty implements Cloneable {
         }
 
         if (this.isString != other.isString) {
+            return false;
+        }
+
+        if (this.isHashName != other.isHashName) {
             return false;
         }
 

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/DefaultCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/DefaultCodegen.java
@@ -1572,6 +1572,7 @@ public class DefaultCodegen {
 
         CodegenProperty property = CodegenModelFactory.newInstance(CodegenModelType.PROPERTY);
         property.name = toVarName(name);
+        property.isHashName = property.name.equals("hash");
         property.baseName = name;
         property.nameInCamelCase = camelize(property.name, false);
         property.description = escapeText(p.getDescription());
@@ -1653,6 +1654,7 @@ public class DefaultCodegen {
                 property.hasValidation = true;
 
             property.isString = true;
+
             if (sp.getEnum() != null) {
                 List<String> _enum = sp.getEnum();
                 property._enum = _enum;
@@ -3190,6 +3192,11 @@ public class DefaultCodegen {
                 // set model's hasOnlyReadOnly to false if the property is read-only
                 if (!Boolean.TRUE.equals(cp.isReadOnly)) {
                     m.hasOnlyReadOnly = false;
+                }
+
+                // set model's hasHashProperty to true if the property has the name "hash"
+                if (Boolean.TRUE.equals(cp.isHashName)) {
+                    m.hasHashProperty = true;
                 }
 
                 if (i+1 != totalCount) {

--- a/modules/swagger-codegen/src/main/resources/ruby/partial_model_generic.mustache
+++ b/modules/swagger-codegen/src/main/resources/ruby/partial_model_generic.mustache
@@ -269,11 +269,23 @@
       self == o
     end
 
+    {{^hasHashProperty}}
     # Calculates hash code according to all attributes.
     # @return [Fixnum] Hash code
     def hash
       [{{#vars}}{{name}}{{#hasMore}}, {{/hasMore}}{{/vars}}].hash
     end
+    {{/hasHashProperty}}
+    {{#hasHashProperty}}
+    # Skipped hash method that calculates a hash code according to all attributes because
+    # there exists an attribute by the name "hash".
+    #
+    # Calculates hash code according to all attributes.
+    # @return [Fixnum] Hash code
+    # def hash
+    #   [{{#vars}}{{name}}{{#hasMore}}, {{/hasMore}}{{/vars}}].hash
+    # end
+    {{/hasHashProperty}}
 
 {{> base_object}}
   end


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [x] Filed the PR against the correct branch: `3.0.0` branch for changes related to OpenAPI spec 3.0. Default: `master`.
- [x] Copied the [technical committee](https://github.com/swagger-api/swagger-codegen/#swagger-codegen-technical-committee) to review the pull request if your PR is targeting a particular programming language. (👋 @zlx)

### Description of the PR

Fixes #9488. Major kudos to @cchawn for finding this bug.

If a model has the property name "hash", the existing `#hash` method that is supposed to be the hash of all attributes will recurse infinitely, resulting in a `StackTraceError`.

This simply skips the defining of such a method, as the intent by the author is likely to override Ruby's `Object#hash` and have it be a property.

**Will add tests if maintainers are happy with approach. Java is not my first, or even second, language.**
