### PR TITLE
Fix #7669 [csharp] Model inheriting Dictionnary set isArrayModel to True

### DIFF
--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/CSharpClientCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/CSharpClientCodegen.java
@@ -580,6 +580,12 @@ public class CSharpClientCodegen extends AbstractCSharpCodegen {
             }
         }
 
+        // Disable overrides for inherited type 'Dictionary'.
+        // https://github.com/swagger-api/swagger-codegen/issues/7669
+        if (codegenModel.parent != null && codegenModel.parent.startsWith("Dictionary")) {
+            codegenModel.isArrayModel = true;
+        }
+
         return codegenModel;
     }
 


### PR DESCRIPTION
Fix #7669 [csharp] Model inheriting Dictionnary set isArrayModel to True.

This change enable the modelGeneric.mustache templates to distinguish between generated type and native dictionary type.
* "BaseValidate" reference is no longer incorrectly generated in IValidatableObject.Validate().
* "Override" keyword is no longer added to the `ToJson()` method.

@mandrean
### PR checklist

- [ ] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [ ] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [ ] Filed the PR against the correct branch: `3.0.0` branch for changes related to OpenAPI spec 3.0. Default: `master`.
- [ ] Copied the [technical committee](https://github.com/swagger-api/swagger-codegen/#swagger-codegen-technical-committee) to review the pull request if your PR is targeting a particular programming language.