### PR TITLE
Add `localVariablePrefix` to the maven plugin README.md

### DIFF
--- a/modules/swagger-codegen-maven-plugin/README.md
+++ b/modules/swagger-codegen-maven-plugin/README.md
@@ -46,6 +46,7 @@ mvn clean compile
 - `apiPackage` - the package to use for generated api objects/classes
 - `invokerPackage` - the package to use for the generated invoker objects
 - `modelNamePrefix` and `modelNameSuffix` - Sets the pre- or suffix for model classes and enums
+- `localVariablePrefix` - adds a prefix for all generated local variables. Helps if your API has method names that conflict with local variable names.
 - `withXml` - enable XML annotations inside the generated models and API (only works with Java `language` and libraries that provide support for JSON and XML)
 - `configOptions` - a map of language-specific parameters (see below)
 - `configHelp` - dumps the configuration help for the specified library (generates no sources)


### PR DESCRIPTION
Added info about `localVariablePrefix` which is no where else in the docs.

### PR checklist

- [X] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [ ] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [X] Filed the PR against the correct branch: `3.0.0` branch for changes related to OpenAPI spec 3.0. Default: `master`.
- [ ] Copied the [technical committee](https://github.com/swagger-api/swagger-codegen/#swagger-codegen-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

Added some documentation that I only found via stack overflow to fix a variable naming conflict. 

https://stackoverflow.com/questions/60506131/swagger-codegen-generates-duplicated-variables
https://github.com/swagger-api/swagger-codegen/issues/12328
