### PR TITLE
bump Apache Commons IO version in order to fix vulnerability

### DIFF
--- a/pom.docker.xml
+++ b/pom.docker.xml
@@ -1071,7 +1071,7 @@
         <jackson-version>2.12.1</jackson-version>
         <scala-version>2.11.1</scala-version>
         <felix-version>3.3.0</felix-version>
-        <commons-io-version>2.7</commons-io-version>
+        <commons-io-version>2.11.0</commons-io-version>
         <commons-cli-version>1.2</commons-cli-version>
         <junit-version>4.13.1</junit-version>
         <maven-plugin-version>1.0.0</maven-plugin-version>

--- a/pom.docker.xml
+++ b/pom.docker.xml
@@ -1071,7 +1071,7 @@
         <jackson-version>2.12.1</jackson-version>
         <scala-version>2.11.1</scala-version>
         <felix-version>3.3.0</felix-version>
-        <commons-io-version>2.4</commons-io-version>
+        <commons-io-version>2.7</commons-io-version>
         <commons-cli-version>1.2</commons-cli-version>
         <junit-version>4.13.1</junit-version>
         <maven-plugin-version>1.0.0</maven-plugin-version>

--- a/pom.xml
+++ b/pom.xml
@@ -1164,7 +1164,7 @@
         <jackson-version>2.12.1</jackson-version>
         <scala-version>2.11.1</scala-version>
         <felix-version>3.3.0</felix-version>
-        <commons-io-version>2.4</commons-io-version>
+        <commons-io-version>2.7</commons-io-version>
         <commons-cli-version>1.2</commons-cli-version>
         <junit-version>4.13.1</junit-version>
         <maven-plugin-version>1.0.0</maven-plugin-version>

--- a/pom.xml
+++ b/pom.xml
@@ -1164,7 +1164,7 @@
         <jackson-version>2.12.1</jackson-version>
         <scala-version>2.11.1</scala-version>
         <felix-version>3.3.0</felix-version>
-        <commons-io-version>2.7</commons-io-version>
+        <commons-io-version>2.11.0</commons-io-version>
         <commons-cli-version>1.2</commons-cli-version>
         <junit-version>4.13.1</junit-version>
         <maven-plugin-version>1.0.0</maven-plugin-version>


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [ ] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [x] Filed the PR against the correct branch: `3.0.0` branch for changes related to OpenAPI spec 3.0. Default: `master`.
- [ ] Copied the [technical committee](https://github.com/swagger-api/swagger-codegen/#swagger-codegen-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

As discussed with @ponelat via security email before here is the PR fixing the issue.

Bump Apache Commons IO from 2.4 to 2.11 in order to fix vulnerability in < 2.7
See related CVE: https://nvd.nist.gov/vuln/detail/CVE-2021-29425

EDIT: bumped to most lastest 2.11 version

Testing:
I run "mvn clean package" locally and all tests passed.