### PR TITLE
escape quotes in paths - release 2.4.35

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,10 +6,10 @@
 
 [![Build Status](https://jenkins.swagger.io/view/OSS%20-%20Java/job/oss-swagger-codegen-master-java7/badge/icon?subject=jenkins%20build%20-%20java%207)](https://jenkins.swagger.io/view/OSS%20-%20Java/job/oss-swagger-codegen-master-java7/)
 
-- Master (2.4.35-SNAPSHOT): [![Java Test](https://img.shields.io/jenkins/build.svg?jobUrl=https://jenkins.swagger.io/job/oss-swagger-codegen-master)](https://jenkins.swagger.io/view/OSS%20-%20Java/job/oss-swagger-codegen-master)
+- Master (2.4.36-SNAPSHOT): [![Java Test](https://img.shields.io/jenkins/build.svg?jobUrl=https://jenkins.swagger.io/job/oss-swagger-codegen-master)](https://jenkins.swagger.io/view/OSS%20-%20Java/job/oss-swagger-codegen-master)
 [![Windows Test](https://ci.appveyor.com/api/projects/status/github/swagger-api/swagger-codegen?branch=master&svg=true&passingText=Windows%20Test%20-%20OK&failingText=Windows%20Test%20-%20Fails)](https://ci.appveyor.com/project/swaggerhub-bot/swagger-codegen)
 
-- 3.0.50-SNAPSHOT:  [![Java Test](https://img.shields.io/jenkins/build.svg?jobUrl=https://jenkins.swagger.io/job/oss-swagger-codegen-3)](https://jenkins.swagger.io/view/OSS%20-%20Java/job/oss-swagger-codegen-3)
+- 3.0.51-SNAPSHOT:  [![Java Test](https://img.shields.io/jenkins/build.svg?jobUrl=https://jenkins.swagger.io/job/oss-swagger-codegen-3)](https://jenkins.swagger.io/view/OSS%20-%20Java/job/oss-swagger-codegen-3)
 [![Windows Test](https://ci.appveyor.com/api/projects/status/github/swagger-api/swagger-codegen?branch=3.0.0&svg=true&passingText=Windows%20Test%20-%20OK&failingText=Windows%20Test%20-%20Fails)](https://ci.appveyor.com/project/swaggerhub-bot/swagger-codegen)
 
 
@@ -50,7 +50,7 @@ dependency example:
 <dependency>
     <groupId>io.swagger</groupId>
     <artifactId>swagger-codegen-maven-plugin</artifactId>
-    <version>2.4.34</version>
+    <version>2.4.35</version>
 </dependency>
 ```
 
@@ -68,7 +68,7 @@ dependency example:
 <dependency>
     <groupId>io.swagger.codegen.v3</groupId>
     <artifactId>swagger-codegen-maven-plugin</artifactId>
-    <version>3.0.49</version>
+    <version>3.0.50</version>
 </dependency>
 ```
 
@@ -132,8 +132,9 @@ The OpenAPI Specification has undergone 3 revisions since initial creation in 20
 
 Swagger Codegen Version    | Release Date | OpenAPI Spec compatibility | Notes
 -------------------------- |--------------| -------------------------- | -----
-3.0.50-SNAPSHOT (current 3.0.0, upcoming minor release) [SNAPSHOT](https://oss.sonatype.org/content/repositories/snapshots/io/swagger/codegen/v3/swagger-codegen-cli/3.0.50-SNAPSHOT/)| TBD          | 1.0, 1.1, 1.2, 2.0, 3.0 | Minor release
-[3.0.49](https://github.com/swagger-api/swagger-codegen/releases/tag/v3.0.49) (**current stable**) | 2023-10-23   | 1.0, 1.1, 1.2, 2.0, 3.0   | [tag v3.0.49](https://github.com/swagger-api/swagger-codegen/tree/v3.0.49)
+3.0.51-SNAPSHOT (current 3.0.0, upcoming minor release) [SNAPSHOT](https://oss.sonatype.org/content/repositories/snapshots/io/swagger/codegen/v3/swagger-codegen-cli/3.0.51-SNAPSHOT/)| TBD          | 1.0, 1.1, 1.2, 2.0, 3.0 | Minor release
+[3.0.50](https://github.com/swagger-api/swagger-codegen/releases/tag/v3.0.50) (**current stable**) | 2023-10-26   | 1.0, 1.1, 1.2, 2.0, 3.0   | [tag v3.0.50](https://github.com/swagger-api/swagger-codegen/tree/v3.0.50)
+[3.0.49](https://github.com/swagger-api/swagger-codegen/releases/tag/v3.0.49) | 2023-10-23   | 1.0, 1.1, 1.2, 2.0, 3.0   | [tag v3.0.49](https://github.com/swagger-api/swagger-codegen/tree/v3.0.49)
 [3.0.48](https://github.com/swagger-api/swagger-codegen/releases/tag/v3.0.48) | 2023-10-19   | 1.0, 1.1, 1.2, 2.0, 3.0   | [tag v3.0.48](https://github.com/swagger-api/swagger-codegen/tree/v3.0.48)
 [3.0.47](https://github.com/swagger-api/swagger-codegen/releases/tag/v3.0.47) | 2023-10-02   | 1.0, 1.1, 1.2, 2.0, 3.0   | [tag v3.0.47](https://github.com/swagger-api/swagger-codegen/tree/v3.0.47)
 [3.0.46](https://github.com/swagger-api/swagger-codegen/releases/tag/v3.0.46) | 2023-06-07   | 1.0, 1.1, 1.2, 2.0, 3.0   | [tag v3.0.46](https://github.com/swagger-api/swagger-codegen/tree/v3.0.46)
@@ -182,7 +183,8 @@ Swagger Codegen Version    | Release Date | OpenAPI Spec compatibility | Notes
 [3.0.2](https://github.com/swagger-api/swagger-codegen/releases/tag/v3.0.2)| 2018-10-19   | 1.0, 1.1, 1.2, 2.0, 3.0 | Minor release
 [3.0.1](https://github.com/swagger-api/swagger-codegen/releases/tag/v3.0.1)| 2018-10-05   | 1.0, 1.1, 1.2, 2.0, 3.0 | Major release with breaking changes
 [3.0.0](https://github.com/swagger-api/swagger-codegen/releases/tag/v3.0.0)| 2018-09-06   | 1.0, 1.1, 1.2, 2.0, 3.0 | Major release with breaking changes
-2.4.35-SNAPSHOT (current master, upcoming minor release) [SNAPSHOT](https://oss.sonatype.org/content/repositories/snapshots/io/swagger/swagger-codegen-cli/2.4.34-SNAPSHOT/)| TBD          | 1.0, 1.1, 1.2, 2.0   | Minor release
+2.4.36-SNAPSHOT (current master, upcoming minor release) [SNAPSHOT](https://oss.sonatype.org/content/repositories/snapshots/io/swagger/swagger-codegen-cli/2.4.36-SNAPSHOT/)| TBD          | 1.0, 1.1, 1.2, 2.0   | Minor release
+[2.4.35](https://github.com/swagger-api/swagger-codegen/releases/tag/v2.4.35) (**current stable**) | 2023-10-26   | 1.0, 1.1, 1.2, 2.0   | [tag v2.4.35](https://github.com/swagger-api/swagger-codegen/tree/v2.4.35)
 [2.4.34](https://github.com/swagger-api/swagger-codegen/releases/tag/v2.4.34) (**current stable**) | 2023-10-19   | 1.0, 1.1, 1.2, 2.0   | [tag v2.4.34](https://github.com/swagger-api/swagger-codegen/tree/v2.4.34)
 [2.4.33](https://github.com/swagger-api/swagger-codegen/releases/tag/v2.4.33) | 2023-10-02   | 1.0, 1.1, 1.2, 2.0   | [tag v2.4.33](https://github.com/swagger-api/swagger-codegen/tree/v2.4.33)
 [2.4.32](https://github.com/swagger-api/swagger-codegen/releases/tag/v2.4.32) | 2023-05-17   | 1.0, 1.1, 1.2, 2.0   | [tag v2.4.32](https://github.com/swagger-api/swagger-codegen/tree/v2.4.32)
@@ -231,17 +233,17 @@ If you're looking for the latest stable version, you can grab it directly from M
 
 ```sh
 # Download current stable 2.x.x branch (Swagger and OpenAPI version 2)
-wget https://repo1.maven.org/maven2/io/swagger/swagger-codegen-cli/2.4.34/swagger-codegen-cli-2.4.34.jar -O swagger-codegen-cli.jar
+wget https://repo1.maven.org/maven2/io/swagger/swagger-codegen-cli/2.4.35/swagger-codegen-cli-2.4.35.jar -O swagger-codegen-cli.jar
 
 java -jar swagger-codegen-cli.jar help
 
 # Download current stable 3.x.x branch (OpenAPI version 3)
-wget https://repo1.maven.org/maven2/io/swagger/codegen/v3/swagger-codegen-cli/3.0.49/swagger-codegen-cli-3.0.49.jar -O swagger-codegen-cli.jar
+wget https://repo1.maven.org/maven2/io/swagger/codegen/v3/swagger-codegen-cli/3.0.50/swagger-codegen-cli-3.0.50.jar -O swagger-codegen-cli.jar
 
 java -jar swagger-codegen-cli.jar --help
 ```
 
-For Windows users, you will need to install [wget](http://gnuwin32.sourceforge.net/packages/wget.htm) or you can use Invoke-WebRequest in PowerShell (3.0+), e.g. `Invoke-WebRequest -OutFile swagger-codegen-cli.jar https://repo1.maven.org/maven2/io/swagger/swagger-codegen-cli/2.4.34/swagger-codegen-cli-2.4.34.jar`
+For Windows users, you will need to install [wget](http://gnuwin32.sourceforge.net/packages/wget.htm) or you can use Invoke-WebRequest in PowerShell (3.0+), e.g. `Invoke-WebRequest -OutFile swagger-codegen-cli.jar https://repo1.maven.org/maven2/io/swagger/swagger-codegen-cli/2.4.35/swagger-codegen-cli-2.4.35.jar`
 
 On a mac, it's even easier with `brew`:
 ```sh
@@ -389,7 +391,7 @@ java -jar modules/swagger-codegen-cli/target/swagger-codegen-cli.jar generate \
 ```
 (if you're on Windows, replace the last command with `java -jar modules\swagger-codegen-cli\target\swagger-codegen-cli.jar generate -i https://petstore.swagger.io/v2/swagger.json -l php -o c:\temp\php_api_client`)
 
-You can also download the JAR (latest release) directly from [maven.org](https://repo1.maven.org/maven2/io/swagger/swagger-codegen-cli/2.4.34/swagger-codegen-cli-2.4.34.jar)
+You can also download the JAR (latest release) directly from [maven.org](https://repo1.maven.org/maven2/io/swagger/swagger-codegen-cli/2.4.35/swagger-codegen-cli-2.4.35.jar)
 
 To get a list of **general** options available, please run `java -jar modules/swagger-codegen-cli/target/swagger-codegen-cli.jar help generate` (for version 3.x check [3.0.0 branch](https://github.com/swagger-api/swagger-codegen/tree/3.0.0))
 

--- a/modules/swagger-codegen-cli/pom.xml
+++ b/modules/swagger-codegen-cli/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>io.swagger</groupId>
         <artifactId>swagger-codegen-project</artifactId>
-        <version>2.4.34</version>
+        <version>2.4.35</version>
         <relativePath>../..</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/modules/swagger-codegen-maven-plugin/pom.xml
+++ b/modules/swagger-codegen-maven-plugin/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>io.swagger</groupId>
         <artifactId>swagger-codegen-project</artifactId>
-        <version>2.4.34</version>
+        <version>2.4.35</version>
         <relativePath>../..</relativePath>
     </parent>
     <artifactId>swagger-codegen-maven-plugin</artifactId>

--- a/modules/swagger-codegen/pom.xml
+++ b/modules/swagger-codegen/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>io.swagger</groupId>
         <artifactId>swagger-codegen-project</artifactId>
-        <version>2.4.34</version>
+        <version>2.4.35</version>
         <relativePath>../..</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/DefaultGenerator.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/DefaultGenerator.java
@@ -908,9 +908,9 @@ public class DefaultGenerator extends AbstractGenerator implements Generator {
 
         for (Tag tag : tags) {
             try {
-                CodegenOperation codegenOperation = config.fromOperation(resourcePath, httpMethod, operation, swagger.getDefinitions(), swagger);
+                CodegenOperation codegenOperation = config.fromOperation(config.escapeQuotationMark(resourcePath), httpMethod, operation, swagger.getDefinitions(), swagger);
                 codegenOperation.tags = new ArrayList<Tag>(tags);
-                config.addOperationToGroup(config.sanitizeTag(tag.getName()), resourcePath, operation, codegenOperation, operations);
+                config.addOperationToGroup(config.sanitizeTag(tag.getName()), config.escapeQuotationMark(resourcePath), operation, codegenOperation, operations);
 
                 List<Map<String, List<String>>> securities = operation.getSecurity();
                 if (securities == null && swagger.getSecurity() != null) {

--- a/modules/swagger-generator/pom.xml
+++ b/modules/swagger-generator/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>io.swagger</groupId>
         <artifactId>swagger-codegen-project</artifactId>
-        <version>2.4.34</version>
+        <version>2.4.35</version>
         <relativePath>../..</relativePath>
     </parent>
     <artifactId>swagger-generator</artifactId>

--- a/modules/swagger-generator/pom.xml.jenkins
+++ b/modules/swagger-generator/pom.xml.jenkins
@@ -4,7 +4,7 @@
     <parent>
         <groupId>io.swagger</groupId>
         <artifactId>swagger-codegen-project</artifactId>
-        <version>2.4.34</version>
+        <version>2.4.35</version>
         <relativePath>../..</relativePath>
     </parent>
     <artifactId>swagger-generator</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
     <artifactId>swagger-codegen-project</artifactId>
     <packaging>pom</packaging>
     <name>swagger-codegen-project</name>
-    <version>2.4.34</version>
+    <version>2.4.35</version>
     <url>https://github.com/swagger-api/swagger-codegen</url>
     <scm>
         <connection>scm:git:git@github.com:swagger-api/swagger-codegen.git</connection>

--- a/pom.xml.jenkins
+++ b/pom.xml.jenkins
@@ -9,7 +9,7 @@
     <artifactId>swagger-codegen-project</artifactId>
     <packaging>pom</packaging>
     <name>swagger-codegen-project</name>
-    <version>2.4.34</version>
+    <version>2.4.35</version>
     <url>https://github.com/swagger-api/swagger-codegen</url>
     <scm>
         <connection>scm:git:git@github.com:swagger-api/swagger-codegen.git</connection>


### PR DESCRIPTION
* [escape quotes in paths](https://github.com/swagger-api/swagger-codegen/commit/25a0296f4e9ac88f38a6ce5266f1e3980c311625)

* [prepare release 2.4.35](https://github.com/swagger-api/swagger-codegen/commit/b1f700bd63fd369f25ade39b3a704cced279dbc6)