### PR TITLE
chore: release workflow for codegen 3.0 - fix no pinentry error

### DIFF
--- a/.github/workflows/release-codegen-3.yml
+++ b/.github/workflows/release-codegen-3.yml
@@ -208,7 +208,9 @@ jobs:
       - name: Deploy swagger-codegen-generators
         # Recovery controls: deploy can be skipped with dry_run/skip_maven_deploy.
         if: inputs.skip_maven_deploy != 'true' && inputs.dry_run != 'true'
-        run: mvn --no-transfer-progress -B -Prelease deploy
+        run: |
+          mvn --no-transfer-progress -B -Prelease deploy \
+            -Dgpg.pinentry.mode=loopback
 
       - name: Skip swagger-codegen-generators deploy
         if: inputs.skip_maven_deploy == 'true' || inputs.dry_run == 'true'
@@ -268,7 +270,8 @@ jobs:
         if: inputs.skip_maven_deploy != 'true' && inputs.dry_run != 'true'
         run: |
           mvn --no-transfer-progress -B -Prelease deploy \
-            -Dswagger-codegen-generators-version="${{ needs.validate.outputs.codegen_build_generators_version }}"
+            -Dswagger-codegen-generators-version="${{ needs.validate.outputs.codegen_build_generators_version }}" \
+            -Dgpg.pinentry.mode=loopback
 
       - name: Skip swagger-codegen deploy
         if: inputs.skip_maven_deploy == 'true' || inputs.dry_run == 'true'


### PR DESCRIPTION
### PR checklist

- [ ] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [ ] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [ ] Filed the PR against the correct branch: `3.0.0` branch for changes related to OpenAPI spec 3.0. Default: `master`.

### Description of the PR

(details of the change, additional tests that have been done, reference to the issue for tracking, etc)

