### PR TITLE
[issue #11788 fix] include antihax/optional import when the parameter type is array of primitives

### DIFF
--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/AbstractGoCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/AbstractGoCodegen.java
@@ -333,7 +333,7 @@ public abstract class AbstractGoCodegen extends DefaultCodegen implements Codege
                 }
 
                 // import "optionals" package if the parameter is primitive and optional
-                if (!param.required && param.isPrimitiveType) {
+                if (!param.required && (param.isPrimitiveType || languageSpecificPrimitives.contains(param.baseType))) {
                     if (!addedOptionalImport) {
                         imports.add(createMapping("import", "github.com/antihax/optional"));
                         addedOptionalImport = true;


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [x] Filed the PR against the correct branch: `3.0.0` branch for changes related to OpenAPI spec 3.0. Default: `master`.
- [x] Copied the [technical committee](https://github.com/swagger-api/swagger-codegen/#swagger-codegen-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

Ticket: https://github.com/swagger-api/swagger-codegen/issues/11788

Testing Done: ran swagger-codegen on a swagger.json file which contained a single optional parameter type (array of strings) for the entire endpoint. This same swagger specification would previously generate uncompilable client code, since it would miss the import of this optional package. With this update, it works as expected.

