### PR TITLE
Fixed outer enum issue on jaxrs-resteasy and jaxrs-resteasy-eap

### DIFF
--- a/modules/swagger-codegen/src/main/resources/JavaJaxRS/resteasy/eap/enumOuterClass.mustache
+++ b/modules/swagger-codegen/src/main/resources/JavaJaxRS/resteasy/eap/enumOuterClass.mustache
@@ -1,7 +1,20 @@
-public enum {{classname}} {
-  {{#allowableValues}}
-  {{#enumVars}}
-  {{{name}}}{{^-last}},{{/-last}}{{#-last}};{{/-last}}
-  {{/enumVars}}
-  {{/allowableValues}}
+/**
+ * {{^description}}Gets or Sets {{{name}}}{{/description}}{{#description}}{{description}}{{/description}}
+ */
+public enum {{#datatypeWithEnum}}{{{.}}}{{/datatypeWithEnum}}{{^datatypeWithEnum}}{{{classname}}}{{/datatypeWithEnum}} {
+  {{#allowableValues}}{{#enumVars}}
+  {{{name}}}({{{value}}}){{^-last}},
+  {{/-last}}{{#-last}};{{/-last}}{{/enumVars}}{{/allowableValues}}
+
+  private {{{dataType}}} value;
+
+  {{#datatypeWithEnum}}{{{.}}}{{/datatypeWithEnum}}{{^datatypeWithEnum}}{{{classname}}}{{/datatypeWithEnum}}({{{dataType}}} value) {
+    this.value = value;
+  }
+
+  @Override
+  @JsonValue
+  public String toString() {
+    return String.valueOf(value);
+  }
 }

--- a/modules/swagger-codegen/src/main/resources/JavaJaxRS/resteasy/enumOuterClass.mustache
+++ b/modules/swagger-codegen/src/main/resources/JavaJaxRS/resteasy/enumOuterClass.mustache
@@ -1,3 +1,20 @@
-public enum {{classname}} {
-    {{#allowableValues}}{{.}}{{^-last}}, {{/-last}}{{/allowableValues}}
+/**
+ * {{^description}}Gets or Sets {{{name}}}{{/description}}{{#description}}{{description}}{{/description}}
+ */
+public enum {{#datatypeWithEnum}}{{{.}}}{{/datatypeWithEnum}}{{^datatypeWithEnum}}{{{classname}}}{{/datatypeWithEnum}} {
+  {{#allowableValues}}{{#enumVars}}
+  {{{name}}}({{{value}}}){{^-last}},
+  {{/-last}}{{#-last}};{{/-last}}{{/enumVars}}{{/allowableValues}}
+
+  private {{{dataType}}} value;
+
+  {{#datatypeWithEnum}}{{{.}}}{{/datatypeWithEnum}}{{^datatypeWithEnum}}{{{classname}}}{{/datatypeWithEnum}}({{{dataType}}} value) {
+    this.value = value;
+  }
+
+  @Override
+  @JsonValue
+  public String toString() {
+    return String.valueOf(value);
+  }
 }

--- a/modules/swagger-codegen/src/test/java/io/swagger/codegen/jaxrs/JavaResteasyOuterEnumTest.java
+++ b/modules/swagger-codegen/src/test/java/io/swagger/codegen/jaxrs/JavaResteasyOuterEnumTest.java
@@ -1,0 +1,73 @@
+package io.swagger.codegen.jaxrs;
+
+import io.swagger.codegen.ClientOptInput;
+import io.swagger.codegen.ClientOpts;
+import io.swagger.codegen.CodegenConfig;
+import io.swagger.codegen.DefaultGenerator;
+import io.swagger.codegen.languages.JavaResteasyEapServerCodegen;
+import io.swagger.codegen.languages.JavaResteasyServerCodegen;
+import io.swagger.models.Swagger;
+import io.swagger.parser.SwaggerParser;
+import org.apache.commons.io.FileUtils;
+import org.junit.rules.TemporaryFolder;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import java.io.File;
+import java.io.IOException;
+
+import static org.testng.Assert.assertTrue;
+
+public class JavaResteasyOuterEnumTest {
+
+    public TemporaryFolder folder = new TemporaryFolder();
+
+    @BeforeMethod
+    public void setUp() throws Exception {
+        folder.create();
+    }
+
+    @AfterMethod
+    public void tearDown() throws Exception {
+        folder.delete();
+    }
+
+    @DataProvider(name = "codegenConfigs")
+    public Object[][] codegenConfigs() {
+        return new Object[][]{
+                {new JavaResteasyServerCodegen()},
+                {new JavaResteasyEapServerCodegen()}
+        };
+    }
+
+    @Test(dataProvider = "codegenConfigs", description = "outer enum has value constructor and @JsonValue")
+    public void outerEnumTest(CodegenConfig codegenConfig) throws IOException {
+        final File outputFolder = folder.getRoot();
+        final Swagger swagger = new SwaggerParser().read("2_0/issue-3856.yaml");
+        codegenConfig.setOutputDir(outputFolder.getAbsolutePath());
+
+        final ClientOptInput clientOptInput = new ClientOptInput().opts(new ClientOpts()).swagger(swagger).config(codegenConfig);
+        new DefaultGenerator().opts(clientOptInput).generate();
+
+        final File outerEnum = new File(outputFolder, "src/gen/java/io/swagger/model/OrderStatus.java");
+        assertTrue(outerEnum.exists());
+        assertTrue(containsString(outerEnum, "import com.fasterxml.jackson.annotation.JsonValue;"));
+        assertTrue(containsString(outerEnum, "public enum OrderStatus {"));
+        assertTrue(containsString(outerEnum, "PLACED(\"placed\"),"));
+        assertTrue(containsString(outerEnum, "APPROVED(\"approved\"),"));
+        assertTrue(containsString(outerEnum, "DELIVERED(\"delivered\");"));
+        assertTrue(containsString(outerEnum, "private String value;"));
+        assertTrue(containsString(outerEnum, "OrderStatus(String value) {"));
+        assertTrue(containsString(outerEnum, "@JsonValue\n  public String toString() {"));
+    }
+
+    private boolean containsString(File file, String search) throws IOException {
+        return normalize(FileUtils.readFileToString(file)).contains(normalize(search));
+    }
+
+    private String normalize(String value) {
+        return value.replace("\r\n", "\n");
+    }
+}

--- a/modules/swagger-codegen/src/test/resources/2_0/issue-3856.yaml
+++ b/modules/swagger-codegen/src/test/resources/2_0/issue-3856.yaml
@@ -1,0 +1,35 @@
+swagger: '2.0'
+info:
+  title: Outer enum generation (issue 3856)
+  version: 1.0.0
+basePath: /v1
+paths:
+  /orders/{orderId}/status:
+    get:
+      operationId: getOrderStatus
+      parameters:
+        - name: orderId
+          in: path
+          required: true
+          type: string
+      responses:
+        '200':
+          description: successful operation
+          schema:
+            $ref: '#/definitions/OrderStatus'
+definitions:
+  OrderStatus:
+    type: string
+    description: Status of the order
+    enum:
+      - placed
+      - approved
+      - delivered
+  Order:
+    type: object
+    properties:
+      id:
+        type: integer
+        format: int64
+      status:
+        $ref: '#/definitions/OrderStatus'


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [x] Filed the PR against the correct branch: `3.0.0` branch for changes related to OpenAPI spec 3.0. Default: `master`.
- [x] Copied the [technical committee](https://github.com/swagger-api/swagger-codegen/#swagger-codegen-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

* Fixed outer enum issue on jaxrs-resteasy and jaxrs-reasteasy-eap languages (similar to jaxrs-spec, see #3856)

### Ping
@HugoMario 
