### PR TITLE
Support to decode the contentType text/plain

### DIFF
--- a/modules/swagger-codegen/src/main/resources/go/client.mustache
+++ b/modules/swagger-codegen/src/main/resources/go/client.mustache
@@ -324,6 +324,13 @@ func (c *APIClient) decode(v interface{}, b []byte, contentType string) (err err
 				return err
 			}
 			return nil
+		} else if strings.Contains(contentType, "text/plain") {
+			p, ok := v.(*string)
+			if ok {
+				ret := string(b)
+				*p = ret
+			}
+			return nil
 		}
 	return errors.New("undefined response type")
 }


### PR DESCRIPTION
I encountered an issue where the Apache NiFi CreateAccessToken API returned a token string with the content type of text/plain, which caused the client to return an "undefined response type" error. To resolve this issue, I updated the decode function to support the content type text/plain

