### PR TITLE
chore: prepare release workflow for codegen 3.0 adjustments

### DIFF
--- a/.github/workflows/prepare-release-3.yml
+++ b/.github/workflows/prepare-release-3.yml
@@ -33,8 +33,18 @@ permissions:
   pull-requests: write
 
 jobs:
+  validate-branch:
+    if: github.ref_name != '3.0.0'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Require 3.0.0 branch
+        run: |
+          echo "This workflow can run only from branch 3.0.0 (current: ${GITHUB_REF_NAME})."
+          exit 1
+
   prepare:
     # Resolves release versions, applies file updates, validates build, then opens PR.
+    if: github.ref_name == '3.0.0'
     runs-on: ubuntu-latest
     env:
       CODEGEN_VERSION: ${{ inputs.codegen_version }}
@@ -84,6 +94,17 @@ jobs:
         id: prepare-release
         # Performs version bump to release and updates docs/poms/openapi.
         run: bash CI/release/prepare-codegen-release.sh
+
+      - name: Create or update draft GitHub release
+        uses: ncipollo/release-action@v1
+        with:
+          allowUpdates: true
+          bodyFile: ${{ steps.prepare-release.outputs.release_notes_file }}
+          commit: 3.0.0
+          draft: true
+          name: v${{ steps.prepare-release.outputs.codegen_version }}
+          tag: v${{ steps.prepare-release.outputs.codegen_version }}
+          token: ${{ steps.generate-token.outputs.token }}
 
       - name: Build release candidate
         # Build with the resolved generators version to catch dependency issues early.

--- a/CI/release/prepare-codegen-release.sh
+++ b/CI/release/prepare-codegen-release.sh
@@ -13,6 +13,8 @@ previous_generators_version="${PREVIOUS_GENERATORS_VERSION:-}"
 build_generators_version=""
 
 # Prepare flow must start from a SNAPSHOT on branch 3.0.0.
+current_branch="$(git rev-parse --abbrev-ref HEAD)"
+[[ "${current_branch}" == "3.0.0" ]] || fail "Prepare release can run only on branch 3.0.0, got ${current_branch}"
 current_version="$(maven_project_version)"
 [[ "${current_version}" =~ SNAPSHOT$ ]] || fail "Prepare release must start from a SNAPSHOT codegen version, got ${current_version}"
 
@@ -76,9 +78,10 @@ mvn -B versions:set -DnewVersion="${codegen_version}"
 mvn -B versions:commit
 
 # Generate a minimal release-notes draft aligned with current GitHub release style.
-mkdir -p docs/release-notes
+release_notes_dir="${RUNNER_TEMP:-/tmp}/swagger-codegen-release-drafts"
+mkdir -p "${release_notes_dir}"
 previous_tag="$(git tag --merged HEAD --list 'v3.*' | sort -V | tail -n 1 || true)"
-release_notes_file="docs/release-notes/v${codegen_version}.md"
+release_notes_file="${release_notes_dir}/v${codegen_version}.md"
 {
   echo "# Swagger Codegen v${codegen_version}"
   echo
@@ -97,6 +100,10 @@ release_notes_file="docs/release-notes/v${codegen_version}.md"
     echo
   fi
 } > "${release_notes_file}"
+
+if [[ -n "${GITHUB_OUTPUT:-}" ]]; then
+  echo "release_notes_file=${release_notes_file}" >> "${GITHUB_OUTPUT}"
+fi
 
 update_codegen_release_files_script="CI/release/update-codegen-release-files.py"
 [[ -f "${update_codegen_release_files_script}" ]] || fail "Missing ${update_codegen_release_files_script}"

--- a/CI/release/update-codegen-release-files.py
+++ b/CI/release/update-codegen-release-files.py
@@ -66,6 +66,22 @@ def update_generators_poms(generators_version: str) -> None:
     replace_text("pom.docker.xml", replacements)
 
 
+def update_sample_meta_codegen_pom(codegen_version: str) -> None:
+    # Keep sample project pinned to the codegen version being prepared.
+    replace_text(
+        "samples/meta-codegen/pom.xml",
+        [(r"<swagger-codegen-version>[^<]+</swagger-codegen-version>", f"<swagger-codegen-version>{codegen_version}</swagger-codegen-version>")],
+    )
+
+
+def update_docker_pom_version(codegen_version: str) -> None:
+    # Keep root project version in pom.docker.xml aligned with released codegen version.
+    replace_text(
+        "pom.docker.xml",
+        [(r"<version>3\.0\.[0-9]+(?:-SNAPSHOT)?</version>", f"<version>{codegen_version}</version>")],
+    )
+
+
 def update_openapi_version(version: str) -> None:
     # Reflect current codegen version in online generator OpenAPI metadata.
     replace_text(
@@ -121,6 +137,8 @@ def main() -> int:
             return 2
         codegen_version, next_snapshot, generators_version = sys.argv[2:5]
         update_generators_poms(generators_version)
+        update_sample_meta_codegen_pom(codegen_version)
+        update_docker_pom_version(codegen_version)
         update_openapi_version(codegen_version)
         update_snapshot_rows(next_snapshot)
         update_release_rows(codegen_version)


### PR DESCRIPTION
### PR checklist

- [ ] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [ ] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [ ] Filed the PR against the correct branch: `3.0.0` branch for changes related to OpenAPI spec 3.0. Default: `master`.

### Description of the PR

(details of the change, additional tests that have been done, reference to the issue for tracking, etc)

