### PR TITLE
Issue 8412: Replace vars with defaults in server evaluation.

### DIFF
--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/v3/utils/URLPathUtil.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/v3/utils/URLPathUtil.java
@@ -3,13 +3,17 @@ package io.swagger.codegen.v3.utils;
 import io.swagger.codegen.v3.CodegenConfig;
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.servers.Server;
+import io.swagger.v3.oas.models.servers.ServerVariables;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.text.StrSubstitutor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 public class URLPathUtil {
 
@@ -30,7 +34,8 @@ public class URLPathUtil {
             url = LOCAL_HOST + url;
         }
         try {
-            return new URL(url);
+            String varReplacedUrl = replaceServerVarsWthDefaultValues(url, server.getVariables());
+            return new URL(varReplacedUrl);
         } catch (MalformedURLException e) {
             LOGGER.warn("Not valid URL: " + server.getUrl(), e);
             return null;
@@ -67,7 +72,8 @@ public class URLPathUtil {
                 serverUrl = inputURL;
                 break;
             }
-            return new URL(serverUrl);
+            String varReplacedUrl = replaceServerVarsWthDefaultValues(serverUrl, server.getVariables());
+            return new URL(varReplacedUrl);
         } catch (Exception e) {
             LOGGER.warn("Not valid URL: " + server.getUrl(), e);
             return null;
@@ -93,5 +99,17 @@ public class URLPathUtil {
             return openAPI.getServers().get(0).getUrl();
         }
         return LOCAL_HOST;
+    }
+
+    private static String replaceServerVarsWthDefaultValues(String url, ServerVariables vars) {
+        if (vars != null && vars.size() > 0) {
+            Map<String, Object> defaultValues = vars.entrySet()
+                .stream()
+                .collect(Collectors.toMap(
+                    Map.Entry::getKey,
+                    e -> e.getValue().getDefault()));
+            return StrSubstitutor.replace(url, defaultValues, "{", "}");
+        }
+        return url;
     }
 }

--- a/modules/swagger-codegen/src/test/java/io/swagger/codegen/v3/utils/URLPathUtilTest.java
+++ b/modules/swagger-codegen/src/test/java/io/swagger/codegen/v3/utils/URLPathUtilTest.java
@@ -3,6 +3,8 @@ package io.swagger.codegen.v3.utils;
 import io.swagger.codegen.v3.CodegenConfig;
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.servers.Server;
+import io.swagger.v3.oas.models.servers.ServerVariable;
+import io.swagger.v3.oas.models.servers.ServerVariables;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import org.testng.Assert;
@@ -117,5 +119,37 @@ public class URLPathUtilTest {
         verify(openAPI).getServers();
         verify(servers).isEmpty();
         verify(config).getInputURL();
+    }
+
+    @Test (description = "verify a url with variable substitutions.")
+    public void testVariableSubstitution() throws Exception {
+        ServerVariable portVariable = new ServerVariable();
+        portVariable.setDefault("8080");
+
+        ServerVariables vars = new ServerVariables();
+        vars.addServerVariable("port", portVariable);
+
+        when(server.getVariables()).thenReturn(vars);
+        when(server.getUrl()).thenReturn("http://myhost:{port}/mypath");
+
+        URL url = URLPathUtil.getServerURL(openAPI, config);
+
+        Assert.assertEquals(new URL("http://myhost:8080/mypath"), url);
+    }
+
+    @Test (description = "verify a url with variable substitutions when default is missing.")
+    public void testVariableSubstitutionMissingDefault() throws Exception {
+        ServerVariable portVariable = new ServerVariable();
+
+        ServerVariables vars = new ServerVariables();
+        vars.addServerVariable("port", portVariable);
+
+        when(server.getVariables()).thenReturn(vars);
+        when(server.getUrl()).thenReturn("http://myhost:{port}/mypath");
+
+        // No default for port, resulting URL is invalid.
+        URL url = URLPathUtil.getServerURL(openAPI, config);
+
+        Assert.assertNull(url);
     }
 }


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [ ] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [x] Filed the PR against the correct branch: `3.0.0` branch for changes related to OpenAPI spec 3.0. Default: `master`.
- [ ] Copied the [technical committee](https://github.com/swagger-api/swagger-codegen/#swagger-codegen-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

Fixes problem addressed in https://github.com/swagger-api/swagger-codegen/issues/8412. See that issue for full details.

(details of the change, additional tests that have been done, reference to the issue for tracking, etc)

