### PR TITLE
Fix #12135 - Upgrading slf4j to latest

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1228,7 +1228,7 @@
         <junit-version>4.13.2</junit-version>
         <maven-plugin-version>1.0.0</maven-plugin-version>
         <commons-lang-version>3.12.0</commons-lang-version>
-        <slf4j-version>1.7.36</slf4j-version>
+        <slf4j-version>2.0.7</slf4j-version>
         <logback-version>1.4.6</logback-version>
         <scala-maven-plugin-version>3.2.1</scala-maven-plugin-version>
         <jmustache-version>1.15</jmustache-version>


### PR DESCRIPTION
### PR checklist

- [ Yes ] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [ N/A ] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [ Yes ] Filed the PR against the correct branch: `3.0.0` branch for changes related to OpenAPI spec 3.0. Default: `master`.
- [ N/A ] Copied the [technical committee](https://github.com/swagger-api/swagger-codegen/#swagger-codegen-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

I have verified that both options of downgrading logback to 1.2.12 and upgrading slf4j to 2.0.7 solve the logging problems experienced with the cli.  This PR is suggesting an upgrade to slf4j, but may technically be riskier than the logback downgrade.  Fortunately the logback downgrade is similarly trivial, and could be employed as an alternative.

This has been broken since 3.0.42 on April 5, 2023, which is impacting all brew users of the swagger-codegen cli.