### PR TITLE
Use buildx to generate multiarch docker images (3.0.0 branch)

### DIFF
--- a/.github/workflows/docker-release-3.0.yml
+++ b/.github/workflows/docker-release-3.0.yml
@@ -12,6 +12,13 @@ jobs:
 
     runs-on: ubuntu-latest
 
+    env:
+      DOCKER_PLATFORMS: |
+        linux/amd64
+        linux/arm64
+      DOCKER_PUSH: false
+      TAG: ${{ github.event.inputs.tag }}
+
     steps:
       - uses: actions/checkout@v3
         name: git checkout 3.0.0
@@ -53,55 +60,49 @@ jobs:
       - name: Build with Maven
         run: |
           mvn -DJETTY_TEST_HTTP_PORT=8090 -DJETTY_TEST_STOP_PORT=8089 clean install -Pdocker --settings $HOME/.m2/settings.xml
-      - name: docker build and push
-        run: |
-          export TAG=${{ env.TAG }}
-          export DOCKER_PLATFORMS=linux/amd64,linux/arm64
-          export DOCKER_OUTPUT=type=image
 
-          export DOCKER_GENERATOR_IMAGE_NAME=swaggerapi/swagger-generator-v3-minimal
-          export DOCKER_GENERATOR_FULL_IMAGE_NAME=swaggerapi/swagger-generator-v3
-          export DOCKER_GENERATOR_ROOT_FULL_IMAGE_NAME=swaggerapi/swagger-generator-v3-root
-          export DOCKER_CODEGEN_CLI_IMAGE_NAME=swaggerapi/swagger-codegen-cli-v3
+      - name: Docker build and push (full)
+        uses: docker/build-push-action@v4
+        with:
+          context: modules/swagger-generator
+          file: modules/swagger-generator/Dockerfile
+          platforms: ${{ env.DOCKER_PLATFORMS }}
+          push: ${{ env.DOCKER_PUSH }}
+          tags: |
+            swaggerapi/swagger-generator-v3:latest
+            swaggerapi/swagger-generator-v3:${{ env.TAG }}
 
-          echo Building $DOCKER_GENERATOR_FULL_IMAGE_NAME
-          docker buildx build \
-              -t $DOCKER_GENERATOR_FULL_IMAGE_NAME:$TAG \
-              -t $DOCKER_GENERATOR_FULL_IMAGE_NAME:latest \
-              --output $DOCKER_OUTPUT \
-              --platform $DOCKER_PLATFORMS \
-              -f ./modules/swagger-generator/Dockerfile ./modules/swagger-generator
+      - name: Docker build and push (root)
+        uses: docker/build-push-action@v4
+        with:
+          context: modules/swagger-generator
+          file: modules/swagger-generator/Dockerfile_root
+          platforms: ${{ env.DOCKER_PLATFORMS }}
+          push: ${{ env.DOCKER_PUSH }}
+          tags: |
+            swaggerapi/swagger-generator-v3-root:latest
+            swaggerapi/swagger-generator-v3-root:${{ env.TAG }}
 
-          echo
-          echo Building $DOCKER_GENERATOR_ROOT_FULL_IMAGE_NAME
-          docker buildx build \
-              -t $DOCKER_GENERATOR_ROOT_FULL_IMAGE_NAME:$TAG \
-              -t $DOCKER_GENERATOR_ROOT_FULL_IMAGE_NAME:latest \
-              --output $DOCKER_OUTPUT \
-              --platform $DOCKER_PLATFORMS \
-              -f ./modules/swagger-generator/Dockerfile_root ./modules/swagger-generator
+      - name: Docker build and push (minimal)
+        uses: docker/build-push-action@v4
+        with:
+          context: modules/swagger-generator
+          file: modules/swagger-generator/Dockerfile_minimal
+          platforms: ${{ env.DOCKER_PLATFORMS }}
+          push: ${{ env.DOCKER_PUSH }}
+          tags: |
+            swaggerapi/swagger-generator-v3-minimal:latest
+            swaggerapi/swagger-generator-v3-minimal:${{ env.TAG }}
 
-          echo
-          echo Building $DOCKER_GENERATOR_IMAGE_NAME
-          docker buildx build \
-              -t $DOCKER_GENERATOR_IMAGE_NAME:$TAG \
-              -t $DOCKER_GENERATOR_IMAGE_NAME:latest \
-              --output $DOCKER_OUTPUT \
-              --platform $DOCKER_PLATFORMS \
-              -f ./modules/swagger-generator/Dockerfile_minimal ./modules/swagger-generator
-
-          echo
-          echo Building $DOCKER_CODEGEN_CLI_IMAGE
-          docker buildx build \
-              -t $DOCKER_CODEGEN_CLI_IMAGE_NAME:$TAG \
-              -t $DOCKER_CODEGEN_CLI_IMAGE_NAME:latest \
-              --output $DOCKER_OUTPUT \
-              --platform $DOCKER_PLATFORMS \
-              ./modules/swagger-codegen-cli
-
-          echo
-          echo "docker images:"
-          docker images | grep -i generator
+      - name: Docker build and push (CLI)
+        uses: docker/build-push-action@v4
+        with:
+          context: ./modules/swagger-codegen-cli
+          platforms: ${{ env.DOCKER_PLATFORMS }}
+          push: ${{ env.DOCKER_PUSH }}
+          tags: |
+            swaggerapi/swagger-codegen-cli-v3:latest
+            swaggerapi/swagger-codegen-cli-v3:${{ env.TAG }}
 
       - name: deploy
         run: |
@@ -217,5 +218,4 @@ jobs:
           fi
           echo "Exiting Build..."
           exit 0
-    env:
-      TAG: ${{ github.event.inputs.tag }}
+

--- a/.github/workflows/docker-release-3.0.yml
+++ b/.github/workflows/docker-release-3.0.yml
@@ -16,7 +16,7 @@ jobs:
       DOCKER_PLATFORMS: |
         linux/amd64
         linux/arm64
-      DOCKER_PUSH: false
+      DOCKER_PUSH: true
       TAG: ${{ github.event.inputs.tag }}
 
     steps:
@@ -44,7 +44,6 @@ jobs:
           /bin/bash ./bin/utils/detect_tab_in_java_class.sh
       - uses: s4u/maven-settings-action@v2.8.0
         name: setup maven settings.xml
-        if: false
         with:
           servers: |
             [{

--- a/.github/workflows/docker-release-3.0.yml
+++ b/.github/workflows/docker-release-3.0.yml
@@ -23,6 +23,8 @@ jobs:
           java-version: 17
           distribution: temurin
           cache: maven
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
       - name: preliminary checks
         run: |
           docker login --username=${{ secrets.DOCKERHUB_SB_USERNAME }} --password=${{ secrets.DOCKERHUB_SB_PASSWORD }}
@@ -35,6 +37,7 @@ jobs:
           /bin/bash ./bin/utils/detect_tab_in_java_class.sh
       - uses: s4u/maven-settings-action@v2.8.0
         name: setup maven settings.xml
+        if: false
         with:
           servers: |
             [{
@@ -49,34 +52,57 @@ jobs:
             }]
       - name: Build with Maven
         run: |
-          # mvn clean install -U -Pdocker -Plinux -DJETTY_TEST_HTTP_PORT=8090 -DJETTY_TEST_STOP_PORT=8089
+          mvn -DJETTY_TEST_HTTP_PORT=8090 -DJETTY_TEST_STOP_PORT=8089 clean install -Pdocker --settings $HOME/.m2/settings.xml
       - name: docker build and push
         run: |
+          export TAG=${{ env.TAG }}
+          export DOCKER_PLATFORMS=linux/amd64,linux/arm64
+          export DOCKER_OUTPUT=type=image
+
           export DOCKER_GENERATOR_IMAGE_NAME=swaggerapi/swagger-generator-v3-minimal
           export DOCKER_GENERATOR_FULL_IMAGE_NAME=swaggerapi/swagger-generator-v3
           export DOCKER_GENERATOR_ROOT_FULL_IMAGE_NAME=swaggerapi/swagger-generator-v3-root
           export DOCKER_CODEGEN_CLI_IMAGE_NAME=swaggerapi/swagger-codegen-cli-v3
-          mvn -DJETTY_TEST_HTTP_PORT=8090 -DJETTY_TEST_STOP_PORT=8089 clean install -Pdocker -Prelease --settings $HOME/.m2/settings.xml
-          docker build --rm=false -t $DOCKER_GENERATOR_IMAGE_NAME:${{ env.TAG }} -f ./modules/swagger-generator/Dockerfile_minimal ./modules/swagger-generator
-          docker tag $DOCKER_GENERATOR_IMAGE_NAME:${{ env.TAG }} $DOCKER_GENERATOR_IMAGE_NAME:latest
-          docker push $DOCKER_GENERATOR_IMAGE_NAME:${{ env.TAG }}
-          docker push $DOCKER_GENERATOR_IMAGE_NAME:latest
-          docker build --rm=false -t $DOCKER_CODEGEN_CLI_IMAGE_NAME:${{ env.TAG }} ./modules/swagger-codegen-cli
-          docker tag $DOCKER_CODEGEN_CLI_IMAGE_NAME:${{ env.TAG }} $DOCKER_CODEGEN_CLI_IMAGE_NAME:latest
-          docker push $DOCKER_CODEGEN_CLI_IMAGE_NAME:${{ env.TAG }}
-          docker push $DOCKER_CODEGEN_CLI_IMAGE_NAME:latest
-          docker push $DOCKER_GENERATOR_FULL_IMAGE_NAME:${{ env.TAG }}
-          docker push $DOCKER_GENERATOR_FULL_IMAGE_NAME:latest
+
+          echo Building $DOCKER_GENERATOR_FULL_IMAGE_NAME
+          docker buildx build \
+              -t $DOCKER_GENERATOR_FULL_IMAGE_NAME:$TAG \
+              -t $DOCKER_GENERATOR_FULL_IMAGE_NAME:latest \
+              --output $DOCKER_OUTPUT \
+              --platform $DOCKER_PLATFORMS \
+              -f ./modules/swagger-generator/Dockerfile ./modules/swagger-generator
+
+          echo
+          echo Building $DOCKER_GENERATOR_ROOT_FULL_IMAGE_NAME
+          docker buildx build \
+              -t $DOCKER_GENERATOR_ROOT_FULL_IMAGE_NAME:$TAG \
+              -t $DOCKER_GENERATOR_ROOT_FULL_IMAGE_NAME:latest \
+              --output $DOCKER_OUTPUT \
+              --platform $DOCKER_PLATFORMS \
+              -f ./modules/swagger-generator/Dockerfile_root ./modules/swagger-generator
+
+          echo
+          echo Building $DOCKER_GENERATOR_IMAGE_NAME
+          docker buildx build \
+              -t $DOCKER_GENERATOR_IMAGE_NAME:$TAG \
+              -t $DOCKER_GENERATOR_IMAGE_NAME:latest \
+              --output $DOCKER_OUTPUT \
+              --platform $DOCKER_PLATFORMS \
+              -f ./modules/swagger-generator/Dockerfile_minimal ./modules/swagger-generator
+
+          echo
+          echo Building $DOCKER_CODEGEN_CLI_IMAGE
+          docker buildx build \
+              -t $DOCKER_CODEGEN_CLI_IMAGE_NAME:$TAG \
+              -t $DOCKER_CODEGEN_CLI_IMAGE_NAME:latest \
+              --output $DOCKER_OUTPUT \
+              --platform $DOCKER_PLATFORMS \
+              ./modules/swagger-codegen-cli
+
+          echo
           echo "docker images:"
           docker images | grep -i generator
-          echo "pushing $DOCKER_GENERATOR_ROOT_FULL_IMAGE_NAME:${{ env.TAG }}"
-          docker push $DOCKER_GENERATOR_ROOT_FULL_IMAGE_NAME:${{ env.TAG }}
-          echo "pushing $DOCKER_GENERATOR_ROOT_FULL_IMAGE_NAME:latest"
-          docker push $DOCKER_GENERATOR_ROOT_FULL_IMAGE_NAME:latest
-          echo "tagging $DOCKER_GENERATOR_FULL_IMAGE_NAME:${{ env.TAG }}-root"
-          docker tag $DOCKER_GENERATOR_ROOT_FULL_IMAGE_NAME:${{ env.TAG }} $DOCKER_GENERATOR_FULL_IMAGE_NAME:${{ env.TAG }}-root
-          echo "pushing $DOCKER_GENERATOR_FULL_IMAGE_NAME:${{ env.TAG }}-root"
-          docker -D -l debug push $DOCKER_GENERATOR_FULL_IMAGE_NAME:${{ env.TAG }}-root
+
       - name: deploy
         run: |
           echo "${{ env.TAG }}"

--- a/modules/swagger-generator/Dockerfile
+++ b/modules/swagger-generator/Dockerfile
@@ -27,12 +27,9 @@ COPY docker/ROOT.xml /generator/webapps/ROOT.xml
 COPY target/*.war /generator/webapps/ROOT.war
 COPY grantall.policy /generator/grantall.policy
 ENV JETTY_BASE /generator
-ARG HIDDEN_OPTIONS_DEFAULT_PATH
-COPY ${HIDDEN_OPTIONS_DEFAULT_PATH} /generator/resources/
-ARG HTTP_PORT
-ENV HTTP_PORT ${HTTP_PORT}
-ARG JAVA_MEM
-ENV JAVA_MEM ${JAVA_MEM}
+COPY hiddenOptions.yaml /generator/lib/
+ENV HTTP_PORT 8080
+ENV JAVA_MEM 1024m
 ENV EXIT_ON_OUTOFMEMORYERROR ""
 WORKDIR $JETTY_BASE
 

--- a/modules/swagger-generator/Dockerfile_root
+++ b/modules/swagger-generator/Dockerfile_root
@@ -26,12 +26,9 @@ COPY docker/ROOT.xml /generator/webapps/ROOT.xml
 COPY target/*.war /generator/webapps/ROOT.war
 COPY grantall.policy /generator/grantall.policy
 ENV JETTY_BASE /generator
-ARG HIDDEN_OPTIONS_DEFAULT_PATH
-COPY ${HIDDEN_OPTIONS_DEFAULT_PATH} /generator/resources/
-ARG HTTP_PORT
-ENV HTTP_PORT ${HTTP_PORT}
-ARG JAVA_MEM
-ENV JAVA_MEM ${JAVA_MEM}
+COPY hiddenOptions.yaml /generator/lib/
+ENV HTTP_PORT 8080
+ENV JAVA_MEM 1024m
 ENV EXIT_ON_OUTOFMEMORYERROR ""
 WORKDIR $JETTY_BASE
 CMD ["./start"]

--- a/modules/swagger-generator/pom.xml
+++ b/modules/swagger-generator/pom.xml
@@ -143,25 +143,7 @@
     </build>
     <profiles>
         <profile>
-            <id>linux</id>
-            <properties>
-                <docker-host-ip>localhost</docker-host-ip>
-            </properties>
-        </profile>
-        <profile>
-            <id>release</id>
-            <properties>
-                <docker-latest-tag>latest</docker-latest-tag>
-                <dockerfile.tag.skip>false</dockerfile.tag.skip>
-            </properties>
-        </profile>
-        <profile>
             <id>docker</id>
-            <properties>
-                <HIDDEN_OPTIONS_DEFAULT_PATH>hiddenOptions.yaml</HIDDEN_OPTIONS_DEFAULT_PATH>
-                <JAVA_MEM>1024m</JAVA_MEM>
-                <HTTP_PORT>8080</HTTP_PORT>
-            </properties>
             <build>
                 <plugins>
                     <plugin>
@@ -263,84 +245,6 @@
                             </execution>
                         </executions>
                     </plugin>
-                    <plugin>
-                        <groupId>com.spotify</groupId>
-                        <artifactId>dockerfile-maven-plugin</artifactId>
-                        <version>1.4.13</version>
-                        <executions>
-                            <execution>
-                                <id>build</id>
-                                <goals>
-                                    <goal>build</goal>
-                                </goals>
-                                <configuration>
-                                    <repository>swaggerapi/swagger-generator-v3</repository>
-                                    <tag>${docker-latest-tag}</tag>
-                                    <buildArgs>
-                                        <HIDDEN_OPTIONS_DEFAULT_PATH>${HIDDEN_OPTIONS_DEFAULT_PATH}</HIDDEN_OPTIONS_DEFAULT_PATH>
-                                        <JAVA_MEM>${JAVA_MEM}</JAVA_MEM>
-                                        <HTTP_PORT>${HTTP_PORT}</HTTP_PORT>
-                                    </buildArgs>
-                                </configuration>
-                            </execution>
-                            <execution>
-                                <id>tag</id>
-                                <goals>
-                                    <goal>tag</goal>
-                                </goals>
-                                <configuration>
-                                    <repository>swaggerapi/swagger-generator-v3</repository>
-                                    <tag>${project.version}</tag>
-                                </configuration>
-                            </execution>
-                            <execution>
-                                <id>build-root</id>
-                                <goals>
-                                    <goal>build</goal>
-                                </goals>
-                                <configuration>
-                                    <repository>swaggerapi/swagger-generator-v3-root</repository>
-                                    <tag>${docker-latest-tag}</tag>
-                                    <buildArgs>
-                                        <HIDDEN_OPTIONS_DEFAULT_PATH>${HIDDEN_OPTIONS_DEFAULT_PATH}</HIDDEN_OPTIONS_DEFAULT_PATH>
-                                        <JAVA_MEM>${JAVA_MEM}</JAVA_MEM>
-                                        <HTTP_PORT>${HTTP_PORT}</HTTP_PORT>
-                                    </buildArgs>
-                                    <dockerfile>Dockerfile_root</dockerfile>
-                                </configuration>
-                            </execution>
-                            <execution>
-                                <id>tag-root</id>
-                                <goals>
-                                    <goal>tag</goal>
-                                </goals>
-                                <configuration>
-                                    <repository>swaggerapi/swagger-generator-v3-root</repository>
-                                    <tag>${project.version}</tag>
-                                </configuration>
-                            </execution>
-                            <execution>
-                                <id>push</id>
-                                <goals>
-                                    <goal>push</goal>
-                                </goals>
-                                <configuration>
-                                    <repository>swaggerapi/swagger-generator-v3</repository>
-                                    <tag>${docker-latest-tag}</tag>
-                                </configuration>
-                            </execution>
-                            <execution>
-                                <id>push-root</id>
-                                <goals>
-                                    <goal>push</goal>
-                                </goals>
-                                <configuration>
-                                    <repository>swaggerapi/swagger-generator-v3-root</repository>
-                                    <tag>${docker-latest-tag}</tag>
-                                </configuration>
-                            </execution>
-                        </executions>
-                    </plugin>
                 </plugins>
             </build>
         </profile>
@@ -427,8 +331,6 @@
     </dependencies>
     <properties>
         <java.security.policy>grantall.policy</java.security.policy>
-        <dockerfile.tag.skip>true</dockerfile.tag.skip>
-        <docker-latest-tag>unstable</docker-latest-tag>
         <maven-plugin-version>1.0.0</maven-plugin-version>
         <jetty-version>9.4.51.v20230217</jetty-version>
         <inflector-version>2.0.9</inflector-version>


### PR DESCRIPTION
### Description of the PR

This PR updates the `docker-release-3.0` workflow to build docker images using dockerx, with multiarch support for amd64 and arm64

(Arm64 support was brought up a couple of times (#11020, #11650, #11772), mostly due to Apple Silicon becoming mainstream)

In order to achieve that I replaced the `dockerfile-maven-plugin` with `docker/build-push-action@v4`

### PR checklist

- [x] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [ ] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [x] Filed the PR against the correct branch: `3.0.0` branch for changes related to OpenAPI spec 3.0. Default: `master`.
- [ ] Copied the [technical committee](https://github.com/swagger-api/swagger-codegen/#swagger-codegen-technical-committee) to review the pull request if your PR is targeting a particular programming language.
