### PR TITLE
chore: refactor date library usage to use CodegenConstants.DATE_LIBRARY

### DIFF
--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/CodegenConstants.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/CodegenConstants.java
@@ -239,4 +239,6 @@ public class CodegenConstants {
     public static final String INTERFACE_CONTROLLER = "interface-controller";
 
     public static final String IGNORE_IMPORT_MAPPING_OPTION = "ignoreImportMappings";
+
+    public static final String DATE_LIBRARY = "dateLibrary";
 }

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/AbstractJavaCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/AbstractJavaCodegen.java
@@ -55,8 +55,10 @@ public abstract class AbstractJavaCodegen extends DefaultCodegen implements Code
 
     static Logger LOGGER = LoggerFactory.getLogger(AbstractJavaCodegen.class);
     public static final String FULL_JAVA_UTIL = "fullJavaUtil";
+    /** @deprecated Use {@link CodegenConstants#DATE_LIBRARY} instead. */
+    @Deprecated
+    public static final String DATE_LIBRARY = CodegenConstants.DATE_LIBRARY;
     public static final String DEFAULT_LIBRARY = "<default>";
-    public static final String DATE_LIBRARY = "dateLibrary";
     public static final String JAVA8_MODE = "java8";
     public static final String JAVA11_MODE = "java11";
     public static final String SUPPORT_ASYNC = "supportAsync";
@@ -185,7 +187,7 @@ public abstract class AbstractJavaCodegen extends DefaultCodegen implements Code
             cliOptions.add(CliOption.newBoolean(IGNORE_UNKNOWN_JACKSON_ANNOTATION,
                 "adds @JsonIgnoreProperties(ignoreUnknown = true) annotation to model classes"));
         }
-        CliOption dateLibrary = new CliOption(DATE_LIBRARY, "Option. Date library to use");
+        CliOption dateLibrary = new CliOption(CodegenConstants.DATE_LIBRARY, "Option. Date library to use");
         Map<String, String> dateOptions = new HashMap<String, String>();
         dateOptions.put("java8", "Java 8 native JSR310 (preferred for jdk 1.8+) - note: this also sets \"" + JAVA8_MODE + "\" to true");
         dateOptions.put("java11", "Java 11 native JSR384 (preferred for jdk 11+) - note: this also sets \"" + JAVA11_MODE + "\" to true");
@@ -491,8 +493,8 @@ public abstract class AbstractJavaCodegen extends DefaultCodegen implements Code
             }
         }
 
-        if (additionalProperties.containsKey(DATE_LIBRARY)) {
-            setDateLibrary(additionalProperties.get("dateLibrary").toString());
+        if (additionalProperties.containsKey(CodegenConstants.DATE_LIBRARY)) {
+            setDateLibrary(additionalProperties.get(CodegenConstants.DATE_LIBRARY).toString());
         } else if (java8Mode) {
             setDateLibrary("java8");
         }

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/KotlinClientCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/KotlinClientCodegen.java
@@ -13,7 +13,9 @@ import java.util.Map;
 
 public class KotlinClientCodegen extends AbstractKotlinCodegen {
 
-    public static final String DATE_LIBRARY = "dateLibrary";
+    /** @deprecated Use {@link CodegenConstants#DATE_LIBRARY} instead. */
+    @Deprecated
+    public static final String DATE_LIBRARY = CodegenConstants.DATE_LIBRARY;
     protected CodegenConstants.ENUM_PROPERTY_NAMING_TYPE enumPropertyNaming = CodegenConstants.ENUM_PROPERTY_NAMING_TYPE.camelCase;
     static Logger LOGGER = LoggerFactory.getLogger(KotlinClientCodegen.class);
 
@@ -49,7 +51,7 @@ public class KotlinClientCodegen extends AbstractKotlinCodegen {
         apiPackage = packageName + ".apis";
         modelPackage = packageName + ".models";
 
-        CliOption dateLibrary = new CliOption(DATE_LIBRARY, "Option. Date library to use");
+        CliOption dateLibrary = new CliOption(CodegenConstants.DATE_LIBRARY, "Option. Date library to use");
         Map<String, String> dateOptions = new HashMap<>();
         dateOptions.put(DateLibrary.THREETENBP.value, "Threetenbp");
         dateOptions.put(DateLibrary.STRING.value, "String");
@@ -78,8 +80,8 @@ public class KotlinClientCodegen extends AbstractKotlinCodegen {
     public void processOpts() {
         super.processOpts();
 
-        if (additionalProperties.containsKey(DATE_LIBRARY)) {
-            setDateLibrary(additionalProperties.get(DATE_LIBRARY).toString());
+        if (additionalProperties.containsKey(CodegenConstants.DATE_LIBRARY)) {
+            setDateLibrary(additionalProperties.get(CodegenConstants.DATE_LIBRARY).toString());
         }
 
         if (DateLibrary.THREETENBP.value.equals(dateLibrary)) {

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/SpringCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/SpringCodegen.java
@@ -135,7 +135,7 @@ public class SpringCodegen extends AbstractJavaCodegen
         if (this.java8) {
             additionalProperties.put("javaVersion", "1.8");
             additionalProperties.put("jdk8", "true");
-            if (!additionalProperties.containsKey(DATE_LIBRARY)) {
+            if (!additionalProperties.containsKey(CodegenConstants.DATE_LIBRARY)) {
                 setDateLibrary("java8");
             }
         }

--- a/modules/swagger-codegen/src/test/java/io/swagger/codegen/options/JavaOptionsProvider.java
+++ b/modules/swagger-codegen/src/test/java/io/swagger/codegen/options/JavaOptionsProvider.java
@@ -74,7 +74,7 @@ public class JavaOptionsProvider implements OptionsProvider {
                 .put(JavaClientCodegen.JAVA8_MODE, JAVA8_MODE_VALUE)
                 .put(JavaClientCodegen.JAVA11_MODE, JAVA11_MODE_VALUE)
                 .put(CodegenConstants.SERIALIZE_BIG_DECIMAL_AS_STRING, "true")
-                .put(JavaClientCodegen.DATE_LIBRARY, "joda")
+                .put(CodegenConstants.DATE_LIBRARY, "joda")
                 .put(JavaClientCodegen.DISABLE_HTML_ESCAPING, "false")
                 .put("hideGenerationTimestamp", "true")
                 .put(CodegenConstants.ALLOW_UNICODE_IDENTIFIERS, ALLOW_UNICODE_IDENTIFIERS_VALUE)

--- a/modules/swagger-codegen/src/test/java/io/swagger/codegen/options/JaxRSServerOptionsProvider.java
+++ b/modules/swagger-codegen/src/test/java/io/swagger/codegen/options/JaxRSServerOptionsProvider.java
@@ -60,7 +60,7 @@ public class JaxRSServerOptionsProvider implements OptionsProvider {
     public Map<String, String> createOptions() {
         ImmutableMap.Builder<String, String> builder = new ImmutableMap.Builder<String, String>();
         builder.put(CodegenConstants.IMPL_FOLDER, IMPL_FOLDER_VALUE)
-            .put(JavaClientCodegen.DATE_LIBRARY, "joda") //java.lang.IllegalArgumentException: Multiple entries with same key: dateLibrary=joda and dateLibrary=joda
+            .put(CodegenConstants.DATE_LIBRARY, JODA_DATE_LIBRARY) //java.lang.IllegalArgumentException: Multiple entries with same key: dateLibrary=joda and dateLibrary=joda
             .put("title", "Test title")
             .put(CodegenConstants.MODEL_PACKAGE, MODEL_PACKAGE_VALUE)
             .put(CodegenConstants.API_PACKAGE, API_PACKAGE_VALUE)

--- a/modules/swagger-codegen/src/test/java/io/swagger/codegen/options/KotlinClientCodegenOptionsProvider.java
+++ b/modules/swagger-codegen/src/test/java/io/swagger/codegen/options/KotlinClientCodegenOptionsProvider.java
@@ -31,7 +31,7 @@ public class KotlinClientCodegenOptionsProvider implements OptionsProvider {
                 .put(CodegenConstants.GROUP_ID, GROUP_ID)
                 .put(CodegenConstants.SOURCE_FOLDER, SOURCE_FOLDER)
                 .put(CodegenConstants.ENUM_PROPERTY_NAMING, ENUM_PROPERTY_NAMING)
-                .put(KotlinClientCodegen.DATE_LIBRARY, DATE_LIBRARY)
+                .put(CodegenConstants.DATE_LIBRARY, DATE_LIBRARY)
                 .build();
     }
 


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [ ] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [ ] Filed the PR against the correct branch: `3.0.0` branch for changes related to OpenAPI spec 3.0. Default: `master`.

### Description of the PR

**Since this may be considered as a breaking change, I would like to leave the decision making to the team.**

- Move `DATE_LIBRARY` to `CodegenConstants` as it is shared across
  the Java and Kotlin language families
- Add `@Deprecated` aliases in `AbstractJavaCodegen` and
  `KotlinClientCodegen` for backward compatibility