### PR TITLE
package.mustache - update mocha >= 8.0.1

### DIFF
--- a/modules/swagger-codegen/src/main/resources/Javascript/package.mustache
+++ b/modules/swagger-codegen/src/main/resources/Javascript/package.mustache
@@ -15,7 +15,7 @@
     "querystring": "0.2.0"
   },
   "devDependencies": {
-    "mocha": "~2.3.4",
+    "mocha": "^8.0.1",
     "sinon": "1.17.3",
     "expect.js": "~0.3.1"{{#loadTestDataFromFile}},
     "json-pointer": "0.6.0"{{/loadTestDataFromFile}}


### PR DESCRIPTION
mocha 2.3.4 contains multiple vulnerabilities.

### PR checklist

- [X] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [ ] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [X] Filed the PR against the correct branch: `3.0.0` branch for changes related to OpenAPI spec 3.0. Default: `master`.
- [ ] Copied the [technical committee](https://github.com/swagger-api/swagger-codegen/#swagger-codegen-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

*mocha* 2.3.4 exposes multiple vulnerabilities as shown by `npm audit`, so I propose an upgrade to a more recent version which addresses them.