### PR TITLE
fixed issued with TermsOfService

### DIFF
--- a/modules/swagger-codegen/src/main/resources/aspnetcore/3.0/Startup.mustache
+++ b/modules/swagger-codegen/src/main/resources/aspnetcore/3.0/Startup.mustache
@@ -89,8 +89,8 @@ namespace {{packageName}}
                            Name = "{{#infoName}}{{{infoName}}}{{/infoName}}{{^infoName}}Swagger Codegen Contributors{{/infoName}}",
                            Url = new Uri("{{#infoUrl}}{{{infoUrl}}}{{/infoUrl}}{{^infoUrl}}https://github.com/swagger-api/swagger-codegen{{/infoUrl}}"),
                            Email = "{{#infoEmail}}{{{infoEmail}}}{{/infoEmail}}"
-                        },
-                        TermsOfService = new Uri("{{#termsOfService}}{{{termsOfService}}}{{/termsOfService}}")
+                        }{{#termsOfService}}{,
+                        TermsOfService = new Uri("{{termsOfService}}")}{{/termsOfService}}
                     });
                     c.CustomSchemaIds(type => type.FullName);
                     c.IncludeXmlComments($"{AppContext.BaseDirectory}{Path.DirectorySeparatorChar}{_hostingEnv.ApplicationName}.xml");

--- a/modules/swagger-codegen/src/main/resources/aspnetcore/Startup.mustache
+++ b/modules/swagger-codegen/src/main/resources/aspnetcore/Startup.mustache
@@ -86,8 +86,8 @@ namespace {{packageName}}
                            Name = "{{#infoName}}{{{infoName}}}{{/infoName}}{{^infoName}}Swagger Codegen Contributors{{/infoName}}",
                            Url = "{{#infoUrl}}{{{infoUrl}}}{{/infoUrl}}{{^infoUrl}}https://github.com/swagger-api/swagger-codegen{{/infoUrl}}",
                            Email = "{{#infoEmail}}{{{infoEmail}}}{{/infoEmail}}"
-                        },
-                        TermsOfService = "{{#termsOfService}}{{{termsOfService}}}{{/termsOfService}}"
+                        }{{#termsOfService}}{,
+                        TermsOfService = "{{termsOfService}}"}{{/termsOfService}}
                     });
                     c.CustomSchemaIds(type => type.FriendlyId(true));
                     c.DescribeAllEnumsAsStrings();


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [x] Filed the PR against the correct branch: `3.0.0` branch for changes related to OpenAPI spec 3.0. Default: `master`.
- [x] Copied the [technical committee](https://github.com/swagger-api/swagger-codegen/#swagger-codegen-technical-committee) to review the pull request if your PR is targeting a particular programming language.

This PR resolves issue #10215 and has been tested per the issue's description and supposed resolution. Thanks for the opportunity to serve the ASP.NET Core community by making this and out-of-the-box working experience with the most minimal set of arguments. 

Copying @mandrean, as @mandrean is mentioned as the maintainer of the C# generators. The ASP.NET Core generator's owner isn't specifically mentioned, so if you're looking for one, I'd be willing to own it. 

