### PR TITLE
bumb version of snakeyaml to fix security issue in snakeyaml < 1.26

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -947,6 +947,6 @@
         <surefire-version>2.19.1</surefire-version>
         <jmockit-version>1.25</jmockit-version>
         <reflections-version>0.9.11</reflections-version>
-        <snakeyaml-version>1.24</snakeyaml-version>
+        <snakeyaml-version>1.29</snakeyaml-version>
     </properties>
 </project>

--- a/pom.xml.jenkins
+++ b/pom.xml.jenkins
@@ -1009,6 +1009,6 @@
         <surefire-version>2.19.1</surefire-version>
         <jmockit-version>1.25</jmockit-version>
         <reflections-version>0.9.11</reflections-version>
-        <snakeyaml-version>1.24</snakeyaml-version>
+        <snakeyaml-version>1.29</snakeyaml-version>
     </properties>
 </project>


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [ ] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [x] Filed the PR against the correct branch: `3.0.0` branch for changes related to OpenAPI spec 3.0. Default: `master`.
- [ ] Copied the [technical committee](https://github.com/swagger-api/swagger-codegen/#swagger-codegen-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

Version bump of snakeyaml to recent version in order to fix a security vulnerability in snakeyaml < 1.26.

Background: One of my clients uses Blackduck to scan security of their products.
Blackduck reported swagger-codegen-cli-2.4.21.jar to have transitive dependency to snakeyaml-1.24.

"SnakeYAML is vulnerable to a billion laughs attack. An attacker able to supply specially crafted input to the application could cause excessive memory consumption, resulting in a denial-of-service (DoS)."

SnakeYaml Issue: https://bitbucket.org/asomov/snakeyaml/issues/377/allow-configuration-for-preventing-billion

Fixed in https://bitbucket.org/asomov/snakeyaml/src/snakeyaml-1.26/
Fix Commit ID: : https://bitbucket.org/asomov/snakeyaml/commits/da11ddbd91c1f8392ea932b37fa48110fa54ed8c"

