### PR TITLE
Synchronize generated gemspec with current bundler template

### DIFF
--- a/modules/swagger-codegen/src/main/resources/ruby/gemspec.mustache
+++ b/modules/swagger-codegen/src/main/resources/ruby/gemspec.mustache
@@ -36,8 +36,14 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'autotest-growl', '~> 0.2', '>= 0.2.16'
   s.add_development_dependency 'autotest-fsevent', '~> 0.2', '>= 0.2.12'
 
-  s.files         = `find *`.split("\n").uniq.sort.select { |f| !f.empty? }
-  s.test_files    = `find spec/*`.split("\n")
+  gemspec = File.basename(__FILE__)
+  spec.files = IO.popen(%w[find * -print0], chdir: __dir__, err: IO::NULL) do |ls|
+    ls.readlines("\x0", chomp: true).reject do |f|
+      (f == gemspec) ||
+        f.start_with?(*%w[bin/ test/ spec/ features/ .git Gemfile]) ||
+        f.end_with?(".gem")
+    end
+  end
   s.executables   = []
   s.require_paths = ["lib"]
 end


### PR DESCRIPTION
See template at https://github.com/rubygems/rubygems/blob/d786a1ccca3922d21572f77b021c51bfaf005819/bundler/lib/bundler/templates/newgem/newgem.gemspec.tt#L34

Additionally, exclude .gem files, since there seem to be several gems built from swagger-codegen that are recursively including older .gem versions, and thus growing in size exponentially

### PR checklist

- [ ] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [ ] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [ ] Filed the PR against the correct branch: `3.0.0` branch for changes related to OpenAPI spec 3.0. Default: `master`.
- [ ] Copied the [technical committee](https://github.com/swagger-api/swagger-codegen/#swagger-codegen-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

(details of the change, additional tests that have been done, reference to the issue for tracking, etc)

