### PR TITLE
FIX use url encoding in query string paramaters

### DIFF
--- a/modules/swagger-codegen/src/main/resources/Java/libraries/resttemplate/ApiClient.mustache
+++ b/modules/swagger-codegen/src/main/resources/Java/libraries/resttemplate/ApiClient.mustache
@@ -33,6 +33,10 @@ import org.springframework.util.StringUtils;
 import org.springframework.web.client.RestClientException;
 import org.springframework.web.client.RestTemplate;
 import org.springframework.web.util.UriComponentsBuilder;
+import java.io.UnsupportedEncodingException;
+import java.net.URLEncoder;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 {{#threetenbp}}
 import org.threeten.bp.*;
 import com.fasterxml.jackson.datatype.threetenbp.ThreeTenModule;
@@ -84,6 +88,10 @@ public class ApiClient {
     
     private boolean debugging = false;
     
+    private boolean useUrlEncoding = true;
+    
+	private Charset encoding = StandardCharsets.UTF_8;
+    
     private HttpHeaders defaultHeaders = new HttpHeaders();
     
     private String basePath = "{{basePath}}";
@@ -124,6 +132,29 @@ public class ApiClient {
         // Prevent the authentications from being modified.
         authentications = Collections.unmodifiableMap(authentications);
     }
+    
+    public Charset getEncoding() {
+		return encoding;
+	}
+    /**
+    * Set the new encoding for url query strings.
+    */
+	public void setEncoding(Charset encoding) {
+		this.encoding = encoding;
+	}
+    
+    /**
+    * Get the current urlenconding option
+    */
+    public boolean useURLEncoding() {
+		return useUrlEncoding;
+	}
+    /**
+    * Set true to use url encoding in URIBuilder. otherwise no.
+    */
+	public void setUseURLEncoding(boolean useURLEncoding) {
+		this.useUrlEncoding = useURLEncoding;
+	}
     
     /**
      * Get the current base path
@@ -338,10 +369,10 @@ public class ApiClient {
      * @return String the parameter represented as a String
      */
     public String parameterToString(Object param) {
-        if (param == null) {
-            return "";
+       if (param == null) {
+    		return "";
         } else if (param instanceof Date) {
-            return formatDate( (Date) param);
+        	return formatDate( (Date) param);
         } else if (param instanceof Collection) {
             StringBuilder b = new StringBuilder();
             for(Object o : (Collection<?>) param) {
@@ -352,7 +383,12 @@ public class ApiClient {
             }
             return b.toString();
         } else {
-            return String.valueOf(param);
+        	try {
+				return this.useURLEncoding() ?  URLEncoder.encode(String.valueOf(param), encoding.toString()) : String.valueOf(param);
+			} catch (UnsupportedEncodingException e) {
+				e.printStackTrace();
+				return String.valueOf(param);
+			}
         }
     }
 
@@ -511,7 +547,7 @@ public class ApiClient {
             builder.queryParams(queryParams);
         }
         
-        final BodyBuilder requestBuilder = RequestEntity.method(method, builder.build().toUri());
+        final BodyBuilder requestBuilder = RequestEntity.method(method, builder.build(useURLEncoding()).toUri());
         if(accept != null) {
             requestBuilder.accept(accept.toArray(new MediaType[accept.size()]));
         }


### PR DESCRIPTION
It will properly use the default char-encoding in the api client.
Also using the new UriComponentsBuilder.builder(encode true or false).toUri().
Wich is causing the issue

### PR checklist

- [ ] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [ ] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [ ] Filed the PR against the correct branch: `3.0.0` branch for changes related to OpenAPI spec 3.0. Default: `master`.
- [ ] Copied the [technical committee](https://github.com/swagger-api/swagger-codegen/#swagger-codegen-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

(details of the change, additional tests that have been done, reference to the issue for tracking, etc)

