### PR TITLE
added to option to write csproj file in output code for csharpDorNet2…

### DIFF
--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/CsharpDotNet2ClientCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/CsharpDotNet2ClientCodegen.java
@@ -9,6 +9,7 @@ import java.io.File;
 
 public class CsharpDotNet2ClientCodegen extends AbstractCSharpCodegen {
     public static final String CLIENT_PACKAGE = "clientPackage";
+    public static final String USE_CSPROJ_FILE = "useCsProjFile";
     protected String clientPackage = "IO.Swagger.Client";
     protected String apiDocPath = "docs/";
     protected String modelDocPath = "docs/";
@@ -68,6 +69,9 @@ public class CsharpDotNet2ClientCodegen extends AbstractCSharpCodegen {
         supportingFiles.add(new SupportingFile("packages.config.mustache", "vendor", "packages.config"));
         supportingFiles.add(new SupportingFile("compile-mono.sh.mustache", "", "compile-mono.sh"));
         supportingFiles.add(new SupportingFile("README.mustache", "", "README.md"));
+        if (additionalProperties.containsKey(USE_CSPROJ_FILE) && Boolean.parseBoolean(additionalProperties.get(USE_CSPROJ_FILE).toString())) {
+            supportingFiles.add(new SupportingFile("csproj.mustache", "", clientPackage + ".csproj"));
+        }
 
     }
 

--- a/modules/swagger-codegen/src/main/resources/csharp-dotnet2/csproj.mustache
+++ b/modules/swagger-codegen/src/main/resources/csharp-dotnet2/csproj.mustache
@@ -1,0 +1,23 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+    <RootNamespace>{{clientPackage}}</RootNamespace>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <!-- Nuget Package Metadata -->
+    <PackageId>{{packageName}}</PackageId>
+    <PackageVersion>{{packageVersion}}</PackageVersion>
+    <Authors>{{packageAuthors}}</Authors>
+    <Owners>{{packageCompany}}</Owners>
+    <Title>{{packageTitle}}</Title>
+    <Description>{{packageDescription}}</Description>
+    <Copyright>{{packageCopyright}}</Copyright>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Newtonsoft.Json" Version="12.0.1" />
+    <PackageReference Include="RestSharp" Version="105.0.1" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
… generator

### PR checklist

- [x] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [x] Filed the PR against the correct branch: `3.0.0` branch for changes related to OpenAPI spec 3.0. Default: `master`.
- [x] Copied the [technical committee](https://github.com/swagger-api/swagger-codegen/#swagger-codegen-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

fixes #8334 