### PR TITLE
[Documentation] Use HTTPS for petstore urls

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,7 +236,7 @@ To install, run `brew install swagger-codegen`
 
 Here is an example usage:
 ```sh
-swagger-codegen generate -i http://petstore.swagger.io/v2/swagger.json -l ruby -o /tmp/test/
+swagger-codegen generate -i https://petstore.swagger.io/v2/swagger.json -l ruby -o /tmp/test/
 ```
 
 ### Docker
@@ -301,7 +301,7 @@ sleep 5
 GEN_IP=$(docker inspect --format '{{.NetworkSettings.IPAddress}}'  $CID)
 # Execute an HTTP request and store the download link
 RESULT=$(curl -X POST --header 'Content-Type: application/json' --header 'Accept: application/json' -d '{
-  "swaggerUrl": "http://petstore.swagger.io/v2/swagger.json"
+  "swaggerUrl": "https://petstore.swagger.io/v2/swagger.json"
 }' 'http://localhost:8188/api/gen/clients/javascript' | jq '.link' | tr -d '"')
 # Download the generated zip and redirect to a file
 curl $RESULT > result.zip
@@ -321,7 +321,7 @@ Example:
 
 ```sh
 docker run --rm -v ${PWD}:/local swaggerapi/swagger-codegen-cli generate \
-    -i http://petstore.swagger.io/v2/swagger.json \
+    -i https://petstore.swagger.io/v2/swagger.json \
     -l go \
     -o /local/out/go
 ```
@@ -332,17 +332,17 @@ The generated code will be located under `./out/go` in the current directory.
 
 ## Getting Started
 
-To generate a PHP client for http://petstore.swagger.io/v2/swagger.json, please run the following
+To generate a PHP client for https://petstore.swagger.io/v2/swagger.json, please run the following
 ```sh
 git clone https://github.com/swagger-api/swagger-codegen
 cd swagger-codegen
 mvn clean package
 java -jar modules/swagger-codegen-cli/target/swagger-codegen-cli.jar generate \
-   -i http://petstore.swagger.io/v2/swagger.json \
+   -i https://petstore.swagger.io/v2/swagger.json \
    -l php \
    -o /var/tmp/php_api_client
 ```
-(if you're on Windows, replace the last command with `java -jar modules\swagger-codegen-cli\target\swagger-codegen-cli.jar generate -i http://petstore.swagger.io/v2/swagger.json -l php -o c:\temp\php_api_client`)
+(if you're on Windows, replace the last command with `java -jar modules\swagger-codegen-cli\target\swagger-codegen-cli.jar generate -i https://petstore.swagger.io/v2/swagger.json -l php -o c:\temp\php_api_client`)
 
 You can also download the JAR (latest release) directly from [maven.org](https://repo1.maven.org/maven2/io/swagger/swagger-codegen-cli/2.4.15/swagger-codegen-cli-2.4.15.jar)
 
@@ -353,7 +353,7 @@ To get a list of PHP specified options (which can be passed to the generator wit
 ## Generators
 
 ### To generate a sample client library
-You can build a client against the swagger sample [petstore](http://petstore.swagger.io) API as follows:
+You can build a client against the swagger sample [petstore](https://petstore.swagger.io) API as follows:
 
 ```sh
 ./bin/java-petstore.sh
@@ -365,7 +365,7 @@ This will run the generator with this command:
 
 ```sh
 java -jar modules/swagger-codegen-cli/target/swagger-codegen-cli.jar generate \
-  -i http://petstore.swagger.io/v2/swagger.json \
+  -i https://petstore.swagger.io/v2/swagger.json \
   -l java \
   -o samples/client/petstore/java
 ```
@@ -463,7 +463,7 @@ Note the `myClientCodegen` is an option now, and you can use the usual arguments
 ```sh
 java -cp output/myLibrary/target/myClientCodegen-swagger-codegen-1.0.0.jar:modules/swagger-codegen-cli/target/swagger-codegen-cli.jar \
   io.swagger.codegen.SwaggerCodegen generate -l myClientCodegen\
-  -i http://petstore.swagger.io/v2/swagger.json \
+  -i https://petstore.swagger.io/v2/swagger.json \
   -o myClient
 ```
 
@@ -595,7 +595,7 @@ Each of these files creates reasonable defaults so you can get running quickly. 
 
 ```sh
 java -jar modules/swagger-codegen-cli/target/swagger-codegen-cli.jar generate \
-  -i http://petstore.swagger.io/v2/swagger.json \
+  -i https://petstore.swagger.io/v2/swagger.json \
   -l java \
   -o samples/client/petstore/java \
   -c path/to/config.json
@@ -699,7 +699,7 @@ or
 
 You have options.  The easiest is to use our [online validator](https://github.com/swagger-api/validator-badge) which not only will let you validate your spec, but with the debug flag, you can see what's wrong with your spec.  For example:
 
-http://online.swagger.io/validator/debug?url=http://petstore.swagger.io/v2/swagger.json
+http://online.swagger.io/validator/debug?url=https://petstore.swagger.io/v2/swagger.json
 
 ### Generating dynamic html api documentation
 
@@ -775,7 +775,7 @@ One can also generate API client or server using the online generators (https://
 
 For example, to generate Ruby API client, simply send the following HTTP request using curl:
 ```sh
-curl -X POST -H "content-type:application/json" -d '{"swaggerUrl":"http://petstore.swagger.io/v2/swagger.json"}' https://generator.swagger.io/api/gen/clients/ruby
+curl -X POST -H "content-type:application/json" -d '{"swaggerUrl":"https://petstore.swagger.io/v2/swagger.json"}' https://generator.swagger.io/api/gen/clients/ruby
 ```
 Then you will receive a JSON response with the URL to download the zipped code.
 
@@ -783,7 +783,7 @@ To customize the SDK, you can `POST` to `https://generator.swagger.io/gen/client
 ```json
 {
   "options": {},
-  "swaggerUrl": "http://petstore.swagger.io/v2/swagger.json"
+  "swaggerUrl": "https://petstore.swagger.io/v2/swagger.json"
 }
 ```
 in which the `options` for a language can be obtained by submitting a `GET` request to `https://generator.swagger.io/api/gen/clients/{language}`:
@@ -817,12 +817,12 @@ To set package name to `pet_store`, the HTTP body of the request is as follows:
   "options": {
     "packageName": "pet_store"
   },
-  "swaggerUrl": "http://petstore.swagger.io/v2/swagger.json"
+  "swaggerUrl": "https://petstore.swagger.io/v2/swagger.json"
 }
 ```
 and here is the curl command:
 ```sh
-curl -H "Content-type: application/json" -X POST -d '{"options": {"packageName": "pet_store"},"swaggerUrl": "http://petstore.swagger.io/v2/swagger.json"}' https://generator.swagger.io/api/gen/clients/python
+curl -H "Content-type: application/json" -X POST -d '{"options": {"packageName": "pet_store"},"swaggerUrl": "https://petstore.swagger.io/v2/swagger.json"}' https://generator.swagger.io/api/gen/clients/python
 ```
 
 Instead of using `swaggerUrl` with an URL to the OpenAPI/Swagger spec, one can include the spec in the JSON payload with `spec`, e.g.


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [ ] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [x] Filed the PR against the correct branch: `3.0.0` branch for changes related to OpenAPI spec 3.0. Default: `master`.
- [ ] Copied the [technical committee](https://github.com/swagger-api/swagger-codegen/#swagger-codegen-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

The URLs for the petstore in the `README.md` were using HTTP instead of HTTPS. Currently, if we try to access [http://petstore.swagger.io/v2/swagger.json](https://petstore.swagger.io/v2/swagger.json) we got a 302 to be redirected to the HTTPS version.

This may cause some issue, for example:
```
docker run --rm -v ${PWD}:/local swaggerapi/swagger-codegen-cli generate \
    -i http://petstore.swagger.io/v2/swagger.json \
    -l go \
    -o /local/out/go
```

Will return:
```
[main] INFO io.swagger.parser.Swagger20Parser - reading from http://petstore.swagger.io/v2/swagger.json
[main] INFO io.swagger.parser.Swagger20Parser - reading from http://petstore.swagger.io/v2/swagger.json
[main] ERROR io.swagger.parser.SwaggerCompatConverter - failed to read resource listing
com.fasterxml.jackson.core.JsonParseException: Unexpected character ('<' (code 60)): expected a valid value (JSON String, Number, Array, Object or token 'null', 'true' or 'false')
 at [Source: (String)"<html>
<head><title>302 Found</title></head>
<body bgcolor="white">
<center><h1>302 Found</h1></center>
</body>
</html>
"; line: 1, column: 2]
	at com.fasterxml.jackson.core.JsonParser._constructError(JsonParser.java:1840)
	at com.fasterxml.jackson.core.base.ParserMinimalBase._reportError(ParserMinimalBase.java:712)
	at com.fasterxml.jackson.core.base.ParserMinimalBase._reportUnexpectedChar(ParserMinimalBase.java:637)
	at com.fasterxml.jackson.core.json.ReaderBasedJsonParser._handleOddValue(ReaderBasedJsonParser.java:1917)
	at com.fasterxml.jackson.core.json.ReaderBasedJsonParser.nextToken(ReaderBasedJsonParser.java:773)
	at com.fasterxml.jackson.databind.ObjectMapper._readTreeAndClose(ObjectMapper.java:4231)
	at com.fasterxml.jackson.databind.ObjectMapper.readTree(ObjectMapper.java:2711)
	at io.swagger.parser.SwaggerCompatConverter.readResourceListing(SwaggerCompatConverter.java:194)
	at io.swagger.parser.SwaggerCompatConverter.read(SwaggerCompatConverter.java:123)
	at io.swagger.parser.SwaggerParser.read(SwaggerParser.java:83)
	at io.swagger.codegen.config.CodegenConfigurator.toClientOptInput(CodegenConfigurator.java:437)
	at io.swagger.codegen.cmd.Generate.run(Generate.java:297)
	at io.swagger.codegen.SwaggerCodegen.main(SwaggerCodegen.java:35)
[main] INFO io.swagger.codegen.ignore.CodegenIgnoreProcessor - No .swagger-codegen-ignore file found.
Exception in thread "main" java.lang.RuntimeException: missing swagger input or config!
	at io.swagger.codegen.DefaultGenerator.generate(DefaultGenerator.java:763)
	at io.swagger.codegen.cmd.Generate.run(Generate.java:299)
	at io.swagger.codegen.SwaggerCodegen.main(SwaggerCodegen.java:35)
```
Because there is a 302 redirect.