### PR TITLE
Fix the go generation scripts and docker runner script

### DIFF
--- a/bin/go-petstore-server.sh
+++ b/bin/go-petstore-server.sh
@@ -27,6 +27,6 @@ fi
 # if you've executed sbt assembly previously it will use that instead.
 export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -Dlogback.configurationFile=bin/logback.xml"
 
-ags="$@ generate -t modules/swagger-codegen/src/main/resources/go-server -i modules/swagger-codegen/src/test/resources/2_0/petstore.yaml -l go-server -o samples/server/petstore/go-api-server -DpackageName=petstoreserver  --additional-properties hideGenerationTimestamp=true -Dservice"
+ags="$@ generate -t modules/swagger-codegen/target/classes/go-server -i modules/swagger-codegen/src/test/resources/2_0/petstore.yaml -l go-server -o samples/server/petstore/go-api-server -DpackageName=petstoreserver  --additional-properties hideGenerationTimestamp=true -Dservice"
 
 # java $JAVA_OPTS -jar $executable $ags

--- a/bin/go-petstore.sh
+++ b/bin/go-petstore.sh
@@ -26,6 +26,6 @@ fi
 
 # if you've executed sbt assembly previously it will use that instead.
 export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -Dlogback.configurationFile=bin/logback.xml"
-ags="$@ generate -t modules/swagger-codegen/src/main/resources/go -i modules/swagger-codegen/src/test/resources/2_0/petstore-with-fake-endpoints-models-for-testing.yaml -l go -o samples/client/petstore/go/go-petstore -DpackageName=petstore "
+ags="$@ generate -t modules/swagger-codegen/target/classes/go -i modules/swagger-codegen/src/test/resources/2_0/petstore-with-fake-endpoints-models-for-testing.yaml -l go -o samples/client/petstore/go/go-petstore -DpackageName=petstore "
 
 # java $JAVA_OPTS -jar $executable $ags

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -8,7 +8,7 @@ JAVA_OPTS=${JAVA_OPTS:-"-Xmx1024M -Dlogback.configurationFile=conf/logback.xml"}
 
 cli="${GEN_DIR}/modules/swagger-codegen-cli"
 codegen="${cli}/target/swagger-codegen-cli.jar"
-cmdsrc="${cli}/src/main/java/io/swagger/codegen/cmd"
+cmdsrc="${cli}/src/main/java/io/swagger/codegen/v3/cli/cmd"
 
 pattern="${1^} implements Runnable"
 if expr "x$1" : 'x[a-z][a-z-]*$' > /dev/null && fgrep -qe "$pattern" "$cmdsrc"/*.java || expr "$1" = 'help' > /dev/null; then


### PR DESCRIPTION
fix #10015 

### PR checklist

- [x] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [x] Filed the PR against the correct branch: `3.0.0` branch for changes related to OpenAPI spec 3.0. Default: `master`.
- [x] Copied the [technical committee](https://github.com/swagger-api/swagger-codegen/#swagger-codegen-technical-committee) to review the pull request if your PR is targeting a particular programming language.

Fixes the issues with `./run-in-docker.sh`, ./bin/go-petstore.sh` and `./bin/go-petstore-server.sh` scriptss
