### PR TITLE
Update ruby codegen info based on template

### DIFF
--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/RubyClientCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/RubyClientCodegen.java
@@ -42,9 +42,9 @@ public class RubyClientCodegen extends DefaultCodegen implements CodegenConfig {
     protected String gemVersion = "1.0.0";
     protected String specFolder = "spec";
     protected String libFolder = "lib";
-    protected String gemLicense = "proprietary";
+    protected String gemLicense = "Unlicense";
     protected String gemRequiredRubyVersion = ">= 1.9";
-    protected String gemHomepage = "http://swagger.io";
+    protected String gemHomepage = "https://github.com/swagger-api/swagger-codegen";
     protected String gemSummary = "A ruby wrapper for the swagger APIs";
     protected String gemDescription = "This gem maps to a swagger API";
     protected String gemAuthor = "";


### PR DESCRIPTION
This aims to get codegen info more in-line with ./modules/swagger-codegen/src/main/resources/ruby/gemspec.mustache

I think that at least the license information should be in-line

### PR checklist

- [ ] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [ ] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [ ] Filed the PR against the correct branch: `3.0.0` branch for changes related to OpenAPI spec 3.0. Default: `master`.
- [ ] Copied the [technical committee](https://github.com/swagger-api/swagger-codegen/#swagger-codegen-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

(details of the change, additional tests that have been done, reference to the issue for tracking, etc)

