### PR TITLE
Fix Vagrantfile 3.0.0

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -6,7 +6,7 @@ VAGRANTFILE_API_VERSION = "2"
 
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
 
-  config.vm.box = "ubuntu/trusty64"
+  config.vm.box = "ubuntu/bionic64"
 
   config.vm.provider "virtualbox" do |v|
     v.name = "swagger-codegen"
@@ -24,12 +24,12 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   #Provision
   config.vm.provision "shell", inline: <<-SHELL
     sudo touch /var/lib/cloud/instance/locale-check.skip
-    sudo apt-key adv --keyserver hkp://pgp.mit.edu:80 --recv-keys 58118E89F3A912897C070ADBF76221572C52609D
-    sudo sh -c 'echo "deb https://apt.dockerproject.org/repo ubuntu-trusty main" > /etc/apt/sources.list.d/docker.list'
-    sudo apt-cache policy docker-engine
+    sudo apt-get install ca-certificates curl gnupg lsb-release -y
+    curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo gpg --dearmor -o /usr/share/keyrings/docker-archive-keyring.gpg
+    echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/docker-archive-keyring.gpg] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable" | sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
     sudo apt-get update
     sudo apt-get upgrade -y
-    sudo apt-get install -y docker-engine
+    sudo apt-get install -y docker-ce docker-ce-cli containerd.io
     sudo usermod -aG docker vagrant
   SHELL
 


### PR DESCRIPTION
### PR checklist

- [X] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [X] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [X] Filed the PR against the correct branch: `3.0.0` branch for changes related to OpenAPI spec 3.0. Default: `master`.
- [ ] Copied the [technical committee](https://github.com/swagger-api/swagger-codegen/#swagger-codegen-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

(details of the change, additional tests that have been done, reference to the issue for tracking, etc)

1. Repositories from dockerproject.com are no longer supported, update to use the repositories at download.docker.com. 
    https://www.docker.com/blog/changes-dockerproject-org-apt-yum-repositories/

>     default: W: Failed to fetch https://apt.dockerproject.org/repo/dists/ubuntu-trusty/main/binary-amd64/Packages  gnutls_handshake() failed: Handshake failed

>     default: E: Unable to locate package docker-engine

2. Provision according to docker docs.
    https://docs.docker.com/engine/install/ubuntu/

3. Ubuntu 14.04 LTS Trusty Thar "End of Standard Support April 2019"
    Change from Vagrant "ubuntu/trusty64" to supported "ubuntu/bionic64"


4. Test

INFO] Reactor Summary for swagger-codegen-project 3.0.31-SNAPSHOT:
[INFO] 
[INFO] swagger-codegen-project ............................ SUCCESS [ 13.909 s]
[INFO] swagger-codegen (core library) ..................... SUCCESS [02:56 min]
[INFO] swagger-codegen (executable) ....................... SUCCESS [ 17.660 s]
[INFO] swagger-codegen (maven-plugin) ..................... SUCCESS [ 23.428 s]
[INFO] swagger-generator .................................. SUCCESS [ 45.578 s]
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS


 



