### PR TITLE
feat: compute and upload SBOMs for various generator v3 flavors

### DIFF
--- a/.github/workflows/docker-release-3.0.yml
+++ b/.github/workflows/docker-release-3.0.yml
@@ -93,6 +93,44 @@ jobs:
           platforms: linux/amd64,linux/arm/v7,linux/arm64/v8,linux/ppc64le,linux/s390x
           provenance: false
           tags: swaggerapi/swagger-generator-v3-minimal:latest,swaggerapi/swagger-generator-v3-minimal:${{ env.TAG }}
+      - name: Install cosign
+        uses: sigstore/cosign-installer@v3.7.0
+      - name: Generate SBOM for swagger-generator-v3
+        uses: anchore/sbom-action@v0
+        with:
+          image: swaggerapi/swagger-generator-v3:${{ env.TAG }}
+          format: spdx-json
+          output-file: swagger-generator-v3.spdx.json
+      - name: Attach SBOM to swagger-generator-v3
+        run: |
+          cosign attach sbom --sbom swagger-generator-v3.spdx.json swaggerapi/swagger-generator-v3:${{ env.TAG }}
+      - name: Generate SBOM for swagger-generator-v3-root
+        uses: anchore/sbom-action@v0
+        with:
+          image: swaggerapi/swagger-generator-v3-root:${{ env.TAG }}
+          format: spdx-json
+          output-file: swagger-generator-v3-root.spdx.json
+      - name: Attach SBOM to swagger-generator-v3-root
+        run: |
+          cosign attach sbom --sbom swagger-generator-v3-root.spdx.json swaggerapi/swagger-generator-v3-root:${{ env.TAG }}
+      - name: Generate SBOM for swagger-codegen-cli-v3
+        uses: anchore/sbom-action@v0
+        with:
+          image: swaggerapi/swagger-codegen-cli-v3:${{ env.TAG }}
+          format: spdx-json
+          output-file: swagger-codegen-cli-v3.spdx.json
+      - name: Attach SBOM to swagger-codegen-cli-v3
+        run: |
+          cosign attach sbom --sbom swagger-codegen-cli-v3.spdx.json swaggerapi/swagger-codegen-cli-v3:${{ env.TAG }}
+      - name: Generate SBOM for swagger-generator-v3-minimal
+        uses: anchore/sbom-action@v0
+        with:
+          image: swaggerapi/swagger-generator-v3-minimal:${{ env.TAG }}
+          format: spdx-json
+          output-file: swagger-generator-v3-minimal.spdx.json
+      - name: Attach SBOM to swagger-generator-v3-minimal
+        run: |
+          cosign attach sbom --sbom swagger-generator-v3-minimal.spdx.json swaggerapi/swagger-generator-v3-minimal:${{ env.TAG }}
       - name: deploy
         run: |
           echo "${{ env.TAG }}"

--- a/.github/workflows/docker-release-master.yml
+++ b/.github/workflows/docker-release-master.yml
@@ -2,7 +2,6 @@ name: Build And Push Docker Release Master
 
 on:
   workflow_dispatch:
-    branches: [ "master" ]
     inputs:
       tag:
         description: tag/version to release
@@ -65,6 +64,26 @@ jobs:
           platforms: linux/amd64,linux/arm/v7,linux/arm64/v8,linux/ppc64le,linux/s390x
           provenance: false
           tags: swaggerapi/swagger-codegen-cli:${{ env.TAG }},swaggerapi/swagger-codegen-cli:latest
+      - name: Generate SBOM for generator image (SPDX-JSON)
+        uses: anchore/sbom-action@v0
+        with:
+          image: swaggerapi/swagger-generator:${{ env.TAG }}
+          format: spdx-json
+          output-file: swagger-generator.spdx.json
+      - name: Generate SBOM for CLI image (SPDX-JSON)
+        uses: anchore/sbom-action@v0
+        with:
+          image: swaggerapi/swagger-codegen-cli:${{ env.TAG }}
+          format: spdx-json
+          output-file: swagger-codegen-cli.spdx.json
+      - name: Install cosign
+        uses: sigstore/cosign-installer@v3.7.0
+      - name: Attach SBOM to generator image using cosign
+        run: |
+          cosign attach sbom --sbom swagger-generator.spdx.json swaggerapi/swagger-generator:${{ env.TAG }}
+      - name: Attach SBOM to CLI image using cosign
+        run: |
+          cosign attach sbom --sbom swagger-codegen-cli.spdx.json swaggerapi/swagger-codegen-cli:${{ env.TAG }}
       - name: deploy
         run: |
           echo "${{ env.TAG }}"


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [ ] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [x] Filed the PR against the correct branch: `3.0.0` branch for changes related to OpenAPI spec 3.0. Default: `master`.

### Description of the PR

This pull request enhances the Docker release workflows by adding automated generation and attachment of Software Bill of Materials (SBOM) files to Docker images, improving supply chain security and transparency. It introduces the use of the `anchore/sbom-action` for SBOM creation and `cosign` for attaching SBOMs to images in both the master and 3.0 release workflows.

**SBOM Generation and Attachment Enhancements:**

* Added steps to generate SBOMs in SPDX-JSON format for all relevant Docker images using the `anchore/sbom-action` GitHub Action in both `.github/workflows/docker-release-master.yml` and `.github/workflows/docker-release-3.0.yml`. [[1]](diffhunk://#diff-b25b8a75ca8af03396633a0d76c824de800a287ca93e2accce245d8bb93938c0R67-R86) [[2]](diffhunk://#diff-a3f06665a7d4fcd81291f65608d5424225d2fc6c5ba85cdc5b991b9398e9a538R96-R133)
* Introduced installation and usage of `cosign` to attach the generated SBOMs to the respective Docker images, further automating the supply chain security process. [[1]](diffhunk://#diff-b25b8a75ca8af03396633a0d76c824de800a287ca93e2accce245d8bb93938c0R67-R86) [[2]](diffhunk://#diff-a3f06665a7d4fcd81291f65608d5424225d2fc6c5ba85cdc5b991b9398e9a538R96-R133)

**Workflow Configuration Update:**

* Removed the unused `branches: [ "master" ]` input from the `workflow_dispatch` trigger in `.github/workflows/docker-release-master.yml` for cleaner configuration.

