### PR TITLE
Update pojo.mustache

### DIFF
--- a/modules/swagger-codegen/src/main/resources/Java/pojo.mustache
+++ b/modules/swagger-codegen/src/main/resources/Java/pojo.mustache
@@ -146,7 +146,7 @@ public class {{classname}} {{#parent}}extends {{{parent}}} {{/parent}}{{#parcela
 {{#vendorExtensions.extraAnnotation}}
   {{{vendorExtensions.extraAnnotation}}}
 {{/vendorExtensions.extraAnnotation}}
-  public {{{datatypeWithEnum}}} {{#isBoolean}}is{{/isBoolean}}{{getter}}() {
+  public {{{datatypeWithEnum}}} {{#isBoolean}}is{{#lambda.titlecase}}{{name}}{{/lambda.titlecase}}{{/isBoolean}}{{^isBoolean}}{{getter}}{{/isBoolean}}() {
     return {{name}};
   }
   {{^isReadOnly}}


### PR DESCRIPTION
this is a fix for the java pojo gen with Boolean...
The problem was taht getter for Boolean become isgetVariableName(), with proposed change it will be for Boolean isVariableName() and for not Boolean getVariableName()

There maybe the case for get or is for Boolean values... the solution would be to seperate both based on the boolean flag ie:

public {{{datatypeWithEnum}}} {{getter}}() {
    return {{name}};
  }
followed by:
{{#isBoolean}}
public {{{datatypeWithEnum}}} is{{#lambda.titlecase}}{{name}}{{/lambda.titlecase}}() {
    return {{name}};
  }
{{/isBoolean}}

### PR checklist

- [ ] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [ ] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [ ] Filed the PR against the correct branch: `3.0.0` branch for changes related to OpenAPI spec 3.0. Default: `master`.
- [ ] Copied the [technical committee](https://github.com/swagger-api/swagger-codegen/#swagger-codegen-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

(details of the change, additional tests that have been done, reference to the issue for tracking, etc)

