### PR TITLE
Fix for string list parameter code generation

### DIFF
--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/DefaultCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/DefaultCodegen.java
@@ -2726,7 +2726,7 @@ public class DefaultCodegen {
                     innerCp = innerCp.items;
                 }
 
-                p.items = cp;
+                p.items = cp.items;
                 p.dataType = cp.datatype;
                 p.baseType = cp.complexType;
                 p.isPrimitiveType = cp.isPrimitiveType;


### PR DESCRIPTION
### PR checklist

- [ ] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [ ] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [ ] Filed the PR against the correct branch: `3.0.0` branch for changes related to OpenAPI spec 3.0. Default: `master`.
- [ ] Copied the [technical committee](https://github.com/swagger-api/swagger-codegen/#swagger-codegen-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

Proposed change fixes code generated for the following sample parameter declaration:
```
"parameters": [
    {
        "name": "payload",
        "required": true,
        "in": "body",
        "schema": {
            "type": "array",
            "items": {
                "type": "string",
                "description": "Key"
            }
        }
    }
]
```

API code generated prior to fix:
```
for( auto& item : payload )
{
    jsonArray.push_back( item.get() ? item->toJson() : web::json::value::null() );
}
```

Fixed API code:
```
for( auto& item : payload )
{
    jsonArray.push_back(ModelBase::toJson(item));
}
```