### PR TITLE
Build swagger-codegen-cli-v3 with correct Dockerfile

### DIFF
--- a/.github/workflows/docker-release-3.0.yml
+++ b/.github/workflows/docker-release-3.0.yml
@@ -83,8 +83,8 @@ jobs:
       - name: docker cli build and push
         uses: docker/build-push-action@v5
         with:
-          context: ./modules/swagger-generator
-          file: ./modules/swagger-generator/Dockerfile_minimal
+          context: ./modules/swagger-codegen-cli
+          file: ./modules/swagger-codegen-cli/Dockerfile
           push: true
           platforms: linux/amd64,linux/arm/v7,linux/arm64/v8,linux/ppc64le,linux/s390x
           provenance: false


### PR DESCRIPTION
closes #12321

### PR checklist

- [ X] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [ NA] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [ X] Filed the PR against the correct branch: `3.0.0` branch for changes related to OpenAPI spec 3.0. Default: `master`.
- [ NA] Copied the [technical committee](https://github.com/swagger-api/swagger-codegen/#swagger-codegen-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

As described in [the comments of 12321](https://github.com/swagger-api/swagger-codegen/issues/12321#issuecomment-1925030033), use the `swagger-codegen-cli` context / Dockerfile instead of `swagger-generator/Dockerfile_minimal`.  I do not know of an easy way to test GitHub CI scripts like this, so I have not tested it, but this fix looks straightforward.

