### PR TITLE
demo rust failing `amount` deserialization

### DIFF
--- a/samples/client/petstore/rust/tests/deserialize_json.rs
+++ b/samples/client/petstore/rust/tests/deserialize_json.rs
@@ -1,0 +1,17 @@
+#[test]
+fn user_empty() {
+    let json = r#"{}"#;
+    let amount: petstore_client::models::User = serde_json::from_str(json).unwrap();
+}
+
+#[test]
+fn user_with_id() {
+    let json = r#"{"id": 12}"#;
+    let amount: petstore_client::models::User = serde_json::from_str(json).unwrap();
+}
+
+#[test]
+fn amount_from_str() {
+    let json = r#"{"value": 36.14, "currency": "HRK" }"#;
+    let amount: petstore_client::models::Amount = serde_json::from_str(json).unwrap();
+}


### PR DESCRIPTION
This is just a bug report, not meant to be merged directly. With an amount json of:

``` json
{"value": 36.14, "currency": "HRK" }
```

the current rust client code can not deserialize it. Looking around at the various codebases, I'm guessing many are not able to. The Angular TypeScript is [defining it correctly](https://github.com/swagger-api/swagger-codegen/blob/master/samples%2Fclient%2Fpetstore%2Ftypescript-angular-v6%2Fnpm%2Fmodel%2Fcurrency.ts#L17) as:

``` ts
export type Currency = string;
```

But the rust generates:
``` rs
#[derive(Debug, Serialize, Deserialize)]
pub struct Currency {
}
```

When the swagger yaml is:
``` yaml
  Currency:
    type: string
    pattern: '^[A-Z]{3,3}$'
    description: >
      some description
```

The output of this test shows:
```
Camerons-MacBook-Pro:rust cameron$ pwd
/Users/cameron/vmcp/swagger-codegen/samples/client/petstore/rust
Camerons-MacBook-Pro:rust cameron$ cargo test
    Finished dev [unoptimized + debuginfo] target(s) in 0.06s
     Running target/debug/deps/petstore_client-0187db4343fc1397

running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out

     Running target/debug/deps/deserialize_json-7a96cb089118c8e1

running 3 tests
test user_empty ... ok
test user_with_id ... ok
test amount_from_str ... FAILED

failures:

---- amount_from_str stdout ----
thread 'amount_from_str' panicked at 'called `Result::unwrap()` on an `Err` value: Error("invalid type: string \"HRK\", expected struct Currency", line: 1, column: 34)', src/libcore/result.rs:1084:5
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace.


failures:
    amount_from_str

test result: FAILED. 2 passed; 1 failed; 0 ignored; 0 measured; 0 filtered out

error: test failed, to rerun pass '--test deserialize_json'
```