### PR TITLE
Fix issue #12071.

### DIFF
--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/v3/DefaultGenerator.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/v3/DefaultGenerator.java
@@ -465,9 +465,6 @@ public class DefaultGenerator extends AbstractGenerator implements Generator {
     }
 
     private void generateApis(List<File> files, List<Object> allOperations, List<Object> allModels) {
-        if (!generateApis) {
-            return;
-        }
         boolean hasModel = true;
         if (allModels == null || allModels.isEmpty()) {
             hasModel = false;
@@ -536,6 +533,12 @@ public class DefaultGenerator extends AbstractGenerator implements Generator {
                         oo.put("hasMore", "true");
                     }
                 }
+
+		// Some target languages refer to API operations in
+		// their supporting files and so we always process the
+		// API operations above, even when we need to skip the
+		// actual API generation.
+		if (!generateApis) continue;
 
                 for (String templateName : config.apiTemplateFiles().keySet()) {
                     String filename = config.apiFilename(templateName, tag);


### PR DESCRIPTION
Adjust the DefaultGenerator class so that the private method generateApis() runs partialy regardless of whether or not we are generating APIs. The part that always runs computes API data that is used by some supporting files templates.

This affects the the Go client target among others.

Allow supporting files that refer to the API to be generated properly.

### PR checklist

- [ ] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [ ] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [ ] Filed the PR against the correct branch: `3.0.0` branch for changes related to OpenAPI spec 3.0. Default: `master`.
- [ ] Copied the [technical committee](https://github.com/swagger-api/swagger-codegen/#swagger-codegen-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

I allowed the loop that processes all the input files to run, but now each iteration terminates early if ``!generateApis``. This allows all the input data to be accumulated correctly.

