### PR TITLE
Fix Docs for HeaderSelector

### DIFF
--- a/modules/swagger-codegen/src/main/resources/php/HeaderSelector.mustache
+++ b/modules/swagger-codegen/src/main/resources/php/HeaderSelector.mustache
@@ -1,6 +1,6 @@
 <?php
 /**
- * ApiException
+ * HeaderSelector
  * PHP version 5
  *
  * @category Class
@@ -18,10 +18,8 @@
 
 namespace {{invokerPackage}};
 
-use \Exception;
-
 /**
- * ApiException Class Doc Comment
+ * HeaderSelector Class Doc Comment
  *
  * @category Class
  * @package  {{invokerPackage}}


### PR DESCRIPTION
### PR checklist

- [ x] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [x ] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [x ] Filed the PR against the correct branch: `3.0.0` branch for changes related to OpenAPI spec 3.0. Default: `master`.
- [ ] Copied the [technical committee](https://github.com/swagger-api/swagger-codegen/#swagger-codegen-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR
There is what appears to be some copy paste errors in PHP's HeaderSelector.mustache where the documentation references the ApiException class and there is a stray use that is not used. Seems like a pretty easy and obvious fix.

## Note
I was a little confused by the checklist. I went through it but I didn't include the petstore changes because they seems drastic and unrelated. Let me know if I made a mistake, I'll be happy to fix it.
