### PR TITLE
added parent if it was not assigned by parser on allOf composed model

### DIFF
--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/DefaultCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/DefaultCodegen.java
@@ -1398,6 +1398,12 @@ public class DefaultCodegen {
             List<String> required = new ArrayList<String>();
             Map<String, Property> allProperties;
             List<String> allRequired;
+
+            List<Model> allComponents = composed.getAllOf();
+            if (allComponents.size() > 0 && composed.getParent() == null) {
+                composed.setParent(allComponents.get(0));
+            }
+
             if (supportsInheritance || supportsMixins) {
                 allProperties = new LinkedHashMap<String, Property>();
                 allRequired = new ArrayList<String>();

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/DefaultCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/DefaultCodegen.java
@@ -1401,7 +1401,7 @@ public class DefaultCodegen {
 
             List<Model> allComponents = composed.getAllOf();
             if (allComponents.size() > 0 && composed.getParent() == null) {
-                composed.setParent(allComponents.get(0));
+                rebuildComponents(composed);
             }
 
             if (supportsInheritance || supportsMixins) {
@@ -1538,6 +1538,30 @@ public class DefaultCodegen {
             }
         }
         return m;
+    }
+
+    private void rebuildComponents(ComposedModel composedModel) {
+        List<Model> allComponents = composedModel.getAllOf();
+        if (allComponents.size() >= 1) {
+            composedModel.setParent(allComponents.get(0));
+            if (allComponents.size() >= 2) {
+                composedModel.setChild(allComponents.get(allComponents.size() - 1));
+                List<RefModel> interfaces = new ArrayList();
+                int size = allComponents.size();
+                Iterator modelIterator = allComponents.subList(1, size - 1).iterator();
+
+                while(modelIterator.hasNext()) {
+                    Model model = (Model)modelIterator.next();
+                    if (model instanceof RefModel) {
+                        RefModel ref = (RefModel)model;
+                        interfaces.add(ref);
+                    }
+                }
+                composedModel.setInterfaces(interfaces);
+            } else {
+                composedModel.setChild(new ModelImpl());
+            }
+        }
     }
 
     /**

--- a/modules/swagger-codegen/src/test/java/io/swagger/codegen/CodegenTest.java
+++ b/modules/swagger-codegen/src/test/java/io/swagger/codegen/CodegenTest.java
@@ -26,7 +26,7 @@ public class CodegenTest {
         Assert.assertEquals(composed.vars.get(0).baseName, "modelOneProp");
         Assert.assertEquals(composed.vars.get(1).baseName, "properties");
         Assert.assertEquals(composed.vars.get(2).baseName, "zones");
-        Assert.assertNull(composed.parent);
+        Assert.assertNotNull(composed.parent);
     }
 
     @Test(description = "test sanitizeTag")
@@ -267,11 +267,10 @@ public class CodegenTest {
         final Model model = swagger.getDefinitions().get("SimpleComposition");
         CodegenModel composed = codegen.fromModel("SimpleComposition", model, swagger.getDefinitions());
 
-        Assert.assertEquals(composed.vars.size(), 3);
-        Assert.assertEquals(composed.vars.get(0).baseName, "modelOneProp");
-        Assert.assertEquals(composed.vars.get(1).baseName, "modelTwoProp");
-        Assert.assertEquals(composed.vars.get(2).baseName, "simpleCompositionProp");
-        Assert.assertNull(composed.parent);
+        Assert.assertEquals(composed.vars.size(), 2);
+        Assert.assertEquals(composed.vars.get(0).baseName, "modelTwoProp");
+        Assert.assertEquals(composed.vars.get(1).baseName, "simpleCompositionProp");
+        Assert.assertNotNull(composed.parent);
     }
 
     @Test(description = "handle multi level composition")
@@ -282,13 +281,10 @@ public class CodegenTest {
         final Model model = swagger.getDefinitions().get("CompositionOfSimpleComposition");
         CodegenModel composed = codegen.fromModel("CompositionOfSimpleComposition", model, swagger.getDefinitions());
 
-        Assert.assertEquals(composed.vars.size(), 5);
-        Assert.assertEquals(composed.vars.get(0).baseName, "modelOneProp");
-        Assert.assertEquals(composed.vars.get(1).baseName, "modelTwoProp");
-        Assert.assertEquals(composed.vars.get(2).baseName, "simpleCompositionProp");
-        Assert.assertEquals(composed.vars.get(3).baseName, "modelThreeProp");
-        Assert.assertEquals(composed.vars.get(4).baseName, "compositionOfSimpleCompositionProp");
-        Assert.assertNull(composed.parent);
+        Assert.assertEquals(composed.vars.size(), 2);
+        Assert.assertEquals(composed.vars.get(0).baseName, "modelThreeProp");
+        Assert.assertEquals(composed.vars.get(1).baseName, "compositionOfSimpleCompositionProp");
+        Assert.assertNotNull(composed.parent);
     }
 
     @Test(description = "handle simple inheritance")
@@ -299,10 +295,11 @@ public class CodegenTest {
         final Model model = swagger.getDefinitions().get("ChildOfSimpleParent");
         CodegenModel child = codegen.fromModel("ChildOfSimpleParent", model, swagger.getDefinitions());
 
-        Assert.assertEquals(child.vars.size(), 2);
-        Assert.assertEquals(child.vars.get(0).baseName, "modelOneProp");
-        Assert.assertEquals(child.vars.get(1).baseName, "childOfSimpleParentProp");
-        Assert.assertEquals(child.parent, "SimpleParent");
+        Assert.assertEquals(child.vars.size(), 3);
+        Assert.assertEquals(child.vars.get(0).baseName, "disc");
+        Assert.assertEquals(child.vars.get(1).baseName, "simpleParentProp");
+        Assert.assertEquals(child.vars.get(2).baseName, "childOfSimpleParentProp");
+        Assert.assertEquals(child.parent, "ModelOne");
     }
 
     @Test(description = "handle multi level inheritance")


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [x] Filed the PR against the correct branch: `3.0.0` branch for changes related to OpenAPI spec 3.0. Default: `master`.
- [x] Copied the [technical committee](https://github.com/swagger-api/swagger-codegen/#swagger-codegen-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

fixed #9693 

