### PR TITLE
Fixes (de)serialization of java.time.Instant Objects for Java (java8 + dateLibrary=java8-instant) 

### DIFF
--- a/modules/swagger-codegen/src/main/resources/Java/JSON.mustache
+++ b/modules/swagger-codegen/src/main/resources/Java/JSON.mustache
@@ -66,7 +66,7 @@ public class JSON {
     private InstantTypeAdapter instantTypeAdapter = new InstantTypeAdapter();
     {{/java8-instant}}
 
-      public static GsonBuilder createGson() {
+    public static GsonBuilder createGson() {
         GsonFireBuilder fireBuilder = new GsonFireBuilder()
         {{#parent}}
           .registerTypeSelector({{classname}}.class, new TypeSelector() {

--- a/modules/swagger-codegen/src/main/resources/Java/JSON.mustache
+++ b/modules/swagger-codegen/src/main/resources/Java/JSON.mustache
@@ -41,6 +41,9 @@ import java.time.LocalDate;
 import java.time.OffsetDateTime;
 import java.time.format.DateTimeFormatter;
 {{/java8}}
+{{#java8-instant}}
+import java.time.Instant;
+{{/java8-instant}}
 import java.util.Date;
 import java.util.Map;
 import java.util.HashMap;
@@ -59,8 +62,11 @@ public class JSON {
     private LocalDateTypeAdapter localDateTypeAdapter = new LocalDateTypeAdapter();
     {{/jsr310}}
     private ByteArrayAdapter byteArrayAdapter = new ByteArrayAdapter();
+    {{#java8-instant}}
+    private InstantTypeAdapter instantTypeAdapter = new InstantTypeAdapter();
+    {{/java8-instant}}
 
-    public static GsonBuilder createGson() {
+      public static GsonBuilder createGson() {
         GsonFireBuilder fireBuilder = new GsonFireBuilder()
         {{#parent}}
           .registerTypeSelector({{classname}}.class, new TypeSelector() {
@@ -113,6 +119,9 @@ public class JSON {
             .registerTypeAdapter(OffsetDateTime.class, offsetDateTimeTypeAdapter)
             .registerTypeAdapter(LocalDate.class, localDateTypeAdapter)
             {{/jsr310}}
+            {{#java8-instant}}
+            .registerTypeAdapter(Instant.class, instantTypeAdapter)
+            {{/java8-instant}}
             .registerTypeAdapter(byte[].class, byteArrayAdapter)
             .create();
     }
@@ -401,6 +410,35 @@ public class JSON {
     }
 
     {{/jsr310}}
+    {{#java8-instant}}
+    /**
+     * Gson TypeAdapter for java.time.Instant type
+     */
+    public class InstantTypeAdapter extends TypeAdapter<Instant> {
+
+        @Override
+        public void write(JsonWriter out, Instant instant) throws IOException {
+            if (instant == null) {
+                out.nullValue();
+            } else {
+                out.value(instant.toString());
+            }
+        }
+
+        @Override
+        public Instant read(JsonReader in) throws IOException {
+            switch (in.peek()) {
+                case NULL:
+                    in.nextNull();
+                    return null;
+                default:
+                    String date = in.nextString();
+                    return Instant.parse(date);
+            }
+        }
+    }
+
+    {{/java8-instant}}
     /**
      * Gson TypeAdapter for java.sql.Date type
      * If the dateFormat is null, a simple "yyyy-MM-dd" format will be used


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [x] Filed the PR against the correct branch: `3.0.0` branch for changes related to OpenAPI spec 3.0. Default: `master`.
- [x] Copied the [technical committee](https://github.com/swagger-api/swagger-codegen/#swagger-codegen-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

We're generating a Java client with `java8=true` and `dateLibrary=java8-instant`. Unfortunately the deserialization is broken (with 2.4.9 at least) as the `JSON.java` is missing Instant type support.

We've fixed it for our use case and I wanted to share the fix.

possibly: fix #1542
