### PR TITLE
fix: [Python] Nullable bugfix in model.mustache

### DIFF
--- a/modules/swagger-codegen/src/main/resources/python/model.mustache
+++ b/modules/swagger-codegen/src/main/resources/python/model.mustache
@@ -99,8 +99,10 @@ class {{classname}}(object):
         :type: {{datatype}}
         """
 {{#required}}
+{{^nullable}}
         if self._configuration.client_side_validation and {{name}} is None:
             raise ValueError("Invalid value for `{{name}}`, must not be `None`")  # noqa: E501
+{{/nullable}}
 {{/required}}
 {{#isEnum}}
 {{#isContainer}}


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [ ] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [x] Filed the PR against the correct branch: `3.0.0` branch for changes related to OpenAPI spec 3.0. Default: `master`.
- [x] Copied the [technical committee](https://github.com/swagger-api/swagger-codegen/#swagger-codegen-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

(details of the change, additional tests that have been done, reference to the issue for tracking, etc)

