### PR TITLE
update api and model folder when packageName is changed

### DIFF
--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/PowerShellClientCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/PowerShellClientCodegen.java
@@ -171,6 +171,8 @@ public class PowerShellClientCodegen extends DefaultCodegen implements CodegenCo
 
     public void setPackageName(String packageName) {
         this.packageName = packageName;
+        this.apiPackage = packageName + File.separator + "API";
+        this.modelPackage = packageName + File.separator + "Model";
     }
 
     public void setCsharpClientPath(String csharpClientPath) {


### PR DESCRIPTION
### PR checklist

- [x ] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [ ] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [x ] Filed the PR against the correct branch: `3.0.0` branch for changes related to OpenAPI spec 3.0. Default: `master`.
- [ nobody for powershell] Copied the [technical committee](https://github.com/swagger-api/swagger-codegen/#swagger-codegen-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR
propagating the setter of the packagename to API and model package, as they get initialized based on the packagename on that inside the constructor
