### PR TITLE
Fix details about template engine and location

### DIFF
--- a/README.md
+++ b/README.md
@@ -441,9 +441,9 @@ Other languages have petstore samples, too:
 It's just as easy--just use the `-i` flag to point to either a server or file.
 
 ### Modifying the client library format
-Don't like the default swagger client syntax?  Want a different language supported?  No problem!  Swagger Codegen processes mustache templates with the [jmustache](https://github.com/samskivert/jmustache) engine.  You can modify our templates or make your own.
+Don't like the default swagger client syntax?  Want a different language supported?  No problem!  Swagger Codegen processes handlebar templates with the [Handlebars.java](https://github.com/jknack/handlebars.java) engine.  You can modify our templates or make your own.
 
-You can look at `modules/swagger-codegen/src/main/resources/${your-language}` for examples.  To make your own templates, create your own files and use the `-t` flag to specify your template folder.  It actually is that easy.
+You can look at [swagger-codegen-generators](https://github.com/swagger-api/swagger-codegen-generators/tree/master/src/main/resources/handlebars) for examples.  To make your own templates, create your own files and use the `-t` flag to specify your template folder.  It actually is that easy.
 
 ### Making your own codegen modules
 If you're starting a project with a new language and don't see what you need, Swagger Codegen can help you create a project to generate your own libraries:


### PR DESCRIPTION
The previous template engine `mustache` and file location don't apply for version 3.

