### PR TITLE
fix flatten option

### DIFF
--- a/modules/swagger-codegen/pom.xml
+++ b/modules/swagger-codegen/pom.xml
@@ -200,7 +200,7 @@
     </reporting>
     <properties>
         <diffutils-version>1.3.0</diffutils-version>
-        <swagger-codegen-v2-version>2.4.27</swagger-codegen-v2-version>
+        <swagger-codegen-v2-version>2.4.28-SNAPSHOT</swagger-codegen-v2-version>
     </properties>
     <dependencies>
         <dependency>

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/v3/service/Options.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/v3/service/Options.java
@@ -39,6 +39,8 @@ public class Options {
     private String outputDir = "";
     private Boolean resolveFully;
 
+    private Boolean usingFlattenSpecForV2;
+
     private Map<String, String> codegenArguments = new LinkedHashMap<>();
 
     private boolean flattenInlineComposedSchemas = false;
@@ -502,6 +504,23 @@ public class Options {
 
     public Options flattenInlineComposedSchemas(boolean flattenInlineComposedSchemas) {
         this.flattenInlineComposedSchemas = flattenInlineComposedSchemas;
+        return this;
+    }
+
+    public Boolean isUsingFlattenSpecForV2() {
+        return usingFlattenSpecForV2;
+    }
+
+    public Boolean getUsingFlattenSpecForV2() {
+        return usingFlattenSpecForV2;
+    }
+
+    public void setUsingFlattenSpecForV2(Boolean usingFlattenSpecForV2) {
+        this.usingFlattenSpecForV2 = usingFlattenSpecForV2;
+    }
+
+    public Options usingFlattenSpecForV2(Boolean usingFlattenSpecForV2) {
+        this.usingFlattenSpecForV2 = usingFlattenSpecForV2;
         return this;
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -1179,10 +1179,10 @@
     </repositories>
     <properties>
         <swagger-codegen-generators-version>1.0.35-SNAPSHOT</swagger-codegen-generators-version>
-        <swagger-core-version>2.1.13</swagger-core-version>
+        <swagger-core-version>2.2.1-SNAPSHOT</swagger-core-version>
         <swagger-core-version-v1>1.6.6</swagger-core-version-v1>
-        <swagger-parser-version>2.0.30</swagger-parser-version>
-        <swagger-parser-version-v1>1.0.59</swagger-parser-version-v1>
+        <swagger-parser-version>2.1.0-SNAPSHOT</swagger-parser-version>
+        <swagger-parser-version-v1>1.0.61-SNAPSHOT</swagger-parser-version-v1>
         <jackson-version>2.13.2</jackson-version>
         <!--
           jackson-databind 2.13.2 is still affected by CVE-2020-36518.


### PR DESCRIPTION
This PR fixes difference in behavior introduced in https://github.com/swagger-api/swagger-codegen/pull/10841, where `flatten` option while parsing the specification has been removed, if invoked from generator web service. This PR re-introduces it by default, also allowing to provide a new option `usingFlattenSpecForV2` to turn off behavior (`usingFlattenSpecForV2=false` results in specification not being flatten)