### PR TITLE
[docs] Maven repo missing 3.x.x versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,7 +179,11 @@ Swagger Codegen Version    | Release Date | OpenAPI Spec compatibility | Notes
 If you're looking for the latest stable version, you can grab it directly from Maven.org (Java 8 runtime at a minimum):
 
 ```sh
+# Download current stable 2.x.x branch
 wget https://repo1.maven.org/maven2/io/swagger/swagger-codegen-cli/2.4.12/swagger-codegen-cli-2.4.12.jar -O swagger-codegen-cli.jar
+
+# Download current stable 3.x.x branch
+wget https://repo1.maven.org/maven2/io/swagger/codegen/v3/swagger-codegen-cli/3.0.16/swagger-codegen-cli-3.0.16.jar -O swagger-codegen-cli.jar
 
 java -jar swagger-codegen-cli.jar help
 ```

--- a/README.md
+++ b/README.md
@@ -179,10 +179,10 @@ Swagger Codegen Version    | Release Date | OpenAPI Spec compatibility | Notes
 If you're looking for the latest stable version, you can grab it directly from Maven.org (Java 8 runtime at a minimum):
 
 ```sh
-# Download current stable 2.x.x branch
+# Download current stable 2.x.x branch (Swagger and OpenAPI version 2)
 wget https://repo1.maven.org/maven2/io/swagger/swagger-codegen-cli/2.4.12/swagger-codegen-cli-2.4.12.jar -O swagger-codegen-cli.jar
 
-# Download current stable 3.x.x branch
+# Download current stable 3.x.x branch (OpenAPI version 3)
 wget https://repo1.maven.org/maven2/io/swagger/codegen/v3/swagger-codegen-cli/3.0.16/swagger-codegen-cli-3.0.16.jar -O swagger-codegen-cli.jar
 
 java -jar swagger-codegen-cli.jar help


### PR DESCRIPTION
Download url for current stable of the 3.x.x branch was missing in the prerequisites section of the README.
Without this specification the user may not realize their is a newer version available, specially those who don't want to clone the project and build it.

Resolves: #9475
See also: #9588

### PR checklist

- [x] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [ ] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [ ] Filed the PR against the correct branch: `3.0.0` branch for changes related to OpenAPI spec 3.0. Default: `master`.
- [ ] Copied the [technical committee](https://github.com/swagger-api/swagger-codegen/#swagger-codegen-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

Download url for current stable of the 3.x.x branch was missing in the prerequisites section of the README.
Added download link for 3.0.16 current stable of maven repo
Without this specification the user may not realize their is a newer version available, specially those who don't want to clone the project and build it.

