### PR TITLE
Update swagger-generator Dockerfile to install tar

### DIFF
--- a/modules/swagger-generator/Dockerfile
+++ b/modules/swagger-generator/Dockerfile
@@ -2,6 +2,7 @@ FROM redhat/ubi9-minimal:9.1
 RUN microdnf -y install shadow-utils
 RUN microdnf -y install which
 RUN microdnf -y install glibc-langpack-en
+RUN microdnf -y install tar
 ENV disableOas31Resolve=False
 ENV JAVA_HOME=/opt/java/openjdk
 COPY --from=eclipse-temurin:17-jre $JAVA_HOME $JAVA_HOME

--- a/modules/swagger-generator/Dockerfile_root
+++ b/modules/swagger-generator/Dockerfile_root
@@ -1,6 +1,7 @@
 FROM redhat/ubi9-minimal:9.1
 RUN microdnf -y install which
 RUN microdnf -y install glibc-langpack-en
+RUN microdnf -y install tar
 ENV disableOas31Resolve=False
 ENV JAVA_HOME=/opt/java/openjdk
 COPY --from=eclipse-temurin:17-jre $JAVA_HOME $JAVA_HOME


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [x] Filed the PR against the correct branch: `3.0.0` branch for changes related to OpenAPI spec 3.0. Default: `master`.
- [ ] Copied the [technical committee](https://github.com/swagger-api/swagger-codegen/#swagger-codegen-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

Since #12036, the tar command is no longer available in the swagger-generator container. This PR installs the tar package to enable the custom codegen templates work for SwaggerHub On-Premise 2.x