### PR TITLE
Make python codegen respect cookie setting

### DIFF
--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/DefaultCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/DefaultCodegen.java
@@ -2956,7 +2956,8 @@ public class DefaultCodegen {
                 sec.isApiKey = true;
                 sec.keyParamName = apiKeyDefinition.getName();
                 sec.isKeyInHeader = apiKeyDefinition.getIn() == In.HEADER;
-                sec.isKeyInQuery = !sec.isKeyInHeader;
+                sec.isKeyInCookie = apiKeyDefinition.getIn() == In.COOKIE;
+                sec.isKeyInQuery = !sec.isKeyInHeader && !sec.isKeyInCookie;
             } else if(schemeDefinition instanceof BasicAuthDefinition) {
                 sec.isKeyInHeader = sec.isKeyInQuery = sec.isApiKey = sec.isOAuth = false;
                 sec.isBasic = true;

--- a/modules/swagger-codegen/src/main/resources/python/api_client.mustache
+++ b/modules/swagger-codegen/src/main/resources/python/api_client.mustache
@@ -516,9 +516,15 @@ class ApiClient(object):
                     headers[auth_setting['key']] = auth_setting['value']
                 elif auth_setting['in'] == 'query':
                     querys.append((auth_setting['key'], auth_setting['value']))
+                elif auth_setting["in"] == "cookie":
+                    cookies = headers.get("Cookie", "")
+                    cookies = cookies + "; " if cookies else ""
+                    cookies += f"{auth_setting['key']}={auth_setting['value']}"
+                    headers["Cookie"] = cookies
+
                 else:
                     raise ValueError(
-                        'Authentication token must be in `query` or `header`'
+                        'Authentication token must be in `query`, `header` or `cookie`'
                     )
 
     def __deserialize_file(self, response):

--- a/modules/swagger-codegen/src/main/resources/python/configuration.mustache
+++ b/modules/swagger-codegen/src/main/resources/python/configuration.mustache
@@ -231,7 +231,7 @@ class Configuration(object):
             '{{name}}':
                 {
                     'type': 'api_key',
-                    'in': {{#isKeyInHeader}}'header'{{/isKeyInHeader}}{{#isKeyInQuery}}'query'{{/isKeyInQuery}},
+                    'in': {{#isKeyInHeader}}'header'{{/isKeyInHeader}}{{#isKeyInQuery}}'query'{{/isKeyInQuery}}{{#isKeyInCookie}}'cookie'{{/isKeyInCookie}},
                     'key': '{{keyParamName}}',
                     'value': self.get_api_key_with_prefix('{{keyParamName}}')
                 },


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [ ] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [ ] Filed the PR against the correct branch: `3.0.0` branch for changes related to OpenAPI spec 3.0. Default: `master`.
- [ ] Copied the [technical committee](https://github.com/swagger-api/swagger-codegen/#swagger-codegen-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

There is an issue described here https://github.com/swagger-api/swagger-codegen/issues/9254
The problem is that in swagger doc https://swagger.io/docs/specification/authentication/cookie-authentication/ there is a description of Cookie auth. In reality there is nothing in the code that actually implements this cookie auth.

This PR introduces an idea of how to fix it.