### PR TITLE
Scope is not added properly in generating code from

### DIFF
--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/v3/CodegenSecurity.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/v3/CodegenSecurity.java
@@ -81,7 +81,15 @@ public class CodegenSecurity extends CodegenObject {
         return tokenUrl;
     }
 
-    public Collection<Map<String, String>> getScopes() {
+    public Scopes getScopes() {
+        return scopes;
+    }
+    
+    /**
+     * Wraps the scopes into list of maps to be consumable from within the templates.
+     * @return scopes as the list of maps
+     */
+    public Collection<Map<String, String>> getScopesList() {
         final List<Map<String, String>> scopesList = new ArrayList<>();
         if (!getHasScopes()) {
             return scopesList; 
@@ -106,7 +114,7 @@ public class CodegenSecurity extends CodegenObject {
         
         return scopesList;
     }
-    
+
     public Boolean getHasScopes() {
         return scopes != null && !scopes.isEmpty();
     }

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/v3/CodegenSecurity.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/v3/CodegenSecurity.java
@@ -2,7 +2,10 @@ package io.swagger.codegen.v3;
 
 import io.swagger.v3.oas.models.security.Scopes;
 
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 public class CodegenSecurity extends CodegenObject {
@@ -78,10 +81,32 @@ public class CodegenSecurity extends CodegenObject {
         return tokenUrl;
     }
 
-    public Scopes getScopes() {
-        return scopes;
+    public Collection<Map<String, String>> getScopes() {
+        final List<Map<String, String>> scopesList = new ArrayList<>();
+        if (!getHasScopes()) {
+            return scopesList; 
+        }
+        
+        int count = 0;
+        for (final String key: scopes.keySet()) {
+            Map<String, String> scope = new HashMap<>();
+            
+            scope.put("scope", key);
+            scope.put("description", scopes.get(key));
+            count += 1;
+            
+            if (count < scopes.size()) {
+                scope.put("hasMore", "true");
+            } else {
+                scope.put("hasMore", null);
+            }
+            
+            scopesList.add(scope);
+        }
+        
+        return scopesList;
     }
-
+    
     public Boolean getHasScopes() {
         return scopes != null && !scopes.isEmpty();
     }


### PR DESCRIPTION
### PR checklist

- [X] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [X] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [X] Filed the PR against the correct branch: `3.0.0` branch for changes related to OpenAPI spec 3.0. Default: `master`.
- [X] Copied the [technical committee](https://github.com/swagger-api/swagger-codegen/#swagger-codegen-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

The `CodegenSecurity` model exposes `scopes` as a map which is not aligned within its usage in code generation templates. As the result, the `scopes` are not generated properly. The suggested fix is to wrap each scope into a list of maps and pre-populate the properties which templates expect. 

Verified against OAS2 / OAS3 generators, the following specification fragment

```
  securitySchemes:
    oauth2:
      type: oauth2
      flows:
        authorizationCode:
          scopes:
            read: read scope
            write: ""
```

On the generation side, the following code is being generated for OAS2 and OAS3 respectively.

```java
@ApiOperation(                                                             
  value = "",                                                              
  notes = "Search all people",                                             
  response = Person.class,                                                 
  responseContainer = "List",                                              
  authorizations = {                                                       
    @Authorization(                                                        
      value = "oauth2",                                                    
      scopes = {                                                           
        @AuthorizationScope(scope = "read", description = "read scope"),   
        @AuthorizationScope(scope = "write", description = "")             
      }                                                                    
    )                                                                      
  },                                                                       
  tags = {"people"}                                                        
)                                                                          
```

```java
@Operation(                                     
  summary = "",                                 
  description = "Search all people",            
  security = {                                  
    @SecurityRequirement(                       
      name = "oauth2",                          
      scopes = {"read", "write"}                
    )                                           
  },                                            
  tags = {"people"}                             
)                                               
```

Fixes https://github.com/swagger-api/swagger-codegen/issues/10225.
@HugoMario mind taking a look please, thank you.
