### PR TITLE
[Python] Code generator doesn't preserve original case for variables

### DIFF
--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/PythonClientCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/PythonClientCodegen.java
@@ -31,6 +31,7 @@ public class PythonClientCodegen extends DefaultCodegen implements CodegenConfig
     public static final String CAMEL_CASE_OPTION = "camel";
     public static final String SNAKE_CASE_OPTION = "snake";
     public static final String KEBAB_CASE_OPTION = "kebab";
+    public static final String ORIGINAL_CASE_OPTION = "original";
 
     protected String packageName; // e.g. petstore_api
     protected String packageVersion;
@@ -308,7 +309,7 @@ public class PythonClientCodegen extends DefaultCodegen implements CodegenConfig
 
     protected void setCaseType() {
         final String caseType = String.valueOf(additionalProperties.get(CASE_OPTION));
-        if (CAMEL_CASE_OPTION.equalsIgnoreCase(caseType) || SNAKE_CASE_OPTION.equalsIgnoreCase(caseType) || KEBAB_CASE_OPTION.equalsIgnoreCase(caseType)) {
+        if (CAMEL_CASE_OPTION.equalsIgnoreCase(caseType) || SNAKE_CASE_OPTION.equalsIgnoreCase(caseType) || KEBAB_CASE_OPTION.equalsIgnoreCase(caseType) || ORIGINAL_CASE_OPTION.equalsIgnoreCase(caseType)) {
             this.caseType = caseType;
         } else {
             this.caseType = SNAKE_CASE_OPTION;
@@ -425,11 +426,13 @@ public class PythonClientCodegen extends DefaultCodegen implements CodegenConfig
         // remove dollar sign
         name = name.replaceAll("$", "");
 
-        // if it's all uppper case, convert to lower case
-        if (name.matches("^[A-Z_]*$")) {
+        // if it's all upper case, convert to lower case
+        if (!ORIGINAL_CASE_OPTION.equalsIgnoreCase(this.caseType) && name.matches("^[A-Z_]*$")) {
             name = name.toLowerCase();
         }
-        if (CAMEL_CASE_OPTION.equalsIgnoreCase(this.caseType)) {
+        if (ORIGINAL_CASE_OPTION.equalsIgnoreCase(this.caseType)) {
+            // leave the variable name as is
+        } else if (CAMEL_CASE_OPTION.equalsIgnoreCase(this.caseType)) {
             name = camelize(name, true);
         } else if (KEBAB_CASE_OPTION.equalsIgnoreCase(this.caseType)) {
             name = dashize(name);


### PR DESCRIPTION
### PR checklist

- [ ] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [ ] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [ ] Filed the PR against the correct branch: `3.0.0` branch for changes related to OpenAPI spec 3.0. Default: `master`.
- [ ] Copied the [technical committee](https://github.com/swagger-api/swagger-codegen/#swagger-codegen-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

Solves this issue: https://github.com/swagger-api/swagger-codegen/issues/12505
Provides support in codegen for Python to preserve original names for variables

Usage example with maven plugin:
```
<plugin>
                <groupId>io.swagger</groupId>
                <artifactId>swagger-codegen-maven-plugin</artifactId>
                <version>2.4.41</version>
                <executions>
                    <execution>
                        <id>python-swagger-client</id>
                        <goals>
                            <goal>generate</goal>
                        </goals>
                        <configuration>
                            <inputSpec>${basedir}/target/resources/services.yaml</inputSpec>
                            <output>${basedir}/target/generated_sources</output>
                            <templateDirectory>${basedir}/templates</templateDirectory>
                            <generateApiTests>false</generateApiTests>
                            <generateModelTests>false</generateModelTests>
                            <language>python</language>
                            <additionalProperties>
                                <property>case=original</property>
                            </additionalProperties>
                        </configuration>
                    </execution>
                </executions>
            </plugin>
```