### PR TITLE
[pistache-server] hopefully fix pistache-server required object generation in fromJson

### DIFF
--- a/modules/swagger-codegen/src/main/resources/pistache-server/model-source.mustache
+++ b/modules/swagger-codegen/src/main/resources/pistache-server/model-source.mustache
@@ -107,6 +107,11 @@ void {{classname}}::fromJson(nlohmann::json& val)
     }
     {{/required}}{{#required}}{{#isString}}{{setter}}(val.at("{{baseName}}"));
     {{/isString}}{{^isString}}{{#isDateTime}}{{setter}}(val.at("{{baseName}}"));
+    {{/isDateTime}}{{/isString}}{{^isDateTime}}{{^isString}}{
+        {{{datatype}}} newItem({{{defaultValue}}});
+        newItem->fromJson(val["{{baseName}}"]);
+        {{setter}}( newItem );
+    }
     {{/isDateTime}}{{/isString}}{{/required}}{{/isPrimitiveType}}{{/isListContainer}}{{/vars}}
 }
 


### PR DESCRIPTION
### PR checklist

- [ ] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [ ] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [ ] Filed the PR against the correct branch: `3.0.0` branch for changes related to OpenAPI spec 3.0. Default: `master`.
- [ ] Copied the [technical committee](https://github.com/swagger-api/swagger-codegen/#swagger-codegen-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

Adds required object parsing in fromJson method with pistache-server

If I get time later today I may come back and do the appropriate stuff to get it through, but if it cannot be handled in this fashion in some reasonable amount of time, then it may be worthwhile for someone else to take my work here to fix this.

I make no claims that this will actually work because I have not tested it yet.

Links to #10227 

Added required field
