### PR TITLE
3.0.0 fix docker skipped

### DIFF
--- a/.github/workflows/release-codegen-3.yml
+++ b/.github/workflows/release-codegen-3.yml
@@ -345,7 +345,9 @@ jobs:
   docker_release:
     # Reuse the battle-tested docker release workflow with orchestrator-level skip gates.
     needs: codegen
-    if: inputs.skip_docker_push != 'true' && inputs.dry_run != 'true'
+    # always() suppresses the implicit success() check, which would otherwise see
+    # skipped transitive ancestors (generators/bootstrap_codegen) and skip this job.
+    if: always() && needs.codegen.result == 'success' && inputs.skip_docker_push != 'true' && inputs.dry_run != 'true'
     uses: ./.github/workflows/docker-release-3.0.yml
     with:
       tag: ${{ needs.codegen.outputs.codegen_version }}


### PR DESCRIPTION
 Previously, docker_release used only input-based conditions. GitHub still applied implicit success() gating, and skipped transitive ancestors could cause
  docker_release to be skipped even when codegen succeeded and Docker was enabled.

  Updated condition:

  if: always() && needs.codegen.result == 'success' && inputs.skip_docker_push != 'true' && inputs.dry_run != 'true'

  What this changes:

  - always() suppresses implicit success() evaluation.
  - Explicitly requires codegen to succeed.
  - Keeps existing safety toggles: skip when skip_docker_push=true or dry_run=true