### PR TITLE
chore: update dependencies

### DIFF
--- a/modules/swagger-generator/pom.xml
+++ b/modules/swagger-generator/pom.xml
@@ -335,7 +335,7 @@
         <java.security.policy>grantall.policy</java.security.policy>
         <maven-plugin-version>1.0.0</maven-plugin-version>
         <jetty-version>9.4.57.v20241219</jetty-version>
-        <inflector-version>2.0.14</inflector-version>
+        <inflector-version>2.0.17</inflector-version>
         <junit-version>4.13.2</junit-version>
         <servlet-api.version>3.1.0</servlet-api.version>
         <JETTY_TEST_HTTP_PORT>8080</JETTY_TEST_HTTP_PORT>

--- a/pom.xml
+++ b/pom.xml
@@ -905,6 +905,14 @@
     </reporting>
     <dependencyManagement>
         <dependencies>
+            <!-- Jackson BOM -->
+            <dependency>
+                <groupId>com.fasterxml.jackson</groupId>
+                <artifactId>jackson-bom</artifactId>
+                <version>${jackson-version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
             <!-- swagger-core v2 -->
             <dependency>
                 <groupId>io.swagger.core.v3</groupId>
@@ -974,61 +982,6 @@
                 <groupId>io.swagger.codegen.v3</groupId>
                 <artifactId>swagger-codegen-generators</artifactId>
                 <version>${swagger-codegen-generators-version}</version>
-            </dependency>
-            <!-- jackson -->
-            <dependency>
-                <groupId>com.fasterxml.jackson.core</groupId>
-                <artifactId>jackson-databind</artifactId>
-                <version>${jackson-version}</version>
-            </dependency>
-            <dependency>
-                <groupId>com.fasterxml.jackson.core</groupId>
-                <artifactId>jackson-annotations</artifactId>
-                <version>${jackson-version}</version>
-            </dependency>
-            <dependency>
-                <groupId>com.fasterxml.jackson.core</groupId>
-                <artifactId>jackson-core</artifactId>
-                <version>${jackson-version}</version>
-            </dependency>
-
-            <dependency>
-                <groupId>com.fasterxml.jackson.module</groupId>
-                <artifactId>jackson-module-jaxb-annotations</artifactId>
-                <version>${jackson-version}</version>
-            </dependency>
-
-            <dependency>
-                <groupId>com.fasterxml.jackson.dataformat</groupId>
-                <artifactId>jackson-dataformat-xml</artifactId>
-                <version>${jackson-version}</version>
-            </dependency>
-            <dependency>
-                <groupId>com.fasterxml.jackson.dataformat</groupId>
-                <artifactId>jackson-dataformat-yaml</artifactId>
-                <version>${jackson-version}</version>
-            </dependency>
-
-            <dependency>
-                <groupId>com.fasterxml.jackson.jaxrs</groupId>
-                <artifactId>jackson-jaxrs-base</artifactId>
-                <version>${jackson-version}</version>
-            </dependency>
-            <dependency>
-                <groupId>com.fasterxml.jackson.jaxrs</groupId>
-                <artifactId>jackson-jaxrs-json-provider</artifactId>
-                <version>${jackson-version}</version>
-            </dependency>
-            <dependency>
-                <groupId>com.fasterxml.jackson.jaxrs</groupId>
-                <artifactId>jackson-jaxrs-xml-provider</artifactId>
-                <version>${jackson-version}</version>
-            </dependency>
-
-            <dependency>
-                <groupId>com.fasterxml.jackson.datatype</groupId>
-                <artifactId>jackson-datatype-joda</artifactId>
-                <version>${jackson-version}</version>
             </dependency>
             <!-- snakeyaml -->
             <dependency>
@@ -1105,11 +1058,11 @@
     <properties>
         <maven.compiler.release>8</maven.compiler.release>
         <swagger-codegen-generators-version>1.0.60</swagger-codegen-generators-version>
-        <swagger-core-version>2.2.39</swagger-core-version>
+        <swagger-core-version>2.2.48</swagger-core-version>
         <swagger-core-version-v1>1.6.16</swagger-core-version-v1>
-        <swagger-parser-version>2.1.35</swagger-parser-version>
-        <swagger-parser-version-v1>1.0.75</swagger-parser-version-v1>
-        <jackson-version>2.19.2</jackson-version>
+        <swagger-parser-version>2.1.40</swagger-parser-version>
+        <swagger-parser-version-v1>1.0.76</swagger-parser-version-v1>
+        <jackson-version>2.21.2</jackson-version>
         <scala-version>2.11.1</scala-version>
         <commons-io-version>2.20.0</commons-io-version>
         <commons-cli-version>1.9.0</commons-cli-version>
@@ -1117,7 +1070,7 @@
         <maven-plugin-version>1.0.0</maven-plugin-version>
         <commons-lang-version>3.18.0</commons-lang-version>
         <slf4j-version>2.0.9</slf4j-version>
-        <logback-version>1.5.19</logback-version>
+        <logback-version>1.5.32</logback-version>
         <scala-maven-plugin-version>3.2.1</scala-maven-plugin-version>
         <jmustache-version>1.16</jmustache-version>
         <testng-version>7.10.2</testng-version>


### PR DESCRIPTION
- jackson-core → 2.21
- jackson-databind → 2.21.2
- jackson-annotations → 2.21
- logback-core → 1.5.32
- logback-classic → 1.5.32
- swagger-inflector -> 2.0.17
- swagger-core -> 2.2.48
- swagger-parser-v1 -> 1.0.76
- swagger-parser -> 2.1.40

### PR checklist

- [ ] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [ ] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [ ] Filed the PR against the correct branch: `3.0.0` branch for changes related to OpenAPI spec 3.0. Default: `master`.

### Description of the PR

(details of the change, additional tests that have been done, reference to the issue for tracking, etc)

