### PR TITLE
git repository BaseUrl config option PHP

### DIFF
--- a/modules/swagger-codegen-cli/src/main/java/io/swagger/codegen/v3/cli/cmd/Generate.java
+++ b/modules/swagger-codegen-cli/src/main/java/io/swagger/codegen/v3/cli/cmd/Generate.java
@@ -69,6 +69,7 @@ public class Generate implements Runnable {
     protected String library;
     protected String gitUserId;
     protected String gitRepoId;
+    protected String gitRepoBaseURL;
     protected String releaseNote;
     protected String httpUserAgent;
     protected List<String> reservedWordsMappings = new ArrayList<>();
@@ -80,6 +81,7 @@ public class Generate implements Runnable {
     protected Boolean flattenInlineSchema;
     private String url;
     private List<CodegenArgument> codegenArguments;
+
 
     public void setVerbose(Boolean verbose) {
         this.verbose = verbose;
@@ -187,6 +189,10 @@ public class Generate implements Runnable {
 
     public void setGitRepoId(String gitRepoId) {
         this.gitRepoId = gitRepoId;
+    }
+
+    public void setGitRepoBaseURL(String gitRepoBaseURL) {
+        this.gitRepoBaseURL = gitRepoBaseURL;
     }
 
     public void setReleaseNote(String releaseNote) {
@@ -322,6 +328,10 @@ public class Generate implements Runnable {
 
         if (isNotEmpty(gitRepoId)) {
             configurator.setGitRepoId(gitRepoId);
+        }
+
+        if (isNotEmpty(gitRepoBaseURL)) {
+            configurator.setGitRepoBaseURL(gitRepoBaseURL);
         }
 
         if (isNotEmpty(releaseNote)) {

--- a/modules/swagger-codegen/pom.xml
+++ b/modules/swagger-codegen/pom.xml
@@ -200,7 +200,7 @@
     </reporting>
     <properties>
         <diffutils-version>1.3.0</diffutils-version>
-        <swagger-codegen-v2-version>2.4.21</swagger-codegen-v2-version>
+        <swagger-codegen-v2-version>2.4.22-SNAPSHOT</swagger-codegen-v2-version>
     </properties>
     <dependencies>
         <dependency>

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/v3/CodegenConfig.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/v3/CodegenConfig.java
@@ -208,6 +208,10 @@ public interface CodegenConfig {
 
     String getGitRepoId();
 
+    void setGitRepoBaseURL(String gitRepoBaseURL);
+
+    String getGitRepoBaseURL();
+
     void setReleaseNote(String releaseNote);
 
     String getReleaseNote();

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/v3/CodegenConstants.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/v3/CodegenConstants.java
@@ -182,6 +182,9 @@ public class CodegenConstants {
     public static final String GIT_REPO_ID = "gitRepoId";
     public static final String GIT_REPO_ID_DESC = "Git repo ID, e.g. swagger-codegen.";
 
+    public static final String GIT_REPO_BASE_URL = "gitRepoBaseURL";
+    public static final String GIT_REPO_BASE_URL_DESC = "Git repo Base URL, e.g. swagger-codegen.";
+
     public static final String RELEASE_NOTE = "releaseNote";
     public static final String RELEASE_NOTE_DESC = "Release note, default to 'Minor update'.";
 

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/v3/config/CodegenConfigurator.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/v3/config/CodegenConfigurator.java
@@ -87,6 +87,7 @@ public class CodegenConfigurator implements Serializable {
 
     private String gitUserId="GIT_USER_ID";
     private String gitRepoId="GIT_REPO_ID";
+    private String gitRepoBaseURL = "github";
     private String releaseNote="Minor update";
     private String httpUserAgent;
 
@@ -402,6 +403,16 @@ public class CodegenConfigurator implements Serializable {
         return this;
     }
 
+    public String getGitRepoBaseURL() {
+        return gitRepoBaseURL;
+    }
+
+    public CodegenConfigurator setGitRepoBaseURL(String gitRepoBaseURL) {
+        this.gitRepoBaseURL = gitRepoBaseURL;
+        return this;
+    }
+
+
     public String getReleaseNote() {
         return releaseNote;
     }
@@ -633,6 +644,7 @@ public class CodegenConfigurator implements Serializable {
         checkAndSetAdditionalProperty(modelNameSuffix, CodegenConstants.MODEL_NAME_SUFFIX);
         checkAndSetAdditionalProperty(gitUserId, CodegenConstants.GIT_USER_ID);
         checkAndSetAdditionalProperty(gitRepoId, CodegenConstants.GIT_REPO_ID);
+        checkAndSetAdditionalProperty(gitRepoBaseURL, CodegenConstants.GIT_REPO_BASE_URL);
         checkAndSetAdditionalProperty(releaseNote, CodegenConstants.RELEASE_NOTE);
         checkAndSetAdditionalProperty(httpUserAgent, CodegenConstants.HTTP_USER_AGENT);
 

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/v3/service/GeneratorUtil.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/v3/service/GeneratorUtil.java
@@ -185,6 +185,9 @@ public class GeneratorUtil {
         if (isNotEmpty(options.getGitRepoId())) {
             codegenConfig.additionalProperties().put(CodegenConstants.GIT_REPO_ID, options.getGitRepoId());
         }
+        if (isNotEmpty(options.getGitRepoBaseURL())) {
+            codegenConfig.additionalProperties().put(CodegenConstants.GIT_REPO_BASE_URL, options.getGitRepoBaseURL());
+        }
         if (isNotEmpty(options.getReleaseNote())) {
             codegenConfig.additionalProperties().put(CodegenConstants.RELEASE_NOTE, options.getReleaseNote());
         }
@@ -304,6 +307,9 @@ public class GeneratorUtil {
         }
         if (isNotEmpty(options.getGitRepoId())) {
             configurator.setGitRepoId(options.getGitRepoId());
+        }
+        if (isNotEmpty(options.getGitRepoBaseURL())) {
+            configurator.setGitRepoBaseURL(options.getGitRepoBaseURL());
         }
         if (isNotEmpty(options.getReleaseNote())) {
             configurator.setReleaseNote(options.getReleaseNote());

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/v3/service/Options.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/v3/service/Options.java
@@ -28,6 +28,7 @@ public class Options {
     private String library;
     private String gitUserId;
     private String gitRepoId;
+    private String gitRepoBaseURL;
     private String releaseNote;
     private String httpUserAgent;
     private Map<String, String> reservedWordsMappings = new LinkedHashMap<>();
@@ -366,6 +367,19 @@ public class Options {
         this.gitRepoId = gitRepoId;
     }
 
+    public Options gitRepoBaseURL(String gitRepoBaseURL) {
+        this.gitRepoBaseURL = gitRepoBaseURL;
+        return this;
+    }
+
+    public String getGitRepoBaseURL() {
+        return gitRepoBaseURL;
+    }
+
+    public void setGitRepoBaseURL(String gitRepoBaseURL) {
+        this.gitRepoBaseURL = gitRepoBaseURL;
+    }
+
     public Options releaseNote(String releaseNote) {
         this.releaseNote = releaseNote;
         return this;
@@ -490,5 +504,4 @@ public class Options {
         this.flattenInlineComposedSchemas = flattenInlineComposedSchemas;
         return this;
     }
-
 }

--- a/modules/swagger-codegen/src/test/java/io/swagger/codegen/v3/service/GeneratorServiceTest.java
+++ b/modules/swagger-codegen/src/test/java/io/swagger/codegen/v3/service/GeneratorServiceTest.java
@@ -18,8 +18,7 @@ import java.nio.file.Files;
 import java.util.List;
 
 public class GeneratorServiceTest {
-
-
+    
     @Test(description = "test generator service with html2")
     public void testGeneratorService_HTML2_Bearer() throws IOException {
 
@@ -50,7 +49,6 @@ public class GeneratorServiceTest {
                         " -H \"Authorization: Bearer [[accessToken]]\"\\"));
             }
         }
-
     }
 
     @Test(description = "test generator service with html2")

--- a/modules/swagger-codegen/src/test/resources/2_0/readme149.yaml
+++ b/modules/swagger-codegen/src/test/resources/2_0/readme149.yaml
@@ -1,0 +1,114 @@
+swagger: '2.0'
+info:
+  description: This is a simple API
+  version: 1.0.0
+  title: Simple Inventory API
+  contact:
+    email: you@your-company.com
+  license:
+    name: Apache 2.0
+    url: 'http://www.apache.org/licenses/LICENSE-2.0.html'
+tags:
+  - name: admins
+    description: Secured Admin-only calls
+  - name: developers
+    description: Operations available to regular developers
+paths:
+  /inventory:
+    get:
+      tags:
+        - developers
+      summary: searches inventory
+      operationId: searchInventory
+      description: |
+        By passing in the appropriate options, you can search for
+        available inventory in the system
+      produces:
+        - application/json
+      parameters:
+        - in: query
+          name: searchString
+          description: pass an optional search string for looking up inventory
+          required: false
+          type: string
+        - in: query
+          name: skip
+          description: number of records to skip for pagination
+          type: integer
+          format: int32
+          minimum: 0
+        - in: query
+          name: limit
+          description: maximum number of records to return
+          type: integer
+          format: int32
+          minimum: 0
+          maximum: 50
+      responses:
+        '200':
+          description: search results matching criteria
+          schema:
+            type: array
+            items:
+              $ref: '#/definitions/InventoryItem'
+        '400':
+          description: bad input parameter
+    post:
+      tags:
+        - admins
+      summary: adds an inventory item
+      operationId: addInventory
+      description: Adds an item to the system
+      consumes:
+        - application/json
+      produces:
+        - application/json
+      parameters:
+        - in: body
+          name: inventoryItem
+          description: Inventory item to add
+          schema:
+            $ref: '#/definitions/InventoryItem'
+      responses:
+        '201':
+          description: item created
+        '400':
+          description: 'invalid input, object invalid'
+        '409':
+          description: an existing item already exists
+definitions:
+  InventoryItem:
+    type: object
+    required:
+      - id
+      - name
+      - manufacturer
+      - releaseDate
+    properties:
+      id:
+        type: string
+        format: uuid
+        example: d290f1ee-6c54-4b01-90e6-d701748f0851
+      name:
+        type: string
+        example: Widget Adapter
+      releaseDate:
+        type: string
+        format: date-time
+        example: '2016-08-29T09:12:33.001Z'
+      manufacturer:
+        $ref: '#/definitions/Manufacturer'
+  Manufacturer:
+    required:
+      - name
+    properties:
+      name:
+        type: string
+        example: ACME Corporation
+      homePage:
+        type: string
+        format: url
+        example: 'https://www.acme-corp.com'
+      phone:
+        type: string
+        example: 408-867-5309

--- a/modules/swagger-codegen/src/test/resources/3_0_0/readme149_v3.yaml
+++ b/modules/swagger-codegen/src/test/resources/3_0_0/readme149_v3.yaml
@@ -1,0 +1,114 @@
+openapi: 3.0.0
+info:
+  description: This is a simple API
+  version: 1.0.0
+  title: Simple Inventory API
+  contact:
+    email: you@your-company.com
+  license:
+    name: Apache 2.0
+    url: http://www.apache.org/licenses/LICENSE-2.0.html
+tags:
+  - name: admins
+    description: Secured Admin-only calls
+  - name: developers
+    description: Operations available to regular developers
+paths:
+  /inventory:
+    get:
+      tags:
+        - developers
+      summary: searches inventory
+      operationId: searchInventory
+      description: |
+        By passing in the appropriate options, you can search for
+        available inventory in the system
+      parameters:
+        - in: query
+          name: searchString
+          description: pass an optional search string for looking up inventory
+          required: false
+          schema:
+            type: string
+        - in: query
+          name: skip
+          description: number of records to skip for pagination
+          schema:
+            type: integer
+            format: int32
+            minimum: 0
+        - in: query
+          name: limit
+          description: maximum number of records to return
+          schema:
+            type: integer
+            format: int32
+            minimum: 0
+            maximum: 50
+      responses:
+        "200":
+          description: search results matching criteria
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/InventoryItem"
+        "400":
+          description: bad input parameter
+    post:
+      tags:
+        - admins
+      summary: adds an inventory item
+      operationId: addInventory
+      description: Adds an item to the system
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/InventoryItem"
+        description: Inventory item to add
+      responses:
+        "201":
+          description: item created
+        "400":
+          description: invalid input, object invalid
+        "409":
+          description: an existing item already exists
+components:
+  schemas:
+    InventoryItem:
+      type: object
+      required:
+        - id
+        - name
+        - manufacturer
+        - releaseDate
+      properties:
+        id:
+          type: string
+          format: uuid
+          example: d290f1ee-6c54-4b01-90e6-d701748f0851
+        name:
+          type: string
+          example: Widget Adapter
+        releaseDate:
+          type: string
+          format: date-time
+          example: 2016-08-29T09:12:33.001Z
+        manufacturer:
+          $ref: "#/components/schemas/Manufacturer"
+    Manufacturer:
+      required:
+        - name
+      properties:
+        name:
+          type: string
+          example: ACME Corporation
+        homePage:
+          type: string
+          format: url
+          example: https://www.acme-corp.com
+        phone:
+          type: string
+          example: 408-867-5309


### PR DESCRIPTION
This pr creates an option to allow the configuration of the repo base url in the readme and git_push.sh files in php generator.
Option name: gitRepoBaseURL("string of repo url");
depends on (master): https://github.com/swagger-api/swagger-codegen/pull/11170
relates to:  https://github.com/swagger-api/swagger-codegen-generators/pull/962

