### PR TITLE
problem of using custom template Fixed 

### DIFF
--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/v3/templates/HandlebarTemplateEngine.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/v3/templates/HandlebarTemplateEngine.java
@@ -32,7 +32,7 @@ public class HandlebarTemplateEngine implements TemplateEngine {
 
     private com.github.jknack.handlebars.Template getHandlebars(String templateFile) throws IOException {
         templateFile = templateFile.replace(".mustache", StringUtils.EMPTY).replace("\\", "/");
-        String templateDir = config.customTemplateDir() != null ? "" : "handlebars/JavaSpring/";
+        String templateDir = config.customTemplateDir() != null ? "" : config.templateDir().replace("\\", "/");
         String customTemplateDir = config.customTemplateDir() != null ? config.customTemplateDir().replace("\\", "/") : null;
         final TemplateLoader templateLoader;
         templateFile = resolveTemplateFile(templateDir, templateFile);

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/v3/templates/HandlebarTemplateEngine.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/v3/templates/HandlebarTemplateEngine.java
@@ -32,9 +32,9 @@ public class HandlebarTemplateEngine implements TemplateEngine {
 
     private com.github.jknack.handlebars.Template getHandlebars(String templateFile) throws IOException {
         templateFile = templateFile.replace(".mustache", StringUtils.EMPTY).replace("\\", "/");
-        final String templateDir = config.templateDir().replace("\\", "/");
-        final TemplateLoader templateLoader;
+        String templateDir = config.customTemplateDir() != null ? "" : "handlebars/JavaSpring/";
         String customTemplateDir = config.customTemplateDir() != null ? config.customTemplateDir().replace("\\", "/") : null;
+        final TemplateLoader templateLoader;
         templateFile = resolveTemplateFile(templateDir, templateFile);
         templateLoader = new CodegenTemplateLoader("/" + templateDir, ".mustache")
                 .customTemplateDir(customTemplateDir);


### PR DESCRIPTION
fixed #11621 
I found out that the problem was from the wrong prefix. 
The program used to add a relative path to the absolute path !.
So I add an option to avoid adding that relative path when the client want to use its own template files.