### PR TITLE
Use Object instead ERROR_UNKNOWN as default value for empty  names

### DIFF
--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/DefaultCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/DefaultCodegen.java
@@ -3749,8 +3749,8 @@ public class DefaultCodegen {
 
         // better error handling when map/array type is invalid
         if (name == null) {
-            LOGGER.error("String to be sanitized is null. Default to ERROR_UNKNOWN");
-            return "ERROR_UNKNOWN";
+            LOGGER.error("String to be sanitized is null. Default to " + Object.class.getSimpleName());
+            return Object.class.getSimpleName();
         }
 
         // if the name is just '$', map it to 'value' for the time being.


### PR DESCRIPTION
### PR checklist

- [ x] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [ x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bi/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code gen\erator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [ x] Filed the PR against the correct branch: `3.0.0` branch for changes related to OpenAPI spec 3.0. Default: `master`.
- [ x] Copied the [technical committee](https://github.com/swagger-api/swagger-codegen/#swagger-codegen-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR
The `ERROR_UNKNOWN ` "keyword" for empty names was causing build errors on output code given that is not a "keyword" known by any language. Instead, `Object` is being used now.

