### PR TITLE
Dockerfile fix

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM maven:3-eclipse-temurin-11
+FROM maven:3-eclipse-temurin-11-alpine
 
 RUN set -x && \
     apk add --no-cache bash

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,23 +3,25 @@ FROM maven:3-eclipse-temurin-11-alpine
 RUN set -x && \
     apk add --no-cache bash
 
-ENV GEN_DIR /opt/swagger-codegen
+ARG GEN_DIR /opt/swagger-codegen
+ENV GEN_DIR ${GEN_DIR}
 WORKDIR ${GEN_DIR}
-VOLUME  ${MAVEN_HOME}/.m2/repository
+
+VOLUME ${MAVEN_HOME}/.m2/repository
 
 # Required from a licensing standpoint
-COPY ./LICENSE ${GEN_DIR}
+COPY ./LICENSE ./
 
 # Required to compile swagger-codegen
-COPY ./google_checkstyle.xml ${GEN_DIR}
+COPY ./google_checkstyle.xml ./
 
 # Modules are copied individually here to allow for caching of docker layers between major.minor versions
 # NOTE: swagger-generator is not included here, it is available as swaggerapi/swagger-generator
-COPY ./modules/swagger-codegen-maven-plugin ${GEN_DIR}/modules/swagger-codegen-maven-plugin
-COPY ./modules/swagger-codegen-cli ${GEN_DIR}/modules/swagger-codegen-cli
-COPY ./modules/swagger-codegen ${GEN_DIR}/modules/swagger-codegen
-COPY ./modules/swagger-generator ${GEN_DIR}/modules/swagger-generator
-COPY ./pom.xml ${GEN_DIR}
+COPY ./modules/swagger-codegen-maven-plugin ./modules/swagger-codegen-maven-plugin
+COPY ./modules/swagger-codegen-cli ./modules/swagger-codegen-cli
+COPY ./modules/swagger-codegen ./modules/swagger-codegen
+COPY ./modules/swagger-generator ./modules/swagger-generator
+COPY ./pom.xml ./
 
 # Pre-compile swagger-codegen-cli
 RUN mvn -am -pl "modules/swagger-codegen-cli" package


### PR DESCRIPTION
Dockerfile base image had changed from Alpine to Ubun, breaking Docker image build

### PR checklist

- [x] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [ ] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [ ] Filed the PR against the correct branch: `3.0.0` branch for changes related to OpenAPI spec 3.0. Default: `master`.
- [ ] Copied the [technical committee](https://github.com/swagger-api/swagger-codegen/#swagger-codegen-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

Fixes in Dockerfile:

#### 1. Updated base image
As described in #12158, the Docker build is broken since the base image was changed from Alpine to Ubuntu.

#### 2. Added `GEN_DIR` as Build Argument

The `WORKDIR` was previously set by an environment variable `GEN_DIR` at build time. This setup doesn't make sense as it always resolves to the same default value, which makes the Dockerfile harder to read and prone to errors if anyone actually tries to customize this value 
 Assuming there's a valid reason for allowing this to be dynamically set, I've added a build argument (`ARG` instruction) before `ENV`, so it can actually be used effectively. 
