### PR TITLE
New attribute isJson in parameters

### DIFF
--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/v3/CodegenParameter.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/v3/CodegenParameter.java
@@ -17,6 +17,7 @@ public class CodegenParameter extends CodegenObject {
     public Map<String, Object> allowableValues;
     public CodegenProperty items;
     public boolean nullable;
+    public boolean isJson;
 
     /**
      * Determines whether this parameter is mandatory. If the parameter is in "path",
@@ -108,6 +109,7 @@ public class CodegenParameter extends CodegenObject {
         output.unescapedDescription = this.unescapedDescription;
         output.baseType = this.baseType;
         output.nullable = this.nullable;
+        output.isJson = this.isJson;
         output.required = this.required;
         output.maximum = this.maximum;
         output.exclusiveMaximum = this.exclusiveMaximum;
@@ -190,6 +192,8 @@ public class CodegenParameter extends CodegenObject {
             return false;
         if (nullable != that.nullable)
             return false;
+        if (isJson != that.isJson)
+            return false;
         if (required != that.required)
             return false;
         if (maximum != null ? !maximum.equals(that.maximum) : that.maximum != null)
@@ -237,6 +241,7 @@ public class CodegenParameter extends CodegenObject {
         result = 31 * result + (items != null ? items.hashCode() : 0);
         result = 31 * result + (vendorExtensions != null ? vendorExtensions.hashCode() : 0);
         result = 31 * result + (nullable ? 13:31);
+        result = 31 * result + (isJson ? 13:31);
         result = 31 * result + (required ? 13:31);
         result = 31 * result + (maximum != null ? maximum.hashCode() : 0);
         result = 31 * result + (exclusiveMaximum ? 13:31);
@@ -330,6 +335,10 @@ public class CodegenParameter extends CodegenObject {
 
     public boolean getNullable() {
         return nullable;
+    }
+
+    public boolean getIsJson() {
+        return isJson;
     }
 
     public boolean getRequired() {


### PR DESCRIPTION
This PR relates to issue 1173 in `swagger-codegen-generators`:

https://github.com/swagger-api/swagger-codegen-generators/issues/1173

We add a new boolean argument `isJson` in class `CodegenParameter`.

This argument claims that parameter content-type is some kind of JSON. This info can be set and used by generators.