### PR TITLE
fix: use explicit UTF-8 encoding in AuthParser URL decode/encode

### DIFF
--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/v3/auth/AuthParser.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/v3/auth/AuthParser.java
@@ -4,6 +4,7 @@ import io.swagger.v3.parser.core.models.AuthorizationValue;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.io.UncheckedIOException;
 import java.io.UnsupportedEncodingException;
 import java.net.URLDecoder;
 import java.net.URLEncoder;
@@ -27,7 +28,7 @@ public class AuthParser {
                     try {
                         auths.add(new AuthorizationValue(URLDecoder.decode(kvPair[0], StandardCharsets.UTF_8.name()), URLDecoder.decode(kvPair[1], StandardCharsets.UTF_8.name()), "header"));
                     } catch (UnsupportedEncodingException e) {
-                        throw new AssertionError("UTF-8 is not supported", e);
+                        throw new UncheckedIOException("UTF-8 is not supported", e);
                     }
                 }
             }

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/v3/auth/AuthParser.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/v3/auth/AuthParser.java
@@ -4,8 +4,10 @@ import io.swagger.v3.parser.core.models.AuthorizationValue;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.io.UnsupportedEncodingException;
 import java.net.URLDecoder;
 import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -22,8 +24,11 @@ public class AuthParser {
             for (String part : parts) {
                 String[] kvPair = part.split(":");
                 if (kvPair.length == 2) {
-                    // FIXME replace the deprecated method by decode(string, encoding). Which encoding is used ? Default UTF-8 ?
-                    auths.add(new AuthorizationValue(URLDecoder.decode(kvPair[0]), URLDecoder.decode(kvPair[1]), "header"));
+                    try {
+                        auths.add(new AuthorizationValue(URLDecoder.decode(kvPair[0], StandardCharsets.UTF_8.name()), URLDecoder.decode(kvPair[1], StandardCharsets.UTF_8.name()), "header"));
+                    } catch (UnsupportedEncodingException e) {
+                        throw new AssertionError("UTF-8 is not supported", e);
+                    }
                 }
             }
         }
@@ -38,9 +43,9 @@ public class AuthParser {
                     if (b.toString().length() > 0) {
                         b.append(",");
                     }
-                    b.append(URLEncoder.encode(v.getKeyName(), "UTF-8"))
+                    b.append(URLEncoder.encode(v.getKeyName(), StandardCharsets.UTF_8.name()))
                             .append(":")
-                            .append(URLEncoder.encode(v.getValue(), "UTF-8"));
+                            .append(URLEncoder.encode(v.getValue(), StandardCharsets.UTF_8.name()));
                 } catch (Exception e) {
                     // continue
                     LOGGER.error(e.getMessage(), e);


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [ ] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [x] Filed the PR against the correct branch: `3.0.0` branch for changes related to OpenAPI spec 3.0. Default: `master`.

### Description of the PR


- Replace deprecated `URLDecoder.decode(String)` with `URLDecoder.decode(String, String)` using `StandardCharsets.UTF_8` in `AuthParser.parse()`
- Update `URLEncoder.encode()` in `AuthParser.reconstruct()` to use `StandardCharsets.UTF_8.name()` instead of a hardcoded `"UTF-8"` string literal
- Remove 10-year-old FIXME comment (added in PR #1900, Jan 2016)
