### PR TITLE
prevent polynomial regular expression used on uncontrolled data secur…

### DIFF
--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/DefaultCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/DefaultCodegen.java
@@ -3212,28 +3212,20 @@ public class DefaultCodegen {
 
     /**
      * Underscore the given word.
-     * Copied from Twitter elephant bird
-     * https://github.com/twitter/elephant-bird/blob/master/core/src/main/java/com/twitter/elephantbird/util/Strings.java
      *
      * @param word The word
      * @return The underscored version of the word
      */
     public static String underscore(String word) {
-        String firstPattern = "([A-Z]+)([A-Z][a-z][a-z]+)";
-        String secondPattern = "([a-z\\d])([A-Z])";
+        Pattern firstPattern = Pattern.compile("(?<=[A-Z])(?=[A-Z][a-z]{2,})");
+        Pattern secondPattern = Pattern.compile("(?<=[a-z\\d])(?=[A-Z])");
         String replacementPattern = "$1_$2";
-        // Replace package separator with slash.
-        word = word.replaceAll("\\.", "/"); // FIXME: a parameter should not be assigned. Also declare the methods parameters as 'final'.
-        // Replace $ with two underscores for inner classes.
-        word = word.replaceAll("\\$", "__");
-        // Replace capital letter with _ plus lowercase letter.
-        word = word.replaceAll(firstPattern, replacementPattern);
-        word = word.replaceAll(secondPattern, replacementPattern);
-        word = word.replace('-', '_');
-        // replace space with underscore
-        word = word.replace(' ', '_');
-        word = word.toLowerCase();
-        return word;
+
+        String replaced = word.replace('.', '/').replace("$", "__");
+        replaced = firstPattern.matcher(replaced).replaceAll("_");
+        replaced = secondPattern.matcher(replaced).replaceAll("_");
+        replaced = replaced.replace('-', '_').replace(' ', '_').toLowerCase();
+        return replaced;
     }
 
     /**

--- a/modules/swagger-codegen/src/test/java/io/swagger/codegen/CodegenTest.java
+++ b/modules/swagger-codegen/src/test/java/io/swagger/codegen/CodegenTest.java
@@ -51,6 +51,7 @@ public class CodegenTest {
 
         Assert.assertEquals(codegen.underscore("FooBar"), "foo_bar");
         Assert.assertEquals(codegen.underscore("FooBarBaz"), "foo_bar_baz");
+        Assert.assertEquals(codegen.underscore("HTTPServer"), "http_server");
     }
 
     @Test(description = "test camelize")


### PR DESCRIPTION
### Description of the PR

- replaceAll uses a backtracking engine. The pattern ([A-Z]+)([A-Z][a-z][a-z]+) had a greedy quantified group ([A-Z]+) followed by another subpattern that starts with an overlapping class [A-Z] and then [a-z][a-z]+. Inputs like "A...A a...a" (many uppercase, then many lowercase) could have had caused an issue. 
- String.replaceAll did compile the regex on each call. Using Pattern allows to compile regex once and reuse it. 

The outcome of the method should be the same
