### PR TITLE
fix python api client deserialize response

### DIFF
--- a/samples/client/petstore-security-test/python/petstore_api/api_client.py
+++ b/samples/client/petstore-security-test/python/petstore_api/api_client.py
@@ -236,7 +236,10 @@ class ApiClient(object):
         try:
             data = json.loads(response.data)
         except ValueError:
-            data = response.data
+            try:
+                data = response.data.decode("utf-8")
+            except UnicodeDecodeError:
+                data = str(response.data)
 
         return self.__deserialize(data, response_type)
 

--- a/samples/client/petstore/python/petstore_api/api_client.py
+++ b/samples/client/petstore/python/petstore_api/api_client.py
@@ -237,7 +237,10 @@ class ApiClient(object):
         try:
             data = json.loads(response.data)
         except ValueError:
-            data = response.data
+            try:
+                data = response.data.decode("utf-8")
+            except UnicodeDecodeError:
+                data = str(response.data)
 
         return self.__deserialize(data, response_type)
 


### PR DESCRIPTION
### PR checklist

- [ ] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [ ] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [ ] Filed the PR against the correct branch: `3.0.0` branch for changes related to OpenAPI spec 3.0. Default: `master`.
- [ ] Copied the [technical committee](https://github.com/swagger-api/swagger-codegen/#swagger-codegen-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

python api client send request use urllib3, urllib3 returns the body is bytes type, if api server returns empty content, function deserialize's code `json.loads(response.data)` will error, and __deserialize method revc `:param data: dict, list or str.`, so should convert `response.data` to str.

