### PR TITLE
fix(java): use correct dependency for spring-cloud openfeign [10318]

### DIFF
--- a/modules/swagger-codegen/src/main/resources/JavaSpring/libraries/spring-cloud/pom.mustache
+++ b/modules/swagger-codegen/src/main/resources/JavaSpring/libraries/spring-cloud/pom.mustache
@@ -10,6 +10,9 @@
         <maven.compiler.source>${java.version}</maven.compiler.source>
         <maven.compiler.target>${java.version}</maven.compiler.target>
         <swagger-core-version>1.5.18</swagger-core-version>
+        {{#isOpenFeign}}
+        <spring-cloud-starter-openfeign-version>2.2.3.RELEASE</spring-cloud-starter-openfeign-version>
+        {{/isOpenFeign}}
     </properties>
     <parent>
         <groupId>org.springframework.boot</groupId>
@@ -38,10 +41,19 @@
             <artifactId>swagger-annotations</artifactId>
             <version>${swagger-core-version}</version>
         </dependency>
+        {{^isOpenFeign}}
         <dependency>
             <groupId>org.springframework.cloud</groupId>
             <artifactId>spring-cloud-starter-feign</artifactId>
         </dependency>
+        {{/isOpenFeign}}
+        {{#isOpenFeign}}
+        <dependency>
+            <groupId>org.springframework.cloud</groupId>
+            <artifactId>spring-cloud-starter-openfeign</artifactId>
+            <version>${spring-cloud-starter-openfeign-version}</version>
+        </dependency>
+        {{/isOpenFeign}}
         <dependency>
             <groupId>org.springframework.cloud</groupId>
             <artifactId>spring-cloud-security</artifactId>


### PR DESCRIPTION
### Description of the PR

Fix for Issue https://github.com/swagger-api/swagger-codegen/issues/10318

the dependency `spring-cloud-starter-feign` was being used instead of `spring-cloud-starter-openfeign` when trying to autogen a client with openfeign.

This update will utilize the `isOpenFeign` boolean to include the correct dependency for openfeign