### PR TITLE
update jetty version to address https://github.com/eclipse/jetty.project/issues/3241

### DIFF
--- a/modules/swagger-generator/pom.xml
+++ b/modules/swagger-generator/pom.xml
@@ -367,7 +367,7 @@
         <dockerfile.tag.skip>true</dockerfile.tag.skip>
         <docker-latest-tag>unstable</docker-latest-tag>
         <maven-plugin-version>1.0.0</maven-plugin-version>
-        <jetty-version>9.4.14.v20181114</jetty-version>
+        <jetty-version>9.4.15.v20190215</jetty-version>
         <inflector-version>2.0.5</inflector-version>
         <junit-version>4.8.2</junit-version>
         <servlet-api.version>3.1.0</servlet-api.version>


### PR DESCRIPTION
fixes jetty-runner startup issue update jetty version to address https://github.com/eclipse/jetty.project/issues/3241 in docker minimal image
