### PR TITLE
Fixed the problem that when output format is html2, it does not output properly when array has ref structure.

### DIFF
--- a/modules/swagger-codegen/src/main/resources/htmlDocs2/paramB.mustache
+++ b/modules/swagger-codegen/src/main/resources/htmlDocs2/paramB.mustache
@@ -9,6 +9,9 @@ $(document).ready(function() {
   if (schema.$ref != null) {
     schema = defsParser.$refs.get(schema.$ref);
   } else {
+    if(schema.items.$ref !== undefined) {
+        schema.items = defsParser.$refs.get(schema.items.$ref);
+    }
     schemaWrapper.definitions = Object.assign({}, defs);
     $RefParser.dereference(schemaWrapper).catch(function(err) {
       console.log(err);


### PR DESCRIPTION
…t properly when array has ref structure.

### PR checklist

- [ ] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [ ] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [ ] Filed the PR against the correct branch: `3.0.0` branch for changes related to OpenAPI spec 3.0. Default: `master`.
- [ ] Copied the [technical committee](https://github.com/swagger-api/swagger-codegen/#swagger-codegen-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

Fixed the problem that when output format is html2, it does not output properly when array has ref structure.

