### PR TITLE
bump slf4j version to fix possible vulnerability

### DIFF
--- a/pom.docker.xml
+++ b/pom.docker.xml
@@ -1076,7 +1076,7 @@
         <junit-version>4.13.1</junit-version>
         <maven-plugin-version>1.0.0</maven-plugin-version>
         <commons-lang-version>3.4</commons-lang-version>
-        <slf4j-version>1.7.25</slf4j-version>
+        <slf4j-version>1.7.32</slf4j-version>
         <logback-version>1.2.3</logback-version>
         <scala-maven-plugin-version>3.2.1</scala-maven-plugin-version>
         <jmustache-version>1.12</jmustache-version>

--- a/pom.xml
+++ b/pom.xml
@@ -1169,7 +1169,7 @@
         <junit-version>4.13.1</junit-version>
         <maven-plugin-version>1.0.0</maven-plugin-version>
         <commons-lang-version>3.4</commons-lang-version>
-        <slf4j-version>1.7.25</slf4j-version>
+        <slf4j-version>1.7.32</slf4j-version>
         <logback-version>1.2.3</logback-version>
         <scala-maven-plugin-version>3.2.1</scala-maven-plugin-version>
         <jmustache-version>1.12</jmustache-version>


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [ ] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [x] Filed the PR against the correct branch: `3.0.0` branch for changes related to OpenAPI spec 3.0. Default: `master`.
- [ ] Copied the [technical committee](https://github.com/swagger-api/swagger-codegen/#swagger-codegen-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

As dicussed via security mailing list, here is version bump of slf4j.
@ponelat 