### PR TITLE
feat. option gitRepoBaseURL for PHP generator

### DIFF
--- a/modules/swagger-codegen-cli/src/main/java/io/swagger/codegen/cmd/Generate.java
+++ b/modules/swagger-codegen-cli/src/main/java/io/swagger/codegen/cmd/Generate.java
@@ -149,6 +149,10 @@ public class Generate implements Runnable {
             description = CodegenConstants.GIT_REPO_ID_DESC)
     private String gitRepoId;
 
+    @Option(name = {"--git-repo-base-url"}, title = "git repo base url",
+            description = CodegenConstants.GIT_REPO_BASE_URL_DESC)
+    private String gitRepoBaseURL;
+
     @Option(name = {"--release-note"}, title = "release note",
             description = CodegenConstants.RELEASE_NOTE_DESC)
     private String releaseNote;
@@ -261,6 +265,10 @@ public class Generate implements Runnable {
 
         if (isNotEmpty(gitRepoId)) {
             configurator.setGitRepoId(gitRepoId);
+        }
+
+        if (isNotEmpty(gitRepoBaseURL)) {
+            configurator.setGitRepoBaseURL(gitRepoBaseURL);
         }
 
         if (isNotEmpty(releaseNote)) {

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/CodegenConfig.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/CodegenConfig.java
@@ -202,6 +202,10 @@ public interface CodegenConfig {
 
     String getGitRepoId();
 
+    void setGitRepoBaseURL(String repositoryBaseURL);
+
+    String getGitRepoBaseURL();
+
     void setReleaseNote(String releaseNote);
 
     String getReleaseNote();
@@ -233,5 +237,4 @@ public interface CodegenConfig {
     void setIgnoreImportMapping(boolean ignoreImportMapping);
 
     boolean defaultIgnoreImportMappingOption();
-
 }

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/CodegenConstants.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/CodegenConstants.java
@@ -178,6 +178,9 @@ public class CodegenConstants {
     public static final String GIT_REPO_ID = "gitRepoId";
     public static final String GIT_REPO_ID_DESC = "Git repo ID, e.g. swagger-codegen.";
 
+    public static final String GIT_REPO_BASE_URL = "gitRepoBaseURL";
+    public static final String GIT_REPO_BASE_URL_DESC = "Git repo base URL, e.g. https://github.com.";
+
     public static final String RELEASE_NOTE = "releaseNote";
     public static final String RELEASE_NOTE_DESC = "Release note, default to 'Minor update'.";
 

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/DefaultCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/DefaultCodegen.java
@@ -103,7 +103,7 @@ public class DefaultCodegen {
     protected Boolean sortParamsByRequiredFlag = true;
     protected Boolean ensureUniqueParams = true;
     protected Boolean allowUnicodeIdentifiers = false;
-    protected String gitUserId, gitRepoId, releaseNote;
+    protected String gitUserId, gitRepoId, releaseNote, gitRepoBaseURL /*= "github"*/;
     protected String httpUserAgent;
     protected Boolean hideGenerationTimestamp = true;
     protected Boolean skipAliasGeneration;
@@ -116,6 +116,7 @@ public class DefaultCodegen {
     protected Map<String, String> typeAliases = null;
 
     protected String ignoreFilePathOverride;
+
 
     public List<CliOption> cliOptions() {
         return cliOptions;
@@ -3657,6 +3658,24 @@ public class DefaultCodegen {
      */
     public String getGitRepoId() {
         return gitRepoId;
+    }
+
+    /**
+     * Set Git repo Base URL.
+     *
+     * @param gitRepoBaseURL Git repo ID
+     */
+    public void setGitRepoBaseURL(String gitRepoBaseURL) {
+        this.gitRepoBaseURL = gitRepoBaseURL;
+    }
+
+    /**
+     * Git repo Base URL
+     *
+     * @return Git Base URL
+     */
+    public String getGitRepoBaseURL() {
+        return gitRepoBaseURL;
     }
 
     /**

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/config/CodegenConfigurator.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/config/CodegenConfigurator.java
@@ -65,11 +65,12 @@ public class CodegenConfigurator implements Serializable {
     private Map<String, Object> additionalProperties = new HashMap<String, Object>();
     private Map<String, String> importMappings = new HashMap<String, String>();
     private Set<String> languageSpecificPrimitives = new HashSet<String>();
-    private Map<String, String>  reservedWordMappings = new HashMap<String, String>();
+    private Map<String, String> reservedWordMappings = new HashMap<String, String>();
 
-    private String gitUserId="GIT_USER_ID";
-    private String gitRepoId="GIT_REPO_ID";
-    private String releaseNote="Minor update";
+    private String gitUserId = "GIT_USER_ID";
+    private String gitRepoId = "GIT_REPO_ID";
+    private String gitRepoBaseURL = "GIT_REPO_BASE_URL";
+    private String releaseNote = "Minor update";
     private String httpUserAgent;
 
     private final Map<String, Object> dynamicProperties = new HashMap<String, Object>(); //the map that holds the JsonAnySetter/JsonAnyGetter values
@@ -339,6 +340,15 @@ public class CodegenConfigurator implements Serializable {
         return gitRepoId;
     }
 
+    public CodegenConfigurator setGitRepoBaseURL(String gitRepoBaseURL) {
+        this.gitRepoBaseURL = gitRepoBaseURL;
+        return this;
+    }
+
+    public String getGitRepoBaseURL() {
+        return gitRepoBaseURL;
+    }
+
     public CodegenConfigurator setGitRepoId(String gitRepoId) {
         this.gitRepoId = gitRepoId;
         return this;
@@ -358,11 +368,11 @@ public class CodegenConfigurator implements Serializable {
     }
 
     public CodegenConfigurator setHttpUserAgent(String httpUserAgent) {
-        this.httpUserAgent= httpUserAgent;
+        this.httpUserAgent = httpUserAgent;
         return this;
     }
 
-    public  Map<String, String> getReservedWordsMappings() {
+    public Map<String, String> getReservedWordsMappings() {
         return reservedWordMappings;
     }
 
@@ -461,8 +471,7 @@ public class CodegenConfigurator implements Serializable {
             String opt = langCliOption.getOpt();
             if (dynamicProperties.containsKey(opt)) {
                 codegenConfig.additionalProperties().put(opt, dynamicProperties.get(opt));
-            }
-            else if(systemProperties.containsKey(opt)) {
+            } else if (systemProperties.containsKey(opt)) {
                 codegenConfig.additionalProperties().put(opt, systemProperties.get(opt));
             }
         }
@@ -520,5 +529,5 @@ public class CodegenConfigurator implements Serializable {
         }
         return null;
     }
-
 }
+

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/PhpClientCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/PhpClientCodegen.java
@@ -143,6 +143,7 @@ public class PhpClientCodegen extends DefaultCodegen implements CodegenConfig {
         cliOptions.add(new CliOption(CodegenConstants.GIT_USER_ID, CodegenConstants.GIT_USER_ID_DESC));
         cliOptions.add(new CliOption(COMPOSER_PROJECT_NAME, "The project name used in the composer package name. The template uses {{composerVendorName}}/{{composerProjectName}} for the composer package name. e.g. petstore-client. IMPORTANT NOTE (2016/03): composerProjectName will be deprecated and replaced by gitRepoId in the next swagger-codegen release"));
         cliOptions.add(new CliOption(CodegenConstants.GIT_REPO_ID, CodegenConstants.GIT_REPO_ID_DESC));
+        cliOptions.add(new CliOption(CodegenConstants.GIT_REPO_BASE_URL, CodegenConstants.GIT_REPO_BASE_URL_DESC));
         cliOptions.add(new CliOption(CodegenConstants.ARTIFACT_VERSION, "The version to use in the composer package version field. e.g. 1.2.3"));
         cliOptions.add(new CliOption(CodegenConstants.HIDE_GENERATION_TIMESTAMP, CodegenConstants.ALLOW_UNICODE_IDENTIFIERS_DESC)
                 .defaultValue(Boolean.TRUE.toString()));
@@ -269,6 +270,16 @@ public class PhpClientCodegen extends DefaultCodegen implements CodegenConfig {
             this.setGitRepoId((String) additionalProperties.get(CodegenConstants.GIT_REPO_ID));
         } else {
             additionalProperties.put(CodegenConstants.GIT_REPO_ID, gitRepoId);
+        }
+
+        if (additionalProperties.containsKey(CodegenConstants.GIT_REPO_BASE_URL)) {
+            this.setGitRepoBaseURL((String) additionalProperties.get(CodegenConstants.GIT_REPO_BASE_URL));
+        } else {
+            if (gitRepoBaseURL == null) {
+                gitRepoBaseURL = "github";
+            }
+                additionalProperties.put(CodegenConstants.GIT_REPO_BASE_URL, gitRepoBaseURL);
+
         }
 
         if (additionalProperties.containsKey(CodegenConstants.ARTIFACT_VERSION)) {

--- a/modules/swagger-codegen/src/main/resources/php/README.mustache
+++ b/modules/swagger-codegen/src/main/resources/php/README.mustache
@@ -31,7 +31,7 @@ To install the bindings via [Composer](http://getcomposer.org/), add the followi
   "repositories": [
     {
       "type": "git",
-      "url": "https://github.com/{{#composerVendorName}}{{.}}{{/composerVendorName}}{{^composerVendorName}}{{gitUserId}}{{/composerVendorName}}/{{#composerProjectName}}{{.}}{{/composerProjectName}}{{^composerProjectName}}{{gitRepoId}}{{/composerProjectName}}.git"
+      "url": "https://{{gitRepoBaseURL}}.com/{{#composerVendorName}}{{.}}{{/composerVendorName}}{{^composerVendorName}}{{gitUserId}}{{/composerVendorName}}/{{#composerProjectName}}{{.}}{{/composerProjectName}}{{^composerProjectName}}{{gitRepoId}}{{/composerProjectName}}.git"
     }
   ],
   "require": {

--- a/modules/swagger-codegen/src/main/resources/php/git_push.sh.mustache
+++ b/modules/swagger-codegen/src/main/resources/php/git_push.sh.mustache
@@ -37,9 +37,9 @@ if [ "$git_remote" = "" ]; then # git remote not defined
 
     if [ "$GIT_TOKEN" = "" ]; then
         echo "[INFO] \$GIT_TOKEN (environment variable) is not set. Using the git credential in your environment."
-        git remote add origin https://github.com/${git_user_id}/${git_repo_id}.git
+        git remote add origin https://${git_repo_base_url}.com/${git_user_id}/${git_repo_id}.git
     else
-        git remote add origin https://${git_user_id}:${GIT_TOKEN}@github.com/${git_user_id}/${git_repo_id}.git
+        git remote add origin https://${git_user_id}:${GIT_TOKEN}@${git_repo_base_url}.com/${git_user_id}/${git_repo_id}.git
     fi
 
 fi
@@ -47,6 +47,6 @@ fi
 git pull origin master
 
 # Pushes (Forces) the changes in the local repository up to the remote repository
-echo "Git pushing to https://github.com/${git_user_id}/${git_repo_id}.git"
+echo "Git pushing to https://${git_repo_base_url}.com/${git_user_id}/${git_repo_id}.git"
 git push origin master 2>&1 | grep -v 'To https'
 

--- a/modules/swagger-codegen/src/test/java/io/swagger/codegen/DefaultGeneratorTest.java
+++ b/modules/swagger-codegen/src/test/java/io/swagger/codegen/DefaultGeneratorTest.java
@@ -2,6 +2,7 @@ package io.swagger.codegen;
 
 import io.swagger.codegen.config.CodegenConfigurator;
 import io.swagger.codegen.languages.JavaClientCodegen;
+import io.swagger.codegen.languages.PhpClientCodegen;
 import io.swagger.codegen.languages.SpringCodegen;
 import io.swagger.models.ExternalDocs;
 import io.swagger.models.Swagger;
@@ -11,6 +12,7 @@ import io.swagger.parser.util.ParseOptions;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.junit.rules.TemporaryFolder;
+import org.testng.Assert;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
@@ -51,6 +53,57 @@ public class DefaultGeneratorTest {
     @AfterMethod
     public void tearDown() throws Exception {
         folder.delete();
+    }
+
+    @Test
+    public void testPHPRepositoryBaseURLOption() throws Exception {
+        final File output = folder.getRoot();
+        ParseOptions parseOptions = new ParseOptions();
+        parseOptions.setFlatten(true);
+        Swagger swagger = new SwaggerParser().read("src/test/resources/2_0/readmePHP_149.yaml",null, parseOptions);
+        CodegenConfig codegenConfig = new PhpClientCodegen();
+        codegenConfig.setOutputDir(output.getAbsolutePath());
+        codegenConfig.setGitRepoId("test_repository");
+        codegenConfig.setGitUserId("user");
+        codegenConfig.setGitRepoBaseURL("gitlab");
+
+        ClientOptInput clientOptInput = new ClientOptInput().opts(new ClientOpts()).swagger(swagger).config(codegenConfig);
+
+        //generate
+        new DefaultGenerator().opts(clientOptInput).generate();
+
+        final File readme = new File(output, "/SwaggerClient-php/README.md");
+        assertTrue(readme.exists());
+        assertTrue(FileUtils.readFileToString(readme).contains("gitlab"));
+
+        final File gitPush = new File(output, "/SwaggerClient-php/git_push.sh");
+        assertTrue(gitPush.exists());
+        assertFalse(FileUtils.readFileToString(gitPush).contains("https://github.com"));
+    }
+
+    @Test
+    public void testPHPRepositoryBaseURLOption_NoOption() throws Exception {
+        final File output = folder.getRoot();
+        ParseOptions parseOptions = new ParseOptions();
+        parseOptions.setFlatten(true);
+        Swagger swagger = new SwaggerParser().read("src/test/resources/2_0/readmePHP_149.yaml",null, parseOptions);
+        CodegenConfig codegenConfig = new PhpClientCodegen();
+        codegenConfig.setOutputDir(output.getAbsolutePath());
+        codegenConfig.setGitRepoId("test_repository");
+        codegenConfig.setGitUserId("user");
+
+        ClientOptInput clientOptInput = new ClientOptInput().opts(new ClientOpts()).swagger(swagger).config(codegenConfig);
+
+        //generate
+        new DefaultGenerator().opts(clientOptInput).generate();
+
+        final File readme = new File(output, "/SwaggerClient-php/README.md");
+        assertTrue(readme.exists());
+        assertTrue(FileUtils.readFileToString(readme).contains("https://github.com/user"));
+
+        final File gitPush = new File(output, "/SwaggerClient-php/git_push.sh");
+        assertTrue(gitPush.exists());
+        assertFalse(FileUtils.readFileToString(gitPush).contains("https://github.com"));
     }
 
     @Test
@@ -699,6 +752,7 @@ public class DefaultGeneratorTest {
         CodegenConfig codegenConfig = new SpringCodegen();
         codegenConfig.setLibrary("spring-cloud");
         codegenConfig.setOutputDir(output.getAbsolutePath());
+
 
         ClientOptInput clientOptInput = new ClientOptInput().opts(new ClientOpts()).swagger(swagger).config(codegenConfig);
 

--- a/modules/swagger-codegen/src/test/java/io/swagger/codegen/options/PhpClientOptionsProvider.java
+++ b/modules/swagger-codegen/src/test/java/io/swagger/codegen/options/PhpClientOptionsProvider.java
@@ -20,6 +20,7 @@ public class PhpClientOptionsProvider implements OptionsProvider {
     public static final String COMPOSER_PROJECT_NAME_VALUE = "swagger-client-php";
     public static final String GIT_USER_ID_VALUE = "gitSwaggerPhp";
     public static final String GIT_REPO_ID_VALUE = "git-swagger-client-php";
+    public static final String GIT_REPO_BASE_URL_VALUE = "githubPhp";
     public static final String ARTIFACT_VERSION_VALUE = "1.0.0-SNAPSHOT";
     public static final String ALLOW_UNICODE_IDENTIFIERS_VALUE = "false";
 
@@ -44,6 +45,7 @@ public class PhpClientOptionsProvider implements OptionsProvider {
                 .put(CodegenConstants.GIT_USER_ID, GIT_USER_ID_VALUE)
                 .put(PhpClientCodegen.COMPOSER_PROJECT_NAME, COMPOSER_PROJECT_NAME_VALUE)
                 .put(CodegenConstants.GIT_REPO_ID, GIT_REPO_ID_VALUE)
+                .put(CodegenConstants.GIT_REPO_BASE_URL, GIT_REPO_BASE_URL_VALUE)
                 .put(CodegenConstants.ARTIFACT_VERSION, ARTIFACT_VERSION_VALUE)
                 .put(CodegenConstants.HIDE_GENERATION_TIMESTAMP, "true")
                 .put(CodegenConstants.ALLOW_UNICODE_IDENTIFIERS, ALLOW_UNICODE_IDENTIFIERS_VALUE)

--- a/modules/swagger-codegen/src/test/java/io/swagger/codegen/php/PhpClientOptionsTest.java
+++ b/modules/swagger-codegen/src/test/java/io/swagger/codegen/php/PhpClientOptionsTest.java
@@ -48,6 +48,8 @@ public class PhpClientOptionsTest extends AbstractOptionsTest {
             times = 1;
             clientCodegen.setGitRepoId(PhpClientOptionsProvider.GIT_REPO_ID_VALUE);
             times = 1;
+            clientCodegen.setGitRepoBaseURL(PhpClientOptionsProvider.GIT_REPO_BASE_URL_VALUE);
+            times = 1;
             clientCodegen.setArtifactVersion(PhpClientOptionsProvider.ARTIFACT_VERSION_VALUE);
             times = 1;
         }};

--- a/modules/swagger-codegen/src/test/resources/2_0/readmePHP_149.yaml
+++ b/modules/swagger-codegen/src/test/resources/2_0/readmePHP_149.yaml
@@ -1,0 +1,114 @@
+swagger: '2.0'
+info:
+  description: This is a simple API
+  version: 1.0.0
+  title: Simple Inventory API
+  contact:
+    email: you@your-company.com
+  license:
+    name: Apache 2.0
+    url: 'http://www.apache.org/licenses/LICENSE-2.0.html'
+tags:
+  - name: admins
+    description: Secured Admin-only calls
+  - name: developers
+    description: Operations available to regular developers
+paths:
+  /inventory:
+    get:
+      tags:
+        - developers
+      summary: searches inventory
+      operationId: searchInventory
+      description: |
+        By passing in the appropriate options, you can search for
+        available inventory in the system
+      produces:
+        - application/json
+      parameters:
+        - in: query
+          name: searchString
+          description: pass an optional search string for looking up inventory
+          required: false
+          type: string
+        - in: query
+          name: skip
+          description: number of records to skip for pagination
+          type: integer
+          format: int32
+          minimum: 0
+        - in: query
+          name: limit
+          description: maximum number of records to return
+          type: integer
+          format: int32
+          minimum: 0
+          maximum: 50
+      responses:
+        '200':
+          description: search results matching criteria
+          schema:
+            type: array
+            items:
+              $ref: '#/definitions/InventoryItem'
+        '400':
+          description: bad input parameter
+    post:
+      tags:
+        - admins
+      summary: adds an inventory item
+      operationId: addInventory
+      description: Adds an item to the system
+      consumes:
+        - application/json
+      produces:
+        - application/json
+      parameters:
+        - in: body
+          name: inventoryItem
+          description: Inventory item to add
+          schema:
+            $ref: '#/definitions/InventoryItem'
+      responses:
+        '201':
+          description: item created
+        '400':
+          description: 'invalid input, object invalid'
+        '409':
+          description: an existing item already exists
+definitions:
+  InventoryItem:
+    type: object
+    required:
+      - id
+      - name
+      - manufacturer
+      - releaseDate
+    properties:
+      id:
+        type: string
+        format: uuid
+        example: d290f1ee-6c54-4b01-90e6-d701748f0851
+      name:
+        type: string
+        example: Widget Adapter
+      releaseDate:
+        type: string
+        format: date-time
+        example: '2016-08-29T09:12:33.001Z'
+      manufacturer:
+        $ref: '#/definitions/Manufacturer'
+  Manufacturer:
+    required:
+      - name
+    properties:
+      name:
+        type: string
+        example: ACME Corporation
+      homePage:
+        type: string
+        format: url
+        example: 'https://www.acme-corp.com'
+      phone:
+        type: string
+        example: 408-867-5309


### PR DESCRIPTION
This pr creates an option to allow the configuration of the repo base url in the readme  and git_push.sh files in php generator.
Option name: gitRepoBaseURL("string of repo url"); 