### PR TITLE
Fix #9884 - Swift5 - PromiseKit updated to the latest version (v.6).

### DIFF
--- a/modules/swagger-codegen/src/main/resources/swift5/Extensions.mustache
+++ b/modules/swagger-codegen/src/main/resources/swift5/Extensions.mustache
@@ -176,9 +176,9 @@ extension KeyedDecodingContainerProtocol {
         let deferred = Promise<Response<T>>.pending()
         self.execute { (response: Response<T>?, error: Error?) in
             if let response = response {
-                deferred.fulfill(response)
+                deferred.resolver.fulfill(response)
             } else {
-                deferred.reject(error!)
+                deferred.resolver.reject(error!)
             }
         }
         return deferred.promise

--- a/modules/swagger-codegen/src/main/resources/swift5/Podspec.mustache
+++ b/modules/swagger-codegen/src/main/resources/swift5/Podspec.mustache
@@ -16,7 +16,7 @@ Pod::Spec.new do |s|
   s.screenshots = {{& podScreenshots}}{{/podScreenshots}}{{#podDocumentationURL}}
   s.documentation_url = '{{podDocumentationURL}}'{{/podDocumentationURL}}
   s.source_files = '{{projectName}}/Classes/**/*.swift'{{#usePromiseKit}}
-  s.dependency 'PromiseKit/CorePromise', '~> 4.4.0'{{/usePromiseKit}}{{#useRxSwift}}
+  s.dependency 'PromiseKit', '~> 6.8'{{/usePromiseKit}}{{#useRxSwift}}
   s.dependency 'RxSwift', '~> 4.0'{{/useRxSwift}}
   s.dependency 'Alamofire', '~> 4.9.0'
 end

--- a/modules/swagger-codegen/src/main/resources/swift5/api.mustache
+++ b/modules/swagger-codegen/src/main/resources/swift5/api.mustache
@@ -63,9 +63,9 @@ open class {{classname}} {
         let deferred = Promise<{{#returnType}}{{{returnType}}}{{/returnType}}{{^returnType}}Void{{/returnType}}>.pending()
         {{operationId}}({{#allParams}}{{paramName}}: {{paramName}}{{#hasMore}}, {{/hasMore}}{{/allParams}}) { data, error in
             if let error = error {
-                deferred.reject(error)
+                deferred.resolver.reject(error)
             } else {
-                deferred.fulfill(data!)
+                deferred.resolver.fulfill(data!)
             }
         }
         return deferred.promise


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [x] Filed the PR against the correct branch: `3.0.0` branch for changes related to OpenAPI spec 3.0. Default: `master`.
- [x] Copied the [technical committee](https://github.com/swagger-api/swagger-codegen/#swagger-codegen-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

Mustache files updated in part of the activated "PromiseKit" option. Library updated from v.4 to v.6.
Changes:
- Podspec file to generate the latest PromiseKit library. From "> 4.4.0" to "> 6.8"
- API classes generator - fulfill & reject methods were moved to the resolver field in v.6. Updated.
- Execute extension - fulfill & reject methods were moved to the resolver field in v.6. Updated.

@ehyche, please review.