### PR TITLE
ci: auto-dismiss security alerts in samples/

### DIFF
--- a/.github/workflows/auto-dismiss-samples-alerts.yml
+++ b/.github/workflows/auto-dismiss-samples-alerts.yml
@@ -1,0 +1,63 @@
+name: Auto-dismiss security alerts in samples/
+
+on:
+  schedule:
+    - cron: '0 6 * * *'  # daily at 06:00 UTC
+  workflow_dispatch:
+
+permissions:
+  security-events: write
+
+jobs:
+  dismiss:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Dismiss Dependabot alerts in samples/
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          page=1
+          dismissed=0
+          while : ; do
+            response=$(gh api "repos/$GITHUB_REPOSITORY/dependabot/alerts?state=open&per_page=100&page=$page")
+            count=$(echo "$response" | jq 'length')
+            [ "$count" -eq 0 ] && break
+
+            while IFS= read -r number; do
+              gh api --method PATCH "repos/$GITHUB_REPOSITORY/dependabot/alerts/$number" \
+                -f state=dismissed \
+                -f dismissed_reason=tolerable_risk \
+                -f dismissed_comment="samples/ contains generated integration-test fixtures, not production code" \
+                --silent
+              echo "Dismissed Dependabot alert #$number"
+              ((dismissed++))
+            done < <(echo "$response" | jq -r '.[] | select(.dependency.manifest_path | startswith("samples/")) | .number | tostring')
+
+            ((page++))
+          done
+          echo "Total Dependabot alerts dismissed: $dismissed"
+
+      - name: Dismiss code scanning alerts in samples/
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          page=1
+          dismissed=0
+          while : ; do
+            response=$(gh api "repos/$GITHUB_REPOSITORY/code-scanning/alerts?state=open&per_page=100&page=$page")
+            count=$(echo "$response" | jq 'length')
+            [ "$count" -eq 0 ] && break
+
+            while IFS= read -r number; do
+              gh api --method PATCH "repos/$GITHUB_REPOSITORY/code-scanning/alerts/$number" \
+                -f state=dismissed \
+                -f dismissed_reason="used in tests" \
+                -f dismissed_comment="samples/ contains generated integration-test fixtures, not production code" \
+                --silent
+              echo "Dismissed code scanning alert #$number"
+              ((dismissed++))
+            done < <(echo "$response" | jq -r '.[] | select(.most_recent_instance.location.path | startswith("samples/")) | .number | tostring')
+
+            ((page++))
+          done
+          echo "Total code scanning alerts dismissed: $dismissed"


### PR DESCRIPTION
## Summary

- `samples/` contains **generated integration-test fixtures**, not production code — security alerts from it are noise with no actionable fix
- Adds a daily scheduled workflow that auto-dismisses both Dependabot (`tolerable_risk`) and code scanning (`used in tests`) alerts whose path starts with `samples/`
- The workflow also runs on `workflow_dispatch` for on-demand clearing

## What was already in place

- The CodeQL workflow already uses `filter-sarif` to exclude `samples/**` from CodeQL results ✅
- `dependabot.yml` has `exclude-paths: samples/**` — but this only prevents version-update PRs, **not security alerts** ❌

## What this adds

`.github/workflows/auto-dismiss-samples-alerts.yml` — a cron job (daily 06:00 UTC) that:
1. Pages through all open Dependabot alerts, dismisses any with a manifest path under `samples/`
2. Pages through all open code scanning alerts, dismisses any with a location path under `samples/`

## Notes

- The 6 open Dependabot alerts and 1 Wiz IaC alert that were in `samples/` have already been dismissed manually ahead of this PR
- If `GITHUB_TOKEN` turns out to lack Dependabot write permissions in the org context, replace it with a repo-scoped PAT stored as a secret

## Test plan

- [ ] Merge and verify the workflow runs successfully on the next scheduled trigger (or run manually via Actions → "Auto-dismiss security alerts in samples/" → Run workflow)
- [ ] Confirm the Security tab stays clean after the next Dependabot alert cycle

🤖 Generated with [Claude Code](https://claude.com/claude-code)