### PR TITLE
Fix docker release action for CLI

### DIFF
--- a/.github/workflows/docker-release-3.0.yml
+++ b/.github/workflows/docker-release-3.0.yml
@@ -83,8 +83,8 @@ jobs:
       - name: docker cli build and push
         uses: docker/build-push-action@v5
         with:
-          context: ./modules/swagger-generator
-          file: ./modules/swagger-generator/Dockerfile_minimal
+          context: ./modules/swagger-codegen-cli
+          file: ./modules/swagger-codegen-cli/Dockerfile
           push: true
           platforms: linux/amd64,linux/arm/v7,linux/arm64/v8,linux/ppc64le,linux/s390x
           provenance: false


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [ ] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [x] Filed the PR against the correct branch: `3.0.0` branch for changes related to OpenAPI spec 3.0. Default: `master`.
- [x] Copied the [technical committee](https://github.com/swagger-api/swagger-codegen/#swagger-codegen-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

Fixes the CLI docker image generation in #12343, I'm unsure as to the intent for the `minimal` docker image but this should restore parity with the main branch.

