### PR TITLE
[PHP] Added option to use CamelCase with a leading uppercase letter

### DIFF
--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/PhpClientCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/PhpClientCodegen.java
@@ -455,6 +455,10 @@ public class PhpClientCodegen extends DefaultCodegen implements CodegenConfig {
           // return the name in camelCase style
           // phone_number => phoneNumber
           name =  camelize(name, true);
+        } else if ("CamelCase".equals(variableNamingConvention)) {
+          // return the name in camelCase style
+          // phone_number => PhoneNumber
+          name =  camelize(name, false);
         } else { // default to snake case
           // return the name in underscore style
           // PhoneNumber => phone_number


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [ ] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [x] Filed the PR against the correct branch: `3.0.0` branch for changes related to OpenAPI spec 3.0. Default: `master`.
- [x] Copied the [technical committee](https://github.com/swagger-api/swagger-codegen/#swagger-codegen-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR
Added option to use CamelCase with a leading uppercase letter variable naming,

@dkarlovi @mandrean