### PR TITLE
[Java] Fix ExampleGenerator to populate JSON values

### DIFF
--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/v3/examples/ExampleGenerator.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/v3/examples/ExampleGenerator.java
@@ -227,7 +227,14 @@ public class ExampleGenerator {
             logger.warn("Ref property with empty model.");
 
         }*/ else if (property instanceof UUIDSchema) {
-            return "046b6c7f-0b8a-43b9-b35d-6489e6daee91"; 
+            return "046b6c7f-0b8a-43b9-b35d-6489e6daee91";
+        } else if (property.get$ref() != null) {
+            String ref = property.get$ref();
+            String simpleName = ref.replace("#/components/schemas/", "");
+            Schema model = examples.get(simpleName);
+            if (model != null) {
+                return resolveModelToExample(ref, mediaType, model, processedModels);
+            }
         }
 
         return "";
@@ -251,7 +258,7 @@ public class ExampleGenerator {
             return schema.getExample();
         }
         processedModels.add(name);
-        Map<String, Object> values = new HashMap<>();
+        Map<String, Object> values = new LinkedHashMap<>();
 
         logger.debug("Resolving model '{}' to example", name);
 
@@ -261,8 +268,8 @@ public class ExampleGenerator {
         } else if (schema.getProperties() != null) {
             logger.debug("Creating example from model values");
             for (Object propertyName : schema.getProperties().keySet()) {
-                schema.getProperties().get(propertyName.toString());
-                values.put(propertyName.toString(), resolvePropertyToExample(propertyName.toString(), mediaType, schema, processedModels));
+                Schema property = (Schema) schema.getProperties().get(propertyName.toString());
+                values.put(propertyName.toString(), resolvePropertyToExample(propertyName.toString(), mediaType, property, processedModels));
             }
             schema.setExample(values);
         }

--- a/modules/swagger-codegen/src/test/java/io/swagger/codegen/v3/examples/ExampleGeneratorTest.java
+++ b/modules/swagger-codegen/src/test/java/io/swagger/codegen/v3/examples/ExampleGeneratorTest.java
@@ -1,0 +1,169 @@
+//
+// Unit tests for ExampleGenerator.
+//
+
+package io.swagger.codegen.v3.examples;
+
+import io.swagger.v3.core.converter.ModelConverters;
+import io.swagger.v3.oas.annotations.media.ArraySchema;
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.io.IOException;
+import java.io.InputStream;
+import java.math.BigDecimal;
+import java.nio.charset.StandardCharsets;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import javax.validation.constraints.DecimalMax;
+import javax.validation.constraints.DecimalMin;
+import javax.validation.constraints.Max;
+import javax.validation.constraints.Min;
+import javax.validation.constraints.Size;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+public class ExampleGeneratorTest {
+
+  @Test
+  public void testGenerateJson() throws IOException {
+    // Read expected JSON from a resource file.
+    String expectedJson = readResource("examples/example_generator.json");
+
+    // Read the models.
+    Map<String, io.swagger.v3.oas.models.media.Schema> mc =
+        ModelConverters.getInstance().readAll(Example.class);
+    Set<String> expectedKeys = new HashSet<>();
+    Collections.addAll(expectedKeys, "Example", "ExampleItem", "ExampleCoordinate");
+    Assert.assertEquals(mc.keySet(), expectedKeys);
+
+    // Pass the models into the ExampleGenerator and generate the example JSON.
+    ExampleGenerator generator = new ExampleGenerator(mc);
+    List<Map<String, String>> examples =
+        generator.generate(null, Collections.singletonList("application/json"), "Example");
+    String example = examples.get(0).get("example");
+
+    Assert.assertEquals(example, expectedJson);
+  }
+
+  //
+  // Read a resource file into a new String.
+  //
+  // The file contents must be encoded in UTF-8.
+  //
+  private String readResource(String name) throws IOException {
+    InputStream stream = getClass().getClassLoader().getResourceAsStream(name);
+    byte[] data = new byte[10000];
+    int length = Objects.requireNonNull(stream).read(data);
+    return new String(data, 0, length, StandardCharsets.UTF_8);
+  }
+
+  // Example classes used by the above test cases.
+  static class Example {
+    public Integer intNoAnnotation;
+
+    @Schema(description = "An integer", defaultValue = "99", example = "440")
+    public int intDefaultExample;
+
+    @Schema(description = "An integer", defaultValue = "99")
+    public Integer intDefault;
+
+    @Min(1500)
+    @Max(1550)
+    public int intMinMax;
+
+    public String strNoAnnotation;
+
+    @Schema(description = "A string", defaultValue = "computer", example = ":-D")
+    public String strDefaultExample;
+
+    @Schema(description = "A string", defaultValue = "computer")
+    public String strDefault;
+
+    @Schema(
+        description = "A string",
+        allowableValues = {"mercury", "venus", "mars"})
+    public String strAllowableValues;
+
+    @Schema(description = "A string", format = "url")
+    public String strFormatUrl;
+
+    @Schema(description = "A string", format = "uuid")
+    public String strFormatUuid;
+
+    @Size(min = 21, max = 31)
+    public String strSizeMinMax;
+
+    public boolean boolNoAnnotation;
+
+    @Schema(description = "A boolean", defaultValue = "true", example = "false")
+    public Boolean boolDefaultExample;
+
+    @Schema(description = "A boolean", defaultValue = "false")
+    public Boolean boolDefault;
+
+    public BigDecimal decimalNoAnnotation;
+
+    @Schema(description = "A decimal", defaultValue = "77.77", example = "7700.0077")
+    public BigDecimal decimalDefaultExample;
+
+    @Schema(description = "A decimal", defaultValue = "77.77")
+    public BigDecimal decimalDefault;
+
+    @DecimalMin("21.000")
+    @DecimalMax("23.999")
+    public BigDecimal decimalMinMax;
+
+    public List<String> arrayNoAnnotation;
+
+    @ArraySchema(
+        arraySchema =
+            @Schema(
+                description = "An array of strings",
+                example = "[\"AAA111\", \"BBB222\", \"CCC333\"]"))
+    public List<String> arrayExample;
+
+    public List<ExampleItem> arrayItemNoAnnotation;
+
+    @Size(max = 20)
+    public List<ExampleItem> arrayItemSizeMax;
+
+    @ArraySchema(
+        arraySchema =
+            @Schema(
+                description = "An array of items",
+                example =
+                    "[{"
+                        + "  \"str\": \"alpha\","
+                        + "  \"decimal\": 6.01,"
+                        + "  \"coordinate\": {\"x\": -4, \"y\": 12, \"z\": 16 }"
+                        + "}, {"
+                        + "  \"str\": \"beta\","
+                        + "  \"decimal\": -3.005,"
+                        + "  \"coordinate\": {\"x\": 3, \"y\": 7, \"z\": 21 }"
+                        + "}]"))
+    public List<ExampleItem> arrayItemExample;
+
+    public LocalDate dateNoAnnotation;
+
+    public LocalDateTime dateTimeNoAnnotation;
+  }
+
+  static class ExampleItem {
+    public String str;
+    public BigDecimal decimal;
+    public ExampleCoordinate coordinate;
+  }
+
+  static class ExampleCoordinate {
+    public int x;
+    public int y;
+    public int z;
+  }
+}

--- a/modules/swagger-codegen/src/test/resources/examples/example_generator.json
+++ b/modules/swagger-codegen/src/test/resources/examples/example_generator.json
@@ -1,0 +1,139 @@
+{
+  "intNoAnnotation" : 0,
+  "intDefaultExample" : 440,
+  "intDefault" : 6,
+  "intMinMax" : 1507,
+  "strNoAnnotation" : "strNoAnnotation",
+  "strDefaultExample" : ":-D",
+  "strDefault" : "computer",
+  "strAllowableValues" : "mercury",
+  "strFormatUrl" : "http://example.com/aeiou",
+  "strFormatUuid" : "046b6c7f-0b8a-43b9-b35d-6489e6daee91",
+  "strSizeMinMax" : "strSizeMinMax",
+  "boolNoAnnotation" : true,
+  "boolDefaultExample" : false,
+  "boolDefault" : false,
+  "decimalNoAnnotation" : 5.962133916683182,
+  "decimalDefaultExample" : 7700.0077,
+  "decimalDefault" : 5.637376656633329,
+  "decimalMinMax" : 21.690410552491734,
+  "arrayNoAnnotation" : [ "arrayNoAnnotation", "arrayNoAnnotation" ],
+  "arrayExample" : [ "AAA111", "BBB222", "CCC333" ],
+  "arrayItemNoAnnotation" : [ {
+    "str" : "str",
+    "decimal" : 7.061401241503109,
+    "coordinate" : {
+      "x" : 9,
+      "y" : 3,
+      "z" : 2
+    }
+  }, {
+    "str" : "str",
+    "decimal" : 7.061401241503109,
+    "coordinate" : {
+      "x" : 9,
+      "y" : 3,
+      "z" : 2
+    }
+  } ],
+  "arrayItemSizeMax" : [ {
+    "str" : "str",
+    "decimal" : 7.061401241503109,
+    "coordinate" : {
+      "x" : 9,
+      "y" : 3,
+      "z" : 2
+    }
+  }, {
+    "str" : "str",
+    "decimal" : 7.061401241503109,
+    "coordinate" : {
+      "x" : 9,
+      "y" : 3,
+      "z" : 2
+    }
+  }, {
+    "str" : "str",
+    "decimal" : 7.061401241503109,
+    "coordinate" : {
+      "x" : 9,
+      "y" : 3,
+      "z" : 2
+    }
+  }, {
+    "str" : "str",
+    "decimal" : 7.061401241503109,
+    "coordinate" : {
+      "x" : 9,
+      "y" : 3,
+      "z" : 2
+    }
+  }, {
+    "str" : "str",
+    "decimal" : 7.061401241503109,
+    "coordinate" : {
+      "x" : 9,
+      "y" : 3,
+      "z" : 2
+    }
+  }, {
+    "str" : "str",
+    "decimal" : 7.061401241503109,
+    "coordinate" : {
+      "x" : 9,
+      "y" : 3,
+      "z" : 2
+    }
+  }, {
+    "str" : "str",
+    "decimal" : 7.061401241503109,
+    "coordinate" : {
+      "x" : 9,
+      "y" : 3,
+      "z" : 2
+    }
+  }, {
+    "str" : "str",
+    "decimal" : 7.061401241503109,
+    "coordinate" : {
+      "x" : 9,
+      "y" : 3,
+      "z" : 2
+    }
+  }, {
+    "str" : "str",
+    "decimal" : 7.061401241503109,
+    "coordinate" : {
+      "x" : 9,
+      "y" : 3,
+      "z" : 2
+    }
+  }, {
+    "str" : "str",
+    "decimal" : 7.061401241503109,
+    "coordinate" : {
+      "x" : 9,
+      "y" : 3,
+      "z" : 2
+    }
+  } ],
+  "arrayItemExample" : [ {
+    "str" : "alpha",
+    "decimal" : 6.01,
+    "coordinate" : {
+      "x" : -4,
+      "y" : 12,
+      "z" : 16
+    }
+  }, {
+    "str" : "beta",
+    "decimal" : -3.005,
+    "coordinate" : {
+      "x" : 3,
+      "y" : 7,
+      "z" : 21
+    }
+  } ],
+  "dateNoAnnotation" : "2000-01-23",
+  "dateTimeNoAnnotation" : "2000-01-23T04:56:07.000+00:00"
+}


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [x] Filed the PR against the correct branch: `3.0.0` branch for changes related to OpenAPI spec 3.0. Default: `master`.
- [ ] Copied the [technical committee](https://github.com/swagger-api/swagger-codegen/#swagger-codegen-technical-committee) to review the pull request if your PR is targeting a particular programming language. **No one listed for Java.**

### Description of the PR

- Fix ExampleGenerator to correctly populate JSON values instead of populating all values with "".
- Implement recursion into child objects by checking get$ref() method of each property.
- Add a test case ExampleGeneratorTest that generates a JSON example for an annotated set of classes.
