### PR TITLE
Fix namespace issues in R

### DIFF
--- a/modules/swagger-codegen/src/main/resources/r/NAMESPACE.mustache
+++ b/modules/swagger-codegen/src/main/resources/r/NAMESPACE.mustache
@@ -6,3 +6,8 @@
 export({{{classname}}})
 {{/model}}
 {{/models}}
+{{#apiInfo}}
+{{#apis}}
+export({{{classname}}})
+{{/apis}}
+{{/apiInfo}}


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [x] Filed the PR against the correct branch: `3.0.0` branch for changes related to OpenAPI spec 3.0. Default: `master`.
- [ ] Copied the [technical committee](https://github.com/swagger-api/swagger-codegen/#swagger-codegen-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

This PR adds missing namespace modules that are required to properly use the API.

Relates to follwing issue:
https://github.com/swagger-api/swagger-codegen/issues/8607
