### PR TITLE
fix(typescript-angular): use rxjs throwError when RxJS6 is used

### DIFF
--- a/modules/swagger-codegen/src/main/resources/typescript-angular/api.service.mustache
+++ b/modules/swagger-codegen/src/main/resources/typescript-angular/api.service.mustache
@@ -18,7 +18,7 @@ import { CustomQueryEncoderHelper }                          from '../encoder';
 import { Observable }                                        from 'rxjs/Observable';
 {{/useRxJS6}}
 {{#useRxJS6}}
-import { Observable }                                        from 'rxjs';
+import { Observable, throwError }                                        from 'rxjs';
 {{/useRxJS6}}
 {{^useHttpClient}}
 import '../rxjs-operators';
@@ -140,7 +140,12 @@ export class {{classname}} {
         {{/isConstEnumParam}}
         {{^isConstEnumParam}}
         if ({{paramName}} === null || {{paramName}} === undefined) {
+            {{^useRxJS6}}
             throw new Error('Required parameter {{paramName}} was null or undefined when calling {{nickname}}.');
+            {{/useRxJS6}}
+            {{#useRxJS6}}
+            return throwError('Required parameter {{paramName}} was null or undefined when calling {{nickname}}.');
+            {{/useRxJS6}}
         }
         {{/isConstEnumParam}}
 {{/required}}


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [ ] Filed the PR against the correct branch: `3.0.0` branch for changes related to OpenAPI spec 3.0. Default: `master`.
- [x] Copied the [technical committee](https://github.com/swagger-api/swagger-codegen/#swagger-codegen-technical-committee) to review the pull request if your PR is targeting a particular programming language.
@roni-frantchi
### Description of the PR

(details of the change, additional tests that have been done, reference to the issue for tracking, etc)

fix #10561
