### PR TITLE
Fix templateDir generation on Windows

### DIFF
--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/v3/templates/CodegenTemplateLoader.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/v3/templates/CodegenTemplateLoader.java
@@ -2,6 +2,7 @@ package io.swagger.codegen.v3.templates;
 
 import com.github.jknack.handlebars.io.FileTemplateLoader;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.SystemUtils;
 
 import java.io.File;
 import java.io.IOException;
@@ -31,6 +32,9 @@ public class CodegenTemplateLoader extends FileTemplateLoader {
 
     private String resolveTemplateFile(String templateDir, String templateFile) {
         if (templateFile.startsWith(templateDir)) {
+            if (SystemUtils.IS_OS_WINDOWS) {
+                templateDir = templateDir + "/";
+            }
             templateFile = StringUtils.replaceOnce(templateFile, templateDir, StringUtils.EMPTY);
         }
         return templateFile;


### PR DESCRIPTION
closes #11223

### PR checklist

- [ /] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [ /] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [/ ] Filed the PR against the correct branch: `3.0.0` branch for changes related to OpenAPI spec 3.0. Default: `master`.
- [/ ] Copied the [technical committee](https://github.com/swagger-api/swagger-codegen/#swagger-codegen-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR
When generating code from windows using the swagger-codegen-maven-plugin and setting the templateDirectory
you are unable to resolve the template file as it's appending a / in the beginning and with an absolute path of C:/code/templates this becomes /C:/code/templates which can't be resolved
This has been opened in #11223 

