### PR TITLE
Adding init binder feature for JavaSpring

### DIFF
--- a/modules/swagger-codegen/src/main/resources/JavaSpring/apiController.mustache
+++ b/modules/swagger-codegen/src/main/resources/JavaSpring/apiController.mustache
@@ -15,6 +15,8 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 {{/jdk8}}
 import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.InitBinder;
+import org.springframework.web.bind.WebDataBinder;
 {{^jdk8}}
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -67,6 +69,12 @@ public class {{classname}}Controller implements {{classname}} {
         return delegate;
     }
     {{/jdk8}}
+	
+    @InitBinder
+    public void initBinder(WebDataBinder binder) {
+        delegate.initBinder(binder);
+    }
+
 {{/isDelegate}}
 {{^isDelegate}}
     {{^jdk8}}
@@ -92,6 +100,11 @@ public class {{classname}}Controller implements {{classname}} {
     @Override
     public Optional<HttpServletRequest> getRequest() {
         return Optional.ofNullable(request);
+    }
+	
+    @InitBinder
+    public void initBinder(WebDataBinder binder) {
+        //Add custom binding configuration
     }
     {{/jdk8}}
 

--- a/modules/swagger-codegen/src/main/resources/JavaSpring/apiDelegate.mustache
+++ b/modules/swagger-codegen/src/main/resources/JavaSpring/apiDelegate.mustache
@@ -10,6 +10,7 @@ import io.swagger.annotations.*;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.WebDataBinder;
 {{/jdk8}}
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.multipart.MultipartFile;
@@ -54,6 +55,10 @@ public interface {{classname}}Delegate {
 
     default Optional<String> getAcceptHeader() {
         return getRequest().map(r -> r.getHeader("Accept"));
+    }
+
+    default void initBinder(WebDataBinder binder) {
+        //Add custom binding configuration
     }
 {{/jdk8}}
 


### PR DESCRIPTION
### PR checklist

- [ ] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [ ] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [ ] Filed the PR against the correct branch: `3.0.0` branch for changes related to OpenAPI spec 3.0. Default: `master`.
- [ ] Copied the [technical committee](https://github.com/swagger-api/swagger-codegen/#swagger-codegen-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

(details of the change, additional tests that have been done, reference to the issue for tracking, etc)

Added the opportunity to use the functions provided by initBinder in every each Controller. 

https://docs.spring.io/spring/docs/4.1.x/spring-framework-reference/html/validation.html#validation-mvc-configuring

Can be useful to apply some specific rules on a specific controller, and not all project, for example some business validation: checking if between two field are populated even one of them, or apply some specific validation inquiring the database for example, using the Spring validation framework, instead implement in business logic.

The decision to use or not is delegate to develop team. Default implmentation with empty body is provided in Controller and in DelegateApi, in case of upgrade there is no change that have be done by team are using previous version of swagger.

