### PR TITLE
New go-server codegen options

### DIFF
--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/CodegenConstants.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/CodegenConstants.java
@@ -236,4 +236,10 @@ public class CodegenConstants {
     public static final String INTERFACE_CONTROLLER = "interface-controller";
 
     public static final String IGNORE_IMPORT_MAPPING_OPTION = "ignoreImportMappings";
+
+    public static final String GENERATE_MAIN_GO = "generateMainGo";
+    public static final String GENERATE_MAIN_GO_DESC = "A boolean value that describes if main.go should be generated. If true, main.go will be created in the root and sourceFolder for the api cannot be in the root.";
+
+    public static final String GO_SERVER_MUX_TYPE = "goServerMuxType";
+    public static final String GO_SERVER_MUX_TYPE_DESC = "Describes the server mux to generate code for. Current supported options are: [gorilla], any other value results in no mux specific code being generated";
 }

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/AbstractGoCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/AbstractGoCodegen.java
@@ -25,6 +25,12 @@ public abstract class AbstractGoCodegen extends DefaultCodegen implements Codege
 
     protected String packageName = "swagger";
 
+    protected String sourceFolder = "go";
+
+    protected boolean generateMainGo = true;
+
+    protected String serverMuxType = "gorilla";
+
     public AbstractGoCodegen() {
         super();
 
@@ -436,6 +442,18 @@ public abstract class AbstractGoCodegen extends DefaultCodegen implements Codege
 
     public void setPackageName(String packageName) {
         this.packageName = packageName;
+    }
+
+    public void setSourceFolder(String sourceFolder) {
+        this.sourceFolder = sourceFolder;
+    }
+
+    public void setGenerateMainGo(boolean generateMainGo) {
+        this.generateMainGo = generateMainGo;
+    }
+
+    public void setServerMuxType(String serverMuxType) {
+        this.serverMuxType = serverMuxType;
     }
 
     @Override

--- a/modules/swagger-codegen/src/main/resources/go-server/main.mustache
+++ b/modules/swagger-codegen/src/main/resources/go-server/main.mustache
@@ -12,13 +12,29 @@ import (
 	//
 	//    sw "github.com/myname/myrepo/{{apiPath}}"
 	//
-	sw "./{{apiPath}}"
+	api "./{{apiPath}}"
 )
 
-func main() {
+func main() {	
+	{{#muxEnabled}}
+	router := api.NewRouter()
+
 	log.Printf("Server started")
 
-	router := sw.NewRouter()
-
 	log.Fatal(http.ListenAndServe(":{{serverPort}}", router))
+	{{/muxEnabled}}
+	{{^muxEnabled}}
+	routes := api.GetRoutes()
+	routeMap := make(map[string]string)
+	for _, r := range routes {
+		if _, exist := routeMap[r.Pattern]; !exist {
+			http.Handle(r.Pattern, r.HandlerFunc)
+			routeMap[r.Pattern] = r.Pattern
+		} else{
+			log.Printf("Warning: route %s thrown away, duplicate paths are not supported by DefaultServeMux", r.Pattern)
+		}
+	}
+	log.Printf("Server started")
+	log.Fatal(http.ListenAndServe(":8080", nil))
+	{{/muxEnabled}}
 }

--- a/modules/swagger-codegen/src/main/resources/go-server/routes.mustache
+++ b/modules/swagger-codegen/src/main/resources/go-server/routes.mustache
@@ -1,0 +1,39 @@
+{{>partial_header}}
+package {{packageName}}
+
+import (
+    "fmt"
+    "net/http"
+    "strings"
+)
+
+type Route struct {
+    Name        string
+    Method      string
+    Pattern     string
+    HandlerFunc http.HandlerFunc
+}
+
+func index(w http.ResponseWriter, r *http.Request) {
+    fmt.Fprintf(w, "Hello World!")
+}
+
+func GetRoutes() []Route {
+
+    routes := []Route{
+        Route{
+            "Index",
+            "GET",
+            "{{{basePathWithoutHost}}}/",
+            index,
+        },{{#apiInfo}}{{#apis}}{{#operations}}{{#operation}}
+
+        Route{
+            "{{operationId}}",
+            strings.ToUpper("{{httpMethod}}"),
+            "{{{basePathWithoutHost}}}{{{path}}}",
+            {{operationId}},
+        },{{/operation}}{{/operations}}{{/apis}}{{/apiInfo}}
+    }
+    return routes
+}


### PR DESCRIPTION
Introduces 3 new configuration options for go-server codegen:

   1) sourceFolder -> source folder for generated code (Default: go)

   2) goServerMuxType -> Describes the server mux to generate code for. Current supported options are: [gorilla], any other value results in no mux specific code being generated (Default: gorilla)

   3) generateMainGo -> A boolean value that describes if main.go should be generated. If true, main.go will be created in the root and sourceFolder for the api cannot be in the root. (Default: true)

### PR checklist

- [ ] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [ ] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [ ] Filed the PR against the correct branch: `3.0.0` branch for changes related to OpenAPI spec 3.0. Default: `master`.
- [ ] Copied the [technical committee](https://github.com/swagger-api/swagger-codegen/#swagger-codegen-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

(details of the change, additional tests that have been done, reference to the issue for tracking, etc)

