### PR TITLE
Cache Handlebars runtime and compiled templates per generation (~4.5x speed-up)

### DIFF
--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/v3/templates/HandlebarTemplateEngine.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/v3/templates/HandlebarTemplateEngine.java
@@ -7,10 +7,26 @@ import io.swagger.codegen.v3.CodegenConstants;
 
 import java.io.IOException;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 
+// Caches both the Handlebars runtime and compiled templates for the lifetime of one generation:
+//   * one Handlebars instance, built lazily on first use - avoids rebuilding the loader,
+//     re-registering helpers, and re-instantiating the ANTLR runtime on every render;
+//   * a per-templateFile map of compiled Templates so entry templates (controller, model, ...)
+//     are parsed once even though they are rendered hundreds of times;
+//   * IndentAwareTemplateCache so partials referenced via {{> ... }} are parsed once per
+//     unique (filename, applied-indent) pair - this is the dominant share of parse time.
+//     The stock ConcurrentMapTemplateCache from jknack collides distinct include sites of
+//     the same partial because its TemplateSource wrapper's equals/hashCode ignore the
+//     applied indent (see IndentAwareTemplateCache for the full rationale).
+// Before this change, getRendered re-created Handlebars and re-parsed the template (and all of
+// its partials) on every invocation, which made the Handlebars ANTLR lexer ~65% of CPU on
+// realistic specs.
 public class HandlebarTemplateEngine implements TemplateEngine {
 
-    private CodegenConfig config;
+    private final CodegenConfig config;
+    private final Map<String, com.github.jknack.handlebars.Template> compiledTemplates = new ConcurrentHashMap<>();
+    private volatile Handlebars handlebars;
 
     public HandlebarTemplateEngine(CodegenConfig config) {
         this.config = config;
@@ -28,16 +44,37 @@ public class HandlebarTemplateEngine implements TemplateEngine {
     }
 
     private com.github.jknack.handlebars.Template getHandlebars(String templateFile) throws IOException {
-        templateFile = templateFile.replace("\\", "/");
-        final String templateDir = config.templateDir().replace("\\", "/");
-        final TemplateLoader templateLoader;
-        String customTemplateDir = config.customTemplateDir() != null ? config.customTemplateDir().replace("\\", "/") : null;
-        templateLoader = new CodegenTemplateLoader()
-                .templateDir(templateDir)
-                .customTemplateDir(customTemplateDir);
-        final Handlebars handlebars = new Handlebars(templateLoader);
-        handlebars.prettyPrint(true);
-        config.addHandlebarHelpers(handlebars);
-        return handlebars.compile(templateFile);
+        final String key = templateFile.replace("\\", "/");
+        com.github.jknack.handlebars.Template cached = compiledTemplates.get(key);
+        if (cached != null) {
+            return cached;
+        }
+        final com.github.jknack.handlebars.Template compiled = handlebars().compile(key);
+        compiledTemplates.put(key, compiled);
+        return compiled;
+    }
+
+    private Handlebars handlebars() {
+        Handlebars local = handlebars;
+        if (local != null) {
+            return local;
+        }
+        synchronized (this) {
+            if (handlebars == null) {
+                final String templateDir = config.templateDir().replace("\\", "/");
+                final String customTemplateDir = config.customTemplateDir() != null
+                    ? config.customTemplateDir().replace("\\", "/")
+                    : null;
+                final TemplateLoader templateLoader = new CodegenTemplateLoader()
+                    .templateDir(templateDir)
+                    .customTemplateDir(customTemplateDir);
+                final Handlebars hb = new Handlebars(templateLoader);
+                hb.prettyPrint(true);
+                hb.with(new IndentAwareTemplateCache());
+                config.addHandlebarHelpers(hb);
+                handlebars = hb;
+            }
+            return handlebars;
+        }
     }
 }

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/v3/templates/IndentAwareTemplateCache.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/v3/templates/IndentAwareTemplateCache.java
@@ -1,0 +1,96 @@
+package io.swagger.codegen.v3.templates;
+
+import com.github.jknack.handlebars.Parser;
+import com.github.jknack.handlebars.Template;
+import com.github.jknack.handlebars.cache.TemplateCache;
+import com.github.jknack.handlebars.io.TemplateSource;
+
+import java.io.IOException;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+
+// Replacement for jknack's ConcurrentMapTemplateCache that is safe to use with
+// standalone-partial indentation (prettyPrint(true)).
+//
+// Why this exists:
+// jknack's Partial.merge() wraps the partial's TemplateSource via an anonymous class whose
+// equals()/hashCode() delegate ONLY to the underlying source (filename + lastModified).
+// The wrapper's content(), however, is the partial body re-indented by the include site's
+// leading whitespace. Result: the same partial included at two different indents collides
+// on a cache lookup, and the first-compiled indent wins for every subsequent include. That
+// is observable as silently shifted whitespace in generated output when the same partial
+// is included at multiple indent levels.
+//
+// Fix: key the cache on (filename + content), so two wrappers with the same filename but
+// different applied indent get separate entries. Compilation still happens at most once
+// per unique (template, indent) pair, which preserves the bulk of the speed-up the cache
+// is here for in the first place.
+public class IndentAwareTemplateCache implements TemplateCache {
+
+    private final ConcurrentMap<Key, Template> cache = new ConcurrentHashMap<>();
+    private boolean reload;
+
+    @Override
+    public void clear() {
+        cache.clear();
+    }
+
+    @Override
+    public void evict(TemplateSource source) {
+        try {
+            cache.remove(keyFor(source));
+        } catch (IOException ignored) {
+            // best-effort eviction
+        }
+    }
+
+    @Override
+    public Template get(TemplateSource source, Parser parser) throws IOException {
+        final Key key = keyFor(source);
+        Template cached = cache.get(key);
+        if (cached != null && !reload) {
+            return cached;
+        }
+        final Template compiled = parser.parse(source);
+        Template previous = cache.putIfAbsent(key, compiled);
+        return previous != null ? previous : compiled;
+    }
+
+    @Override
+    public TemplateCache setReload(boolean reload) {
+        this.reload = reload;
+        return this;
+    }
+
+    private static Key keyFor(TemplateSource source) throws IOException {
+        return new Key(source.filename(), source.content(java.nio.charset.StandardCharsets.UTF_8));
+    }
+
+    private static final class Key {
+        private final String filename;
+        private final String content;
+        private final int hash;
+
+        Key(String filename, String content) {
+            this.filename = filename;
+            this.content = content;
+            this.hash = 31 * (filename == null ? 0 : filename.hashCode())
+                + (content == null ? 0 : content.hashCode());
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (!(o instanceof Key)) return false;
+            Key other = (Key) o;
+            return hash == other.hash
+                && java.util.Objects.equals(filename, other.filename)
+                && java.util.Objects.equals(content, other.content);
+        }
+
+        @Override
+        public int hashCode() {
+            return hash;
+        }
+    }
+}


### PR DESCRIPTION
Fixes #12745

## Summary

`HandlebarTemplateEngine.getRendered(...)` previously rebuilt the `Handlebars` instance and reparsed the template (and every partial transitively referenced) on each invocation. JFR profiles of a realistic OpenAPI spec show the ANTLR-based jknack lexer accounting for ~65% of CPU — the dominant cost was repeated parsing, not rendering.

This PR caches both the Handlebars runtime and compiled templates for the lifetime of one generation.

## Changes

* **`HandlebarTemplateEngine.java`** (+49 / −12)
  * Build the `Handlebars` instance lazily on first use and reuse it for the lifetime of one generation. Helpers are registered once.
  * Cache the compiled top-level `Template` per `templateFile`, so entry templates (controller, model, …) are parsed once even though they are rendered many times.
  * Install `IndentAwareTemplateCache` so partials referenced via `{{> ... }}` are parsed once per unique `(filename, applied-indent)` pair.

* **`IndentAwareTemplateCache.java`** (new, 96 lines)
  * Replacement for jknack's `ConcurrentMapTemplateCache`. `Partial.merge` wraps the partial's `TemplateSource` via an anonymous class whose `equals`/`hashCode` delegate to the underlying source (filename + lastModified), while its `content()` is re-indented by the include site's leading whitespace. The same partial included at different indents therefore collides on lookup in the stock cache and the first-compiled indent wins for every subsequent include — observable as silently shifted whitespace in generated output. See related jknack issues [#401](https://github.com/jknack/handlebars.java/issues/401) and [#708](https://github.com/jknack/handlebars.java/issues/708).
  * The replacement keys on `(filename, content)` so two wrappers with the same filename but different applied indent get separate entries. Compilation still happens at most once per unique `(template, indent)` pair, which preserves the bulk of the speed-up.

No public API changes. No template changes. No `swagger-codegen-generators` change.

## Performance

Measured on a realistic OpenAPI spec (~75 controllers, 178 output files), warm runs, 3 iterations each:

| | baseline | with this change | speed-up |
|---|---|---|---|
| average | ~55 s | ~12 s | **~4.5× (−78%)** |

The same cache also avoids re-registering helpers and re-instantiating the ANTLR runtime per render, which compounds the savings on smaller specs.

## Tests

* `mvn ... -Prun-dotnet-unit-tests` → 6/6 pass.
* `mvn ... -Prun-dotnet-integration-tests` → 27/27 generator scenarios match expected output **byte-for-byte**, no fixture changes required. The indent-aware key for the partial cache is essential here: an earlier prototype that used the stock `ConcurrentMapTemplateCache` produced silently shifted whitespace in scenarios where the same partial was included at multiple indent levels.

## Out of scope (intentionally)

* No jknack handlebars upgrade. The underlying `Partial.merge` indent-collision behavior is present on the latest 4.5.1 release as well; a workaround at the cache layer keeps this PR small and reviewable. Upgrading the dependency is a separate piece of work.

## Reference

#12313 / its accompanying fix established the same precedent in another hotspot (`AbstractJavaCodegen.toModelName()` was called millions of times and was cached for a 3× improvement). This PR applies the same idea to template parsing.
