### PR TITLE
Update README.md: typo fixed, version 3.X vs 2.X

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ dependency example:
 
 ### Swagger Codegen 3.X ([`3.0.0` branch](https://github.com/swagger-api/swagger-codegen/tree/3.0.0))
 
-Swagger Codegen 2.X supports OpenAPI version 3 (and version 2 via spec conversion to version 3)
+Swagger Codegen 3.X supports OpenAPI version 3 (and version 2 via spec conversion to version 3)
 [Online generator of version 3.X](https://github.com/swagger-api/swagger-codegen/tree/3.0.0#online-generators) supports both generation from Swagger/OpenAPI version 2 (by using engine + generators of 2.X) and version 3 specifications.
 
 group id: `io.swagger.codegen.v3`


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [ ] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [x] Filed the PR against the correct branch: `3.0.0` branch for changes related to OpenAPI spec 3.0. Default: `master`.
- [ ] Copied the [technical committee](https://github.com/swagger-api/swagger-codegen/#swagger-codegen-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

#### Swagger Codegen 3.X content should start with:
_Swagger Codegen **3.X** supports OpenAPI version 3_
not:
_Swagger Codegen **2.X** supports OpenAPI version 3_ 

