### PR TITLE
set default 'ignore mapping' option for java generators with 'false'

### DIFF
--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/AbstractJavaCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/AbstractJavaCodegen.java
@@ -1579,9 +1579,4 @@ public abstract class AbstractJavaCodegen extends DefaultCodegen implements Code
         }
         return tag;
     }
-
-    public boolean defaultIgnoreImportMappingOption() {
-        return true;
-    }
-
 }


### PR DESCRIPTION
fixes #10419