### PR TITLE
DNS cache timeout

### DIFF
--- a/modules/swagger-generator/src/main/java/io/swagger/v3/generator/online/GeneratorController.java
+++ b/modules/swagger-generator/src/main/java/io/swagger/v3/generator/online/GeneratorController.java
@@ -17,6 +17,8 @@ import io.swagger.oas.inflector.models.ResponseContext;
 import io.swagger.v3.core.util.Json;
 import io.swagger.v3.parser.util.ClasspathHelper;
 import io.swagger.v3.parser.util.RemoteUrl;
+import jdk.javadoc.internal.doclets.formats.html.SourceToHTMLConverter;
+
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
@@ -31,6 +33,7 @@ import java.net.URI;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.security.Security;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -53,9 +56,11 @@ public class GeneratorController {
     private static String PROP_HIDDEN_OPTIONS = "HIDDEN_OPTIONS";
 
     static {
-        // allow writing files only to directories configgured via generatorWriteDirs sys prop
-        // e.g. -DgeneratorWriteDirs="/tmp"
         System.setSecurityManager(new FileAccessSecurityManager());
+        // Enabling a SecurityManager disables DNS cache expiration. This can cause issues
+        // for long-running instances of swagger-generator when the IP addresses of referenced
+        // domains change.
+        Security.setProperty("networkaddress.cache.ttl", "60");
 
         hiddenOptions = loadHiddenOptions();
         final ServiceLoader<CodegenConfig> loader = ServiceLoader.load(CodegenConfig.class);

--- a/modules/swagger-generator/src/main/java/io/swagger/v3/generator/online/GeneratorController.java
+++ b/modules/swagger-generator/src/main/java/io/swagger/v3/generator/online/GeneratorController.java
@@ -17,8 +17,6 @@ import io.swagger.oas.inflector.models.ResponseContext;
 import io.swagger.v3.core.util.Json;
 import io.swagger.v3.parser.util.ClasspathHelper;
 import io.swagger.v3.parser.util.RemoteUrl;
-import jdk.javadoc.internal.doclets.formats.html.SourceToHTMLConverter;
-
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;

--- a/modules/swagger-generator/src/main/java/io/swagger/v3/generator/online/GeneratorController.java
+++ b/modules/swagger-generator/src/main/java/io/swagger/v3/generator/online/GeneratorController.java
@@ -54,6 +54,8 @@ public class GeneratorController {
     private static String PROP_HIDDEN_OPTIONS = "HIDDEN_OPTIONS";
 
     static {
+        // allow writing files only to directories configgured via generatorWriteDirs sys prop
+        // e.g. -DgeneratorWriteDirs="/tmp"
         System.setSecurityManager(new FileAccessSecurityManager());
         // Enabling a SecurityManager disables DNS cache expiration. This can cause issues
         // for long-running instances of swagger-generator when the IP addresses of referenced


### PR DESCRIPTION
### PR checklist

- [X] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [ ] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [X] Filed the PR against the correct branch: `3.0.0` branch for changes related to OpenAPI spec 3.0. Default: `master`.
- [ ] Copied the [technical committee](https://github.com/swagger-api/swagger-codegen/#swagger-codegen-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

https://github.com/swagger-api/swagger-codegen/pull/10525 added a `SecurityManager` to the application. When a `SecurityManager` is enabled it causes DNS queries to be cached indefinitely (ref: https://docs.oracle.com/javase/7/docs/technotes/guides/net/properties.html). This causes issues with long-running instances of swagger-generator as the IPs of DNS records change.

This PR re-enables the DNS cache invalidation with a default TTL of 60 seconds.
