### PR TITLE
Pass HTTP response object even if the request fails

### DIFF
--- a/modules/swagger-codegen/src/main/resources/swift5/AlamofireImplementations.mustache
+++ b/modules/swagger-codegen/src/main/resources/swift5/AlamofireImplementations.mustache
@@ -118,27 +118,27 @@ open class AlamofireRequestBuilder<T>: RequestBuilder<T> {
 
         let cleanupRequest = {
             syncQueue.async(flags: .barrier) {
-				_ = managerStore.removeValue(forKey: managerId)
+                _ = managerStore.removeValue(forKey: managerId)
             }
         }
 
         let validatedRequest = request.validate()
-		var responseObj: Response<T>?
-		var error: Error?
+        var responseObj: Response<T>?
+        var error: Error?
 
         switch T.self {
         case is String.Type:
             validatedRequest.responseString(completionHandler: { (stringResponse) in
                 cleanupRequest()
 
-				if stringResponse.result.isFailure {
-					error =  ErrorResponse.error(stringResponse.response?.statusCode ?? 500, stringResponse.data, stringResponse.result.error!)
-				} else {
-					responseObj = Response(
-						response: stringResponse.response!,
-						body: ((stringResponse.result.value ?? "") as! T)
-					)
-				}
+                if stringResponse.result.isFailure {
+                    error =  ErrorResponse.error(stringResponse.response?.statusCode ?? 500, stringResponse.data, stringResponse.result.error!)
+                } else {
+                    responseObj = Response(
+                        response: stringResponse.response!,
+                        body: ((stringResponse.result.value ?? "") as! T)
+                    )
+                }
             })
         case is URL.Type:
             validatedRequest.responseData(completionHandler: { (dataResponse) in
@@ -175,10 +175,10 @@ open class AlamofireRequestBuilder<T>: RequestBuilder<T> {
                     try fileManager.createDirectory(atPath: directoryPath, withIntermediateDirectories: true, attributes: nil)
                     try data.write(to: filePath, options: .atomic)
 
-					responseObj = Response(
-						response: dataResponse.response!,
-						body: (filePath as! T)
-					)
+                    responseObj = Response(
+                        response: dataResponse.response!,
+                        body: (filePath as! T)
+                    )
 
                 } catch let requestParserError as DownloadException {
                     error = ErrorResponse.error(400, dataResponse.data, requestParserError)
@@ -192,34 +192,34 @@ open class AlamofireRequestBuilder<T>: RequestBuilder<T> {
                 cleanupRequest()
 
                 if voidResponse.result.isFailure {
-					error = ErrorResponse.error(voidResponse.response?.statusCode ?? 500, voidResponse.data, voidResponse.result.error!)
-				} else {
-					responseObj = Response(
-						response: voidResponse.response!,
-						body: nil)
-				}
+                    error = ErrorResponse.error(voidResponse.response?.statusCode ?? 500, voidResponse.data, voidResponse.result.error!)
+                } else {
+                    responseObj = Response(
+                        response: voidResponse.response!,
+                        body: nil)
+                }
             })
         default:
             validatedRequest.responseData(completionHandler: { (dataResponse) in
                 cleanupRequest()
 
-				if dataResponse.result.isFailure {
-					error = ErrorResponse.error(dataResponse.response?.statusCode ?? 500, dataResponse.data, dataResponse.result.error!)
-				} else {
-					responseObj = Response(
-						response: dataResponse.response!,
-						body: (dataResponse.data as! T)
-					)
-				}
+                if dataResponse.result.isFailure {
+                    error = ErrorResponse.error(dataResponse.response?.statusCode ?? 500, dataResponse.data, dataResponse.result.error!)
+                } else {
+                    responseObj = Response(
+                        response: dataResponse.response!,
+                        body: (dataResponse.data as! T)
+                    )
+                }
             })
         }
 
 
-		if responseObj == nil, let httpResponse = validatedRequest.response {
-			responseObj = Response(response: httpResponse, body: nil)
-		}
+        if responseObj == nil, let httpResponse = validatedRequest.response {
+            responseObj = Response(response: httpResponse, body: nil)
+        }
 
-		completion(responseObj, error)
+        completion(responseObj, error)
     }
 
     open func buildHeaders() -> [String: String] {
@@ -312,8 +312,8 @@ open class AlamofireDecodableRequestBuilder<T:Decodable>: AlamofireRequestBuilde
         }
 
         let validatedRequest = request.validate()
-		var responseObj: Response<T>?
-		var error: Error?
+        var responseObj: Response<T>?
+        var error: Error?
 
         switch T.self {
         case is String.Type:
@@ -322,25 +322,25 @@ open class AlamofireDecodableRequestBuilder<T:Decodable>: AlamofireRequestBuilde
 
                 if stringResponse.result.isFailure {
                     error = ErrorResponse.error(stringResponse.response?.statusCode ?? 500, stringResponse.data, stringResponse.result.error!)
-				} else {
-					responseObj = Response(
-						response: stringResponse.response!,
-						body: ((stringResponse.result.value ?? "") as! T)
-					)
-				}
+                } else {
+                    responseObj = Response(
+                        response: stringResponse.response!,
+                        body: ((stringResponse.result.value ?? "") as! T)
+                    )
+                }
             })
         case is Void.Type:
             validatedRequest.responseData(completionHandler: { (voidResponse) in
                 cleanupRequest()
 
-				if voidResponse.result.isFailure {
-					error = ErrorResponse.error(voidResponse.response?.statusCode ?? 500, voidResponse.data, voidResponse.result.error!)
-				} else {
-					responseObj = Response(
-						response: voidResponse.response!,
-						body: nil
-					 )
-				}
+                if voidResponse.result.isFailure {
+                    error = ErrorResponse.error(voidResponse.response?.statusCode ?? 500, voidResponse.data, voidResponse.result.error!)
+                } else {
+                    responseObj = Response(
+                        response: voidResponse.response!,
+                        body: nil
+                     )
+                }
 
             })
         case is Data.Type:
@@ -349,46 +349,46 @@ open class AlamofireDecodableRequestBuilder<T:Decodable>: AlamofireRequestBuilde
 
                 if dataResponse.result.isFailure {
                     error = ErrorResponse.error(dataResponse.response?.statusCode ?? 500, dataResponse.data, dataResponse.result.error!)
-				} else {
-					responseObj = Response(
-						response: dataResponse.response!,
-						body: (dataResponse.data as! T)
-					)
-				}
+                } else {
+                    responseObj = Response(
+                        response: dataResponse.response!,
+                        body: (dataResponse.data as! T)
+                    )
+                }
             })
         default:
             validatedRequest.responseData(completionHandler: { (dataResponse: DataResponse<Data>) in
                 cleanupRequest()
-				do {
-					guard dataResponse.result.isSuccess else {
-						throw ErrorResponse.error(dataResponse.response?.statusCode ?? 500, dataResponse.data, dataResponse.result.error!)
-					}
+                do {
+                    guard dataResponse.result.isSuccess else {
+                        throw ErrorResponse.error(dataResponse.response?.statusCode ?? 500, dataResponse.data, dataResponse.result.error!)
+                    }
 
-					guard let data = dataResponse.data, !data.isEmpty else {
-						throw ErrorResponse.error(-1, nil, AlamofireDecodableRequestBuilderError.emptyDataResponse)
-					}
+                    guard let data = dataResponse.data, !data.isEmpty else {
+                        throw ErrorResponse.error(-1, nil, AlamofireDecodableRequestBuilderError.emptyDataResponse)
+                    }
 
-					guard let httpResponse = dataResponse.response else {
-						throw ErrorResponse.error(-2, nil, AlamofireDecodableRequestBuilderError.nilHTTPResponse)
-					}
+                    guard let httpResponse = dataResponse.response else {
+                        throw ErrorResponse.error(-2, nil, AlamofireDecodableRequestBuilderError.nilHTTPResponse)
+                    }
 
-					let decodeResult: (decodableObj: T?, error: Error?) = CodableHelper.decode(T.self, from: data)
+                    let decodeResult: (decodableObj: T?, error: Error?) = CodableHelper.decode(T.self, from: data)
 
-					if let _error = decodeResult.error {
-						throw _error
-					}
-					responseObj = Response(response: httpResponse, body: decodeResult.decodableObj)
-				} catch let _error {
-					error = _error
-				}
+                    if let _error = decodeResult.error {
+                        throw _error
+                    }
+                    responseObj = Response(response: httpResponse, body: decodeResult.decodableObj)
+                } catch let _error {
+                    error = _error
+                }
             })
         }
 
-		if responseObj == nil, let httpResponse = validatedRequest.response {
-			responseObj = Response(response: httpResponse, body: nil)
-		}
+        if responseObj == nil, let httpResponse = validatedRequest.response {
+            responseObj = Response(response: httpResponse, body: nil)
+        }
 
-		completion(responseObj, error)
+        completion(responseObj, error)
     }
 
 }

--- a/modules/swagger-codegen/src/main/resources/swift5/AlamofireImplementations.mustache
+++ b/modules/swagger-codegen/src/main/resources/swift5/AlamofireImplementations.mustache
@@ -118,32 +118,27 @@ open class AlamofireRequestBuilder<T>: RequestBuilder<T> {
 
         let cleanupRequest = {
             syncQueue.async(flags: .barrier) {
-                 _ = managerStore.removeValue(forKey: managerId)
+				_ = managerStore.removeValue(forKey: managerId)
             }
         }
 
         let validatedRequest = request.validate()
+		var responseObj: Response<T>?
+		var error: Error?
 
         switch T.self {
         case is String.Type:
             validatedRequest.responseString(completionHandler: { (stringResponse) in
                 cleanupRequest()
 
-                if stringResponse.result.isFailure {
-                    completion(
-                        nil,
-                        ErrorResponse.error(stringResponse.response?.statusCode ?? 500, stringResponse.data, stringResponse.result.error!)
-                    )
-                    return
-                }
-
-                completion(
-                    Response(
-                        response: stringResponse.response!,
-                        body: ((stringResponse.result.value ?? "") as! T)
-                    ),
-                    nil
-                )
+				if stringResponse.result.isFailure {
+					error =  ErrorResponse.error(stringResponse.response?.statusCode ?? 500, stringResponse.data, stringResponse.result.error!)
+				} else {
+					responseObj = Response(
+						response: stringResponse.response!,
+						body: ((stringResponse.result.value ?? "") as! T)
+					)
+				}
             })
         case is URL.Type:
             validatedRequest.responseData(completionHandler: { (dataResponse) in
@@ -180,18 +175,15 @@ open class AlamofireRequestBuilder<T>: RequestBuilder<T> {
                     try fileManager.createDirectory(atPath: directoryPath, withIntermediateDirectories: true, attributes: nil)
                     try data.write(to: filePath, options: .atomic)
 
-                    completion(
-                        Response(
-                            response: dataResponse.response!,
-                            body: (filePath as! T)
-                        ),
-                        nil
-                    )
+					responseObj = Response(
+						response: dataResponse.response!,
+						body: (filePath as! T)
+					)
 
                 } catch let requestParserError as DownloadException {
-                    completion(nil, ErrorResponse.error(400, dataResponse.data, requestParserError))
-                } catch let error {
-                    completion(nil, ErrorResponse.error(400, dataResponse.data, error))
+                    error = ErrorResponse.error(400, dataResponse.data, requestParserError)
+                } catch let _error {
+                    error = ErrorResponse.error(400, dataResponse.data, _error)
                 }
                 return
             })
@@ -200,41 +192,34 @@ open class AlamofireRequestBuilder<T>: RequestBuilder<T> {
                 cleanupRequest()
 
                 if voidResponse.result.isFailure {
-                    completion(
-                        nil,
-                        ErrorResponse.error(voidResponse.response?.statusCode ?? 500, voidResponse.data, voidResponse.result.error!)
-                    )
-                    return
-                }
-
-                completion(
-                    Response(
-                        response: voidResponse.response!,
-                        body: nil),
-                    nil
-                )
+					error = ErrorResponse.error(voidResponse.response?.statusCode ?? 500, voidResponse.data, voidResponse.result.error!)
+				} else {
+					responseObj = Response(
+						response: voidResponse.response!,
+						body: nil)
+				}
             })
         default:
             validatedRequest.responseData(completionHandler: { (dataResponse) in
                 cleanupRequest()
 
-                if dataResponse.result.isFailure {
-                    completion(
-                        nil,
-                        ErrorResponse.error(dataResponse.response?.statusCode ?? 500, dataResponse.data, dataResponse.result.error!)
-                    )
-                    return
-                }
-
-                completion(
-                    Response(
-                        response: dataResponse.response!,
-                        body: (dataResponse.data as! T)
-                    ),
-                    nil
-                )
+				if dataResponse.result.isFailure {
+					error = ErrorResponse.error(dataResponse.response?.statusCode ?? 500, dataResponse.data, dataResponse.result.error!)
+				} else {
+					responseObj = Response(
+						response: dataResponse.response!,
+						body: (dataResponse.data as! T)
+					)
+				}
             })
         }
+
+
+		if responseObj == nil, let httpResponse = validatedRequest.response {
+			responseObj = Response(response: httpResponse, body: nil)
+		}
+
+		completion(responseObj, error)
     }
 
     open func buildHeaders() -> [String: String] {
@@ -327,6 +312,8 @@ open class AlamofireDecodableRequestBuilder<T:Decodable>: AlamofireRequestBuilde
         }
 
         let validatedRequest = request.validate()
+		var responseObj: Response<T>?
+		var error: Error?
 
         switch T.self {
         case is String.Type:
@@ -334,89 +321,74 @@ open class AlamofireDecodableRequestBuilder<T:Decodable>: AlamofireRequestBuilde
                 cleanupRequest()
 
                 if stringResponse.result.isFailure {
-                    completion(
-                        nil,
-                        ErrorResponse.error(stringResponse.response?.statusCode ?? 500, stringResponse.data, stringResponse.result.error!)
-                    )
-                    return
-                }
-
-                completion(
-                    Response(
-                        response: stringResponse.response!,
-                        body: ((stringResponse.result.value ?? "") as! T)
-                    ),
-                    nil
-                )
+                    error = ErrorResponse.error(stringResponse.response?.statusCode ?? 500, stringResponse.data, stringResponse.result.error!)
+				} else {
+					responseObj = Response(
+						response: stringResponse.response!,
+						body: ((stringResponse.result.value ?? "") as! T)
+					)
+				}
             })
         case is Void.Type:
             validatedRequest.responseData(completionHandler: { (voidResponse) in
                 cleanupRequest()
 
-                if voidResponse.result.isFailure {
-                    completion(
-                        nil,
-                        ErrorResponse.error(voidResponse.response?.statusCode ?? 500, voidResponse.data, voidResponse.result.error!)
-                    )
-                    return
-                }
+				if voidResponse.result.isFailure {
+					error = ErrorResponse.error(voidResponse.response?.statusCode ?? 500, voidResponse.data, voidResponse.result.error!)
+				} else {
+					responseObj = Response(
+						response: voidResponse.response!,
+						body: nil
+					 )
+				}
 
-                completion(
-                    Response(
-                        response: voidResponse.response!,
-                        body: nil),
-                    nil
-                )
             })
         case is Data.Type:
             validatedRequest.responseData(completionHandler: { (dataResponse) in
                 cleanupRequest()
 
                 if dataResponse.result.isFailure {
-                    completion(
-                        nil,
-                        ErrorResponse.error(dataResponse.response?.statusCode ?? 500, dataResponse.data, dataResponse.result.error!)
-                    )
-                    return
-                }
-
-                completion(
-                    Response(
-                        response: dataResponse.response!,
-                        body: (dataResponse.data as! T)
-                    ),
-                    nil
-                )
+                    error = ErrorResponse.error(dataResponse.response?.statusCode ?? 500, dataResponse.data, dataResponse.result.error!)
+				} else {
+					responseObj = Response(
+						response: dataResponse.response!,
+						body: (dataResponse.data as! T)
+					)
+				}
             })
         default:
             validatedRequest.responseData(completionHandler: { (dataResponse: DataResponse<Data>) in
                 cleanupRequest()
+				do {
+					guard dataResponse.result.isSuccess else {
+						throw ErrorResponse.error(dataResponse.response?.statusCode ?? 500, dataResponse.data, dataResponse.result.error!)
+					}
 
-                guard dataResponse.result.isSuccess else {
-                    completion(nil, ErrorResponse.error(dataResponse.response?.statusCode ?? 500, dataResponse.data, dataResponse.result.error!))
-                    return
-                }
+					guard let data = dataResponse.data, !data.isEmpty else {
+						throw ErrorResponse.error(-1, nil, AlamofireDecodableRequestBuilderError.emptyDataResponse)
+					}
 
-                guard let data = dataResponse.data, !data.isEmpty else {
-                    completion(nil, ErrorResponse.error(-1, nil, AlamofireDecodableRequestBuilderError.emptyDataResponse))
-                    return
-                }
+					guard let httpResponse = dataResponse.response else {
+						throw ErrorResponse.error(-2, nil, AlamofireDecodableRequestBuilderError.nilHTTPResponse)
+					}
 
-                guard let httpResponse = dataResponse.response else {
-                    completion(nil, ErrorResponse.error(-2, nil, AlamofireDecodableRequestBuilderError.nilHTTPResponse))
-                    return
-                }
+					let decodeResult: (decodableObj: T?, error: Error?) = CodableHelper.decode(T.self, from: data)
 
-                var responseObj: Response<T>? = nil
-
-                let decodeResult: (decodableObj: T?, error: Error?) = CodableHelper.decode(T.self, from: data)
-                if decodeResult.error == nil {
-                    responseObj = Response(response: httpResponse, body: decodeResult.decodableObj)
-                }
-
-                completion(responseObj, decodeResult.error)
+					if let _error = decodeResult.error {
+						throw _error
+					}
+					responseObj = Response(response: httpResponse, body: decodeResult.decodableObj)
+				} catch let _error {
+					error = _error
+				}
             })
         }
+
+		if responseObj == nil, let httpResponse = validatedRequest.response {
+			responseObj = Response(response: httpResponse, body: nil)
+		}
+
+		completion(responseObj, error)
     }
 
 }


### PR DESCRIPTION
### PR checklist

- [ x] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [ ] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [ ] Filed the PR against the correct branch: `3.0.0` branch for changes related to OpenAPI spec 3.0. Default: `master`.
- [ ] Copied the [technical committee](https://github.com/swagger-api/swagger-codegen/#swagger-codegen-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

Some services send HTTP headers with content that helps investigating errors. With the current implementation it is not possible to read those headers.