### PR TITLE
fix: use information in generator host for generating spec

### DIFF
--- a/modules/swagger-generator/src/main/java/io/swagger/generator/Bootstrap.java
+++ b/modules/swagger-generator/src/main/java/io/swagger/generator/Bootstrap.java
@@ -38,9 +38,10 @@ public class Bootstrap extends HttpServlet {
                 if (scheme != null) {
                     bc.setSchemes(new String[] { scheme });
                 }
-                String host = hostURI.getHost();
-                if (host != null) {
-                    bc.setHost(host);
+                String authority = hostURI.getAuthority();
+                if (authority != null) {
+                    // In Swagger host refers to host _and_ port, a.k.a. the URI authority
+                    bc.setHost(authority);
                 }
                 bc.setBasePath(hostURI.getPath() + "/api");
             } catch(URISyntaxException e) {

--- a/modules/swagger-generator/src/main/java/io/swagger/generator/DynamicSwaggerConfig.java
+++ b/modules/swagger-generator/src/main/java/io/swagger/generator/DynamicSwaggerConfig.java
@@ -7,12 +7,15 @@ import io.swagger.jaxrs.config.BeanConfig;
 import io.swagger.models.Operation;
 import io.swagger.models.Path;
 import io.swagger.models.Swagger;
+import io.swagger.models.Scheme;
 import io.swagger.models.parameters.Parameter;
 import io.swagger.models.parameters.PathParameter;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.stream.Collectors;
 
 public class DynamicSwaggerConfig extends BeanConfig {
     static List<String> clients = new ArrayList<String>();
@@ -73,6 +76,15 @@ public class DynamicSwaggerConfig extends BeanConfig {
             }
         }
 
-        return swagger.info(getInfo()).host(getHost()).basePath("/api");
+        Swagger result = swagger
+            .info(getInfo())
+            .host(getHost())
+            .basePath(getBasePath());
+
+        if (getSchemes() != null) {
+            result = result.schemes(Arrays.stream(getSchemes()).map(s -> Scheme.forValue(s)).collect(Collectors.toList()));
+        }
+
+        return result;
     }
 }


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [ ] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [x] Filed the PR against the correct branch: `3.0.0` branch for changes related to OpenAPI spec 3.0. Default: `master`.
- [ ] Copied the [technical committee](https://github.com/swagger-api/swagger-codegen/#swagger-codegen-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

I missed that the current implementation does not consider base path and schemes in the `GENERATOR_HOST` variable correctly, making the generate spec incorrect for some scenarions.

🛠 with ❤ at [Siemens](https://opensource.siemens.com/)