### PR TITLE
fixed build path on php workflows

### DIFF
--- a/.github/workflows/test-framework-php.yml
+++ b/.github/workflows/test-framework-php.yml
@@ -170,7 +170,7 @@ jobs:
         uses: ./.github/actions/build
         continue-on-error: true
         with:
-          path: generated/${{ env.JOB_NAME }}
+          path: generated/${{ env.JOB_NAME }}/SwaggerClient-php
           job-name: ${{ env.JOB_NAME }}
           build-commands: ${{ env.BUILD_COMMANDS }}
       - id: outcome

--- a/.github/workflows/test-framework-v2-php.yml
+++ b/.github/workflows/test-framework-v2-php.yml
@@ -76,7 +76,7 @@ jobs:
         continue-on-error: true
         uses: ./.github/actions/generate
         with:
-          language: javascript
+          language: php
           job-name: ${{ env.JOB_NAME }}
           spec-url: https://raw.githubusercontent.com/swagger-api/swagger-codegen/master/modules/swagger-codegen/src/test/resources/2_0/petstore-with-fake-endpoints-models-for-testing.yaml
           options: " --additional-properties composerVendorName=swagger,composerProjectName=swagger_codegen"
@@ -153,7 +153,7 @@ jobs:
         uses: ./.github/actions/build
         continue-on-error: true
         with:
-          path: generated/${{ env.JOB_NAME }}
+          path: generated/${{ env.JOB_NAME }}/SwaggerClient-php
           job-name: ${{ env.JOB_NAME }}
           build-commands: "composer install__&&__./vendor/bin/phpunit test"
       - id: outcome


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [x] Filed the PR against the correct branch: `3.0.0` branch for changes related to OpenAPI spec 3.0. Default: `master`.
- [x] Copied the [technical committee](https://github.com/swagger-api/swagger-codegen/#swagger-codegen-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

fixed build paths.

