### PR TITLE
Ue4cpp fix

### DIFF
--- a/modules/swagger-codegen/src/main/resources/ue4cpp/api-operations-source.mustache
+++ b/modules/swagger-codegen/src/main/resources/ue4cpp/api-operations-source.mustache
@@ -139,19 +139,17 @@ void {{classname}}::{{operationIdCamelCase}}Request::SetupHttpRequest(const TSha
 		FString JsonBody;
 		JsonWriter Writer = TJsonWriterFactory<>::Create(&JsonBody);
 
-		Writer->WriteObjectStart();
 		{{#bodyParams}}
 		{{#required}}
-		Writer->WriteIdentifierPrefix(TEXT("{{baseName}}")); WriteJsonValue(Writer, {{paramName}});
+		WriteJsonValue(Writer, {{paramName}});
 		{{/required}}
 		{{^required}}
 		if ({{paramName}}.IsSet())
 		{
-			Writer->WriteIdentifierPrefix(TEXT("{{baseName}}")); WriteJsonValue(Writer, {{paramName}}.GetValue());
+			WriteJsonValue(Writer, {{paramName}}.GetValue());
 		}
 		{{/required}}
 		{{/bodyParams}}
-		Writer->WriteObjectEnd();
 		Writer->Close();
 
 		HttpRequest->SetHeader(TEXT("Content-Type"), TEXT("application/json; charset=utf-8"));
@@ -176,14 +174,14 @@ void {{classname}}::{{operationIdCamelCase}}Request::SetupHttpRequest(const TSha
 		{{#isFile}}
 		FormData.AddFilePart(TEXT("{{baseName}}"), {{paramName}});
 		{{/isFile}}
+		{{^isFile}}
 		{{#isBinary}}
 		FormData.AddBinaryPart(TEXT("{{baseName}}"), {{paramName}});
 		{{/isBinary}}
-		{{#isBinary}}
-		{{^isFile}}
+		{{^isBinary}}
 		FormData.AddStringPart(TEXT("{{baseName}}"), *ToUrlString({{paramName}}));
-		{{/isFile}}
 		{{/isBinary}}
+		{{/isFile}}
 		{{/required}}
 		{{^required}}
 		if({{paramName}}.IsSet())
@@ -191,14 +189,14 @@ void {{classname}}::{{operationIdCamelCase}}Request::SetupHttpRequest(const TSha
 			{{#isFile}}
 			FormData.AddFilePart(TEXT("{{baseName}}"), {{paramName}}.GetValue());
 			{{/isFile}}
+			{{^isFile}}
 			{{#isBinary}}
 			FormData.AddBinaryPart(TEXT("{{baseName}}"), {{paramName}}.GetValue());
 			{{/isBinary}}
 			{{^isBinary}}
-			{{^isFile}}
 			FormData.AddStringPart(TEXT("{{baseName}}"), *ToUrlString({{paramName}}.GetValue()));
-			{{/isFile}}
 			{{/isBinary}}
+			{{/isFile}}
 		}
 		{{/required}}
 		{{/isContainer}}

--- a/samples/client/petstore/ue4cpp/Private/SwaggerPetApiOperations.cpp
+++ b/samples/client/petstore/ue4cpp/Private/SwaggerPetApiOperations.cpp
@@ -42,9 +42,7 @@ void SwaggerPetApi::AddPetRequest::SetupHttpRequest(const TSharedRef<IHttpReques
 		FString JsonBody;
 		JsonWriter Writer = TJsonWriterFactory<>::Create(&JsonBody);
 
-		Writer->WriteObjectStart();
-		Writer->WriteIdentifierPrefix(TEXT("body")); WriteJsonValue(Writer, Body);
-		Writer->WriteObjectEnd();
+		WriteJsonValue(Writer, Body);
 		Writer->Close();
 
 		HttpRequest->SetHeader(TEXT("Content-Type"), TEXT("application/json; charset=utf-8"));
@@ -365,9 +363,7 @@ void SwaggerPetApi::UpdatePetRequest::SetupHttpRequest(const TSharedRef<IHttpReq
 		FString JsonBody;
 		JsonWriter Writer = TJsonWriterFactory<>::Create(&JsonBody);
 
-		Writer->WriteObjectStart();
-		Writer->WriteIdentifierPrefix(TEXT("body")); WriteJsonValue(Writer, Body);
-		Writer->WriteObjectEnd();
+		WriteJsonValue(Writer, Body);
 		Writer->Close();
 
 		HttpRequest->SetHeader(TEXT("Content-Type"), TEXT("application/json; charset=utf-8"));

--- a/samples/client/petstore/ue4cpp/Private/SwaggerStoreApiOperations.cpp
+++ b/samples/client/petstore/ue4cpp/Private/SwaggerStoreApiOperations.cpp
@@ -196,9 +196,7 @@ void SwaggerStoreApi::PlaceOrderRequest::SetupHttpRequest(const TSharedRef<IHttp
 		FString JsonBody;
 		JsonWriter Writer = TJsonWriterFactory<>::Create(&JsonBody);
 
-		Writer->WriteObjectStart();
-		Writer->WriteIdentifierPrefix(TEXT("body")); WriteJsonValue(Writer, Body);
-		Writer->WriteObjectEnd();
+		WriteJsonValue(Writer, Body);
 		Writer->Close();
 
 		HttpRequest->SetHeader(TEXT("Content-Type"), TEXT("application/json; charset=utf-8"));

--- a/samples/client/petstore/ue4cpp/Private/SwaggerUserApiOperations.cpp
+++ b/samples/client/petstore/ue4cpp/Private/SwaggerUserApiOperations.cpp
@@ -42,9 +42,7 @@ void SwaggerUserApi::CreateUserRequest::SetupHttpRequest(const TSharedRef<IHttpR
 		FString JsonBody;
 		JsonWriter Writer = TJsonWriterFactory<>::Create(&JsonBody);
 
-		Writer->WriteObjectStart();
-		Writer->WriteIdentifierPrefix(TEXT("body")); WriteJsonValue(Writer, Body);
-		Writer->WriteObjectEnd();
+		WriteJsonValue(Writer, Body);
 		Writer->Close();
 
 		HttpRequest->SetHeader(TEXT("Content-Type"), TEXT("application/json; charset=utf-8"));
@@ -101,9 +99,7 @@ void SwaggerUserApi::CreateUsersWithArrayInputRequest::SetupHttpRequest(const TS
 		FString JsonBody;
 		JsonWriter Writer = TJsonWriterFactory<>::Create(&JsonBody);
 
-		Writer->WriteObjectStart();
-		Writer->WriteIdentifierPrefix(TEXT("body")); WriteJsonValue(Writer, Body);
-		Writer->WriteObjectEnd();
+		WriteJsonValue(Writer, Body);
 		Writer->Close();
 
 		HttpRequest->SetHeader(TEXT("Content-Type"), TEXT("application/json; charset=utf-8"));
@@ -160,9 +156,7 @@ void SwaggerUserApi::CreateUsersWithListInputRequest::SetupHttpRequest(const TSh
 		FString JsonBody;
 		JsonWriter Writer = TJsonWriterFactory<>::Create(&JsonBody);
 
-		Writer->WriteObjectStart();
-		Writer->WriteIdentifierPrefix(TEXT("body")); WriteJsonValue(Writer, Body);
-		Writer->WriteObjectEnd();
+		WriteJsonValue(Writer, Body);
 		Writer->Close();
 
 		HttpRequest->SetHeader(TEXT("Content-Type"), TEXT("application/json; charset=utf-8"));
@@ -432,9 +426,7 @@ void SwaggerUserApi::UpdateUserRequest::SetupHttpRequest(const TSharedRef<IHttpR
 		FString JsonBody;
 		JsonWriter Writer = TJsonWriterFactory<>::Create(&JsonBody);
 
-		Writer->WriteObjectStart();
-		Writer->WriteIdentifierPrefix(TEXT("body")); WriteJsonValue(Writer, Body);
-		Writer->WriteObjectEnd();
+		WriteJsonValue(Writer, Body);
 		Writer->Close();
 
 		HttpRequest->SetHeader(TEXT("Content-Type"), TEXT("application/json; charset=utf-8"));


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [x] Filed the PR against the correct branch: `3.0.0` branch for changes related to OpenAPI spec 3.0. Default: `master`.
- [x] Copied the [technical committee](https://github.com/swagger-api/swagger-codegen/#swagger-codegen-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

Fixed handling of body parameter, now correctly outputs json without creating an additional enclosing "body" object.
Fixed cases where a file parameter is also marked isBinary.

@HugoMario Here is a fix to the PR you recently approved https://github.com/swagger-api/swagger-codegen/pull/10260
