### PR TITLE
added validation check for the config help command

### DIFF
--- a/modules/swagger-codegen-cli/src/main/java/io/swagger/codegen/v3/cli/cmd/ConfigHelp.java
+++ b/modules/swagger-codegen-cli/src/main/java/io/swagger/codegen/v3/cli/cmd/ConfigHelp.java
@@ -3,6 +3,7 @@ package io.swagger.codegen.v3.cli.cmd;
 import io.swagger.codegen.v3.CliOption;
 import io.swagger.codegen.v3.CodegenConfig;
 import io.swagger.codegen.v3.CodegenConfigLoader;
+import org.apache.commons.lang3.Validate;
 
 public class ConfigHelp implements Runnable {
     private String lang;
@@ -13,6 +14,8 @@ public class ConfigHelp implements Runnable {
 
     @Override
     public void run() {
+        Validate.notEmpty(lang, "language must be specified");
+
         System.out.println();
         CodegenConfig config = CodegenConfigLoader.forName(lang);
         System.out.println("CONFIG OPTIONS");


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [ ] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [x] Filed the PR against the correct branch: `3.0.0` branch for changes related to OpenAPI spec 3.0. Default: `master`.
- [ ] Copied the [technical committee](https://github.com/swagger-api/swagger-codegen/#swagger-codegen-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

A simple validation to prevent the CLI from crashing. No lang specific changes.

