### PR TITLE
add case for "multi" to golang

### DIFF
--- a/modules/swagger-codegen/src/main/resources/go/client.mustache
+++ b/modules/swagger-codegen/src/main/resources/go/client.mustache
@@ -138,6 +138,8 @@ func parameterToString(obj interface{}, collectionFormat string) string {
 		delimiter = "\t"
 	case "csv":
 		delimiter = ","
+	case "multi":
+		delimiter = ","
 	}
 
 	if reflect.TypeOf(obj).Kind() == reflect.Slice {


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [ ] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [ ] Filed the PR against the correct branch: `3.0.0` branch for changes related to OpenAPI spec 3.0. Default: `master`.
- [ ] Copied the [technical committee](https://github.com/swagger-api/swagger-codegen/#swagger-codegen-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

This PR is to add a missing case for multi (array) properties. For example, in this api:
```
  /api:
    get:
      parameters:
      - name: ids
        in: query
        required: true
        style: form
        explode: true
        schema:
          type: array
          items:
            minimum: 1
            type: integer
```

When passed multiple integers (eg `[1,2,3,4,5]`), the current go code sends off the param value `12345`. This changes makes the value `1,2,3,4,5`.