### PR TITLE
Handle reference as array items for additionalProperties

### DIFF
--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/DefaultCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/DefaultCodegen.java
@@ -1030,8 +1030,14 @@ public class DefaultCodegen {
                 LOGGER.error("No Type defined for Additional Property " + additionalProperties2 + "\n" //
                         + "\tIn Property: " + p);
             }
-            String inner = getSwaggerType(additionalProperties2);
-            return instantiationTypes.get("map") + "<String, " + inner + ">";
+
+            String additionalPropInstType = toInstantiationType(additionalProperties2);
+            if (additionalPropInstType != null) {
+                return instantiationTypes.get("map") + "<String, " + additionalPropInstType + ">";
+            } else {
+                String inner = getSwaggerType(additionalProperties2);
+                return instantiationTypes.get("map") + "<String, " + inner + ">";
+            }
         } else if (p instanceof ArrayProperty) {
             ArrayProperty ap = (ArrayProperty) p;
             String inner = getSwaggerType(ap.getItems());


### PR DESCRIPTION
- [x] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [x] Filed the PR against the correct branch: `3.0.0` branch for changes related to OpenAPI spec 3.0. Default: `master`.
- [x] Copied the [technical committee](https://github.com/swagger-api/swagger-codegen/#swagger-codegen-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

Handle reference as array items for additionalProperties

close #9425

As a concrete sample, https://github.com/docker/engine/blob/master/api/swagger.yaml#L1146
is generated as `public class PortMap extends HashMap<String, List>` 
shoud be `public class PortMap extends HashMap<String, List<PortBinding>>`