### PR TITLE
added capability to work with language argument options on service

### DIFF
--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/v3/service/GeneratorUtil.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/v3/service/GeneratorUtil.java
@@ -6,6 +6,7 @@ import io.swagger.codegen.CodegenConfig;
 import io.swagger.codegen.CodegenConfigLoader;
 import io.swagger.codegen.CodegenConstants;
 import io.swagger.codegen.v3.ClientOptInput;
+import io.swagger.codegen.v3.CodegenArgument;
 import io.swagger.codegen.v3.config.CodegenConfigurator;
 import io.swagger.codegen.v3.service.exception.BadRequestException;
 import io.swagger.models.Swagger;
@@ -198,6 +199,7 @@ public class GeneratorUtil {
 
         if (isNotEmpty(lang)) {
             configurator.setLang(lang);
+            readCodegenArguments(configurator, options);
         }
         if (isNotEmpty(options.getAuth())) {
             configurator.setAuth(options.getAuth());
@@ -285,5 +287,27 @@ public class GeneratorUtil {
         }
         LOGGER.debug("getClientOptInput - end");
         return configurator.toClientOptInput();
+    }
+
+    private static void readCodegenArguments(CodegenConfigurator configurator, Options options) {
+        if (options == null) {
+            return;
+        }
+        io.swagger.codegen.v3.CodegenConfig config = io.swagger.codegen.v3.CodegenConfigLoader.forName(configurator.getLang());
+        if (config == null) {
+            return;
+        }
+        final List<CodegenArgument> arguments = config.readLanguageArguments();
+        if (arguments == null || arguments.isEmpty()) {
+            return;
+        }
+        for (CodegenArgument codegenArgument : arguments) {
+            final String value = options.getCodegenArguments().get(codegenArgument.getOption().substring(2));
+            if (value == null) {
+                continue;
+            }
+            codegenArgument.setValue(value);
+        }
+        configurator.setCodegenArguments(arguments);
     }
 }

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/v3/service/Options.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/v3/service/Options.java
@@ -37,6 +37,8 @@ public class Options {
     private Boolean skipOverride;
     private String outputDir = "";
 
+    private Map<String, String> codegenArguments = new LinkedHashMap<>();
+
     public Options authorizationValue(AuthorizationValue authorizationValue) {
         this.authorizationValue = authorizationValue;
         return this;
@@ -210,6 +212,25 @@ public class Options {
         this.importMappings.put(key, value);
         return this;
     }
+
+    public Options codegenArguments(Map<String, String> codegenArguments) {
+        this.codegenArguments = codegenArguments;
+        return this;
+    }
+
+    public Map<String, String> getCodegenArguments() {
+        return codegenArguments;
+    }
+
+    public void setCodegenArguments(Map<String, String> codegenArguments) {
+        this.codegenArguments = codegenArguments;
+    }
+
+    public Options addCodegenArgument(String key, String value) {
+        this.codegenArguments.put(key, value);
+        return this;
+    }
+
 
     public Options invokerPackage(String invokerPackage) {
         this.invokerPackage = invokerPackage;


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [x] Filed the PR against the correct branch: `3.0.0` branch for changes related to OpenAPI spec 3.0. Default: `master`.
- [x] Copied the [technical committee](https://github.com/swagger-api/swagger-codegen/#swagger-codegen-technical-committee) to review the pull request if your PR is targeting a particular programming language.

