### PR TITLE
Fix dateLibrary=java8 handling in JacksonConfig.mustache #9753

### DIFF
--- a/modules/swagger-codegen/src/main/resources/JavaJaxRS/resteasy/JacksonConfig.mustache
+++ b/modules/swagger-codegen/src/main/resources/JavaJaxRS/resteasy/JacksonConfig.mustache
@@ -5,10 +5,15 @@ import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializerProvider;
 import com.fasterxml.jackson.databind.ser.std.StdSerializer;
+{{#java8}}
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+{{/java8}}
+{{#joda}}
 import com.fasterxml.jackson.datatype.joda.JodaModule;
 import org.joda.time.DateTime;
 import org.joda.time.LocalDate;
 import org.joda.time.format.ISODateTimeFormat;
+{{/joda}}
 
 import javax.ws.rs.ext.ContextResolver;
 import javax.ws.rs.ext.Provider;
@@ -22,6 +27,10 @@ public class JacksonConfig implements ContextResolver<ObjectMapper> {
 
         objectMapper = new ObjectMapper()
             .setDateFormat(new RFC3339DateFormat())
+{{#java8}}
+            .registerModule(new JavaTimeModule());
+{{/java8}}
+{{#joda}}
             .registerModule(new JodaModule() {
                 {
                     addSerializer(DateTime.class, new StdSerializer<DateTime>(DateTime.class) {
@@ -39,6 +48,7 @@ public class JacksonConfig implements ContextResolver<ObjectMapper> {
 
                 }
             });
+{{/joda}}
     }
 
     public ObjectMapper getContext(Class<?> arg0) {


### PR DESCRIPTION
Previously config option dateLibrary=java8 was ignored and joda
was added instead, causing compilation failure.

Fix #9753

### Description of the PR

See above.
