### PR TITLE
Issue 9638

### DIFF
--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/DefaultCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/DefaultCodegen.java
@@ -3232,12 +3232,10 @@ public class DefaultCodegen {
             return prop;
         }
         Map<PropertyBuilder.PropertyId, Object> args = new HashMap<PropertyBuilder.PropertyId, Object>();
-        // putProperty(args, PropertyId.ENUM, modelImpl.getEnum());
         putProperty(args, PropertyId.TITLE, modelImpl.getTitle());
         putProperty(args, PropertyId.DESCRIPTION, modelImpl.getDescription());
         putProperty(args, PropertyId.DEFAULT, modelImpl.getDefaultValue());
         putProperty(args, PropertyId.PATTERN, modelImpl.getPattern());
-        // putProperty(args, PropertyId.DESCRIMINATOR, modelImpl.getDiscriminator());
         putProperty(args, PropertyId.MIN_LENGTH, modelImpl.getMinLength());
         putProperty(args, PropertyId.MAX_LENGTH, modelImpl.getMaxLength());
         putProperty(args, PropertyId.MINIMUM, modelImpl.getMinimum());
@@ -3251,7 +3249,7 @@ public class DefaultCodegen {
         putProperty(args, PropertyId.ALLOW_EMPTY_VALUE, modelImpl.getAllowEmptyValue());
         putProperty(args, PropertyId.MULTIPLE_OF, modelImpl.getMultipleOf());
 
-        // according to the spec this shouldn't be parsed, kept for compat:
+        // according to the spec these shouldn't be parsed, kept for compat:
         putProperty(args, PropertyId.EXAMPLE, refProperty.getExample());
         putProperty(args, PropertyId.REQUIRED, refProperty.getRequired());
         putProperty(args, PropertyId.DESCRIPTION, refProperty.getDescription());

--- a/modules/swagger-codegen/src/test/java/io/swagger/codegen/CodegenTest.java
+++ b/modules/swagger-codegen/src/test/java/io/swagger/codegen/CodegenTest.java
@@ -506,7 +506,7 @@ public class CodegenTest {
         final CodegenModel codegenModel = codegen.fromModel("Amount", amount, swagger.getDefinitions());
         for (CodegenProperty codegenProperty : codegenModel.vars) {
             if ("currency".equalsIgnoreCase(codegenProperty.name)) {
-                Assert.assertEquals(codegenProperty.pattern, "^[A-Z]{3,3}$");
+                Assert.assertEquals(codegenProperty.pattern, "/^[A-Z]{3,3}$/");
                 break;
             }
         }

--- a/modules/swagger-codegen/src/test/java/io/swagger/codegen/CodegenTest.java
+++ b/modules/swagger-codegen/src/test/java/io/swagger/codegen/CodegenTest.java
@@ -510,6 +510,19 @@ public class CodegenTest {
                 break;
             }
         }
+    }
 
+    @Test(description = "https://github.com/swagger-api/swagger-codegen/issues/9638")
+    public void testRefKeepsFormat() {
+        final Swagger swagger = parseAndPrepareSwagger("src/test/resources/2_0/issue-9638.yaml");
+        ModelImpl test = (ModelImpl) swagger.getDefinitions().get("Test");
+        Assert.assertNotNull(test);
+
+        final DefaultCodegen codegen = new DefaultCodegen();
+
+        final CodegenModel codegenModel = codegen.fromModel("Test", test, swagger.getDefinitions());
+        for (CodegenProperty codegenProperty : codegenModel.vars) {
+            Assert.assertTrue(codegenProperty.isDateTime);
+        }
     }
 }

--- a/modules/swagger-codegen/src/test/resources/2_0/issue-9638.yaml
+++ b/modules/swagger-codegen/src/test/resources/2_0/issue-9638.yaml
@@ -1,0 +1,26 @@
+swagger: "2.0"
+info:
+  title: "Test"
+  version: "2"
+paths:
+  /test:
+    get:
+      produces:
+        - "application/json"
+      responses:
+        200:
+          description: "success"
+          schema:
+            $ref: "#/definitions/Test"
+definitions:
+  Date:
+    type: "string"
+    format: "date-time"
+  Test:
+    type: "object"
+    properties:
+      date1:
+        type: "string"
+        format: "date-time"
+      date2:
+        $ref: '#/definitions/Date'


### PR DESCRIPTION
### PR checklist

- [ ] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [ ] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [ ] Filed the PR against the correct branch: `3.0.0` branch for changes related to OpenAPI spec 3.0. Default: `master`.
- [ ] Copied the [technical committee](https://github.com/swagger-api/swagger-codegen/#swagger-codegen-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

Fix issue #9638.

Use the properties from the referenced Model when parsing variables of a model.
This way detailed type information will be passed to the templates (isNumeric, isDate, etc). 
