### PR TITLE
Added @Valid annotation on bean validation template for java jaxrs-re…

### DIFF
--- a/modules/swagger-codegen/src/main/resources/JavaJaxRS/resteasy/beanValidation.mustache
+++ b/modules/swagger-codegen/src/main/resources/JavaJaxRS/resteasy/beanValidation.mustache
@@ -1,4 +1,16 @@
 {{#required}}
   @NotNull
 {{/required}}
+{{#isContainer}}
+{{^isPrimitiveType}}
+{{^isEnum}}
+  @Valid
+{{/isEnum}}
+{{/isPrimitiveType}}
+{{/isContainer}}
+{{#isNotContainer}}
+{{^isPrimitiveType}}
+  @Valid
+{{/isPrimitiveType}}
+{{/isNotContainer}}
 {{>beanValidationCore}}

--- a/modules/swagger-codegen/src/main/resources/JavaJaxRS/resteasy/eap/beanValidation.mustache
+++ b/modules/swagger-codegen/src/main/resources/JavaJaxRS/resteasy/eap/beanValidation.mustache
@@ -1,6 +1,18 @@
 {{#required}}
   @NotNull
 {{/required}}
+{{#isContainer}}
+{{^isPrimitiveType}}
+{{^isEnum}}
+  @Valid
+{{/isEnum}}
+{{/isPrimitiveType}}
+{{/isContainer}}
+{{#isNotContainer}}
+{{^isPrimitiveType}}
+  @Valid
+{{/isPrimitiveType}}
+{{/isNotContainer}}
 {{#pattern}}
   @Pattern(regexp="{{{pattern}}}")
 {{/pattern}}

--- a/modules/swagger-codegen/src/main/resources/JavaJaxRS/resteasy/eap/model.mustache
+++ b/modules/swagger-codegen/src/main/resources/JavaJaxRS/resteasy/eap/model.mustache
@@ -9,6 +9,7 @@ import java.io.Serializable;
 {{/serializableModel}}
 {{#useBeanValidation}}
 import javax.validation.constraints.*;
+import javax.validation.Valid;
 {{/useBeanValidation}}
 {{#models}}
 {{#model}}

--- a/modules/swagger-codegen/src/main/resources/JavaJaxRS/resteasy/model.mustache
+++ b/modules/swagger-codegen/src/main/resources/JavaJaxRS/resteasy/model.mustache
@@ -9,6 +9,7 @@ import java.io.Serializable;
 {{/serializableModel}}
 {{#useBeanValidation}}
 import javax.validation.constraints.*;
+import javax.validation.Valid;
 {{/useBeanValidation}}
 {{#models}}
 {{#model}}


### PR DESCRIPTION
…steasy and jaxrs-resteasy-eap

### PR checklist

- [x] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [ ] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [x] Filed the PR against the correct branch: `3.0.0` branch for changes related to OpenAPI spec 3.0. Default: `master`.
- [x] Copied the [technical committee](https://github.com/swagger-api/swagger-codegen/#swagger-codegen-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

This pull add @Valid annotation on bean validation template for java jaxrs-resteasy and jaxrs-resteasy-eap.
This feature was already added to jaxrs with pull #10519 

