### PR TITLE
added option to ignore import mappings in model generation.

### DIFF
--- a/modules/swagger-codegen-cli/src/main/java/io/swagger/codegen/cmd/Generate.java
+++ b/modules/swagger-codegen-cli/src/main/java/io/swagger/codegen/cmd/Generate.java
@@ -175,6 +175,9 @@ public class Generate implements Runnable {
     @Option(name = {"--skip-alias-generation"}, title = "skip alias generation.", description = "skip code generation for models identified as alias.")
     private Boolean skipAliasGeneration;
 
+    @Option(name = {"--ignore-import-mapping"}, title = "ignore import mapping", description = "allow generate model classes using names previously listed on import mappings.")
+    private String ignoreImportMappings;
+
     @Override
     public void run() {
 
@@ -278,6 +281,10 @@ public class Generate implements Runnable {
 
         if (skipAliasGeneration != null) {
             configurator.setSkipAliasGeneration(removeOperationIdPrefix);
+        }
+
+        if (ignoreImportMappings != null) {
+            additionalProperties.add(String.format("%s=%s", CodegenConstants.IGNORE_IMPORT_MAPPING_OPTION, Boolean.parseBoolean(ignoreImportMappings)));
         }
 
         applySystemPropertiesKvpList(systemProperties, configurator);

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/CodegenConfig.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/CodegenConfig.java
@@ -226,4 +226,10 @@ public interface CodegenConfig {
 
     Boolean getSkipAliasGeneration();
 
+    boolean getIgnoreImportMapping();
+
+    void setIgnoreImportMapping(boolean ignoreImportMapping);
+
+    boolean defaultIgnoreImportMappingOption();
+
 }

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/CodegenConstants.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/CodegenConstants.java
@@ -234,4 +234,6 @@ public class CodegenConstants {
     public static final String ASP_NET_CORE_VERSION = "aspnetCoreVersion";
     public static final String INTERFACE_ONLY = "interface-only";
     public static final String INTERFACE_CONTROLLER = "interface-controller";
+
+    public static final String IGNORE_IMPORT_MAPPING_OPTION = "ignoreImportMappings";
 }

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/DefaultCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/DefaultCodegen.java
@@ -104,6 +104,7 @@ public class DefaultCodegen {
     protected String httpUserAgent;
     protected Boolean hideGenerationTimestamp = true;
     protected Boolean skipAliasGeneration;
+    protected boolean ignoreImportMapping;
     // How to encode special characters like $
     // They are translated to words like "Dollar" and prefixed with '
     // Then translated back during JSON encoding and decoding
@@ -162,6 +163,12 @@ public class DefaultCodegen {
         if (additionalProperties.containsKey(CodegenConstants.REMOVE_OPERATION_ID_PREFIX)) {
             this.setRemoveOperationIdPrefix(Boolean.valueOf(additionalProperties
                     .get(CodegenConstants.REMOVE_OPERATION_ID_PREFIX).toString()));
+        }
+
+        if (additionalProperties.get(CodegenConstants.IGNORE_IMPORT_MAPPING_OPTION) != null) {
+            setIgnoreImportMapping(Boolean.parseBoolean( additionalProperties.get(CodegenConstants.IGNORE_IMPORT_MAPPING_OPTION).toString()));
+        } else {
+            setIgnoreImportMapping(defaultIgnoreImportMappingOption());
         }
     }
 
@@ -3957,5 +3964,17 @@ public class DefaultCodegen {
             }
         }
         codegenOperation.testPath = path;
+    }
+
+    public boolean getIgnoreImportMapping() {
+        return ignoreImportMapping;
+    }
+
+    public void setIgnoreImportMapping(boolean ignoreImportMapping) {
+        this.ignoreImportMapping = ignoreImportMapping;
+    }
+
+    public boolean defaultIgnoreImportMappingOption() {
+        return false;
     }
 }

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/DefaultGenerator.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/DefaultGenerator.java
@@ -378,7 +378,7 @@ public class DefaultGenerator extends AbstractGenerator implements Generator {
         for (String name : modelKeys) {
             try {
                 //don't generate models that have an import mapping
-                if (config.importMapping().containsKey(name)) {
+                if (!config.getIgnoreImportMapping() && config.importMapping().containsKey(name)) {
                     LOGGER.info("Model " + name + " not imported due to import mapping");
                     continue;
                 }
@@ -409,7 +409,7 @@ public class DefaultGenerator extends AbstractGenerator implements Generator {
             models.put("modelPackage", config.modelPackage());
             try {
                 //don't generate models that have an import mapping
-                if (config.importMapping().containsKey(modelName)) {
+                if (!config.getIgnoreImportMapping() && config.importMapping().containsKey(modelName)) {
                     continue;
                 }
                 Map<String, Object> modelTemplate = (Map<String, Object>) ((List<Object>) models.get("models")).get(0);

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/AbstractJavaCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/AbstractJavaCodegen.java
@@ -603,7 +603,7 @@ public abstract class AbstractJavaCodegen extends DefaultCodegen implements Code
     public String toModelName(final String name) {
         // We need to check if import-mapping has a different model for this class, so we use it
         // instead of the auto-generated one.
-        if (importMapping.containsKey(name)) {
+        if (!getIgnoreImportMapping() && importMapping.containsKey(name)) {
             return importMapping.get(name);
         }
 
@@ -1347,6 +1347,10 @@ public abstract class AbstractJavaCodegen extends DefaultCodegen implements Code
             tag = "Class" + tag;
         }
         return tag;
+    }
+
+    public boolean defaultIgnoreImportMappingOption() {
+        return true;
     }
 
 }


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [x] Filed the PR against the correct branch: `3.0.0` branch for changes related to OpenAPI spec 3.0. Default: `master`.
- [x] Copied the [technical committee](https://github.com/swagger-api/swagger-codegen/#swagger-codegen-technical-committee) to review the pull request if your PR is targeting a particular programming language.

