### PR TITLE
Create directory for custom codegen

### DIFF
--- a/modules/swagger-generator/Dockerfile
+++ b/modules/swagger-generator/Dockerfile
@@ -13,6 +13,8 @@ WORKDIR /jetty_home
 COPY docker/jetty /jetty_home/
 COPY target/lib/jetty* /jetty_home/lib/
 RUN mkdir /jetty_home/lib/shared
+RUN chgrp -R 0 /jetty_home/lib/shared && \
+    chmod -R g=u /jetty_home/lib/shared
 RUN rm /jetty_home/lib/jetty-runner*
 COPY target/lib/javax.servlet-api* /jetty_home/lib/servlet-api-3.1.jar
 COPY target/lib/start.jar /jetty_home/

--- a/modules/swagger-generator/Dockerfile
+++ b/modules/swagger-generator/Dockerfile
@@ -12,6 +12,7 @@ COPY docker/environment /etc/environment
 WORKDIR /jetty_home
 COPY docker/jetty /jetty_home/
 COPY target/lib/jetty* /jetty_home/lib/
+RUN mkdir /jetty_home/lib/shared
 RUN rm /jetty_home/lib/jetty-runner*
 COPY target/lib/javax.servlet-api* /jetty_home/lib/servlet-api-3.1.jar
 COPY target/lib/start.jar /jetty_home/

--- a/modules/swagger-generator/Dockerfile_root
+++ b/modules/swagger-generator/Dockerfile_root
@@ -11,6 +11,7 @@ COPY docker/environment /etc/environment
 WORKDIR /jetty_home
 COPY docker/jetty /jetty_home/
 COPY target/lib/jetty* /jetty_home/lib/
+RUN mkdir /jetty_home/lib/shared
 RUN rm /jetty_home/lib/jetty-runner*
 COPY target/lib/javax.servlet-api* /jetty_home/lib/servlet-api-3.1.jar
 COPY target/lib/start.jar /jetty_home/

--- a/modules/swagger-generator/Dockerfile_root
+++ b/modules/swagger-generator/Dockerfile_root
@@ -12,6 +12,8 @@ WORKDIR /jetty_home
 COPY docker/jetty /jetty_home/
 COPY target/lib/jetty* /jetty_home/lib/
 RUN mkdir /jetty_home/lib/shared
+RUN chgrp -R 0 /jetty_home/lib/shared && \
+    chmod -R g=u /jetty_home/lib/shared
 RUN rm /jetty_home/lib/jetty-runner*
 COPY target/lib/javax.servlet-api* /jetty_home/lib/servlet-api-3.1.jar
 COPY target/lib/start.jar /jetty_home/


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [x] Filed the PR against the correct branch: `3.0.0` branch for changes related to OpenAPI spec 3.0. Default: `master`.
- [ ] Copied the [technical committee](https://github.com/swagger-api/swagger-codegen/#swagger-codegen-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

Changes needed to allow directory to be useable on OpenShift. OpenShift runs with a random user ID. So any directory in the container that needs to be writeable needs to be owned and writeable by the root group. See OpenShift docs here: https://docs.openshift.com/container-platform/4.11/openshift_images/create-images.html#use-uid_create-images

