### PR TITLE
Update maven-javadoc-plugin for Java 11 support

### DIFF
--- a/modules/swagger-codegen/src/main/resources/Java/libraries/feign/pom.mustache
+++ b/modules/swagger-codegen/src/main/resources/Java/libraries/feign/pom.mustache
@@ -137,7 +137,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
-                <version>2.10.4</version>
+                <version>3.1.1</version>
                 <executions>
                     <execution>
                         <id>attach-javadocs</id>

--- a/modules/swagger-codegen/src/main/resources/Java/libraries/google-api-client/pom.mustache
+++ b/modules/swagger-codegen/src/main/resources/Java/libraries/google-api-client/pom.mustache
@@ -154,7 +154,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
-                <version>2.10.4</version>
+                <version>3.1.1</version>
                 <executions>
                     <execution>
                         <id>attach-javadocs</id>

--- a/modules/swagger-codegen/src/main/resources/Java/libraries/jersey2/pom.mustache
+++ b/modules/swagger-codegen/src/main/resources/Java/libraries/jersey2/pom.mustache
@@ -154,7 +154,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
-                <version>2.10.4</version>
+                <version>3.1.1</version>
                 <executions>
                     <execution>
                         <id>attach-javadocs</id>

--- a/modules/swagger-codegen/src/main/resources/Java/libraries/okhttp-gson/pom.mustache
+++ b/modules/swagger-codegen/src/main/resources/Java/libraries/okhttp-gson/pom.mustache
@@ -137,7 +137,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
-                <version>2.10.4</version>
+                <version>3.1.1</version>
                 <executions>
                     <execution>
                         <id>attach-javadocs</id>

--- a/modules/swagger-codegen/src/main/resources/Java/libraries/rest-assured/pom.mustache
+++ b/modules/swagger-codegen/src/main/resources/Java/libraries/rest-assured/pom.mustache
@@ -145,7 +145,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
-                <version>2.10.4</version>
+                <version>3.1.1</version>
                 <executions>
                     <execution>
                         <id>attach-javadocs</id>

--- a/modules/swagger-codegen/src/main/resources/Java/libraries/resteasy/pom.mustache
+++ b/modules/swagger-codegen/src/main/resources/Java/libraries/resteasy/pom.mustache
@@ -135,7 +135,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
-                <version>2.10.4</version>
+                <version>3.1.1</version>
             </plugin>
         </plugins>
     </build>

--- a/modules/swagger-codegen/src/main/resources/Java/libraries/resttemplate/pom.mustache
+++ b/modules/swagger-codegen/src/main/resources/Java/libraries/resttemplate/pom.mustache
@@ -154,7 +154,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
-                <version>2.10.4</version>
+                <version>3.1.1</version>
                 <executions>
                     <execution>
                         <id>attach-javadocs</id>

--- a/modules/swagger-codegen/src/main/resources/Java/libraries/retrofit/pom.mustache
+++ b/modules/swagger-codegen/src/main/resources/Java/libraries/retrofit/pom.mustache
@@ -146,7 +146,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
-                <version>2.10.4</version>
+                <version>3.1.1</version>
                 <executions>
                     <execution>
                         <id>attach-javadocs</id>

--- a/modules/swagger-codegen/src/main/resources/Java/libraries/retrofit2/pom.mustache
+++ b/modules/swagger-codegen/src/main/resources/Java/libraries/retrofit2/pom.mustache
@@ -137,7 +137,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
-                <version>2.10.4</version>
+                <version>3.1.1</version>
                 <executions>
                     <execution>
                         <id>attach-javadocs</id>

--- a/modules/swagger-codegen/src/main/resources/Java/libraries/vertx/pom.mustache
+++ b/modules/swagger-codegen/src/main/resources/Java/libraries/vertx/pom.mustache
@@ -147,7 +147,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
-                <version>2.10.4</version>
+                <version>3.1.1</version>
                 <executions>
                     <execution>
                         <id>attach-javadocs</id>

--- a/modules/swagger-codegen/src/main/resources/Java/pom.mustache
+++ b/modules/swagger-codegen/src/main/resources/Java/pom.mustache
@@ -154,7 +154,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
-                <version>2.10.4</version>
+                <version>3.1.1</version>
                 <executions>
                     <execution>
                         <id>attach-javadocs</id>

--- a/samples/client/petstore-security-test/java/okhttp-gson/pom.xml
+++ b/samples/client/petstore-security-test/java/okhttp-gson/pom.xml
@@ -118,7 +118,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.10.4</version>
+        <version>3.1.1</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>

--- a/samples/client/petstore/java/feign/pom.xml
+++ b/samples/client/petstore/java/feign/pom.xml
@@ -137,7 +137,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
-                <version>2.10.4</version>
+                <version>3.1.1</version>
                 <executions>
                     <execution>
                         <id>attach-javadocs</id>

--- a/samples/client/petstore/java/google-api-client/pom.xml
+++ b/samples/client/petstore/java/google-api-client/pom.xml
@@ -147,7 +147,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
-                <version>2.10.4</version>
+                <version>3.1.1</version>
                 <executions>
                     <execution>
                         <id>attach-javadocs</id>

--- a/samples/client/petstore/java/jersey1/pom.xml
+++ b/samples/client/petstore/java/jersey1/pom.xml
@@ -147,7 +147,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
-                <version>2.10.4</version>
+                <version>3.1.1</version>
                 <executions>
                     <execution>
                         <id>attach-javadocs</id>

--- a/samples/client/petstore/java/jersey2-java6/pom.xml
+++ b/samples/client/petstore/java/jersey2-java6/pom.xml
@@ -147,7 +147,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
-                <version>2.10.4</version>
+                <version>3.1.1</version>
                 <executions>
                     <execution>
                         <id>attach-javadocs</id>

--- a/samples/client/petstore/java/jersey2-java8/pom.xml
+++ b/samples/client/petstore/java/jersey2-java8/pom.xml
@@ -147,7 +147,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
-                <version>2.10.4</version>
+                <version>3.1.1</version>
                 <executions>
                     <execution>
                         <id>attach-javadocs</id>

--- a/samples/client/petstore/java/jersey2/pom.xml
+++ b/samples/client/petstore/java/jersey2/pom.xml
@@ -147,7 +147,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
-                <version>2.10.4</version>
+                <version>3.1.1</version>
                 <executions>
                     <execution>
                         <id>attach-javadocs</id>

--- a/samples/client/petstore/java/okhttp-gson-parcelableModel/pom.xml
+++ b/samples/client/petstore/java/okhttp-gson-parcelableModel/pom.xml
@@ -137,7 +137,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
-                <version>2.10.4</version>
+                <version>3.1.1</version>
                 <executions>
                     <execution>
                         <id>attach-javadocs</id>

--- a/samples/client/petstore/java/okhttp-gson/pom.xml
+++ b/samples/client/petstore/java/okhttp-gson/pom.xml
@@ -137,7 +137,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
-                <version>2.10.4</version>
+                <version>3.1.1</version>
                 <executions>
                     <execution>
                         <id>attach-javadocs</id>

--- a/samples/client/petstore/java/rest-assured/pom.xml
+++ b/samples/client/petstore/java/rest-assured/pom.xml
@@ -145,7 +145,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
-                <version>2.10.4</version>
+                <version>3.1.1</version>
                 <executions>
                     <execution>
                         <id>attach-javadocs</id>

--- a/samples/client/petstore/java/resteasy/pom.xml
+++ b/samples/client/petstore/java/resteasy/pom.xml
@@ -128,7 +128,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
-                <version>2.10.4</version>
+                <version>3.1.1</version>
             </plugin>
         </plugins>
     </build>

--- a/samples/client/petstore/java/resttemplate-withXml/pom.xml
+++ b/samples/client/petstore/java/resttemplate-withXml/pom.xml
@@ -147,7 +147,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
-                <version>2.10.4</version>
+                <version>3.1.1</version>
                 <executions>
                     <execution>
                         <id>attach-javadocs</id>

--- a/samples/client/petstore/java/resttemplate/pom.xml
+++ b/samples/client/petstore/java/resttemplate/pom.xml
@@ -147,7 +147,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
-                <version>2.10.4</version>
+                <version>3.1.1</version>
                 <executions>
                     <execution>
                         <id>attach-javadocs</id>

--- a/samples/client/petstore/java/retrofit/pom.xml
+++ b/samples/client/petstore/java/retrofit/pom.xml
@@ -146,7 +146,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
-                <version>2.10.4</version>
+                <version>3.1.1</version>
                 <executions>
                     <execution>
                         <id>attach-javadocs</id>

--- a/samples/client/petstore/java/retrofit2-play24/pom.xml
+++ b/samples/client/petstore/java/retrofit2-play24/pom.xml
@@ -137,7 +137,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
-                <version>2.10.4</version>
+                <version>3.1.1</version>
                 <executions>
                     <execution>
                         <id>attach-javadocs</id>

--- a/samples/client/petstore/java/retrofit2-play25/pom.xml
+++ b/samples/client/petstore/java/retrofit2-play25/pom.xml
@@ -137,7 +137,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
-                <version>2.10.4</version>
+                <version>3.1.1</version>
                 <executions>
                     <execution>
                         <id>attach-javadocs</id>

--- a/samples/client/petstore/java/retrofit2/pom.xml
+++ b/samples/client/petstore/java/retrofit2/pom.xml
@@ -137,7 +137,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
-                <version>2.10.4</version>
+                <version>3.1.1</version>
                 <executions>
                     <execution>
                         <id>attach-javadocs</id>

--- a/samples/client/petstore/java/retrofit2rx/pom.xml
+++ b/samples/client/petstore/java/retrofit2rx/pom.xml
@@ -137,7 +137,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
-                <version>2.10.4</version>
+                <version>3.1.1</version>
                 <executions>
                     <execution>
                         <id>attach-javadocs</id>

--- a/samples/client/petstore/java/retrofit2rx2/pom.xml
+++ b/samples/client/petstore/java/retrofit2rx2/pom.xml
@@ -137,7 +137,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
-                <version>2.10.4</version>
+                <version>3.1.1</version>
                 <executions>
                     <execution>
                         <id>attach-javadocs</id>

--- a/samples/client/petstore/java/vertx/pom.xml
+++ b/samples/client/petstore/java/vertx/pom.xml
@@ -147,7 +147,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
-                <version>2.10.4</version>
+                <version>3.1.1</version>
                 <executions>
                     <execution>
                         <id>attach-javadocs</id>


### PR DESCRIPTION
### PR checklist

- [X] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [X] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [X] Filed the PR against the correct branch: `3.0.0` branch for changes related to OpenAPI spec 3.0. Default: `master`.

### Description of the PR

Resolves `An error has occurred in Javadoc report generation:
[ERROR] Exit code: 1 - javadoc: error - The code being documented uses modules but the packages defined in https://docs.oracle.com/javase/8/docs/api/ are in the unnamed module` error.
