### PR TITLE
fix: respect configured generator URL in swagger config

### DIFF
--- a/modules/swagger-generator/src/main/java/io/swagger/generator/Bootstrap.java
+++ b/modules/swagger-generator/src/main/java/io/swagger/generator/Bootstrap.java
@@ -14,13 +14,15 @@
 
 package io.swagger.generator;
 
-import org.apache.commons.io.IOUtils;
-
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URI;
+import java.net.URISyntaxException;
 import javax.servlet.ServletConfig;
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServlet;
-import java.io.IOException;
-import java.io.InputStream;
+import org.apache.commons.io.IOUtils;
+import org.apache.commons.lang3.StringUtils;
 
 public class Bootstrap extends HttpServlet {
     private static final long serialVersionUID = 1400930071893332856L;
@@ -28,7 +30,25 @@ public class Bootstrap extends HttpServlet {
     @Override
     public void init(ServletConfig config) throws ServletException {
         DynamicSwaggerConfig bc = new DynamicSwaggerConfig();
-        bc.setBasePath("/api");
+        String hostString = System.getenv("GENERATOR_HOST");
+        if (!StringUtils.isBlank(hostString)) {
+            try {
+                URI hostURI = new URI(hostString);
+                String scheme = hostURI.getScheme();
+                if (scheme != null) {
+                    bc.setSchemes(new String[] { scheme });
+                }
+                String host = hostURI.getHost();
+                if (host != null) {
+                    bc.setHost(host);
+                }
+                bc.setBasePath(hostURI.getPath() + "/api");
+            } catch(URISyntaxException e) {
+                System.out.println("Could not parse configured GENERATOR_HOST as URL: " + e.getMessage());
+            }
+        } else {
+            bc.setBasePath("/api");
+        }
         bc.setTitle("Swagger Generator");
         bc.setDescription("This is an online swagger codegen server.  You can find out more "
                 + "at https://github.com/swagger-api/swagger-codegen or on [irc.freenode.net, #swagger](http://swagger.io/irc/).");


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [ ] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [x] Filed the PR against the correct branch: `3.0.0` branch for changes related to OpenAPI spec 3.0. Default: `master`.
- [ ] Copied the [technical committee](https://github.com/swagger-api/swagger-codegen/#swagger-codegen-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

During the work for #11711 I recognized that the generated OpenAPI spec does not reflect the `GENERATOR_HOST` which causes wrong generated code and non-functional snippets in the UI.

This PR improves that by passing on the relevant parts to the swagger config.

🛠 with ❤ at [Siemens](https://opensource.siemens.com/)