### PR TITLE
Fix README's 'Swagger Generator Docker Image'

### DIFF
--- a/README.md
+++ b/README.md
@@ -289,20 +289,34 @@ The Swagger Generator image can act as a self-hosted web application and API for
 Example usage (note this assumes `jq` is installed for command line processing of JSON):
 
 ```sh
+#!/usr/bin/env bash
+
+# strict-mode
+set -euo pipefail
+IFS=$'\n\t'
+
+cleanup() {
+  # Shutdown the swagger generator image
+  docker stop $CID && docker rm $CID
+}
+
+trap cleanup INT TERM EXIT
+
 # Start container and save the container id
-CID=$(docker run -d swaggerapi/swagger-generator)
+CID=$(docker run -d -p 8188:8080 swaggerapi/swagger-generator)
 # allow for startup
 sleep 5
 # Get the IP of the running container
 GEN_IP=$(docker inspect --format '{{.NetworkSettings.IPAddress}}'  $CID)
 # Execute an HTTP request and store the download link
-RESULT=$(curl -X POST --header 'Content-Type: application/json' --header 'Accept: application/json' -d '{
+RESULT=$(curl --fail -X POST --header 'Content-Type: application/json' --header 'Accept: application/json' -d '{
   "swaggerUrl": "http://petstore.swagger.io/v2/swagger.json"
 }' 'http://localhost:8188/api/gen/clients/javascript' | jq '.link' | tr -d '"')
+
+RESULT="$(echo $RESULT | sed -e 's/https:\/\/generator.swaggerhub.com\/api\/swagger.json/http:\/\/localhost:8188/g')"
 # Download the generated zip and redirect to a file
-curl $RESULT > result.zip
-# Shutdown the swagger generator image
-docker stop $CID && docker rm $CID
+curl --fail $RESULT > result.zip
+unzip -t result.zip
 ```
 
 In the example above, `result.zip` will contain the generated client.


### PR DESCRIPTION
I found that the example shell script in the README did not work out of the box. Some of these changes are for robustness. Some of them fix bugs. Here is a summary of changes:
- [improvement] Use the unofficial "bash strict mode"
- [improvement] Use a trap for clean up of the docker image.This is beneficial if the script stops early. 
- [bug fix] Use `-p` option to map the port of the image being run
- [improvement] Use `--fail` option with curl. The change in the PR do not fail, however if something causes them to fail later this will stop the script at the failure.
- [bug fix] Use sed to change the generator URL to map to the docker image
- [improvement] Use `unzip -t` to verify the zip file is valid. Previously a failed curl would pipe the 404 into result.zip and the user was left troubleshooting why zip tools were saying it was an invalid file.

>Search the open issue and closed issue to ensure no one else has reported something similar before.

I found #9962 addressed the port-mapping bug, this is an alternative solution.

### PR checklist

- [ ] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [ ] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [ ] Filed the PR against the correct branch: `3.0.0` branch for changes related to OpenAPI spec 3.0. Default: `master`.
- [ ] Copied the [technical committee](https://github.com/swagger-api/swagger-codegen/#swagger-codegen-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

(details of the change, additional tests that have been done, reference to the issue for tracking, etc)

