### PR TITLE
fix for #804 subtypeName for discriminator mapping

### DIFF
--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/v3/CodegenModel.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/v3/CodegenModel.java
@@ -4,7 +4,6 @@ import io.swagger.v3.oas.models.ExternalDocumentation;
 import io.swagger.v3.oas.models.media.Discriminator;
 
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -518,11 +517,17 @@ public class CodegenModel extends CodegenObject {
         if (getInterfaceModels()!=null) {
             for (CodegenModel interfaceModel : getInterfaceModels()) {
                 if (interfaceModel.getDiscriminator() != null && interfaceModel.getDiscriminator().getMapping() != null) {
-                    String name = interfaceModel.getDiscriminator().getMapping().get(classname);
-                    return name != null ? name : classname;
+                    String subTypeName = interfaceModel.getDiscriminator().getMapping().get(classname);
+                    if (subTypeName!=null) {
+                        return subTypeName;
+                    }
                 }
             }
         }
-        return classname;
+        if (getParentModel()!=null && getParentModel().getDiscriminator()!=null && getParentModel().getDiscriminator().getMapping()!=null) {
+                String subTypeName = getParentModel().getDiscriminator().getMapping().get(classname);
+                return subTypeName!=null?subTypeName:name;
+        }
+        return name;
     }
 }

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/v3/CodegenModel.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/v3/CodegenModel.java
@@ -509,4 +509,20 @@ public class CodegenModel extends CodegenObject {
     public void setIsComposedModel(boolean isComposedModel) {
         this.isComposedModel = isComposedModel;
     }
+
+    /**
+     * Get the subtype name from the interface model
+     * @return name : the name assigned to the class by the discriminator mapping or classname if mapping not found
+     */
+    public String getSubtypeName() {
+        if (getInterfaceModels()!=null) {
+            for (CodegenModel interfaceModel : getInterfaceModels()) {
+                if (interfaceModel.getDiscriminator() != null && interfaceModel.getDiscriminator().getMapping() != null) {
+                    String name = interfaceModel.getDiscriminator().getMapping().get(classname);
+                    return name != null ? name : classname;
+                }
+            }
+        }
+        return classname;
+    }
 }


### PR DESCRIPTION
### PR checklist

- [ ] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [ ] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [ ] Filed the PR against the correct branch: `3.0.0` branch for changes related to OpenAPI spec 3.0. Default: `master`.
- [ ] Copied the [technical committee](https://github.com/swagger-api/swagger-codegen/#swagger-codegen-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

(details of the change, additional tests that have been done, reference to the issue for tracking, etc)

Fix for [JAVA discriminator mapping #804 in CodegenGenerators](https://github.com/swagger-api/swagger-codegen-generators/issues/804)

JAVA discriminator mapping support added in "codegen-generators". In order to access the defined discriminator mapping in the template, a new getter added to the CodegenModel.