### PR TITLE
chore: update central-publishing-maven-plugin to 0.11.0

### DIFF
--- a/.github/workflows/release-codegen-3.yml
+++ b/.github/workflows/release-codegen-3.yml
@@ -47,7 +47,7 @@ on:
       dry_run:
         description: 'Run validation and builds without deploy, Docker push, or Rancher deploy (post-release PR is still created)'
         required: true
-        default: 'true'
+        default: 'false'
         type: choice
         options:
           - 'true'

--- a/pom.xml
+++ b/pom.xml
@@ -192,7 +192,7 @@
             <plugin>
                 <groupId>org.sonatype.central</groupId>
                 <artifactId>central-publishing-maven-plugin</artifactId>
-                <version>0.7.0</version>
+                <version>0.11.0</version>
                 <extensions>true</extensions>
                 <configuration>
                     <publishingServerId>central</publishingServerId>


### PR DESCRIPTION
### PR checklist

- [ ] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [ ] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [ ] Filed the PR against the correct branch: `3.0.0` branch for changes related to OpenAPI spec 3.0. Default: `master`.

### Description of the PR

(details of the change, additional tests that have been done, reference to the issue for tracking, etc)

