### PR TITLE
SWG-7517 updating the resolving options of swagger-parser-v3

### DIFF
--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/v3/config/CodegenConfigurator.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/v3/config/CodegenConfigurator.java
@@ -34,10 +34,14 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
 import java.util.Set;
 import java.util.function.Predicate;
 
@@ -674,6 +678,21 @@ public class CodegenConfigurator implements Serializable {
         options.setFlatten(true);
         options.setFlattenComposedSchemas(flattenInlineSchema);
         options.setSkipMatches(this.skipInlineModelMatches);
+
+        if (Objects.equals(System.getenv("SAFELY_RESOLVE_URL"), "true")) {
+            List<String> allowList = Optional.ofNullable(System.getenv("REMOTE_REF_ALLOW_LIST"))
+                    .map(str -> Arrays.asList(str.split(",")))
+                    .orElseGet(Collections::emptyList);
+
+            List<String> blockList = Optional.ofNullable(System.getenv("REMOTE_REF_BLOCK_LIST"))
+                    .map(str -> Arrays.asList(str.split(",")))
+                    .orElseGet(Collections::emptyList);
+
+            options.setSafelyResolveURL(true);
+            options.setRemoteRefAllowList(allowList);
+            options.setRemoteRefBlockList(blockList);
+        }
+
         return options;
     }
 

--- a/pom.docker.xml
+++ b/pom.docker.xml
@@ -1116,7 +1116,7 @@
         <swagger-codegen-generators-version>1.0.40-SNAPSHOT</swagger-codegen-generators-version>
         <swagger-core-version>2.2.9</swagger-core-version>
         <swagger-core-version-v1>1.6.10</swagger-core-version-v1>
-        <swagger-parser-version>2.1.13</swagger-parser-version>
+        <swagger-parser-version>2.1.14-SNAPSHOT</swagger-parser-version>
         <swagger-parser-version-v1>1.0.65</swagger-parser-version-v1>
         <jackson-version>2.14.2</jackson-version>
         <jackson-databind-version>2.14.2</jackson-databind-version>

--- a/pom.java11.xml
+++ b/pom.java11.xml
@@ -1217,7 +1217,7 @@
         <swagger-codegen-generators-version>1.0.40-SNAPSHOT</swagger-codegen-generators-version>
         <swagger-core-version>2.2.9</swagger-core-version>
         <swagger-core-version-v1>1.6.10</swagger-core-version-v1>
-        <swagger-parser-version>2.1.13</swagger-parser-version>
+        <swagger-parser-version>2.1.14-SNAPSHOT</swagger-parser-version>
         <swagger-parser-version-v1>1.0.65</swagger-parser-version-v1>
         <jackson-version>2.14.2</jackson-version>
         <jackson-databind-version>2.14.2</jackson-databind-version>

--- a/pom.java8.xml
+++ b/pom.java8.xml
@@ -1220,7 +1220,7 @@
         <swagger-codegen-generators-version>1.0.40-SNAPSHOT</swagger-codegen-generators-version>
         <swagger-core-version>2.2.9</swagger-core-version>
         <swagger-core-version-v1>1.6.10</swagger-core-version-v1>
-        <swagger-parser-version>2.1.13</swagger-parser-version>
+        <swagger-parser-version>2.1.14-SNAPSHOT</swagger-parser-version>
         <swagger-parser-version-v1>1.0.65</swagger-parser-version-v1>
         <jackson-version>2.14.2</jackson-version>
         <jackson-databind-version>2.14.2</jackson-databind-version>

--- a/pom.xml
+++ b/pom.xml
@@ -1217,7 +1217,7 @@
         <swagger-codegen-generators-version>1.0.40-SNAPSHOT</swagger-codegen-generators-version>
         <swagger-core-version>2.2.9</swagger-core-version>
         <swagger-core-version-v1>1.6.10</swagger-core-version-v1>
-        <swagger-parser-version>2.1.13</swagger-parser-version>
+        <swagger-parser-version>2.1.14-SNAPSHOT</swagger-parser-version>
         <swagger-parser-version-v1>1.0.65</swagger-parser-version-v1>
         <jackson-version>2.14.2</jackson-version>
         <jackson-databind-version>2.14.2</jackson-databind-version>


### PR DESCRIPTION
### PR checklist

- [X] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [X] Filed the PR against the correct branch: `3.0.0` branch for changes related to OpenAPI spec 3.0. Default: `master`.
- [X] Copied the [technical committee](https://github.com/swagger-api/swagger-codegen/#swagger-codegen-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR
This PR adds possibility to utilize **allow** and **block** lists provided through environmental variables when using OpenAPIV3Parser (swagger-parser-v3) in order to safely resolve definitions.

To see the detailed explanation of this functionality please see the following pull requests:
https://github.com/swagger-api/swagger-parser/pull/1910
https://github.com/swagger-api/swagger-parser/pull/1911