### PR TITLE
make some module Java 11 friendly - where package javax.xml.bind was remove

### DIFF
--- a/modules/swagger-generator/pom.xml
+++ b/modules/swagger-generator/pom.xml
@@ -276,7 +276,7 @@
         <dependency>
            <groupId>javax.xml.bind</groupId>
            <artifactId>jaxb-api</artifactId>
-           <version>2.3.0</version>
+           <version>${jaxb-api.version}</version>
          </dependency>
          <dependency>
            <groupId>com.sun.xml.bind</groupId>
@@ -333,6 +333,7 @@
         <maven-plugin-version>1.0.0</maven-plugin-version>
         <servlet-api-version>2.5</servlet-api-version>
         <zip-version>2.11.5</zip-version>
+        <jaxb-api.version>2.3.0</jaxb-api.version>
         <jetty-version>9.4.51.v20230217</jetty-version>
         <jersey2-version>2.39.1</jersey2-version>
     </properties>

--- a/samples/server/petstore/jaxrs-datelib-j8/pom.xml
+++ b/samples/server/petstore/jaxrs-datelib-j8/pom.xml
@@ -124,6 +124,11 @@
       <version>${servlet-api-version}</version>
     </dependency>
     <dependency>
+      <groupId>javax.xml.bind</groupId>
+      <artifactId>jaxb-api</artifactId>
+      <version>${jaxb-api.version}</version>
+    </dependency>
+    <dependency>
       <groupId>org.glassfish.jersey.containers</groupId>
       <artifactId>jersey-container-servlet-core</artifactId>
       <version>${jersey2-version}</version>
@@ -171,6 +176,7 @@
   </repositories>
   <properties>
     <java.version>1.8</java.version>
+    <jaxb-api.version>2.3.0</jaxb-api.version>
     <maven.compiler.source>${java.version}</maven.compiler.source>
     <maven.compiler.target>${java.version}</maven.compiler.target>
     <swagger-core-version>1.5.24</swagger-core-version>

--- a/samples/server/petstore/spring-mvc-j8-async/pom.xml
+++ b/samples/server/petstore/spring-mvc-j8-async/pom.xml
@@ -114,6 +114,12 @@
         </dependency>
 
         <dependency>
+            <groupId>javax.xml.bind</groupId>
+            <artifactId>jaxb-api</artifactId>
+            <version>${jaxb-api.version}</version>
+        </dependency>
+
+        <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
             <version>${junit-version}</version>
@@ -160,6 +166,7 @@
     </dependencies>
     <properties>
         <java.version>1.8</java.version>
+        <jaxb-api.version>2.3.0</jaxb-api.version>
         <maven.compiler.source>${java.version}</maven.compiler.source>
         <maven.compiler.target>${java.version}</maven.compiler.target>
         <jetty-version>9.3.27.v20190418</jetty-version>

--- a/samples/server/petstore/spring-mvc-j8-localdatetime/pom.xml
+++ b/samples/server/petstore/spring-mvc-j8-localdatetime/pom.xml
@@ -129,6 +129,7 @@
             <artifactId>servlet-api</artifactId>
             <version>${servlet-api-version}</version>
         </dependency>
+
     <!-- Bean Validation API support -->
     <dependency>
         <groupId>javax.validation</groupId>
@@ -136,6 +137,13 @@
         <version>1.1.0.Final</version>
         <scope>provided</scope>
     </dependency>
+
+        <dependency>
+            <groupId>javax.xml.bind</groupId>
+            <artifactId>jaxb-api</artifactId>
+            <version>${jaxb-api.version}</version>
+        </dependency>
+
     <dependency>
         <groupId>org.testng</groupId>
         <artifactId>testng</artifactId>
@@ -165,6 +173,7 @@
     </dependencies>
     <properties>
         <java.version>1.8</java.version>
+        <jaxb-api.version>2.3.0</jaxb-api.version>
         <maven.compiler.source>${java.version}</maven.compiler.source>
         <maven.compiler.target>${java.version}</maven.compiler.target>
         <jetty-version>9.3.27.v20190418</jetty-version>

--- a/samples/server/petstore/springboot-delegate-j8/pom.xml
+++ b/samples/server/petstore/springboot-delegate-j8/pom.xml
@@ -7,6 +7,7 @@
     <version>1.0.0</version>
     <properties>
         <java.version>1.8</java.version>
+        <jaxb-api.version>2.3.0</jaxb-api.version>
         <maven.compiler.source>${java.version}</maven.compiler.source>
         <maven.compiler.target>${java.version}</maven.compiler.target>
         <springfox-version>2.7.0</springfox-version>
@@ -62,6 +63,11 @@
         <dependency>
             <groupId>javax.validation</groupId>
             <artifactId>validation-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>javax.xml.bind</groupId>
+            <artifactId>jaxb-api</artifactId>
+            <version>${jaxb-api.version}</version>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>


### PR DESCRIPTION
Make some modules Java 11 friendly.
Since Java 17 is LTS, it's quite common for folks to have 11 or 17 as their main while still working on Java 8 interchangeably. Most of cases it should be compatible, except for a few. Like in these modules where javax.xml.bind... is required.

Explicitly declare com.sun.xml.bind:jaxb-api would make it work for both Java 8 and 11+. This is also consistent with what we already have in https://github.com/swagger-api/swagger-codegen/blob/master/modules/swagger-generator/pom.xml.jenkins#L264 

<img width="1065" alt="Screenshot 2023-05-03 at 4 21 28 pm" src="https://user-images.githubusercontent.com/5586453/235849003-636c1d46-3433-420d-9d23-17a6b890e991.png">


