### PR TITLE
fix for missing imports in services 

### DIFF
--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/DefaultCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/DefaultCodegen.java
@@ -2299,11 +2299,15 @@ public class DefaultCodegen {
                 Response response = entry.getValue();
                 CodegenResponse r = fromResponse(entry.getKey(), response);
                 r.hasMore = true;
-                if (r.baseType != null &&
-                        !defaultIncludes.contains(r.baseType) &&
-                        !languageSpecificPrimitives.contains(r.baseType)) {
-                    imports.add(r.baseType);
+                if (r.schema != null) {
+                    Property responseProperty = response.getSchema();
+                    CodegenProperty iterator = fromProperty("response", responseProperty);
+                    while (iterator!=null){
+                        imports.add(iterator.baseType);
+                        iterator = iterator.items;
+                    }
                 }
+                imports.add(r.baseType);
                 r.isDefault = response == methodResponse;
                 op.responses.add(r);
                 if (Boolean.TRUE.equals(r.isBinary) && Boolean.TRUE.equals(r.isDefault)){
@@ -2510,16 +2514,10 @@ public class DefaultCodegen {
             responseProperty.setRequired(true);
             CodegenProperty cm = fromProperty("response", responseProperty);
 
-            if (responseProperty instanceof ArrayProperty) {
-                ArrayProperty ap = (ArrayProperty) responseProperty;
-                CodegenProperty innerProperty = fromProperty("response", ap.getItems());
-                r.baseType = innerProperty.baseType;
+            if (cm.complexType != null) {
+                r.baseType = cm.complexType;
             } else {
-                if (cm.complexType != null) {
-                    r.baseType = cm.complexType;
-                } else {
-                    r.baseType = cm.baseType;
-                }
+                r.baseType = cm.baseType;
             }
             r.dataType = cm.datatype;
 

--- a/modules/swagger-codegen/src/test/java/io/swagger/codegen/java/JavaCodegenTest.java
+++ b/modules/swagger-codegen/src/test/java/io/swagger/codegen/java/JavaCodegenTest.java
@@ -1,0 +1,66 @@
+package io.swagger.codegen.java;
+
+import com.google.common.collect.Sets;
+import io.swagger.codegen.CodegenOperation;
+import io.swagger.codegen.DefaultCodegen;
+import io.swagger.codegen.languages.JavaClientCodegen;
+import io.swagger.models.Operation;
+import io.swagger.models.Swagger;
+import io.swagger.parser.SwaggerParser;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+public class JavaCodegenTest {
+
+	private CodegenOperation createCodegenOperationFromTestData(String path){
+		Swagger model = new SwaggerParser().read("src/test/resources/2_0/petstore-nested-maps-or-arrays.json");
+		DefaultCodegen codegen = new JavaClientCodegen();
+		Operation p = model.getPaths().get(path).getGet();
+		return codegen.fromOperation(path, "get", p, model.getDefinitions());
+	}
+
+	@Test(description = "sets imports of map of array to child object")
+	public void mapOfArrayOfObjectTest() {
+		final CodegenOperation op = createCodegenOperationFromTestData("/one");
+
+		Assert.assertEquals(op.returnType, "Map<String, List<OneDto>>");
+		Assert.assertEquals(op.imports.size(), 3);
+		Assert.assertEquals(op.imports, Sets.newHashSet("OneDto", "List", "Map"));
+	}
+
+	@Test(description = "sets imports of array of array to nested child object")
+	public void arrayOfArrayOfObjectTest() {
+		final CodegenOperation op = createCodegenOperationFromTestData("/two");
+
+		Assert.assertEquals(op.returnType, "List<List<OneDto>>");
+		Assert.assertEquals(op.imports.size(), 2);
+		Assert.assertEquals(op.imports, Sets.newHashSet("OneDto", "List"));
+	}
+
+	@Test(description = "sets imports of array to child object")
+	public void ArrayOfObjectTest() {
+		final CodegenOperation op = createCodegenOperationFromTestData("/three");
+
+		Assert.assertEquals(op.returnType, "List<OneDto>");
+		Assert.assertEquals(op.imports.size(), 2);
+		Assert.assertEquals(op.imports, Sets.newHashSet("OneDto", "List"));
+	}
+
+	@Test(description = "imports for array of primitive type")
+	public void ArrayOfStringTest() {
+		final CodegenOperation op = createCodegenOperationFromTestData("/four");
+
+		Assert.assertEquals(op.returnType, "List<String>");
+		Assert.assertEquals(op.imports.size(), 1);
+		Assert.assertEquals(op.imports, Sets.newHashSet("List"));
+	}
+
+	@Test(description = "sets imports of map of map of array to child object")
+	public void mapOfMapOfArrayOfObjectTest() {
+		final CodegenOperation op = createCodegenOperationFromTestData("/five");
+
+		Assert.assertEquals(op.returnType, "Map<String, Map<String, List<OneDto>>>");
+		Assert.assertEquals(op.imports.size(), 3);
+		Assert.assertEquals(op.imports, Sets.newHashSet("OneDto", "List", "Map"));
+	}
+}

--- a/modules/swagger-codegen/src/test/java/io/swagger/codegen/typescript/typescriptangular/TypescriptAngularCodegenTest.java
+++ b/modules/swagger-codegen/src/test/java/io/swagger/codegen/typescript/typescriptangular/TypescriptAngularCodegenTest.java
@@ -1,0 +1,65 @@
+package io.swagger.codegen.typescript.typescriptangular;
+
+import com.google.common.collect.Sets;
+import io.swagger.codegen.CodegenOperation;
+import io.swagger.codegen.DefaultCodegen;
+import io.swagger.codegen.languages.TypeScriptAngularClientCodegen;
+import io.swagger.models.Operation;
+import io.swagger.models.Swagger;
+import io.swagger.parser.SwaggerParser;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+public class TypescriptAngularCodegenTest {
+
+	private CodegenOperation createCodegenOperationFromTestData(String path){
+		Swagger model = new SwaggerParser().read("src/test/resources/2_0/petstore-nested-maps-or-arrays.json");
+		DefaultCodegen codegen = new TypeScriptAngularClientCodegen();
+		Operation p = model.getPaths().get(path).getGet();
+		return codegen.fromOperation(path, "get", p, model.getDefinitions());
+	}
+
+	@Test(description = "sets imports of map of array to child object")
+	public void mapOfArrayOfObjectTest() {
+		final CodegenOperation op = createCodegenOperationFromTestData("/one");
+
+		Assert.assertEquals(op.returnType, "{ [key: string]: Array<OneDto>; }");
+		Assert.assertEquals(op.imports.size(), 1);
+		Assert.assertEquals(op.imports, Sets.newHashSet("OneDto"));
+	}
+
+	@Test(description = "sets imports of array of array to nested child object")
+	public void arrayOfArrayOfObjectTest() {
+		final CodegenOperation op = createCodegenOperationFromTestData("/two");
+
+		Assert.assertEquals(op.returnType, "Array<Array<OneDto>>");
+		Assert.assertEquals(op.imports.size(), 1);
+		Assert.assertEquals(op.imports, Sets.newHashSet("OneDto"));
+	}
+
+	@Test(description = "sets imports of array to child object")
+	public void ArrayOfObjectTest() {
+		final CodegenOperation op = createCodegenOperationFromTestData("/three");
+
+		Assert.assertEquals(op.returnType, "Array<OneDto>");
+		Assert.assertEquals(op.imports.size(), 1);
+		Assert.assertEquals(op.imports, Sets.newHashSet("OneDto"));
+	}
+
+	@Test(description = "no imports for array of primitive type")
+	public void ArrayOfStringTest() {
+		final CodegenOperation op = createCodegenOperationFromTestData("/four");
+
+		Assert.assertEquals(op.returnType, "Array<string>");
+		Assert.assertEquals(op.imports.size(), 0);
+	}
+
+	@Test(description = "sets imports of map of map of array to child object")
+	public void mapOfMapOfArrayOfObjectTest() {
+		final CodegenOperation op = createCodegenOperationFromTestData("/five");
+
+		Assert.assertEquals(op.returnType, "{ [key: string]: { [key: string]: Array<OneDto>; }; }");
+		Assert.assertEquals(op.imports.size(), 1);
+		Assert.assertEquals(op.imports, Sets.newHashSet("OneDto"));
+	}
+}

--- a/modules/swagger-codegen/src/test/resources/2_0/petstore-nested-maps-or-arrays.json
+++ b/modules/swagger-codegen/src/test/resources/2_0/petstore-nested-maps-or-arrays.json
@@ -1,0 +1,114 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "version": "1.0.0",
+    "title": "Swagger Petstore"
+  },
+  "host": "petstore.swagger.io",
+  "basePath": "/v2",
+  "paths" : {
+    "/one" : {
+      "get" : {
+        "operationId" : "One",
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "type" : "object",
+              "additionalProperties" : {
+                "type" : "array",
+                "items" : {
+                  "$ref" : "#/definitions/OneDto"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/two" : {
+      "get" : {
+        "operationId" : "Two",
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "type" : "array",
+              "items" : {
+                "type" : "array",
+                "items" : {
+                  "$ref" : "#/definitions/OneDto"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/three" : {
+      "get" : {
+        "operationId" : "Three",
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "type" : "array",
+              "items" : {
+                "$ref" : "#/definitions/OneDto"
+              }
+            }
+          }
+        }
+      }
+    },
+    "/four" : {
+      "get" : {
+        "operationId" : "Four",
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "type" : "array",
+              "items" : {
+                "type" : "string"
+              }
+            }
+          }
+        }
+      }
+    },
+    "/five" : {
+      "get" : {
+        "operationId" : "Five",
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "type" : "object",
+              "additionalProperties" : {
+                "type" : "object",
+                "additionalProperties" : {
+                  "type" : "array",
+                  "items" : {
+                    "$ref" : "#/definitions/OneDto"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+
+  "definitions" : {
+    "OneDto" : {
+      "type" : "object",
+      "properties" : {
+        "yes" : {
+          "type" : "string"
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [ ] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [x] Filed the PR against the correct branch: `2.0.0` branch for changes related to OpenAPI spec 2.0. Default: `master`.
- [ ] Copied the [technical committee](https://github.com/swagger-api/swagger-codegen/#swagger-codegen-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

The PR fixes issues related to creating import list for services from response schema
Fixes issues: #11745, #8121, #7189

