### PR TITLE
use URLSearchParams instead of url.URLSeachParams

### DIFF
--- a/modules/swagger-codegen/src/main/resources/typescript-fetch/api.mustache
+++ b/modules/swagger-codegen/src/main/resources/typescript-fetch/api.mustache
@@ -106,7 +106,7 @@ export const {{classname}}FetchParamCreator = function (configuration?: Configur
             const localVarHeaderParameter = {} as any;
             const localVarQueryParameter = {} as any;
     {{#hasFormParams}}
-            const localVarFormParams = new url.URLSearchParams();
+            const localVarFormParams = new URLSearchParams();
     {{/hasFormParams}}
 
     {{#authMethods}}


### PR DESCRIPTION
fixes #6403 for codegen v2