### PR TITLE
fix(sec): upgrade net.lingala.zip4j:zip4j to 2.7.0

### DIFF
--- a/modules/swagger-generator/pom.xml
+++ b/modules/swagger-generator/pom.xml
@@ -1,5 +1,5 @@
-<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>io.swagger</groupId>
@@ -319,7 +319,7 @@
         <logback-version>1.2.10</logback-version>
         <maven-plugin-version>1.0.0</maven-plugin-version>
         <servlet-api-version>2.5</servlet-api-version>
-        <zip-version>1.3.3</zip-version>
+        <zip-version>2.7.0</zip-version>
         <jetty-version>9.4.44.v20210927</jetty-version>
         <jersey2-version>2.35</jersey2-version>
     </properties>


### PR DESCRIPTION
### What happened？
There are 2 security vulnerabilities found in net.lingala.zip4j:zip4j 1.3.3
- [MPS-2022-11881](https://www.oscs1024.com/hd/MPS-2022-11881)
- [MPS-2022-12482](https://www.oscs1024.com/hd/MPS-2022-12482)


### What did I do？
Upgrade net.lingala.zip4j:zip4j from 1.3.3 to 2.7.0 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS