### PR TITLE
fix(swagger-codegen): use Ubuntu-based JRE image

### DIFF
--- a/.github/workflows/docker-release-master.yml
+++ b/.github/workflows/docker-release-master.yml
@@ -59,7 +59,7 @@ jobs:
         with:
           context: ./modules/swagger-generator
           push: true
-          platforms: linux/amd64,linux/arm/v7,linux/arm64/v8,linux/ppc64le,linux/s390x
+          platforms: linux/amd64,linux/arm/v7,linux/arm64/v8,linux/ppc64le
           provenance: false
           tags: swaggerapi/swagger-generator:${{ env.TAG }},swaggerapi/swagger-generator:latest
       - name: Build CLI image and push

--- a/modules/swagger-generator/Dockerfile
+++ b/modules/swagger-generator/Dockerfile
@@ -1,4 +1,4 @@
-FROM eclipse-temurin:8-jre-alpine
+FROM eclipse-temurin:8-jre
 
 WORKDIR /generator
 


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [ ] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [x] Filed the PR against the correct branch: `3.0.0` branch for changes related to OpenAPI spec 3.0. Default: `master`.
- [ ] Copied the [technical committee](https://github.com/swagger-api/swagger-codegen/#swagger-codegen-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR


The Alpine JRE image introduced in https://github.com/swagger-api/swagger-codegen/pull/12470 only supports ARM64 which breaks the Docker workflow, see https://github.com/swagger-api/swagger-codegen/actions/runs/12389035407/job/34581266257.

The default Ubuntu image supports all relevant architectures.

BREAKING CHANGE: This drops support for IBM z Systems (linux/s390x).
