### PR TITLE
[Python] Bugfix in model.mustache

### DIFF
--- a/modules/swagger-codegen/src/main/resources/python/model.mustache
+++ b/modules/swagger-codegen/src/main/resources/python/model.mustache
@@ -99,8 +99,10 @@ class {{classname}}(object):
         :type: {{datatype}}
         """
 {{#required}}
+{{^nullable}}
         if self._configuration.client_side_validation and {{name}} is None:
             raise ValueError("Invalid value for `{{name}}`, must not be `None`")  # noqa: E501
+{{/nullable}}
 {{/required}}
 {{#isEnum}}
 {{#isContainer}}


### PR DESCRIPTION
### Description of the PR
Before bugfix: a required and nullable attribute set to null/None causes a value error when received by the client.
After bugfix: This error is only caused for properties being required and not nullable
General info: The python client cannot distinguish between unset attributes (value=None) and attributes set to null (value=None)

### Issue to solve:
closes: https://github.com/swagger-api/swagger-codegen/issues/10535

### PR checklist

- [x] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [ ] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [ ] Filed the PR against the correct branch: `3.0.0` branch for changes related to OpenAPI spec 3.0. Default: `master`.
- [x] Copied the [technical committee](https://github.com/swagger-api/swagger-codegen/#swagger-codegen-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Performed tests:
Tested with own api-specs as and the swagger-cli:
- The generation works.
- The two lines causing the error are removed in the python client, nothing else changes.


