### PR TITLE
fix: use GENERATOR_HOST variable in server generation

### DIFF
--- a/modules/swagger-generator/src/main/java/io/swagger/generator/resource/SwaggerResource.java
+++ b/modules/swagger-generator/src/main/java/io/swagger/generator/resource/SwaggerResource.java
@@ -91,19 +91,7 @@ public class SwaggerResource {
             throws Exception {
 
         String filename = Generator.generateClient(language, opts);
-        String host = System.getenv("GENERATOR_HOST");
-
-        if (StringUtils.isBlank(host)) {
-            String scheme = request.getHeader("X-SSL");
-            String port = "";
-            if ("1".equals(scheme)) {
-                scheme = "https";
-            } else {
-                scheme = request.getScheme();
-                port = ":" + request.getServerPort();
-            }
-            host = scheme + "://" + request.getServerName() + port;
-        }
+        String host = getHost(request);        
 
         if (filename != null) {
             String code = String.valueOf(UUID.randomUUID().toString());
@@ -192,9 +180,7 @@ public class SwaggerResource {
         String filename = Generator.generateServer(framework, opts);
         System.out.println("generated name: " + filename);
 
-        String host =
-                request.getScheme() + "://" + request.getServerName() + ":"
-                        + request.getServerPort();
+        String host = getHost(request);
 
         if (filename != null) {
             String code = String.valueOf(UUID.randomUUID().toString());
@@ -208,5 +194,23 @@ public class SwaggerResource {
         } else {
             return Response.status(500).build();
         }
+    }
+
+    private String getHost(HttpServletRequest request) {
+        String host = System.getenv("GENERATOR_HOST");
+
+        if (StringUtils.isBlank(host)) {
+            String scheme = request.getHeader("X-SSL");
+            String port = "";
+            if ("1".equals(scheme)) {
+                scheme = "https";
+            } else {
+                scheme = request.getScheme();
+                port = ":" + request.getServerPort();
+            }
+            host = scheme + "://" + request.getServerName() + port;
+        }
+
+        return host;
     }
 }

--- a/modules/swagger-generator/src/main/webapp/index.html
+++ b/modules/swagger-generator/src/main/webapp/index.html
@@ -73,7 +73,7 @@
 window.onload = function() {
   // Build a system
   const ui = SwaggerUIBundle({
-    url: "/api/swagger.json",
+    url: "./api/swagger.json",
     dom_id: '#swagger-ui',
     presets: [
       SwaggerUIBundle.presets.apis,


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [ ] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [x] Filed the PR against the correct branch: `3.0.0` branch for changes related to OpenAPI spec 3.0. Default: `master`.
- [ ] Copied the [technical committee](https://github.com/swagger-api/swagger-codegen/#swagger-codegen-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

The changes in #3373 only made the variable work for client code generation. This PR adds the same logic to the server generation.

🛠 with ❤ at [Siemens](https://opensource.siemens.com/)
