### PR TITLE
[security problem] no escape for query parameters for Dart/Flutter language, so any query parameter with char like ?,&,= etc will have problems

### DIFF
--- a/modules/swagger-codegen/src/main/resources/dart/api_client.mustache
+++ b/modules/swagger-codegen/src/main/resources/dart/api_client.mustache
@@ -105,7 +105,7 @@ class ApiClient {
 
     _updateParamsForAuth(authNames, queryParams, headerParams);
 
-    var ps = queryParams.where((p) => p.value != null).map((p) => '${p.name}=${p.value}');
+    var ps = queryParams.where((p) => p.value != null).map((p) => '${Uri.encodeComponent(p.name)}=${Uri.encodeComponent(p.value)}');
     String queryString = ps.isNotEmpty ?
                          '?' + ps.join('&') :
                          '';


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [ ] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [x] Filed the PR against the correct branch: `3.0.0` branch for changes related to OpenAPI spec 3.0. Default: `master`.
- [x] Copied the [technical committee](https://github.com/swagger-api/swagger-codegen/#swagger-codegen-technical-committee) to review the pull request if your PR is targeting a particular programming language.

@ircecho

### Description of the PR

(details of the change, additional tests that have been done, reference to the issue for tracking, etc)

Closes https://github.com/swagger-api/swagger-codegen/issues/11638

Please see that issue for a long description