### PR TITLE
Add additional option descriptions to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -376,9 +376,9 @@ This will run the generator with this command:
 
 ```sh
 java -jar modules/swagger-codegen-cli/target/swagger-codegen-cli.jar generate \
-  -i http://petstore.swagger.io/v2/swagger.json \
-  -l java \
-  -o samples/client/petstore/java
+  -i http://petstore.swagger.io/v2/swagger.json \                               # The location of the Swagger specifcation file (JSON/YAML).
+  -l java \                                                                     # The desired language for the library.
+  -o samples/client/petstore/java                                               # The output destination.
 ```
 
 with a number of options. You can get the options with the `generate --help` command (below only shows partal results):


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [x] Filed the PR against the correct branch: `3.0.0` branch for changes related to OpenAPI spec 3.0. Default: `master`.
- [x] Copied the [technical committee](https://github.com/swagger-api/swagger-codegen/#swagger-codegen-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

I recently had a consumer of my API reach out and ask, "The Swagger docs indicate that we’ll need a swagger.json file to build the library. I haven’t been able to find a  specific one for your api, just the example on the Swagger repo. So unless that’s forthcoming with the API creds, I might need to be pointed in the right direction." My team uses YAML for our specification file. This question ended up taking a bit of back and forth to discover what the consumer meant because we don't have a 'swagger.json' file we have a YAML file.

My proposal is to add some comments to the generate command for the pet store example to describe the different options that are being passed. The goal being to call out that the http://petstore.swagger.io/v2/swagger.json file is the specification file so that if a situation similar to mine happens again the consumer would ask where the specification file was instead of asking where the swagger.json file is. Additionally I noted that the specification file could be JSON or YAML.

I don't know that this is the best way to convey the additional information, but it was my attempt to solve my minor problem.

Related Issue: https://github.com/swagger-api/swagger-codegen/issues/10507

