### PR TITLE
fix flatten option and minimize quotes

### DIFF
--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/CodegenConfig.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/CodegenConfig.java
@@ -237,4 +237,6 @@ public interface CodegenConfig {
     void setIgnoreImportMapping(boolean ignoreImportMapping);
 
     boolean defaultIgnoreImportMappingOption();
+
+    boolean isUsingFlattenSpec();
 }

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/DefaultCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/DefaultCodegen.java
@@ -4110,4 +4110,8 @@ public class DefaultCodegen {
         }
         return false;
     }
+
+    public boolean isUsingFlattenSpec() {
+        return true;
+    }
 }

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/InlineModelResolver.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/InlineModelResolver.java
@@ -22,7 +22,7 @@ import java.util.Map;
  *  ParseOptions parseOptions = new ParseOptions();
  *  parseOptions.setFlatten(true);
  *  Swagger swagger = new SwaggerParser().read(rootNode, new ArrayList<>(), parseOptions);*/
-
+@Deprecated
 public class InlineModelResolver {
     private Swagger swagger;
     private boolean skipMatches;

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/config/CodegenConfigurator.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/config/CodegenConfigurator.java
@@ -446,7 +446,9 @@ public class CodegenConfigurator implements Serializable {
         final List<AuthorizationValue> authorizationValues = AuthParser.parse(auth);
         ParseOptions parseOptions = new ParseOptions();
         parseOptions.setResolve(true);
-        parseOptions.setFlatten(true);
+        if (config.isUsingFlattenSpec()) {
+            parseOptions.setFlatten(true);
+        }
         Swagger swagger = new SwaggerParser().read(inputSpec, authorizationValues, parseOptions);
 
         input.opts(new ClientOpts())

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/SwaggerYamlGenerator.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/SwaggerYamlGenerator.java
@@ -32,6 +32,8 @@ public class SwaggerYamlGenerator extends DefaultCodegen implements CodegenConfi
 
     public static final String OUTPUT_NAME = "outputFile";
 
+    public static final String MINMIZE_QUOTES = "minimizeQuotes";
+
     public static final String SWAGGER_FILENAME_DEFAULT_YAML = "swagger.yaml";
 
     protected String outputFile = SWAGGER_FILENAME_DEFAULT_YAML;
@@ -45,6 +47,10 @@ public class SwaggerYamlGenerator extends DefaultCodegen implements CodegenConfi
         cliOptions.add(new CliOption(OUTPUT_NAME,
                 "output filename")
                 .defaultValue(SWAGGER_FILENAME_DEFAULT_YAML));
+
+        cliOptions.add(new CliOption(MINMIZE_QUOTES,
+                "minimize quotes")
+                .defaultValue(Boolean.TRUE.toString()));
 
         supportingFiles.add(new SupportingFile("README.md", "", "README.md"));
     }
@@ -80,10 +86,21 @@ public class SwaggerYamlGenerator extends DefaultCodegen implements CodegenConfi
     @Override
     public void processSwagger(Swagger swagger) {
         try {
-            final ObjectMapper mapper = new ObjectMapper(new YAMLFactory()
-                    .configure(YAMLGenerator.Feature.MINIMIZE_QUOTES, true)
+            boolean minimizeQuotes = !additionalProperties.containsKey(MINMIZE_QUOTES) ||
+                    (additionalProperties.containsKey(MINMIZE_QUOTES) &&
+                            additionalProperties.get(MINMIZE_QUOTES) instanceof Boolean ?
+                                (Boolean)additionalProperties.get(MINMIZE_QUOTES) :
+                                Boolean.valueOf((String)additionalProperties.get(MINMIZE_QUOTES)
+                    )
+            );
+            YAMLFactory yamlFactory = new YAMLFactory()
                     .configure(YAMLGenerator.Feature.SPLIT_LINES, false)
-                    .configure(YAMLGenerator.Feature.ALWAYS_QUOTE_NUMBERS_AS_STRINGS, true));
+                    .configure(YAMLGenerator.Feature.ALWAYS_QUOTE_NUMBERS_AS_STRINGS, true);
+
+            yamlFactory.configure(YAMLGenerator.Feature.MINIMIZE_QUOTES, minimizeQuotes);
+
+            final ObjectMapper mapper = new ObjectMapper(yamlFactory);
+
             configureMapper(mapper);
             String swaggerString = mapper.writeValueAsString(swagger);
             String outputFile = outputFolder + File.separator + this.outputFile;

--- a/modules/swagger-codegen/src/test/java/io/swagger/codegen/options/SwaggerYamlOptionsProvider.java
+++ b/modules/swagger-codegen/src/test/java/io/swagger/codegen/options/SwaggerYamlOptionsProvider.java
@@ -12,6 +12,7 @@ public class SwaggerYamlOptionsProvider implements OptionsProvider {
     public static final String ENSURE_UNIQUE_PARAMS_VALUE = "true";
     public static final String OUTPUT_NAME = "swagger.yaml";
     public static final String ALLOW_UNICODE_IDENTIFIERS_VALUE = "false";
+    public static final String MINIMIZE_QUOTES = "true";
 
     @Override
     public String getLanguage() {
@@ -25,6 +26,7 @@ public class SwaggerYamlOptionsProvider implements OptionsProvider {
                 .put(CodegenConstants.ENSURE_UNIQUE_PARAMS, ENSURE_UNIQUE_PARAMS_VALUE)
                 .put(SwaggerYamlGenerator.OUTPUT_NAME, OUTPUT_NAME)
                 .put(CodegenConstants.ALLOW_UNICODE_IDENTIFIERS, ALLOW_UNICODE_IDENTIFIERS_VALUE)
+                .put(SwaggerYamlGenerator.MINMIZE_QUOTES, MINIMIZE_QUOTES)
                 .build();
     }
 

--- a/modules/swagger-generator/src/main/java/io/swagger/generator/model/GeneratorInput.java
+++ b/modules/swagger-generator/src/main/java/io/swagger/generator/model/GeneratorInput.java
@@ -14,6 +14,8 @@ public class GeneratorInput {
     private SecuritySchemeDefinition auth;
     private AuthorizationValue authorizationValue;
 
+    private Boolean usingFlattenSpec = true;
+
     public AuthorizationValue getAuthorizationValue() {
         return authorizationValue;
     }
@@ -57,4 +59,17 @@ public class GeneratorInput {
     public void setSecurityDefinition(SecuritySchemeDefinition auth) {
         this.auth = auth;
     }
+
+    public Boolean isUsingFlattenSpec() {
+        return usingFlattenSpec;
+    }
+
+    public Boolean getUsingFlattenSpec() {
+        return usingFlattenSpec;
+    }
+
+    public void setUsingFlattenSpec(Boolean usingFlattenSpec) {
+        this.usingFlattenSpec = usingFlattenSpec;
+    }
+
 }

--- a/pom.xml
+++ b/pom.xml
@@ -952,7 +952,7 @@
         </repository>
     </repositories>
     <properties>
-        <swagger-parser-version>1.0.59</swagger-parser-version>
+        <swagger-parser-version>1.0.61-SNAPSHOT</swagger-parser-version>
         <scala-version>2.11.1</scala-version>
         <felix-version>3.3.0</felix-version>
         <swagger-core-version>1.6.6</swagger-core-version>


### PR DESCRIPTION
This PR fixes difference in behavior introduced in , where `flatten` option while parsing the specification has been removed, if invoked from generator web service. This PR re-introduce it by default, also allowing to provide a new option `usingFlattenSpec` to turn off behavior (`usingFlattenSpec=false` results in specification not being flatten)