### PR TITLE
refactor: Remove unused codes and ADD @Override code

### DIFF
--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/DefaultGenerator.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/DefaultGenerator.java
@@ -3,7 +3,6 @@ package io.swagger.codegen;
 import com.samskivert.mustache.Mustache;
 import com.samskivert.mustache.Template;
 import io.swagger.codegen.ignore.CodegenIgnoreProcessor;
-import io.swagger.codegen.languages.AbstractJavaCodegen;
 import io.swagger.codegen.utils.ImplementationVersion;
 import io.swagger.models.*;
 import io.swagger.models.auth.OAuth2Definition;

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/SpringCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/SpringCodegen.java
@@ -122,7 +122,7 @@ public class SpringCodegen extends AbstractJavaCodegen
 
         // Process java8 option before common java ones to change the default dateLibrary to java8.
         if (additionalProperties.containsKey(JAVA_8)) {
-            this.setJava8(Boolean.valueOf(additionalProperties.get(JAVA_8).toString()));
+            this.setJava8(Boolean.parseBoolean(additionalProperties.get(JAVA_8).toString()));
         }
         if (this.java8) {
             additionalProperties.put("javaVersion", "1.8");
@@ -160,23 +160,23 @@ public class SpringCodegen extends AbstractJavaCodegen
         }
 
         if (additionalProperties.containsKey(INTERFACE_ONLY)) {
-            this.setInterfaceOnly(Boolean.valueOf(additionalProperties.get(INTERFACE_ONLY).toString()));
+            this.setInterfaceOnly(Boolean.parseBoolean(additionalProperties.get(INTERFACE_ONLY).toString()));
         }
 
         if (additionalProperties.containsKey(DELEGATE_PATTERN)) {
-            this.setDelegatePattern(Boolean.valueOf(additionalProperties.get(DELEGATE_PATTERN).toString()));
+            this.setDelegatePattern(Boolean.parseBoolean(additionalProperties.get(DELEGATE_PATTERN).toString()));
         }
 
         if (additionalProperties.containsKey(SINGLE_CONTENT_TYPES)) {
-            this.setSingleContentTypes(Boolean.valueOf(additionalProperties.get(SINGLE_CONTENT_TYPES).toString()));
+            this.setSingleContentTypes(Boolean.parseBoolean(additionalProperties.get(SINGLE_CONTENT_TYPES).toString()));
         }
 
         if (additionalProperties.containsKey(JAVA_8)) {
-            this.setJava8(Boolean.valueOf(additionalProperties.get(JAVA_8).toString()));
+            this.setJava8(Boolean.parseBoolean(additionalProperties.get(JAVA_8).toString()));
         }
 
         if (additionalProperties.containsKey(ASYNC)) {
-            this.setAsync(Boolean.valueOf(additionalProperties.get(ASYNC).toString()));
+            this.setAsync(Boolean.parseBoolean(additionalProperties.get(ASYNC).toString()));
         }
 
         if (additionalProperties.containsKey(RESPONSE_WRAPPER)) {
@@ -184,7 +184,7 @@ public class SpringCodegen extends AbstractJavaCodegen
         }
 
         if (additionalProperties.containsKey(USE_TAGS)) {
-            this.setUseTags(Boolean.valueOf(additionalProperties.get(USE_TAGS).toString()));
+            this.setUseTags(Boolean.parseBoolean(additionalProperties.get(USE_TAGS).toString()));
         }
 
         if (additionalProperties.containsKey(USE_BEANVALIDATION)) {
@@ -209,11 +209,11 @@ public class SpringCodegen extends AbstractJavaCodegen
         }
 
         if (additionalProperties.containsKey(IMPLICIT_HEADERS)) {
-            this.setImplicitHeaders(Boolean.valueOf(additionalProperties.get(IMPLICIT_HEADERS).toString()));
+            this.setImplicitHeaders(Boolean.parseBoolean(additionalProperties.get(IMPLICIT_HEADERS).toString()));
         }
 
         if (additionalProperties.containsKey(SWAGGER_DOCKET_CONFIG)) {
-            this.setSwaggerDocketConfig(Boolean.valueOf(additionalProperties.get(SWAGGER_DOCKET_CONFIG).toString()));
+            this.setSwaggerDocketConfig(Boolean.parseBoolean(additionalProperties.get(SWAGGER_DOCKET_CONFIG).toString()));
         }
 
         typeMapping.put("file", "Resource");
@@ -669,7 +669,7 @@ public class SpringCodegen extends AbstractJavaCodegen
         }
 
         //Add imports for Jackson
-        if (!Boolean.TRUE.equals(model.isEnum)) {
+        if (Boolean.FALSE.equals(model.isEnum)) {
             model.imports.add("JsonProperty");
 
             if (Boolean.TRUE.equals(model.hasEnums)) {
@@ -705,6 +705,7 @@ public class SpringCodegen extends AbstractJavaCodegen
         return objs;
     }
 
+    @Override
     public void setUseBeanValidation(boolean useBeanValidation) {
         this.useBeanValidation = useBeanValidation;
     }

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/features/BeanValidationFeatures.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/features/BeanValidationFeatures.java
@@ -3,8 +3,8 @@ package io.swagger.codegen.languages.features;
 public interface BeanValidationFeatures {
 
     // Language supports generating BeanValidation-Annotations
-    public static final String USE_BEANVALIDATION = "useBeanValidation";
+    String USE_BEANVALIDATION = "useBeanValidation";
 
-    public void setUseBeanValidation(boolean useBeanValidation);
+    void setUseBeanValidation(boolean useBeanValidation);
     
 }

--- a/modules/swagger-codegen/src/main/resources/codegen/generatorClass.mustache
+++ b/modules/swagger-codegen/src/main/resources/codegen/generatorClass.mustache
@@ -134,6 +134,7 @@ public class {{generatorClass}} extends DefaultCodegen implements CodegenConfig 
    * Location to write model files.  You can use the modelPackage() as defined when the class is
    * instantiated
    */
+  @Override
   public String modelFileFolder() {
     return outputFolder + "/" + sourceFolder + "/" + modelPackage().replace('.', File.separatorChar);
   }


### PR DESCRIPTION
#9786 # PR checklist

- [ ] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [ ] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [ ] Filed the PR against the correct branch: `3.0.0` branch for changes related to OpenAPI spec 3.0. Default: `master`.
- [ ] Copied the [technical committee](https://github.com/swagger-api/swagger-codegen/#swagger-codegen-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

- Change `Boolean.valueOf` to `Boolean.parseBoolean` in SpringCodegen
https://stackoverflow.com/questions/12044721/best-performance-for-string-to-boolean-conversion

- Add @Override in SpringCodegen.setUseBeanValidation, generatorClass.mustache > modelFileFolder
- Remove unused IMPORT AbstractJavaCodegen in DefaultGenerator.java
