### PR TITLE
Added changes to pick OS root cert

### DIFF
--- a/modules/swagger-codegen/src/main/resources/python/configuration.mustache
+++ b/modules/swagger-codegen/src/main/resources/python/configuration.mustache
@@ -75,6 +75,8 @@ class Configuration(object):
         self.cert_file = None
         # client key file
         self.key_file = None
+        # read OS root certificate
+        self.os_root_cert = False
         # Set this to True/False to enable/disable SSL hostname verification.
         self.assert_hostname = None
 

--- a/modules/swagger-codegen/src/main/resources/python/requirements.mustache
+++ b/modules/swagger-codegen/src/main/resources/python/requirements.mustache
@@ -3,3 +3,4 @@ six >= 1.10
 python_dateutil >= 2.5.3
 setuptools >= 21.0.0
 urllib3 >= 1.15.1
+truststore >= 0.5.0

--- a/modules/swagger-codegen/src/main/resources/python/rest.mustache
+++ b/modules/swagger-codegen/src/main/resources/python/rest.mustache
@@ -9,6 +9,8 @@ import json
 import logging
 import re
 import ssl
+import truststore
+import sys
 
 import certifi
 # python 2 and python 3 compatibility library
@@ -40,6 +42,8 @@ class RESTResponse(io.IOBase):
         """Returns a given response header."""
         return self.urllib3_response.getheader(name, default)
 
+class PythonVersionException(Exception):
+    """Raised when Python version is below 3.10 and requested OS root certificate"""
 
 class RESTClientObject(object):
 
@@ -62,6 +66,13 @@ class RESTClientObject(object):
         else:
             # if not set certificate file, use Mozilla's root certificates.
             ca_certs = certifi.where()
+        
+        if configuration.os_root_cert:
+            py_sys_version = sys.version_info
+            if py_sys_version.major>=3 and py_sys_version.minor>=10:
+                ctx = truststore.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
+            else:
+                raise PythonVersionException("Python version 3.10 and above required to use OS Root Cert!") 
 
         addition_pool_args = {}
         if configuration.assert_hostname is not None:
@@ -73,28 +84,48 @@ class RESTClientObject(object):
             else:
                 maxsize = 4
 
-        # https pool manager
-        if configuration.proxy:
-            self.pool_manager = urllib3.ProxyManager(
-                num_pools=pools_size,
-                maxsize=maxsize,
-                cert_reqs=cert_reqs,
-                ca_certs=ca_certs,
-                cert_file=configuration.cert_file,
-                key_file=configuration.key_file,
-                proxy_url=configuration.proxy,
-                **addition_pool_args
-            )
+
+        if configuration.os_root_cert:
+            # https pool manager
+            if configuration.proxy:
+                    self.pool_manager = urllib3.ProxyManager(
+                    num_pools=pools_size,
+                    maxsize=maxsize,
+                    ssl_context=ctx,
+                    proxy_url=configuration.proxy,
+                    **addition_pool_args
+                )
+            else:
+                self.pool_manager = urllib3.PoolManager(
+                    num_pools=pools_size,
+                    maxsize=maxsize,
+                    ssl_context=ctx,
+                    **addition_pool_args
+                )
         else:
-            self.pool_manager = urllib3.PoolManager(
-                num_pools=pools_size,
-                maxsize=maxsize,
-                cert_reqs=cert_reqs,
-                ca_certs=ca_certs,
-                cert_file=configuration.cert_file,
-                key_file=configuration.key_file,
-                **addition_pool_args
-            )
+            # https pool manager
+            if configuration.proxy:
+                self.pool_manager = urllib3.ProxyManager(
+                    num_pools=pools_size,
+                    maxsize=maxsize,
+                    cert_reqs=cert_reqs,
+                    ca_certs=ca_certs,
+                    cert_file=configuration.cert_file,
+                    key_file=configuration.key_file,
+                    proxy_url=configuration.proxy,
+                    **addition_pool_args
+                )
+            else:
+                self.pool_manager = urllib3.PoolManager(
+                    num_pools=pools_size,
+                    maxsize=maxsize,
+                    cert_reqs=cert_reqs,
+                    ca_certs=ca_certs,
+                    cert_file=configuration.cert_file,
+                    key_file=configuration.key_file,
+                    **addition_pool_args
+                )
+
 
     def request(self, method, url, query_params=None, headers=None,
                 body=None, post_params=None, _preload_content=True,


### PR DESCRIPTION
### PR checklist

- [ ] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [ ] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [ ] Filed the PR against the correct branch: `3.0.0` branch for changes related to OpenAPI spec 3.0. Default: `master`.
- [ ] Copied the [technical committee](https://github.com/swagger-api/swagger-codegen/#swagger-codegen-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

- Added change in rest.mustache to read OS Root Cert using truststore
- Added change in configuration.mustache to ask user if user wants to use OS root CA
- Added dependency of truststore to requirements.mustache

