### PR TITLE
Long example string 2023

### DIFF
--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/SpringCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/SpringCodegen.java
@@ -7,6 +7,8 @@ import io.swagger.codegen.languages.features.BeanValidationFeatures;
 import io.swagger.codegen.languages.features.NotNullAnnotationFeatures;
 import io.swagger.codegen.languages.features.IgnoreUnknownJacksonFeatures;
 import io.swagger.codegen.languages.features.OptionalFeatures;
+import io.swagger.codegen.mustache.SplitStringLambda;
+import io.swagger.codegen.mustache.TrimWhitespaceLambda;
 import io.swagger.models.Operation;
 import io.swagger.models.Path;
 import io.swagger.models.Swagger;
@@ -376,6 +378,10 @@ public class SpringCodegen extends AbstractJavaCodegen
                 writer.write(fragment.execute().replaceAll("\\r|\\n", ""));
             }
         });
+
+        additionalProperties.put("lambdaTrimWhitespace", new TrimWhitespaceLambda());
+
+        additionalProperties.put("lambdaSplitString", new SplitStringLambda());
     }
 
     @Override

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/mustache/SplitStringLambda.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/mustache/SplitStringLambda.java
@@ -1,0 +1,86 @@
+package io.swagger.codegen.mustache;
+
+import java.io.IOException;
+import java.io.Writer;
+
+import com.samskivert.mustache.Mustache;
+import com.samskivert.mustache.Template.Fragment;
+
+/**
+ * Splits long fragments into smaller strings and uses a StringBuilder to merge
+ * them back.
+ *
+ * Register:
+ *
+ * <pre>
+ * additionalProperties.put("lambdaSplitString", new SplitStringLambda());
+ * </pre>
+ *
+ * Use:
+ *
+ * <pre>
+ * {{#lambdaSplitString}}{{summary}}{{/lambdaSplitString}}
+ * </pre>
+ */
+public class SplitStringLambda implements Mustache.Lambda {
+    private static final int DEFAULT_MAX_LENGTH = 65535;
+
+    private static final String SPLIT_INIT = "new StringBuilder(%d)";
+
+    private static final String SPLIT_PART = ".append(\"%s\")";
+
+    private static final String SPLIT_SUFFIX = ".toString()";
+
+    private final int maxLength;
+
+    public SplitStringLambda() {
+        this(DEFAULT_MAX_LENGTH);
+    }
+
+    public SplitStringLambda(int maxLength) {
+        this.maxLength = maxLength;
+    }
+
+    @Override
+    public void execute(Fragment fragment, Writer writer) throws IOException {
+        String input = fragment.execute();
+        int inputLength = input.length();
+
+        StringBuilder builder = new StringBuilder();
+        if (inputLength > maxLength) {
+
+            // Initialize a StringBuilder
+            builder.append(String.format(SPLIT_INIT, inputLength));
+
+            int currentPosition = 0;
+            int currentStringLength = 0;
+            char currentLastChar = '\\';
+
+            // Split input into parts of at most maxLength and not ending with an escape character
+            // Append each part to the StringBuilder
+            while (currentPosition + maxLength < input.length()) {
+                currentStringLength = maxLength;
+                currentLastChar = input.charAt(currentPosition + currentStringLength - 1);
+                if (currentLastChar == '\\') {
+                    --currentStringLength;
+                }
+
+                builder.append(String.format(SPLIT_PART, input.substring(currentPosition, currentPosition + currentStringLength)));
+                currentPosition += currentStringLength;
+            }
+
+            // Append last part if necessary
+            if (currentPosition < input.length()) {
+                builder.append(String.format(SPLIT_PART, input.substring(currentPosition)));
+            }
+
+            // Close the builder and merge everything back to a string
+            builder.append(SPLIT_SUFFIX);
+        } else {
+            builder.append(String.format("\"%s\"", input));
+        }
+
+        writer.write(builder.toString());
+    }
+
+}

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/mustache/TrimWhitespaceLambda.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/mustache/TrimWhitespaceLambda.java
@@ -1,0 +1,34 @@
+package io.swagger.codegen.mustache;
+
+import java.io.IOException;
+import java.io.Writer;
+
+import com.samskivert.mustache.Mustache;
+import com.samskivert.mustache.Template.Fragment;
+
+/**
+ * Replaces duplicate whitespace characters in a fragment with single space.
+ *
+ * Register:
+ *
+ * <pre>
+ * additionalProperties.put("lambdaTrimWhitespace", new TrimWhitespaceLambda());
+ * </pre>
+ *
+ * Use:
+ *
+ * <pre>
+ * {{#lambdaTrimWhitespace}}{{summary}}{{/lambdaTrimWhitespace}}
+ * </pre>
+ */
+public class TrimWhitespaceLambda implements Mustache.Lambda {
+    private static final String SINGLE_SPACE = " ";
+
+    private static final String WHITESPACE_REGEX = "\\s+";
+
+    @Override
+    public void execute(Fragment fragment, Writer writer) throws IOException {
+        writer.write(fragment.execute().replaceAll(WHITESPACE_REGEX, SINGLE_SPACE));
+    }
+
+}

--- a/modules/swagger-codegen/src/main/resources/JavaSpring/api.mustache
+++ b/modules/swagger-codegen/src/main/resources/JavaSpring/api.mustache
@@ -123,7 +123,8 @@ public interface {{classname}} {
         {{#examples}}
             if (getAcceptHeader().get().contains("{{{contentType}}}")) {
                 try {
-                    return {{#async}}CompletableFuture.completedFuture({{/async}}new ResponseEntity<>(getObjectMapper().get().readValue("{{#lambdaRemoveLineBreak}}{{#lambdaEscapeDoubleQuote}}{{{example}}}{{/lambdaEscapeDoubleQuote}}{{/lambdaRemoveLineBreak}}", {{>exampleReturnTypes}}.class), HttpStatus.NOT_IMPLEMENTED){{#async}}){{/async}};
+                    String exampleString = "{{#lambdaRemoveLineBreak}}{{#lambdaEscapeDoubleQuote}}{{{example}}}{{/lambdaEscapeDoubleQuote}}{{/lambdaRemoveLineBreak}}";
+                    return {{#async}}CompletableFuture.completedFuture({{/async}}new ResponseEntity<>(getObjectMapper().get().readValue(exampleString, {{>exampleReturnTypes}}.class), HttpStatus.NOT_IMPLEMENTED){{#async}}){{/async}};
                 } catch (IOException e) {
                     log.error("Couldn't serialize response for content type {{{contentType}}}", e);
                     return {{#async}}CompletableFuture.completedFuture({{/async}}new ResponseEntity<>(HttpStatus.INTERNAL_SERVER_ERROR){{#async}}){{/async}};

--- a/modules/swagger-codegen/src/main/resources/JavaSpring/api.mustache
+++ b/modules/swagger-codegen/src/main/resources/JavaSpring/api.mustache
@@ -123,7 +123,7 @@ public interface {{classname}} {
         {{#examples}}
             if (getAcceptHeader().get().contains("{{{contentType}}}")) {
                 try {
-                    String exampleString = "{{#lambdaRemoveLineBreak}}{{#lambdaEscapeDoubleQuote}}{{{example}}}{{/lambdaEscapeDoubleQuote}}{{/lambdaRemoveLineBreak}}";
+                    String exampleString = {{#lambdaSplitString}}{{#lambdaRemoveLineBreak}}{{#lambdaEscapeDoubleQuote}}{{#lambdaTrimWhitespace}}{{{example}}}{{/lambdaTrimWhitespace}}{{/lambdaEscapeDoubleQuote}}{{/lambdaRemoveLineBreak}}{{/lambdaSplitString}};
                     return {{#async}}CompletableFuture.completedFuture({{/async}}new ResponseEntity<>(getObjectMapper().get().readValue(exampleString, {{>exampleReturnTypes}}.class), HttpStatus.NOT_IMPLEMENTED){{#async}}){{/async}};
                 } catch (IOException e) {
                     log.error("Couldn't serialize response for content type {{{contentType}}}", e);

--- a/modules/swagger-codegen/src/test/java/io/swagger/codegen/mustache/SplitStringLambdaTest.java
+++ b/modules/swagger-codegen/src/test/java/io/swagger/codegen/mustache/SplitStringLambdaTest.java
@@ -1,0 +1,85 @@
+package io.swagger.codegen.mustache;
+
+import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertEquals;
+
+import java.io.IOException;
+import java.io.StringWriter;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.MockitoAnnotations;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import com.samskivert.mustache.Template.Fragment;
+
+public class SplitStringLambdaTest {
+    private static final String INPUT_STRING = "1112223334";
+
+    private static final Map<Integer, String> EXPECTED_OUTPUTS;
+    static {
+        EXPECTED_OUTPUTS = new HashMap<>();
+        EXPECTED_OUTPUTS.put(2,
+                String.format(
+                        "new StringBuilder(%d).append(\"11\").append(\"12\").append(\"22\").append(\"33\").append(\"34\").toString()",
+                        INPUT_STRING.length()));
+        EXPECTED_OUTPUTS.put(3,
+                String.format(
+                        "new StringBuilder(%d).append(\"111\").append(\"222\").append(\"333\").append(\"4\").toString()",
+                        INPUT_STRING.length()));
+    }
+
+    private static final String INPUT_QUOTED_STRING = "1\\\"11\\\"2223\\\"334";
+    private static final String INPUT_QUOTED_OUTPUT = String.format(
+            "new StringBuilder(%d).append(\"1\\\"\").append(\"11\").append(\"\\\"2\").append(\"223\").append(\"\\\"3\").append(\"34\").toString()",
+            INPUT_QUOTED_STRING.length());
+
+    @Mock
+    private Fragment fragment;
+
+    @BeforeMethod
+    public void init() {
+        MockitoAnnotations.initMocks(this);
+    }
+
+    @AfterMethod
+    public void reset() {
+        Mockito.reset(fragment);
+    }
+
+    private void testString(String input, int maxLength, String expected) throws IOException {
+        when(fragment.execute()).thenReturn(input);
+
+        StringWriter output = new StringWriter();
+        new SplitStringLambda(maxLength).execute(fragment, output);
+        assertEquals(output.toString(), expected);
+    }
+
+    @Test
+    public void testSplitGroupsOf2() throws IOException {
+        int maxLength = 2;
+        testString(INPUT_STRING, maxLength, EXPECTED_OUTPUTS.get(maxLength));
+    }
+
+    @Test
+    public void testSplitGroupsOf3() throws IOException {
+        int maxLength = 3;
+        testString(INPUT_STRING, maxLength, EXPECTED_OUTPUTS.get(maxLength));
+    }
+
+    @Test
+    public void testSplitQuotedString() throws IOException {
+        int maxLength = 3;
+        testString(INPUT_QUOTED_STRING, maxLength, INPUT_QUOTED_OUTPUT);
+    }
+
+    @Test
+    public void testShortString() throws IOException {
+        testString(INPUT_STRING, INPUT_STRING.length(), String.format("\"%s\"", INPUT_STRING));
+    }
+
+}

--- a/modules/swagger-codegen/src/test/java/io/swagger/codegen/mustache/TrimWhitespaceLambdaTest.java
+++ b/modules/swagger-codegen/src/test/java/io/swagger/codegen/mustache/TrimWhitespaceLambdaTest.java
@@ -1,0 +1,42 @@
+package io.swagger.codegen.mustache;
+
+import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertEquals;
+
+import java.io.IOException;
+import java.io.StringWriter;
+
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.MockitoAnnotations;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import com.samskivert.mustache.Template.Fragment;
+
+public class TrimWhitespaceLambdaTest {
+
+    @Mock
+    private Fragment fragment;
+
+    @BeforeMethod
+    public void init() {
+        MockitoAnnotations.initMocks(this);
+    }
+
+    @AfterMethod
+    public void reset() {
+        Mockito.reset(fragment);
+    }
+
+    @Test
+    public void testTrimWhitespace() throws IOException {
+        when(fragment.execute()).thenReturn("\t a  b\t\tc \t");
+
+        StringWriter output = new StringWriter();
+        new TrimWhitespaceLambda().execute(fragment, output);
+        assertEquals(output.toString(), " a b c ");
+    }
+
+}


### PR DESCRIPTION
### PR checklist

- [ ] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [ ] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [ ] Filed the PR against the correct branch: `3.0.0` branch for changes related to OpenAPI spec 3.0. Default: `master`.
- [ ] Copied the [technical committee](https://github.com/swagger-api/swagger-codegen/#swagger-codegen-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR
Creating new PR as suggested in #8691

If definitions start to get complicated, example response bodies can exceed Java compiler's limit for constant strings.

This PR addresses this issue by introducing and using two new lambdas to remove any unnecessary whitespace and (if still needed) to split the constant string into smaller compilable parts using a StringBuilder to merge them back again.

Fixes #9055.