### PR TITLE
Inline response schemas with additionalProperties with boolean values are no longer ignored

### DIFF
--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/InlineModelResolver.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/InlineModelResolver.java
@@ -163,6 +163,10 @@ public class InlineModelResolver {
                                                 swagger.addDefinition(modelName, innerModel);
                                             }
                                         }
+                                    } else if (innerProperty instanceof UntypedProperty) {
+                                        Model mapModel = new PropertyModelConverter().propertyToModel(mp);
+                                        response.setResponseSchema(mapModel);
+                                        swagger.addDefinition(mp.getName(), mapModel);
                                     }
                                 }
                             }

--- a/modules/swagger-codegen/src/test/java/io/swagger/codegen/CodegenTest.java
+++ b/modules/swagger-codegen/src/test/java/io/swagger/codegen/CodegenTest.java
@@ -14,6 +14,32 @@ import java.util.List;
 
 public class CodegenTest {
 
+    @Test(description = "handle boolean additionalProperties in embedded model")
+    public void booleanAdditionalPropertiesTest() {
+        final Swagger model = parseAndPrepareSwagger("src/test/resources/2_0/additionalProperties.json");
+        final DefaultCodegen codegen = new DefaultCodegen();
+        final String path = "/user/email/v1";
+        final Operation p = model.getPaths().get(path).getPost();
+        final CodegenOperation op = codegen.fromOperation(path, "post", p, model.getDefinitions());
+        System.out.println(model.getDefinitions());
+        Assert.assertEquals(model.getDefinitions().size(), 2);
+//        Assert.assertEquals(op.operationId, "postUserEmailV1");
+//        Assert.assertEquals(op.httpMethod, "POST");
+//        Assert.assertTrue(op.hasConsumes);
+//        Assert.assertEquals(op.consumes.size(), 1);
+//        Assert.assertEquals(op.consumes.get(0).get("mediaType"), "multipart/form-data");
+//        Assert.assertTrue(op.hasProduces);
+//        Assert.assertEquals(op.allParams.size(), 3);
+//        Assert.assertEquals(op.formParams.size(), 2);
+//
+//        final CodegenParameter file = op.formParams.get(1);
+//        Assert.assertTrue(file.isFormParam);
+//        Assert.assertEquals(file.dataType, "File");
+//        Assert.assertFalse(file.required);
+//        Assert.assertTrue(file.isFile);
+//        Assert.assertFalse(file.hasMore);
+    }
+
     @Test(description = "handle simple composition")
     public void  propertiesInComposedModelTest() {
         final Swagger swagger = parseAndPrepareSwagger("src/test/resources/2_0/allOfProperties.yaml");

--- a/modules/swagger-codegen/src/test/resources/2_0/additionalProperties.json
+++ b/modules/swagger-codegen/src/test/resources/2_0/additionalProperties.json
@@ -1,0 +1,75 @@
+{
+  "info": {
+  },
+  "paths": {
+    "/user/email/v1": {
+      "post": {
+        "description": "email address",
+        "operationId": "post_user_email_v1",
+        "parameters": [
+          {
+            "description": "The future business user's email address. AdditionalProperties are allowed in order to accept utm_params",
+            "in": "body",
+            "name": "body",
+            "required": true,
+            "schema": {
+              "additionalProperties": true,
+              "properties": {
+                "enc_email_addr": {
+                  "description": "An email address",
+                  "type": "string"
+                },
+                "utm_campaign": {
+                  "description": "(Optional) The campaign of the request, provided by the deep link URL",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "enc_email_addr"
+              ],
+              "type": "object",
+              "x-model": "PostUserEmailV1_RequestData"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "A successful request will return a email address",
+            "examples": {
+              "application/json": {
+                "email": "testuser@example.com"
+              }
+            },
+            "schema": {
+              "additionalProperties": false,
+              "properties": {
+                "email": {
+                  "description": "Email address",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "email"
+              ],
+              "type": "object",
+              "x-model": "PostUserEmailV1_ResponseData"
+            }
+          },
+          "default": {
+            "description": "Error response",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          }
+        }
+      }
+    }
+  },
+  "produces": [
+    "application/json"
+  ],
+  "schemes": [
+    "http"
+  ],
+  "swagger": "2.0"
+}


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [x] Filed the PR against the correct branch: `3.0.0` branch for changes related to OpenAPI spec 3.0. Default: `master`.
- [x] Copied the [technical committee](https://github.com/swagger-api/swagger-codegen/#swagger-codegen-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR
This is meant to be released in the next v2.0.x release. It's branched off of the v2.0.14 tag. This PR resolves https://github.com/swagger-api/swagger-codegen/issues/9885

My understanding is that `additionalProperties` fields with boolean values should be ignored, as they are not explicitly in or against the OpenAPI 2/3 spec. However in the current V2.0.x and v3.0.x releases, if an `additionalProperties` field with a boolean value is contained within an inline response schema, the response model is never added to the list of definitions on `swagger.definitions` which causes `swagger-codegen` to fail to generate it. 

That is because they're treated as `UntypedProperty` which previously wasn't a handled case. This PR adds a case for `additionalProperties` to be an `UntypedProperty`, and effectively ignores the value of `additionalProperties`.

Let me know if yall (the maintainers) think this is a good solution or if  you have any additional feedback. Java isn't my primary language, so apologies if I've broken conventions.

Thanks!


(details of the change, additional tests that have been done, reference to the issue for tracking, etc)

