### PR TITLE
[Objective-C] Thread safety fix for Object class

### DIFF
--- a/modules/swagger-codegen/src/main/resources/objc/Object-body.mustache
+++ b/modules/swagger-codegen/src/main/resources/objc/Object-body.mustache
@@ -8,13 +8,15 @@
  */
 - (instancetype)initWithDictionary:(NSDictionary *)dict error:(NSError **)err {
     static NSMutableSet *classNames;
+    static NSObject *lock;
     static dispatch_once_t onceToken;
     dispatch_once(&onceToken, ^{
         classNames = [NSMutableSet new];
+        lock = [NSObject new];
     });
     
     BOOL initSync;
-    @synchronized([self class])
+    @synchronized(lock)
     {
         NSString *className = NSStringFromClass([self class]);
         initSync = ![classNames containsObject:className];

--- a/samples/client/petstore-security-test/objc/SwaggerClient/Core/SWGObject.m
+++ b/samples/client/petstore-security-test/objc/SwaggerClient/Core/SWGObject.m
@@ -8,13 +8,15 @@
  */
 - (instancetype)initWithDictionary:(NSDictionary *)dict error:(NSError **)err {
     static NSMutableSet *classNames;
+    static NSObject *lock;
     static dispatch_once_t onceToken;
     dispatch_once(&onceToken, ^{
         classNames = [NSMutableSet new];
+        lock = [NSObject new];
     });
     
     BOOL initSync;
-    @synchronized([self class])
+    @synchronized(lock)
     {
         NSString *className = NSStringFromClass([self class]);
         initSync = ![classNames containsObject:className];

--- a/samples/client/petstore/objc/core-data/SwaggerClient/Core/SWGObject.m
+++ b/samples/client/petstore/objc/core-data/SwaggerClient/Core/SWGObject.m
@@ -8,13 +8,15 @@
  */
 - (instancetype)initWithDictionary:(NSDictionary *)dict error:(NSError **)err {
     static NSMutableSet *classNames;
+    static NSObject *lock;
     static dispatch_once_t onceToken;
     dispatch_once(&onceToken, ^{
         classNames = [NSMutableSet new];
+        lock = [NSObject new];
     });
     
     BOOL initSync;
-    @synchronized([self class])
+    @synchronized(lock)
     {
         NSString *className = NSStringFromClass([self class]);
         initSync = ![classNames containsObject:className];

--- a/samples/client/petstore/objc/default/SwaggerClient/Core/SWGObject.m
+++ b/samples/client/petstore/objc/default/SwaggerClient/Core/SWGObject.m
@@ -8,13 +8,15 @@
  */
 - (instancetype)initWithDictionary:(NSDictionary *)dict error:(NSError **)err {
     static NSMutableSet *classNames;
+    static NSObject *lock;
     static dispatch_once_t onceToken;
     dispatch_once(&onceToken, ^{
         classNames = [NSMutableSet new];
+        lock = [NSObject new];
     });
     
     BOOL initSync;
-    @synchronized([self class])
+    @synchronized(lock)
     {
         NSString *className = NSStringFromClass([self class]);
         initSync = ![classNames containsObject:className];


### PR DESCRIPTION
Synchronizing on [self class] makes several critical sections across all inheriting classes with one shared NSDictionary object (classNames). I believe it wasn't the intention of the author of this fix (based on a JSONModel issue ticket). To make one critical section we need one static object (lock).

### PR checklist

- [X] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [ ] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [X] Filed the PR against the correct branch: `3.0.0` branch for changes related to OpenAPI spec 3.0. Default: `master`.
- [ ] Copied the [technical committee](https://github.com/swagger-api/swagger-codegen/#swagger-codegen-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

Synchronizing on [self class] makes several critical sections across all inheriting classes with one shared NSDictionary object (classNames). I believe it wasn't the intention of the author of this fix (based on a JSONModel issue ticket). To make one critical section we need one static object (lock).

