### PR TITLE
[Kotlin] Support gson for serialization in addition to moshi

### DIFF
--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/CodegenConstants.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/CodegenConstants.java
@@ -163,6 +163,10 @@ public class CodegenConstants {
     public static final String ENUM_PROPERTY_NAMING = "enumPropertyNaming";
     public static final String ENUM_PROPERTY_NAMING_DESC = "Naming convention for enum properties: 'camelCase', 'PascalCase', 'snake_case', 'UPPERCASE', and 'original'";
 
+    public static final String SERIALIZATION_ENGINE = "serializationEngine";
+    public static final String SERIALIZATION_ENGINE_DESC = "What serialization enging to use: 'moshi' (default), or 'gson'";
+    public static enum SERIALIZATION_ENGINE_TYPE {moshi, gson}
+
     public static final String MODEL_NAME_PREFIX = "modelNamePrefix";
     public static final String MODEL_NAME_PREFIX_DESC = "Prefix that will be prepended to all model names. Default is the empty string.";
 

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/CodegenConstants.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/CodegenConstants.java
@@ -164,7 +164,7 @@ public class CodegenConstants {
     public static final String ENUM_PROPERTY_NAMING_DESC = "Naming convention for enum properties: 'camelCase', 'PascalCase', 'snake_case', 'UPPERCASE', and 'original'";
 
     public static final String SERIALIZATION_ENGINE = "serializationEngine";
-    public static final String SERIALIZATION_ENGINE_DESC = "What serialization enging to use: 'moshi' (default), or 'gson'";
+    public static final String SERIALIZATION_ENGINE_DESC = "What serialization engine to use: 'moshi' (default), or 'gson'";
     public static enum SERIALIZATION_ENGINE_TYPE {moshi, gson}
 
     public static final String MODEL_NAME_PREFIX = "modelNamePrefix";

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/AbstractKotlinCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/AbstractKotlinCodegen.java
@@ -30,6 +30,7 @@ public abstract class AbstractKotlinCodegen extends DefaultCodegen implements Co
     protected String modelDocPath = "docs/";
 
     protected CodegenConstants.ENUM_PROPERTY_NAMING_TYPE enumPropertyNaming = CodegenConstants.ENUM_PROPERTY_NAMING_TYPE.camelCase;
+    protected CodegenConstants.SERIALIZATION_ENGINE_TYPE serializationEngine = CodegenConstants.SERIALIZATION_ENGINE_TYPE.moshi;
 
     public AbstractKotlinCodegen() {
         super();
@@ -179,6 +180,9 @@ public abstract class AbstractKotlinCodegen extends DefaultCodegen implements Co
 
         CliOption enumPropertyNamingOpt = new CliOption(CodegenConstants.ENUM_PROPERTY_NAMING, CodegenConstants.ENUM_PROPERTY_NAMING_DESC);
         cliOptions.add(enumPropertyNamingOpt.defaultValue(enumPropertyNaming.name()));
+
+        CliOption serializationEngineOpt = new CliOption(CodegenConstants.SERIALIZATION_ENGINE, CodegenConstants.SERIALIZATION_ENGINE_DESC);
+        cliOptions.add(serializationEngineOpt.defaultValue(serializationEngine.name()));
     }
 
     @Override
@@ -212,6 +216,10 @@ public abstract class AbstractKotlinCodegen extends DefaultCodegen implements Co
         return this.enumPropertyNaming;
     }
 
+    public CodegenConstants.SERIALIZATION_ENGINE_TYPE getSerializationEngine() {
+        return this.serializationEngine;
+    }
+
     /**
      * Sets the naming convention for Kotlin enum properties
      *
@@ -223,6 +231,23 @@ public abstract class AbstractKotlinCodegen extends DefaultCodegen implements Co
         } catch (IllegalArgumentException ex) {
             StringBuilder sb = new StringBuilder(enumPropertyNamingType + " is an invalid enum property naming option. Please choose from:");
             for (CodegenConstants.ENUM_PROPERTY_NAMING_TYPE t : CodegenConstants.ENUM_PROPERTY_NAMING_TYPE.values()) {
+                sb.append("\n  ").append(t.name());
+            }
+            throw new RuntimeException(sb.toString());
+        }
+    }
+
+    /**
+     * Sets the serialization engine for Kotlin
+     *
+     * @param enumSerializationEngine The string representation of the serialization engine as defined by {@link CodegenConstants.SERIALIZATION_ENGINE_TYPE}
+     */
+    public void setSerializationEngine(final String enumSerializationEngine) {
+        try {
+            this.serializationEngine = CodegenConstants.SERIALIZATION_ENGINE_TYPE.valueOf(enumSerializationEngine);
+        } catch (IllegalArgumentException ex) {
+            StringBuilder sb = new StringBuilder(enumSerializationEngine + " is an invalid enum property naming option. Please choose from:");
+            for (CodegenConstants.SERIALIZATION_ENGINE_TYPE t : CodegenConstants.SERIALIZATION_ENGINE_TYPE.values()) {
                 sb.append("\n  ").append(t.name());
             }
             throw new RuntimeException(sb.toString());
@@ -292,6 +317,11 @@ public abstract class AbstractKotlinCodegen extends DefaultCodegen implements Co
 
         if (additionalProperties.containsKey(CodegenConstants.ENUM_PROPERTY_NAMING)) {
             setEnumPropertyNaming((String) additionalProperties.get(CodegenConstants.ENUM_PROPERTY_NAMING));
+        }
+
+        if (additionalProperties.containsKey(CodegenConstants.SERIALIZATION_ENGINE)) {
+            setSerializationEngine((String) additionalProperties.get(CodegenConstants.SERIALIZATION_ENGINE));
+            additionalProperties.put(this.serializationEngine.name(), true);
         }
 
         if (additionalProperties.containsKey(CodegenConstants.SOURCE_FOLDER)) {

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/KotlinClientCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/KotlinClientCodegen.java
@@ -15,6 +15,7 @@ public class KotlinClientCodegen extends AbstractKotlinCodegen {
 
     public static final String DATE_LIBRARY = "dateLibrary";
     protected CodegenConstants.ENUM_PROPERTY_NAMING_TYPE enumPropertyNaming = CodegenConstants.ENUM_PROPERTY_NAMING_TYPE.camelCase;
+    protected CodegenConstants.SERIALIZATION_ENGINE_TYPE serializationEngine = CodegenConstants.SERIALIZATION_ENGINE_TYPE.moshi;
     static Logger LOGGER = LoggerFactory.getLogger(KotlinClientCodegen.class);
 
     protected String dateLibrary = DateLibrary.JAVA8.value;

--- a/modules/swagger-codegen/src/main/resources/kotlin-client/data_class.mustache
+++ b/modules/swagger-codegen/src/main/resources/kotlin-client/data_class.mustache
@@ -1,5 +1,10 @@
 {{#hasEnums}}
+{{#gson}}
+import com.google.gson.annotations.SerializedName
+{{/gson}}
+{{#moshi}}
 import com.squareup.moshi.Json
+{{/moshi}}
 {{/hasEnums}}
 /**
  * {{{description}}}
@@ -13,16 +18,23 @@ data class {{classname}} (
 {{/-last}}{{/requiredVars}}{{#hasRequired}}{{#hasOptional}},
 {{/hasOptional}}{{/hasRequired}}{{#optionalVars}}{{>data_class_opt_var}}{{^-last}},
 {{/-last}}{{/optionalVars}}
-) {
+)
 {{#hasEnums}}{{#vars}}{{#isEnum}}
-    /**
+{
+   /**
     * {{{description}}}
     * Values: {{#allowableValues}}{{#enumVars}}{{&name}}{{^-last}},{{/-last}}{{/enumVars}}{{/allowableValues}}
     */
     enum class {{nameInCamelCase}}(val value: {{datatype}}){
     {{#allowableValues}}{{#enumVars}}
+    {{#moshi}}
         @Json(name = {{{value}}}) {{&name}}({{{value}}}){{^-last}},{{/-last}}{{#-last}};{{/-last}}
+    {{/moshi}}
+    {{#gson}}
+        @SerializedName(value={{{value}}})  {{&name}}({{{value}}}){{^-last}},{{/-last}}{{#-last}};{{/-last}}
+    {{/gson}}
     {{/enumVars}}{{/allowableValues}}
     }
-{{/isEnum}}{{/vars}}{{/hasEnums}}
 }
+{{/isEnum}}{{/vars}}{{/hasEnums}}
+

--- a/modules/swagger-codegen/src/main/resources/kotlin-client/data_class_opt_var.mustache
+++ b/modules/swagger-codegen/src/main/resources/kotlin-client/data_class_opt_var.mustache
@@ -1,4 +1,5 @@
 {{#description}}
     /* {{{description}}} */
 {{/description}}
+    {{#gson}}@SerializedName("{{name}}"){{/gson}}
     val {{{name}}}: {{#isEnum}}{{classname}}.{{nameInCamelCase}}{{/isEnum}}{{^isEnum}}{{{datatype}}}{{/isEnum}}? = {{#defaultvalue}}{{defaultvalue}}{{/defaultvalue}}{{^defaultvalue}}null{{/defaultvalue}}

--- a/modules/swagger-codegen/src/main/resources/kotlin-client/data_class_req_var.mustache
+++ b/modules/swagger-codegen/src/main/resources/kotlin-client/data_class_req_var.mustache
@@ -1,4 +1,5 @@
 {{#description}}
     /* {{{description}}} */
 {{/description}}
+    {{#gson}}@SerializedName("{{name}}"){{/gson}}
     val {{{name}}}: {{#isEnum}}{{classname}}.{{nameInCamelCase}}{{/isEnum}}{{^isEnum}}{{{datatype}}}{{/isEnum}}

--- a/modules/swagger-codegen/src/main/resources/kotlin-client/enum_class.mustache
+++ b/modules/swagger-codegen/src/main/resources/kotlin-client/enum_class.mustache
@@ -1,11 +1,20 @@
+{{#gson}}
+import com.google.gson.annotations.SerializedName
+{{/gson}}
+{{#moshi}}
 import com.squareup.moshi.Json
-
+{{/moshi}}
 /**
 * {{{description}}}
 * Values: {{#allowableValues}}{{#enumVars}}{{&name}}{{^-last}},{{/-last}}{{/enumVars}}{{/allowableValues}}
 */
 enum class {{classname}}(val value: {{dataType}}){
 {{#allowableValues}}{{#enumVars}}
+{{#moshi}}
     @Json(name = {{{value}}}) {{&name}}({{{value}}}){{^-last}},{{/-last}}{{#-last}};{{/-last}}
+{{/moshi}}
+{{#gson}}
+    @SerializedName(value={{{value}}})  {{&name}}({{{value}}}){{^-last}},{{/-last}}{{#-last}};{{/-last}}
+{{/gson}}
 {{/enumVars}}{{/allowableValues}}
 }

--- a/modules/swagger-codegen/src/test/java/io/swagger/codegen/kotlin/KotlinClientCodegenOptionsTest.java
+++ b/modules/swagger-codegen/src/test/java/io/swagger/codegen/kotlin/KotlinClientCodegenOptionsTest.java
@@ -38,6 +38,8 @@ public class KotlinClientCodegenOptionsTest extends AbstractOptionsTest {
             times = 1;
             codegen.setEnumPropertyNaming(KotlinClientCodegenOptionsProvider.ENUM_PROPERTY_NAMING);
             times = 1;
+            codegen.setSerializationEngine(KotlinClientCodegenOptionsProvider.SERIALIZATION_ENGINE);
+            times = 1;
             codegen.setDateLibrary(KotlinClientCodegenOptionsProvider.DATE_LIBRARY);
         }};
     }

--- a/modules/swagger-codegen/src/test/java/io/swagger/codegen/options/KotlinClientCodegenOptionsProvider.java
+++ b/modules/swagger-codegen/src/test/java/io/swagger/codegen/options/KotlinClientCodegenOptionsProvider.java
@@ -14,6 +14,7 @@ public class KotlinClientCodegenOptionsProvider implements OptionsProvider {
     public static final String GROUP_ID = "io.swagger.tests";
     public static final String SOURCE_FOLDER = "./generated/kotlin";
     public static final String ENUM_PROPERTY_NAMING = "camelCase";
+    public static final String SERIALIZATION_ENGINE = "gson";
     public static final String DATE_LIBRARY = KotlinClientCodegen.DateLibrary.JAVA8.value;
 
     @Override
@@ -31,6 +32,7 @@ public class KotlinClientCodegenOptionsProvider implements OptionsProvider {
                 .put(CodegenConstants.GROUP_ID, GROUP_ID)
                 .put(CodegenConstants.SOURCE_FOLDER, SOURCE_FOLDER)
                 .put(CodegenConstants.ENUM_PROPERTY_NAMING, ENUM_PROPERTY_NAMING)
+                .put(CodegenConstants.SERIALIZATION_ENGINE, SERIALIZATION_ENGINE)
                 .put(KotlinClientCodegen.DATE_LIBRARY, DATE_LIBRARY)
                 .build();
     }


### PR DESCRIPTION
Issue #9655

### PR checklist

- [x ] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [ x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run **`./bin/kotlin-client-petstore.sh`** and **`./bin/security/kotlin-client-petstore.sh`** if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
  ./bin/security/kotlin-client-petstore.sh 
  ./bin/security/kotlin-client-petstore.sh -DserializationEngine=foo --> generated the right error message
  ./bin/security/kotlin-client-petstore.sh -DserializationEngine=gson

- [x ] Filed the PR against the correct branch: `3.0.0` branch for changes related to OpenAPI spec 3.0. Default: `master`.
- [**could not find Kotlin committee name** ] Copied the [technical committee](https://github.com/swagger-api/swagger-codegen/#swagger-codegen-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

I would like to use gson serialization engine in kotlin-client generated code.
Summary of changes:

- Added a new 'serializationEngine' option for config.json with 2 valid values: "moshi" (default) and "gson"
- updated to kotlin-client mustache templates to support gson's @SerializedName annotation - this also helps with proguard which can break JSON binding to object in release code
- removed empty {} in the data class body when there is no enums

