### PR TITLE
Allow customization of path variable serialization

### DIFF
--- a/modules/swagger-codegen/src/main/resources/Java/api.mustache
+++ b/modules/swagger-codegen/src/main/resources/Java/api.mustache
@@ -73,7 +73,7 @@ public class {{classname}} {
     {{/required}}{{/allParams}}
     // create path and map variables
     String {{localVariablePrefix}}localVarPath = "{{{path}}}"{{#pathParams}}
-      .replaceAll("\\{" + "{{baseName}}" + "\\}", {{localVariablePrefix}}apiClient.escapeString({{{paramName}}}.toString())){{/pathParams}};
+      .replaceAll("\\{" + "{{baseName}}" + "\\}", {{localVariablePrefix}}apiClient.escapeString({{localVariablePrefix}}apiClient.parameterToString({{{paramName}}}))){{/pathParams}};
 
     // query params
     {{javaUtilPrefix}}List<Pair> {{localVariablePrefix}}localVarQueryParams = new {{javaUtilPrefix}}ArrayList<Pair>();

--- a/modules/swagger-codegen/src/main/resources/Java/libraries/jersey2/api.mustache
+++ b/modules/swagger-codegen/src/main/resources/Java/libraries/jersey2/api.mustache
@@ -100,7 +100,7 @@ public class {{classname}} {
     {{/required}}{{/allParams}}
     // create path and map variables
     String {{localVariablePrefix}}localVarPath = "{{{path}}}"{{#pathParams}}
-      .replaceAll("\\{" + "{{baseName}}" + "\\}", {{localVariablePrefix}}apiClient.escapeString({{{paramName}}}.toString())){{/pathParams}};
+      .replaceAll("\\{" + "{{baseName}}" + "\\}", {{localVariablePrefix}}apiClient.escapeString({{localVariablePrefix}}apiClient.parameterToString({{{paramName}}}))){{/pathParams}};
 
     // query params
     {{javaUtilPrefix}}List<Pair> {{localVariablePrefix}}localVarQueryParams = new {{javaUtilPrefix}}ArrayList<Pair>();

--- a/modules/swagger-codegen/src/main/resources/Java/libraries/okhttp-gson/api.mustache
+++ b/modules/swagger-codegen/src/main/resources/Java/libraries/okhttp-gson/api.mustache
@@ -86,7 +86,7 @@ public class {{classname}} {
 
         // create path and map variables
         String {{localVariablePrefix}}localVarPath = "{{{path}}}"{{#pathParams}}
-            .replaceAll("\\{" + "{{baseName}}" + "\\}", {{localVariablePrefix}}apiClient.escapeString({{{paramName}}}.toString())){{/pathParams}};
+            .replaceAll("\\{" + "{{baseName}}" + "\\}", {{localVariablePrefix}}apiClient.escapeString({{localVariablePrefix}}apiClient.parameterToString({{{paramName}}}))){{/pathParams}};
 
         {{javaUtilPrefix}}List<Pair> {{localVariablePrefix}}localVarQueryParams = new {{javaUtilPrefix}}ArrayList<Pair>();
         {{javaUtilPrefix}}List<Pair> {{localVariablePrefix}}localVarCollectionQueryParams = new {{javaUtilPrefix}}ArrayList<Pair>();{{#queryParams}}

--- a/modules/swagger-codegen/src/main/resources/Java/libraries/resteasy/api.mustache
+++ b/modules/swagger-codegen/src/main/resources/Java/libraries/resteasy/api.mustache
@@ -66,7 +66,7 @@ public class {{classname}} {
     {{/required}}{{/allParams}}
     // create path and map variables
     String {{localVariablePrefix}}localVarPath = "{{{path}}}".replaceAll("\\{format\\}","json"){{#pathParams}}
-      .replaceAll("\\{" + "{{baseName}}" + "\\}", {{localVariablePrefix}}apiClient.escapeString({{{paramName}}}.toString())){{/pathParams}};
+      .replaceAll("\\{" + "{{baseName}}" + "\\}", {{localVariablePrefix}}apiClient.escapeString({{localVariablePrefix}}apiClient.parameterToString({{{paramName}}}))){{/pathParams}};
 
     // query params
     {{javaUtilPrefix}}List<Pair> {{localVariablePrefix}}localVarQueryParams = new {{javaUtilPrefix}}ArrayList<Pair>();

--- a/modules/swagger-codegen/src/test/resources/2_0/templates/Java/libraries/jersey2/api.mustache
+++ b/modules/swagger-codegen/src/test/resources/2_0/templates/Java/libraries/jersey2/api.mustache
@@ -62,7 +62,7 @@ public class {{classname}} {
     {{/required}}{{/allParams}}
     // create path and map variables
     String {{localVariablePrefix}}localVarPath = "{{{path}}}".replaceAll("\\{format\\}","json"){{#pathParams}}
-      .replaceAll("\\{" + "{{baseName}}" + "\\}", {{localVariablePrefix}}apiClient.escapeString({{{paramName}}}.toString())){{/pathParams}};
+      .replaceAll("\\{" + "{{baseName}}" + "\\}", {{localVariablePrefix}}apiClient.escapeString({{localVariablePrefix}}apiClient.parameterToString({{{paramName}}}))){{/pathParams}};
 
     // query params
     {{javaUtilPrefix}}List<Pair> {{localVariablePrefix}}localVarQueryParams = new {{javaUtilPrefix}}ArrayList<Pair>();

--- a/samples/client/petstore/java/jersey1/src/main/java/io/swagger/client/api/PetApi.java
+++ b/samples/client/petstore/java/jersey1/src/main/java/io/swagger/client/api/PetApi.java
@@ -108,7 +108,7 @@ public class PetApi {
     
     // create path and map variables
     String localVarPath = "/pet/{petId}"
-      .replaceAll("\\{" + "petId" + "\\}", apiClient.escapeString(petId.toString()));
+      .replaceAll("\\{" + "petId" + "\\}", apiClient.escapeString(apiClient.parameterToString(petId)));
 
     // query params
     List<Pair> localVarQueryParams = new ArrayList<Pair>();
@@ -241,7 +241,7 @@ public class PetApi {
     
     // create path and map variables
     String localVarPath = "/pet/{petId}"
-      .replaceAll("\\{" + "petId" + "\\}", apiClient.escapeString(petId.toString()));
+      .replaceAll("\\{" + "petId" + "\\}", apiClient.escapeString(apiClient.parameterToString(petId)));
 
     // query params
     List<Pair> localVarQueryParams = new ArrayList<Pair>();
@@ -326,7 +326,7 @@ public class PetApi {
     
     // create path and map variables
     String localVarPath = "/pet/{petId}"
-      .replaceAll("\\{" + "petId" + "\\}", apiClient.escapeString(petId.toString()));
+      .replaceAll("\\{" + "petId" + "\\}", apiClient.escapeString(apiClient.parameterToString(petId)));
 
     // query params
     List<Pair> localVarQueryParams = new ArrayList<Pair>();
@@ -375,7 +375,7 @@ if (status != null)
     
     // create path and map variables
     String localVarPath = "/pet/{petId}/uploadImage"
-      .replaceAll("\\{" + "petId" + "\\}", apiClient.escapeString(petId.toString()));
+      .replaceAll("\\{" + "petId" + "\\}", apiClient.escapeString(apiClient.parameterToString(petId)));
 
     // query params
     List<Pair> localVarQueryParams = new ArrayList<Pair>();

--- a/samples/client/petstore/java/jersey1/src/main/java/io/swagger/client/api/StoreApi.java
+++ b/samples/client/petstore/java/jersey1/src/main/java/io/swagger/client/api/StoreApi.java
@@ -64,7 +64,7 @@ public class StoreApi {
     
     // create path and map variables
     String localVarPath = "/store/order/{order_id}"
-      .replaceAll("\\{" + "order_id" + "\\}", apiClient.escapeString(orderId.toString()));
+      .replaceAll("\\{" + "order_id" + "\\}", apiClient.escapeString(apiClient.parameterToString(orderId)));
 
     // query params
     List<Pair> localVarQueryParams = new ArrayList<Pair>();
@@ -143,7 +143,7 @@ public class StoreApi {
     
     // create path and map variables
     String localVarPath = "/store/order/{order_id}"
-      .replaceAll("\\{" + "order_id" + "\\}", apiClient.escapeString(orderId.toString()));
+      .replaceAll("\\{" + "order_id" + "\\}", apiClient.escapeString(apiClient.parameterToString(orderId)));
 
     // query params
     List<Pair> localVarQueryParams = new ArrayList<Pair>();

--- a/samples/client/petstore/java/jersey1/src/main/java/io/swagger/client/api/UserApi.java
+++ b/samples/client/petstore/java/jersey1/src/main/java/io/swagger/client/api/UserApi.java
@@ -187,7 +187,7 @@ public class UserApi {
     
     // create path and map variables
     String localVarPath = "/user/{username}"
-      .replaceAll("\\{" + "username" + "\\}", apiClient.escapeString(username.toString()));
+      .replaceAll("\\{" + "username" + "\\}", apiClient.escapeString(apiClient.parameterToString(username)));
 
     // query params
     List<Pair> localVarQueryParams = new ArrayList<Pair>();
@@ -230,7 +230,7 @@ public class UserApi {
     
     // create path and map variables
     String localVarPath = "/user/{username}"
-      .replaceAll("\\{" + "username" + "\\}", apiClient.escapeString(username.toString()));
+      .replaceAll("\\{" + "username" + "\\}", apiClient.escapeString(apiClient.parameterToString(username)));
 
     // query params
     List<Pair> localVarQueryParams = new ArrayList<Pair>();
@@ -363,7 +363,7 @@ public class UserApi {
     
     // create path and map variables
     String localVarPath = "/user/{username}"
-      .replaceAll("\\{" + "username" + "\\}", apiClient.escapeString(username.toString()));
+      .replaceAll("\\{" + "username" + "\\}", apiClient.escapeString(apiClient.parameterToString(username)));
 
     // query params
     List<Pair> localVarQueryParams = new ArrayList<Pair>();

--- a/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/io/swagger/client/api/PetApi.java
+++ b/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/io/swagger/client/api/PetApi.java
@@ -188,7 +188,7 @@ public class PetApi {
 
         // create path and map variables
         String localVarPath = "/pet/{petId}"
-            .replaceAll("\\{" + "petId" + "\\}", apiClient.escapeString(petId.toString()));
+            .replaceAll("\\{" + "petId" + "\\}", apiClient.escapeString(apiClient.parameterToString(petId)));
 
         List<Pair> localVarQueryParams = new ArrayList<Pair>();
         List<Pair> localVarCollectionQueryParams = new ArrayList<Pair>();
@@ -569,7 +569,7 @@ public class PetApi {
 
         // create path and map variables
         String localVarPath = "/pet/{petId}"
-            .replaceAll("\\{" + "petId" + "\\}", apiClient.escapeString(petId.toString()));
+            .replaceAll("\\{" + "petId" + "\\}", apiClient.escapeString(apiClient.parameterToString(petId)));
 
         List<Pair> localVarQueryParams = new ArrayList<Pair>();
         List<Pair> localVarCollectionQueryParams = new ArrayList<Pair>();
@@ -812,7 +812,7 @@ public class PetApi {
 
         // create path and map variables
         String localVarPath = "/pet/{petId}"
-            .replaceAll("\\{" + "petId" + "\\}", apiClient.escapeString(petId.toString()));
+            .replaceAll("\\{" + "petId" + "\\}", apiClient.escapeString(apiClient.parameterToString(petId)));
 
         List<Pair> localVarQueryParams = new ArrayList<Pair>();
         List<Pair> localVarCollectionQueryParams = new ArrayList<Pair>();
@@ -943,7 +943,7 @@ public class PetApi {
 
         // create path and map variables
         String localVarPath = "/pet/{petId}/uploadImage"
-            .replaceAll("\\{" + "petId" + "\\}", apiClient.escapeString(petId.toString()));
+            .replaceAll("\\{" + "petId" + "\\}", apiClient.escapeString(apiClient.parameterToString(petId)));
 
         List<Pair> localVarQueryParams = new ArrayList<Pair>();
         List<Pair> localVarCollectionQueryParams = new ArrayList<Pair>();

--- a/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/io/swagger/client/api/StoreApi.java
+++ b/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/io/swagger/client/api/StoreApi.java
@@ -67,7 +67,7 @@ public class StoreApi {
 
         // create path and map variables
         String localVarPath = "/store/order/{order_id}"
-            .replaceAll("\\{" + "order_id" + "\\}", apiClient.escapeString(orderId.toString()));
+            .replaceAll("\\{" + "order_id" + "\\}", apiClient.escapeString(apiClient.parameterToString(orderId)));
 
         List<Pair> localVarQueryParams = new ArrayList<Pair>();
         List<Pair> localVarCollectionQueryParams = new ArrayList<Pair>();
@@ -299,7 +299,7 @@ public class StoreApi {
 
         // create path and map variables
         String localVarPath = "/store/order/{order_id}"
-            .replaceAll("\\{" + "order_id" + "\\}", apiClient.escapeString(orderId.toString()));
+            .replaceAll("\\{" + "order_id" + "\\}", apiClient.escapeString(apiClient.parameterToString(orderId)));
 
         List<Pair> localVarQueryParams = new ArrayList<Pair>();
         List<Pair> localVarCollectionQueryParams = new ArrayList<Pair>();

--- a/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/io/swagger/client/api/UserApi.java
+++ b/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/io/swagger/client/api/UserApi.java
@@ -421,7 +421,7 @@ public class UserApi {
 
         // create path and map variables
         String localVarPath = "/user/{username}"
-            .replaceAll("\\{" + "username" + "\\}", apiClient.escapeString(username.toString()));
+            .replaceAll("\\{" + "username" + "\\}", apiClient.escapeString(apiClient.parameterToString(username)));
 
         List<Pair> localVarQueryParams = new ArrayList<Pair>();
         List<Pair> localVarCollectionQueryParams = new ArrayList<Pair>();
@@ -540,7 +540,7 @@ public class UserApi {
 
         // create path and map variables
         String localVarPath = "/user/{username}"
-            .replaceAll("\\{" + "username" + "\\}", apiClient.escapeString(username.toString()));
+            .replaceAll("\\{" + "username" + "\\}", apiClient.escapeString(apiClient.parameterToString(username)));
 
         List<Pair> localVarQueryParams = new ArrayList<Pair>();
         List<Pair> localVarCollectionQueryParams = new ArrayList<Pair>();
@@ -908,7 +908,7 @@ public class UserApi {
 
         // create path and map variables
         String localVarPath = "/user/{username}"
-            .replaceAll("\\{" + "username" + "\\}", apiClient.escapeString(username.toString()));
+            .replaceAll("\\{" + "username" + "\\}", apiClient.escapeString(apiClient.parameterToString(username)));
 
         List<Pair> localVarQueryParams = new ArrayList<Pair>();
         List<Pair> localVarCollectionQueryParams = new ArrayList<Pair>();

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/io/swagger/client/api/PetApi.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/io/swagger/client/api/PetApi.java
@@ -188,7 +188,7 @@ public class PetApi {
 
         // create path and map variables
         String localVarPath = "/pet/{petId}"
-            .replaceAll("\\{" + "petId" + "\\}", apiClient.escapeString(petId.toString()));
+            .replaceAll("\\{" + "petId" + "\\}", apiClient.escapeString(apiClient.parameterToString(petId)));
 
         List<Pair> localVarQueryParams = new ArrayList<Pair>();
         List<Pair> localVarCollectionQueryParams = new ArrayList<Pair>();
@@ -569,7 +569,7 @@ public class PetApi {
 
         // create path and map variables
         String localVarPath = "/pet/{petId}"
-            .replaceAll("\\{" + "petId" + "\\}", apiClient.escapeString(petId.toString()));
+            .replaceAll("\\{" + "petId" + "\\}", apiClient.escapeString(apiClient.parameterToString(petId)));
 
         List<Pair> localVarQueryParams = new ArrayList<Pair>();
         List<Pair> localVarCollectionQueryParams = new ArrayList<Pair>();
@@ -812,7 +812,7 @@ public class PetApi {
 
         // create path and map variables
         String localVarPath = "/pet/{petId}"
-            .replaceAll("\\{" + "petId" + "\\}", apiClient.escapeString(petId.toString()));
+            .replaceAll("\\{" + "petId" + "\\}", apiClient.escapeString(apiClient.parameterToString(petId)));
 
         List<Pair> localVarQueryParams = new ArrayList<Pair>();
         List<Pair> localVarCollectionQueryParams = new ArrayList<Pair>();
@@ -943,7 +943,7 @@ public class PetApi {
 
         // create path and map variables
         String localVarPath = "/pet/{petId}/uploadImage"
-            .replaceAll("\\{" + "petId" + "\\}", apiClient.escapeString(petId.toString()));
+            .replaceAll("\\{" + "petId" + "\\}", apiClient.escapeString(apiClient.parameterToString(petId)));
 
         List<Pair> localVarQueryParams = new ArrayList<Pair>();
         List<Pair> localVarCollectionQueryParams = new ArrayList<Pair>();

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/io/swagger/client/api/StoreApi.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/io/swagger/client/api/StoreApi.java
@@ -67,7 +67,7 @@ public class StoreApi {
 
         // create path and map variables
         String localVarPath = "/store/order/{order_id}"
-            .replaceAll("\\{" + "order_id" + "\\}", apiClient.escapeString(orderId.toString()));
+            .replaceAll("\\{" + "order_id" + "\\}", apiClient.escapeString(apiClient.parameterToString(orderId)));
 
         List<Pair> localVarQueryParams = new ArrayList<Pair>();
         List<Pair> localVarCollectionQueryParams = new ArrayList<Pair>();
@@ -299,7 +299,7 @@ public class StoreApi {
 
         // create path and map variables
         String localVarPath = "/store/order/{order_id}"
-            .replaceAll("\\{" + "order_id" + "\\}", apiClient.escapeString(orderId.toString()));
+            .replaceAll("\\{" + "order_id" + "\\}", apiClient.escapeString(apiClient.parameterToString(orderId)));
 
         List<Pair> localVarQueryParams = new ArrayList<Pair>();
         List<Pair> localVarCollectionQueryParams = new ArrayList<Pair>();

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/io/swagger/client/api/UserApi.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/io/swagger/client/api/UserApi.java
@@ -421,7 +421,7 @@ public class UserApi {
 
         // create path and map variables
         String localVarPath = "/user/{username}"
-            .replaceAll("\\{" + "username" + "\\}", apiClient.escapeString(username.toString()));
+            .replaceAll("\\{" + "username" + "\\}", apiClient.escapeString(apiClient.parameterToString(username)));
 
         List<Pair> localVarQueryParams = new ArrayList<Pair>();
         List<Pair> localVarCollectionQueryParams = new ArrayList<Pair>();
@@ -540,7 +540,7 @@ public class UserApi {
 
         // create path and map variables
         String localVarPath = "/user/{username}"
-            .replaceAll("\\{" + "username" + "\\}", apiClient.escapeString(username.toString()));
+            .replaceAll("\\{" + "username" + "\\}", apiClient.escapeString(apiClient.parameterToString(username)));
 
         List<Pair> localVarQueryParams = new ArrayList<Pair>();
         List<Pair> localVarCollectionQueryParams = new ArrayList<Pair>();
@@ -908,7 +908,7 @@ public class UserApi {
 
         // create path and map variables
         String localVarPath = "/user/{username}"
-            .replaceAll("\\{" + "username" + "\\}", apiClient.escapeString(username.toString()));
+            .replaceAll("\\{" + "username" + "\\}", apiClient.escapeString(apiClient.parameterToString(username)));
 
         List<Pair> localVarQueryParams = new ArrayList<Pair>();
         List<Pair> localVarCollectionQueryParams = new ArrayList<Pair>();


### PR DESCRIPTION
### PR checklist

- [x ] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [x ] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [ x] Filed the PR against the correct branch: `3.0.0` branch for changes related to OpenAPI spec 3.0. Default: `master`.
- [ ?] Copied the [technical committee](https://github.com/swagger-api/swagger-codegen/#swagger-codegen-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

This PR passes Java path variables through the already present `apiClient.parameterToString` method instead of just calling `.toString()`. This allows for customizing serialization properly, since `.toString()` should not in general be used for such thing.
This change is backwards incompatible regarding types already handled in `apiClient.parameterToString` method. If this is considered a problem (I don't know), then a new method purely for path variable serialization (with a default implementation of calling `.toString()`) could be added instead.