### PR TITLE
Update cli docker base to eclipse-temurin:17-jre-alpine

### DIFF
--- a/modules/swagger-codegen-cli/Dockerfile
+++ b/modules/swagger-codegen-cli/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:8-jre-alpine
+FROM eclipse-temurin:17-jre-alpine
 
 ADD target/swagger-codegen-cli.jar /opt/swagger-codegen-cli/swagger-codegen-cli.jar
 


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
   N/A - not targeting a specific generator here and it doesn't appear any of these scripts use the docker image.
- [x] Filed the PR against the correct branch: `3.0.0` branch for changes related to OpenAPI spec 3.0. Default: `master`.
- [x] Copied the [technical committee](https://github.com/swagger-api/swagger-codegen/#swagger-codegen-technical-committee) to review the pull request if your PR is targeting a particular programming language.
   N/A - not targeting particular programming language

### Description of the PR

This addresses the `UnsupportedClassVersionError` exceptions reported in issues #12240 and #12242 for the 3.0.0 branch.

The error can be reproduced simply by running the docker image with `generate --help`:

``` 
$ docker run --rm --volume "$(pwd)":/local swaggerapi/swagger-codegen-cli-v3:3.0.50 generate --help 
Exception in thread "main" java.lang.UnsupportedClassVersionError: ch/qos/logback/classic/spi/LogbackServiceProvider has been compiled by a more recent version of the Java Runtime (class file version 55.0), this version of the Java Runtime only recognizes class file versions up to 52.0
        at java.lang.ClassLoader.defineClass1(Native Method)
        at java.lang.ClassLoader.defineClass(ClassLoader.java:763)
        ...
        at java.util.ServiceLoader$1.next(ServiceLoader.java:480)
        at org.slf4j.LoggerFactory.safelyInstantiate(LoggerFactory.java:148)
        at org.slf4j.LoggerFactory.findServiceProviders(LoggerFactory.java:129)
        at org.slf4j.LoggerFactory.bind(LoggerFactory.java:190)
```


The `UnsupportedClassVersionError` is because the `swaggerapi/swagger-generator-v3:3.0.50` docker image installs Java 8  (class version 52) as can be seen in the docker image history [1] and the Dockerfile itself [2]. The Logback library version 1.4.11 [3] used by swagger codegen is being built targeting Java 11 [4] (class file version 55).

The logback library could potentially be rolled back to a version built targeting Java 8 (1.3.x [4]). However, the codegen CLI is the only Dockerfile here on the 3.0.0 branch that is using a Java 8 runtime. The others are using Java 17 though from different base images:

- The top-level Dockerfile is based on `openjdk:17-jdk-alpine`: https://github.com/swagger-api/swagger-codegen/blob/fc4e952d9e39c6d9bcafaae85b979db302796313/Dockerfile#L1 

- The swagger-generator module Dockerfile uses Java 17 via `eclipse-temurin:17-jre`: https://github.com/swagger-api/swagger-codegen/blob/fc4e952d9e39c6d9bcafaae85b979db302796313/modules/swagger-generator/Dockerfile#L9

- The swagger-codegen-cli module Dockerfile uses Java 8 via `openjdk-8-jre-alpine`: https://github.com/swagger-api/swagger-codegen/blob/fc4e952d9e39c6d9bcafaae85b979db302796313/modules/swagger-codegen-cli/Dockerfile#L1

Given that, it seems reasonable to update swagger-codegen-cli to also use Java 17 which is the change I have made here.

I validated the change by manually building the image and testing `generate --help` and running a go client generation:

```
$ docker run --rm --volume "$(pwd)":/local swaggerapi/swagger-codegen-cli-v3:jre17-alpine generate --help 
usage: swagger-codegen generate [-h] [-v []] [-l] [-o] [-i] [-t]
                       [--template-version] [--template-engine] [-a] [-c]
                       [-D [ [ ...]]] [-s] [--api-package]
                       [--model-package] [--model-name-prefix]
                       ...
```
 
References:
[1] https://hub.docker.com/layers/swaggerapi/swagger-codegen-cli-v3/3.0.50/images/sha256-10f28ee6ef4dc6ad4871947b38347cd1fa61dea6537a87d0309605cd6f2b9185?context=explore
[2]  https://github.com/swagger-api/swagger-codegen/blob/fc4e952d9e39c6d9bcafaae85b979db302796313/modules/swagger-codegen-cli/Dockerfile#L1
[3] https://github.com/swagger-api/swagger-codegen/blob/fc4e952d9e39c6d9bcafaae85b979db302796313/pom.docker.xml#L1136
[4] https://github.com/qos-ch/logback/blob/master/README.md#java-ee-and-jakarta-ee-versions
