### PR TITLE
nullable is only allowed for struct types not for types like arrays t…

### DIFF
--- a/modules/swagger-codegen/src/main/resources/powershell/model.mustache
+++ b/modules/swagger-codegen/src/main/resources/powershell/model.mustache
@@ -5,7 +5,7 @@ function New-{{{classname}}} {
     Param (
 {{#vars}}
         [Parameter(Position = 0, ValueFromPipelineByPropertyName = $true{{#required}}, Mandatory = $true{{/required}})]
-        [{{#isString}}{{{datatype}}}{{/isString}}{{^isString}}{{^required}}System.Nullable[{{/required}}{{datatype}}{{^required}}]{{/required}}{{/isString}}]
+        [{{#isString}}{{{datatype}}}{{/isString}}{{^isString}}{{#isListContainer}}{{{datatype}}}{{/isListContainer}}{{^isListContainer}}{{^required}}System.Nullable[{{/required}}{{datatype}}{{^required}}]{{/required}}{{/isListContainer}}{{/isString}}]
         {{=<% %>=}}
         ${<%name%>}<%^-last%>,<%/-last%>
         <%={{ }}=%>


### PR DESCRIPTION
…hat are anyhow nullable

### PR checklist

- [x] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [ ] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [x ] Filed the PR against the correct branch: `3.0.0` branch for changes related to OpenAPI spec 3.0. Default: `master`.
- [ nobody listed for powershell] Copied the [technical committee](https://github.com/swagger-api/swagger-codegen/#swagger-codegen-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

do not use nullable wrapper for isListContainer in mustache template
